### PR TITLE
placed map attribution control above legend

### DIFF
--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -23,6 +23,25 @@
     canvas {
       display: block;
     }
+
+    // overrides spacing/sizing rules for MapBox attribution control
+    .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
+      bottom: 115px;
+
+      .mapboxgl-ctrl-attrib.mapboxgl-compact:after {
+        width: 20px;
+        height: 20px;
+      }
+
+      @include for-phone-only() {
+        bottom: 60px;
+
+        .mapboxgl-ctrl-attrib.mapboxgl-compact {
+          margin: 0 5px 10px 10px;
+        }
+      }
+
+    }
   }
 
   .PropertiesMap__error {


### PR DESCRIPTION
seems like react-mapbox-gl doesn't support custom positioning for the attribution control... so in the meantime I'm going to place the standard control above the map legend ( fixes #145 )