### PR TITLE
adding landlord contact table and endpoint

### DIFF
--- a/server/controllers/landlord.js
+++ b/server/controllers/landlord.js
@@ -1,0 +1,16 @@
+const db = require('../services/db'),
+      geo = require('../services/geoclient'),
+      csv = require('csv-express'),
+      rollbar = require('rollbar');
+      Promise = require('bluebird');
+
+module.exports = {
+  query: (req, res) => {
+    db.queryLandlord(req.query.bbl)
+      .then(result => res.status(200).send({ result: result }) )
+      .catch(err => {
+        rollbar.error(err, req);
+        res.status(200).send({ error: err.message });
+      });
+  }
+};

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,9 +1,11 @@
 const router = require('express').Router();
 
 const address = require('./controllers/address');
+const landlord = require('./controllers/landlord');
 
 router.get('/address', address.query);
 router.get('/address/aggregate', address.aggregate);
 router.get('/address/export', address.export);
+router.get('/landlord', landlord.query);
 
 module.exports = router;

--- a/server/services/db.js
+++ b/server/services/db.js
@@ -5,5 +5,6 @@ const db = pgp(process.env.DATABASE_URL);
 
 module.exports = {
   queryAddress: bbl => db.func('get_assoc_addrs_from_bbl', bbl),
-  queryAggregate: bbl => db.func('get_agg_info_from_bbl', bbl)
+  queryAggregate: bbl => db.func('get_agg_info_from_bbl', bbl),
+  queryLandlord: bbl => db.any('SELECT * FROM hpd_landlord_contact WHERE bbl = $1', bbl)
 };

--- a/sql/landlord_contact.sql
+++ b/sql/landlord_contact.sql
@@ -1,0 +1,49 @@
+DROP TABLE IF EXISTS hpd_landlord_contact;
+
+-- This is the table to query landlord contact information for JustFix letters of complaint
+-- The convention is to use the name of the head officer and the buisness address from the
+-- corporate owner.
+CREATE TABLE hpd_landlord_contact
+as SELECT
+  registrations.housenumber,
+  registrations.streetname,
+  registrations.zip,
+  registrations.boro,
+  registrations.registrationid,
+  registrations.bbl,
+  registrations.bin,
+  contacts.businessaddr,
+  contacts.ownername
+FROM hpd_registrations AS registrations
+LEFT JOIN (
+  SELECT
+    (
+      array_agg(
+        nullif(concat_ws(' ', businesshousenumber, businessstreetname, businessapartment, businesszip), '   ')
+      )
+      FILTER (
+        WHERE (
+          type = 'CorporateOwner' AND
+          (businesshousenumber <> '') IS TRUE AND
+          (businessstreetname <> '') IS TRUE AND
+          (businesszip <> '') IS TRUE
+        )
+      )
+    )[1] AS businessaddr,
+
+    (
+      array_agg(
+        firstname || ' ' || lastname
+      )
+      FILTER (
+        WHERE type = 'HeadOfficer' OR  type = 'IndividualOwner' AND
+        firstname IS NOT NULL AND
+        lastname IS NOT NULL
+      )
+    )[1] AS ownername,
+    registrationid
+  FROM hpd_contacts
+  GROUP BY registrationid
+) contacts ON (registrations.registrationid = contacts.registrationid);
+
+create index on hpd_landlord_contact (bbl);


### PR DESCRIPTION
This addresses #39 by adding a `landlord_contact` table to Postgres and supplying an accompanying endpoint at `/api/landlord`. It requires a BBL in the querystring as such:

`https://whoownswhat.justfix.nyc/api/landlord?bbl=3012380016`

should return:

```
{
    "result": [
        {
            "housenumber": "654",
            "streetname": "PARK PLACE",
            "zip": "11216",
            "boro": "BROOKLYN",
            "registrationid": 352819,
            "bbl": "3012380016",
            "bin": 3031404,
            "businessaddr": "12 SPENCER STREET 4 11205",
            "ownername": "MOSES GUTMAN"
        }
    ]
}
```

Some notes:

Fields aren't guaranteed, obviously. See this query:

![image](https://user-images.githubusercontent.com/627751/46049974-752ee080-c0ff-11e8-98e9-c182cc36dc8c.png)

So we usually have the name but maybe not the business address. We know from WoW development that we're taking a narrow view of the address (i.e. only looking at the `CorporateOwner` field, so there's definitely room for improvement at increasing coverage for this. But definitely a cool starting point!