### PR TITLE
fixed inaccurate tooltip for Total HPD Violations

### DIFF
--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -131,7 +131,7 @@ export default class DetailView extends Component {
                                 <label>Open Violations</label>
                                 { this.props.addr.openviolations }
                               </div>
-                              <div  title="This represents the total number of HPD Violations (both open & closed) filed since 2015.">
+                              <div  title="This represents the total number of HPD Violations (both open & closed) recorded by the city.">
                                 <label>Total Violations</label>
                                 { this.props.addr.totalviolations }
                               </div>


### PR DESCRIPTION
I considered limiting the HPD Violations count, but since there are some violations still open that were issued in the 60s, 70s (oof!), we'd then have cases where there were more "open violations" than "total violations" listed for a building. I thought that would be confusing and misleading to users, so instead I'm keeping to full total count. 