### PR TITLE
Bug fix + updated avg. violations per unit count for Property Summary view

### DIFF
--- a/client/src/components/PropertiesSummary.js
+++ b/client/src/components/PropertiesSummary.js
@@ -10,10 +10,12 @@ import 'styles/PropertiesSummary.css';
 import fbIcon from '../assets/img/fb.svg';
 import twitterIcon from '../assets/img/twitter.svg';
 
-const VIOLATIONS_AVG = 0.7; // By Unit
+const VIOLATIONS_AVG = 0.9; // By Unit
 
-// 1588195 open violations according to wow_bldgs
-// 2299803 total units in registered buildings, according to wow_bldgs
+// 1981721 open violations according to wow_bldgs
+// 2314462 total units in registered buildings, according to wow_bldgs
+
+// Data updated 2/11/19
 
 export default class PropertiesSummary extends Component {
   constructor(props) {
@@ -56,11 +58,11 @@ export default class PropertiesSummary extends Component {
             <div>
               <h6>General info</h6>
               <p>
-                There {agg.bldgs === 1 ? 
+                There {parseInt(agg.bldgs) === 1 ? 
                   <span>is <b>1</b> building </span> :
                   <span>are <b>{agg.bldgs}</b> buildings </span>}
-                in this portfolio with a total of {agg.units} unit{agg.units === 1 ? "" : "s"}.
-                The {agg.bldgs === 1 ? "" : "average"} age of {agg.bldgs === 1 ? "this building " : "these buildings "}
+                in this portfolio with a total of {agg.units} unit{parseInt(agg.units) === 1 ? "" : "s"}.
+                The {parseInt(agg.bldgs) === 1 ? "" : "average"} age of {parseInt(agg.bldgs) === 1 ? "this building " : "these buildings "}
                 is <b>{agg.age}</b> years old.
               </p>
               <aside>
@@ -100,19 +102,19 @@ export default class PropertiesSummary extends Component {
               </p>
               <h6>Evictions</h6>
               <p>
-                In 2017, NYC Marshals scheduled <b>{agg.totalevictions > 0 ? agg.totalevictions : "0"}</b> eviction{agg.totalevictions === 1 ? "" : "s"} across this portfolio.
+                In 2017, NYC Marshals scheduled <b>{agg.totalevictions > 0 ? agg.totalevictions : "0"}</b> eviction{parseInt(agg.totalevictions) === 1 ? "" : "s"} across this portfolio.
                 {agg.totalevictions > 0 ?
                   <span> The building with the most evictions was&nbsp;
                     {agg.evictionsaddr && (
                       <span>
-                        <b>{agg.evictionsaddr.housenumber} {agg.evictionsaddr.streetname}, {agg.evictionsaddr.boro}</b> with <b>{agg.evictionsaddr.evictions}</b> eviction{agg.totalevictions === 1 ? "" : "s"} that year
+                        <b>{agg.evictionsaddr.housenumber} {agg.evictionsaddr.streetname}, {agg.evictionsaddr.boro}</b> with <b>{agg.evictionsaddr.evictions}</b> eviction{parseInt(agg.totalevictions) === 1 ? "" : "s"} that year
                       </span>
                     )}.
                   </span> : ""}
               </p>
               <h6>Rent stabilization</h6>
               <p>
-                This portfolio also had an estimated <b>net {agg.totalrsdiff > 0 ? "gain" : "loss"}</b> of <b>{Math.abs(parseInt(agg.totalrsdiff, 10)) || 0}</b> rent stabilized unit{agg.totalrsdiff === 1 ? "" : "s"} since 2007 (gained {Math.abs(parseInt(agg.totalrsgain, 10)) || 0}, lost {Math.abs(parseInt(agg.totalrsloss, 10)) || 0}).
+                This portfolio also had an estimated <b>net {agg.totalrsdiff > 0 ? "gain" : "loss"}</b> of <b>{Math.abs(parseInt(agg.totalrsdiff, 10)) || 0}</b> rent stabilized unit{parseInt(agg.totalrsdiff) === 1 ? "" : "s"} since 2007 (gained {Math.abs(parseInt(agg.totalrsgain, 10)) || 0}, lost {Math.abs(parseInt(agg.totalrsloss, 10)) || 0}).
                 This represents <b>{agg.rsproportion || 0}%</b> of the total size of this portfolio. 
                 {agg.rslossaddr && (agg.rslossaddr.rsdiff < 0) ?
                 (<span> The building that has lost the most units is&nbsp;


### PR DESCRIPTION
- Calculating on recent data, average hpd violations per registered unit goes up to 0.9 :/ I updated a constant to change this number in summary tab
- Fixed a bug where certain fields of type `bigint` from the agg data table were actually of type text when called within the Property Summary component (@toolness I actually noticed this bug after merging #95, where you swapped out `==` for `===`)  I used `parseInt` to convert the non-int values to int so we can use them in comparison statements.

@toolness and @romeboards, is it worrying that there is a type mismatch between data from our agg table and what actually gets called within the Property Summary component? 

