### PR TITLE
Evictions count bug fix

### DIFF
--- a/client/src/components/PropertiesSummary.js
+++ b/client/src/components/PropertiesSummary.js
@@ -80,7 +80,12 @@ export default class PropertiesSummary extends Component {
               </p>
               <h6>Evictions</h6>
               <p>
-                In 2017, there were an average of <b>{agg.avgevictions}</b> evictions per building scheduled by NYC Marshals.
+                In 2017, NYC Marshals scheduled <b>{agg.totalevictions}</b> evictions across this portfolio. The building with the most evictions was&nbsp;
+                {agg.evictionsaddr && (
+                  <span>
+                    <b>{agg.evictionsaddr.housenumber} {agg.evictionsaddr.streetname}, {agg.evictionsaddr.boro}</b> with <b>{agg.evictionsaddr.evictions}</b> evictions that year
+                  </span>
+                )}.
               </p>
               <h6>Rent stabilization</h6>
               <p>

--- a/client/src/components/PropertiesSummary.js
+++ b/client/src/components/PropertiesSummary.js
@@ -80,12 +80,15 @@ export default class PropertiesSummary extends Component {
               </p>
               <h6>Evictions</h6>
               <p>
-                In 2017, NYC Marshals scheduled <b>{agg.totalevictions}</b> eviction{agg.totalevictions == 1 ? "" : "s"} across this portfolio. The building with the most evictions was&nbsp;
-                {agg.evictionsaddr && (
-                  <span>
-                    <b>{agg.evictionsaddr.housenumber} {agg.evictionsaddr.streetname}, {agg.evictionsaddr.boro}</b> with <b>{agg.evictionsaddr.evictions}</b> eviction{agg.totalevictions == 1 ? "" : "s"} that year
-                  </span>
-                )}.
+                In 2017, NYC Marshals scheduled <b>{agg.totalevictions > 0 ? agg.totalevictions : "0"}</b> eviction{agg.totalevictions == 1 ? "" : "s"} across this portfolio. 
+                {agg.totalevictions > 0 ? 
+                  <span> The building with the most evictions was&nbsp;
+                    {agg.evictionsaddr && (
+                      <span>
+                        <b>{agg.evictionsaddr.housenumber} {agg.evictionsaddr.streetname}, {agg.evictionsaddr.boro}</b> with <b>{agg.evictionsaddr.evictions}</b> eviction{agg.totalevictions == 1 ? "" : "s"} that year
+                      </span>
+                    )}. 
+                  </span> : ""} 
               </p>
               <h6>Rent stabilization</h6>
               <p>

--- a/sql/agg_function.sql
+++ b/sql/agg_function.sql
@@ -17,6 +17,7 @@ RETURNS TABLE (
   avgrspercent numeric,
   rsproportion numeric,
   rslossaddr json,
+  evictionsaddr json,
   violationsaddr json
   -- , hasjustfix boolean
   -- , countjustfix bigint
@@ -70,11 +71,21 @@ RETURNS TABLE (
       (array_agg (
         json_build_object (
           'housenumber', housenumber, 'streetname', streetname, 'boro', boro,
+          'lat', lat, 'lng', lng, 'evictions', evictions
+        )
+        ORDER BY evictions DESC NULLS LAST
+      ))[1]
+    foo1) as evictionsaddr,
+
+    (SELECT
+      (array_agg (
+        json_build_object (
+          'housenumber', housenumber, 'streetname', streetname, 'boro', boro,
           'lat', lat, 'lng', lng, 'openviolations', openviolations
         )
         ORDER BY openviolations DESC
       ))[1]
-    foo1) as violationsaddr
+    foo2) as violationsaddr
    -- ,bool_or(hasjustfix) as hasjustfix
     -- perform a boolean OR to see if at least one property in the portfolio has justfix
  


### PR DESCRIPTION
Changed formatting on the summary page for buildings that had 0 evictions portfolio-wide. Now actually says "0" and doesn't list a top address. 