### PR TITLE
Move WoW db config out to a YAML file.

### DIFF
--- a/dbtool.py
+++ b/dbtool.py
@@ -341,7 +341,7 @@ if __name__ == '__main__':
     )
     parser_builddb.add_argument(
         '--update', action='store_true',
-        help=('Delete downloaded data & tables for the most frequently-updated '
+        help=('Delete downloaded data & tables for the '
               'data sets so they can be re-downloaded and re-installed.')
     )
     parser_builddb.set_defaults(cmd='builddb')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nycdb==0.1.18
 psycopg2-binary==2.7.7
 mypy==0.660
+PyYAML>=4.2b1

--- a/who-owns-what.yml
+++ b/who-owns-what.yml
@@ -1,0 +1,17 @@
+---
+dependencies:
+  # These are NYCDB datasets needed by the SQL scripts.
+  - pluto_18v1
+  - rentstab_summary
+  - marshal_evictions_17
+  - hpd_registrations
+  - hpd_violations
+sql:
+  # These SQL scripts must be executed in order, as
+  # some of them depend on others.
+  - registrations_with_contacts.sql
+  - create_bldgs_table.sql
+  - helper_functions.sql
+  - search_function.sql
+  - agg_function.sql
+  - landlord_contact.sql


### PR DESCRIPTION
We need to be able to load/update the WoW database from our containerized DB updater at https://github.com/JustFixNYC/nycdb-k8s-loader/pull/22.  One simple way to do this is by putting all our database configuration into a YAML file, similar to what NYCDB is already doing.

This PR moves the names of all the NYCDB dataset dependencies and the SQL filenames into a new `who-owns-what.yml` file.  It also makes the following changes:

* We no longer load the `pluto_17v1` dataset; it seems this was entirely superseded by `pluto_18v1`, although I should check with @sraby to make sure this is OK.

* The `--update` option for `dbtool.py builddb` now wipes _all_ nycdb data instead of just a subset of tables. This simplified the structure of the YAML and seems OK since nycdb-k8s-loader will now be responsible for updating WoW in a more rigorous manner. If we really want to add this feature back in, we might want to add a separate flag that allows the user to manually specify which datasets to refresh.

* It automatically figures out what the tables in a dataset are by consulting the `nycdb` module.
