### PR TITLE
Resolves issue #93

### DIFF
--- a/client/src/containers/HomePage.js
+++ b/client/src/containers/HomePage.js
@@ -77,7 +77,7 @@ class HomePage extends Component {
       if(!this.state.results.addrs || !this.state.results.addrs.length) {
         window.gtag('event', 'search-notfound');
         return (
-          <Redirect to={{
+          <Redirect push to={{
             pathname: '/not-found',
             state: { geoclient, searchAddress }
           }}></Redirect>
@@ -87,7 +87,7 @@ class HomePage extends Component {
       } else {
         window.gtag('event', 'search-found', { 'value': this.state.results.addrs.length });
         return (
-          <Redirect to={{
+          <Redirect push to={{
             pathname: `/address/${this.state.searchAddress.boro}/${this.state.searchAddress.housenumber}/${this.state.searchAddress.streetname}`,
             state: { results }
           }}></Redirect>


### PR DESCRIPTION
I found an explanation in this SO post:
https://stackoverflow.com/questions/48731207/react-router-dom-and-redirect-not-being-added-to-history

That post references this part in the router docs:
https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/Redirect.md#push-bool

When redirecting to the search results, nothing was being added to the history, as if the user had never left the initial home page. When clicking the back button, the browser would have to go back to a different page unless the user had clicked any other links on the WOW page.