### PR TITLE
Adds handling for browsers where WebGL is disabled or unavailable

### DIFF
--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -25,6 +25,21 @@
     }
   }
 
+  .PropertiesMap__error {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #fff;
+    position: relative;
+    z-index: 30;
+
+    h4 {
+      padding: 3rem;
+    }
+  }
+
   .PropertiesMap__legend {
     // background: $primary-color;
     // color: $background;

--- a/client/src/util/mapping.js
+++ b/client/src/util/mapping.js
@@ -19,5 +19,19 @@ export default {
     }
 
     return [[bs.xMin, bs.yMin],[bs.xMax, bs.yMax]];
+  },
+
+  hasWebGLContext() {
+    var canvas = document.createElement("canvas");
+    // Get WebGLRenderingContext from canvas element.
+    var gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+    // Report the result.
+    if (gl && gl instanceof WebGLRenderingContext) {
+        // alert("Congratulations! Your browser supports WebGL.");
+        return true;
+    } else {
+        // alert("Your browser or device may not support WebGL.");
+        return false;
+    }
   }
 }


### PR DESCRIPTION
This was a tricky one. Apparently there is little or no accounting for this - I looked through [react-mapbox-gl](https://github.com/alex3165/react-mapbox-gl/blob/master/docs/API.md) and tried some of the event handlers (`onWebGlContextLost`, `onError`?) but they didn't seem to affect anything.

So in the meantime I threw in some code that detects if the browser has WebGL or not (see `MapHelpers`), and throws up a terrible error message and doesn't allow the user to use the map at all:

![image](https://user-images.githubusercontent.com/627751/47048551-bb101f00-d168-11e8-8b5e-d864a5722174.png)

### How to reproduce
You can disable WebGL/hardware acceleration on Chrome in Settings > Advanced Settings > Use hardware acceleration when available:

![image](https://user-images.githubusercontent.com/627751/47048607-e98dfa00-d168-11e8-86ba-0f10b073e831.png)


@toolness @sraby interested to hear your thoughts! Specifically it would be good to know if we can find a way to degrade this in a better fashion so a version of the map could still maybe be displayed...

