### PR TITLE
Bug fix: map now pans when new address selected from list view

### DIFF
--- a/client/src/components/PropertiesMap.js
+++ b/client/src/components/PropertiesMap.js
@@ -171,7 +171,7 @@ export default class PropertiesMap extends Component {
             fitBounds: [minPos, maxPos]
           }});
 
-          console.log("I panned the map!");
+          // console.log("I panned the map!");
       }
     }
   }

--- a/client/src/components/PropertiesMap.js
+++ b/client/src/components/PropertiesMap.js
@@ -171,7 +171,7 @@ export default class PropertiesMap extends Component {
             fitBounds: [minPos, maxPos]
           }});
 
-          //console.log("I panned the map!");
+          console.log("I panned the map!");
       }
     }
   }
@@ -186,7 +186,7 @@ export default class PropertiesMap extends Component {
   }
 
   handleAddrSelect = (addr, e) => {
-    this.props.onOpenDetail(addr);
+    this.props.onAddrChange(addr);
   }
 
   render() {

--- a/client/src/components/PropertiesMap.js
+++ b/client/src/components/PropertiesMap.js
@@ -186,6 +186,7 @@ export default class PropertiesMap extends Component {
   }
 
   handleAddrSelect = (addr, e) => {
+    // updates state with new focus address
     this.props.onAddrChange(addr);
   }
 

--- a/client/src/components/PropertiesMap.js
+++ b/client/src/components/PropertiesMap.js
@@ -158,6 +158,22 @@ export default class PropertiesMap extends Component {
     if(!prevProps.isVisible && this.props.isVisible) {
       if(this.state.mapRef) this.state.mapRef.resize();
     }
+
+    // meant to pan the map any time the detail address changes 
+    if(prevProps.detailAddr && this.props.detailAddr) {
+      if(!Helpers.addrsAreEqual(prevProps.detailAddr,this.props.detailAddr)) {
+          let addr = this.props.detailAddr;
+          // build a bounding box around our new detail addr
+          let minPos = [parseFloat(addr.lng) - DETAIL_OFFSET, parseFloat(addr.lat) - DETAIL_OFFSET];
+          let maxPos = [parseFloat(addr.lng) + DETAIL_OFFSET, parseFloat(addr.lat) + DETAIL_OFFSET];
+          this.setState({ mapProps: {
+            ...this.state.mapProps,
+            fitBounds: [minPos, maxPos]
+          }});
+
+          //console.log("I panned the map!");
+      }
+    }
   }
 
   handleMouseMove = (map, e) => {
@@ -170,15 +186,6 @@ export default class PropertiesMap extends Component {
   }
 
   handleAddrSelect = (addr, e) => {
-
-    // build a bounding box around our new detail addr
-    let minPos = [parseFloat(addr.lng) - DETAIL_OFFSET, parseFloat(addr.lat) - DETAIL_OFFSET];
-    let maxPos = [parseFloat(addr.lng) + DETAIL_OFFSET, parseFloat(addr.lat) + DETAIL_OFFSET];
-    this.setState({ mapProps: {
-      ...this.state.mapProps,
-      fitBounds: [minPos, maxPos]
-    }});
-
     this.props.onOpenDetail(addr);
   }
 

--- a/client/src/containers/AddressPage.js
+++ b/client/src/containers/AddressPage.js
@@ -67,12 +67,12 @@ export default class AddressPage extends Component {
       geoclient: geoclient,
       assocAddrs: addrs
     }, () => {
-      this.handleOpenDetail(this.state.userAddr);
+      this.handleAddrChange(this.state.userAddr);
     });
 
   }
 
-  handleOpenDetail = (addr) => {
+  handleAddrChange = (addr) => {
     this.setState({
       detailAddr: addr,
       detailMobileSlide: true,
@@ -151,7 +151,7 @@ export default class AddressPage extends Component {
             addrs={this.state.assocAddrs}
             userAddr={this.state.userAddr}
             detailAddr={this.state.detailAddr}
-            onOpenDetail={this.handleOpenDetail}
+            onAddrChange={this.handleAddrChange}
             isVisible={this.state.currentTab === 0}
           />
           <DetailView
@@ -166,7 +166,7 @@ export default class AddressPage extends Component {
           {
            <PropertiesList
               addrs={this.state.assocAddrs}
-              onOpenDetail={this.handleOpenDetail}
+              onOpenDetail={this.handleAddrChange}
             />
           }
         </div>


### PR DESCRIPTION
I refactored PropertiesMap component so that the map pans anytime the detail address prop changes. I suspect this isn't the best way to do this? Open to discussion @romeboards @toolness :) 

Still to do: 
- [x] Test whether we need `this.props.onOpenDetail(addr);` to be called in onClick event handler for point clicks in Property Map component