### PR TITLE
url support for searching via full bbl

### DIFF
--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -212,7 +212,7 @@ export default class DetailView extends Component {
                           <FacebookButton
                             className="btn btn-steps"
                             sharer={true}
-                            url={'https://whoownswhat.justfix.nyc/address/' + this.props.addr.boro + '/' + this.props.addr.housenumber + '/' + this.props.addr.streetname}
+                            url={encodeURI('https://whoownswhat.justfix.nyc/address/' + this.props.addr.boro + '/' + this.props.addr.housenumber + '/' + this.props.addr.streetname)}
                             appId={`247990609143668`}
                             message={"The " + (this.props.portfolioSize > 1 ? this.props.portfolioSize + " " : " ")  + "buildings that my landlord \"owns\" 👀... #WhoOwnsWhat @JustFixNYC"}>
                             <img src={fbIcon} className="icon mx-1" alt="Facebook" />
@@ -220,14 +220,14 @@ export default class DetailView extends Component {
                           </FacebookButton>
                           <TwitterButton
                             className="btn btn-steps"
-                            url={'https://whoownswhat.justfix.nyc/address/' + this.props.addr.boro + '/' + this.props.addr.housenumber + '/' + this.props.addr.streetname}
+                            url={encodeURI('https://whoownswhat.justfix.nyc/address/' + this.props.addr.boro + '/' + this.props.addr.housenumber + '/' + this.props.addr.streetname)}
                             message={"The " + (this.props.portfolioSize > 1 ? this.props.portfolioSize + " " : " ")  + "buildings that my landlord \"owns\" 👀... #WhoOwnsWhat @JustFixNYC"}>
                             <img src={twitterIcon} className="icon mx-1" alt="Twitter" />
                             <span>Twitter</span>
                           </TwitterButton>
                           <EmailButton
                             className="btn btn-steps"
-                            url={'https://whoownswhat.justfix.nyc/address/' + this.props.addr.boro + '/' + this.props.addr.housenumber + '/' + this.props.addr.streetname}
+                            url={encodeURI('https://whoownswhat.justfix.nyc/address/' + this.props.addr.boro + '/' + this.props.addr.housenumber + '/' + this.props.addr.streetname)}
                             target="_blank"
                             message={"The " + (this.props.portfolioSize > 1 ? this.props.portfolioSize + " " : " ")  + "buildings owned by my landlord (via Who Owns What)"}>
                             <i className="icon icon-mail mx-2" />

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -97,6 +97,7 @@ render() {
             <Route path="/not-found" component={NotRegisteredPage} />
             <Route path="/address/:boro/:housenumber/:streetname" component={AddressPage} />
             <Route path="/bbl/:boro/:block/:lot" component={BBLPage} />
+            <Route path="/bbl/:bbl" component={BBLPage} />
             <Route path="/about" component={AboutPage} />
             <Route path="/how-it-works" component={HowItWorksPage} />
             <Route path="/terms-of-use" component={TermsOfUsePage} />

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import {
   BrowserRouter as Router,
   Route,
+  Switch,
   NavLink,
   Link
 } from 'react-router-dom';
@@ -93,15 +94,17 @@ render() {
             </Modal>
           </div>
           <div className="App__body">
-            <Route exact path="/" component={HomePage} />
-            <Route path="/not-found" component={NotRegisteredPage} />
-            <Route path="/address/:boro/:housenumber/:streetname" component={AddressPage} />
-            <Route path="/bbl/:boro/:block/:lot" component={BBLPage} />
-            <Route path="/bbl/:bbl" component={BBLPage} />
-            <Route path="/about" component={AboutPage} />
-            <Route path="/how-it-works" component={HowItWorksPage} />
-            <Route path="/terms-of-use" component={TermsOfUsePage} />
-            <Route path="/privacy-policy" component={PrivacyPolicyPage} />
+            <Switch>
+              <Route exact path="/" component={HomePage} />
+              <Route path="/not-found" component={NotRegisteredPage} />
+              <Route path="/address/:boro/:housenumber/:streetname" component={AddressPage} />
+              <Route path="/bbl/:boro/:block/:lot" component={BBLPage} />
+              <Route path="/bbl/:bbl" component={BBLPage} />
+              <Route path="/about" component={AboutPage} />
+              <Route path="/how-it-works" component={HowItWorksPage} />
+              <Route path="/terms-of-use" component={TermsOfUsePage} />
+              <Route path="/privacy-policy" component={PrivacyPolicyPage} />
+            </Switch>
           </div>
         </div>
         </ScrollToTop>

--- a/client/src/containers/BBLPage.js
+++ b/client/src/containers/BBLPage.js
@@ -11,7 +11,7 @@ export default class BBLPage extends Component {
     super(props);
 
     this.state = {
-      searchBBL: { ...props.match.params },
+      searchBBL: { ...props.match.params }, // either {boro, block, lot} or {bbl}, based on url params
       results: null
     };
   }
@@ -20,6 +20,7 @@ export default class BBLPage extends Component {
 
     window.gtag('event', 'direct-link');
 
+    // handling for when url parameter is full bbl
     if (this.state.searchBBL.bbl.length == 10) {
       let bbl = this.state.searchBBL.bbl;
       this.state.searchBBL = {

--- a/client/src/containers/BBLPage.js
+++ b/client/src/containers/BBLPage.js
@@ -19,6 +19,16 @@ export default class BBLPage extends Component {
   componentDidMount() {
 
     window.gtag('event', 'direct-link');
+
+    if (this.state.searchBBL.bbl.length == 10) {
+      let bbl = this.state.searchBBL.bbl;
+      this.state.searchBBL = {
+        boro: bbl.slice(0,1),
+        block: bbl.slice(1,6),
+        lot: bbl.slice(6,10)
+      };
+    }
+
     APIClient.searchBBL(this.state.searchBBL)
       .then(results => {
         this.setState({

--- a/client/src/containers/BBLPage.js
+++ b/client/src/containers/BBLPage.js
@@ -16,19 +16,27 @@ export default class BBLPage extends Component {
     };
   }
 
+  componentWillMount() {
+
+    // handling for when url parameter is full bbl
+
+    if (this.state.searchBBL.bbl) {
+      let bbl = this.state.searchBBL.bbl;
+      this.setState({
+        searchBBL: {
+          boro: bbl.slice(0,1),
+          block: bbl.slice(1,6),
+          lot: bbl.slice(6,10)
+        }
+      });
+    }
+
+  }
+
+
   componentDidMount() {
 
     window.gtag('event', 'direct-link');
-
-    // handling for when url parameter is full bbl
-    if (this.state.searchBBL.bbl.length == 10) {
-      let bbl = this.state.searchBBL.bbl;
-      this.state.searchBBL = {
-        boro: bbl.slice(0,1),
-        block: bbl.slice(1,6),
-        lot: bbl.slice(6,10)
-      };
-    }
 
     APIClient.searchBBL(this.state.searchBBL)
       .then(results => {

--- a/client/src/styles/LegalFooter.scss
+++ b/client/src/styles/LegalFooter.scss
@@ -10,6 +10,10 @@
   align-items: flex-start;
   position: relative;
 
+  @include for-tablet-landscape-up() {
+    height: 0px;
+  }
+
   @include for-tablet-landscape-down() {
     padding: 8px;
     min-height: 60px;


### PR DESCRIPTION
(mainly out of convenience for myself) I added a route with one single url parameter for a full non-delimited bbl, and a small IF statement to BBLPage to slice out each boro, block, and lot from that input. 

So, for example, the url `.../bbl/2031840066` should work sans backslashes! 