### PR TITLE
Fix silent server crashes in development, and make MAILCHIMP_API_KEY optional.

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -5,8 +5,11 @@ const bodyParser = require('body-parser');
 const Rollbar = require('rollbar');
 const rollbar = Rollbar.init({
   accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
-  captureUncaught: true,
-  captureUnhandledRejections: true
+  // Only capture uncaught exceptions/unhandled rejections in production;
+  // otherwise Rollbar appears to eat the exception and exit the
+  // process with a 0 exit code, which is EXTREMELY confusing.
+  captureUncaught: process.env.NODE_ENV === 'production',
+  captureUnhandledRejections: process.env.NODE_ENV === 'production'
 });
 
 // TODO: change when migrating off heroku

--- a/server/services/mailchimp.js
+++ b/server/services/mailchimp.js
@@ -1,7 +1,12 @@
 const rp = require('request-promise');
 const rollbar = require('rollbar');
 
-const API_KEY = process.env.MAILCHIMP_API_KEY;
+const API_KEY = process.env.MAILCHIMP_API_KEY || '';
+
+if (!API_KEY) {
+  console.warn('WARNING: MAILCHIMP_API_KEY is not defined, so mailchimp integration will fail.');
+}
+
 // region is the last 4 characters of the api key: usXX
 const REGION = API_KEY.substr(-4, API_KEY.length - 1);
 const API_URL = `https://${REGION}.api.mailchimp.com/3.0`;


### PR DESCRIPTION
While working on #92, I ran into a problem where the API server on port 3001 silently crashed with a 0 exit code (0 meaning "I finished without crashing").  I eventually found out that it was silently crashing because Rollbar installed an uncaught exception handler that was exiting with a 0 exit code (which still strikes me as extremely odd).

This allowed me to see the actual exception that was causing the crash, which was due to my `MAILCHIMP_API_KEY` environment variable being undefined. This environment variable isn't actually documented anywhere, so there was no way for me to know that it even needed to be defined. I modified the code to default the environment variable to the empty string instead of `undefined`, thereby preventing the crash; I also added a logging statement that warns the user that mailchimp integration is disabled whenever this is the case.

## To do

- [ ] Actually document `MAILCHIMP_API_KEY`, or file an issue to do it later.
- [ ] Actually document `ROLLBAR_ACCESS_TOKEN`, or file an issue to do it later.
