### PR TITLE
Convert AddressToolbar and Modal components to TypeScript

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,10 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@types/gtag.js": "^0.0.2",
     "@types/jest": "^24.0.6",
     "@types/node": "^11.9.4",
     "@types/react": "^16.8.3",
     "@types/react-dom": "^16.8.2",
+    "@types/react-modal": "^3.8.2",
+    "@types/react-router-dom": "^4.3.4",
     "babel-polyfill": "^6.26.0",
     "chart.js": "^2.8.0",
     "chartjs-plugin-annotation": "^0.5.7",

--- a/client/src/components/AddressToolbar.tsx
+++ b/client/src/components/AddressToolbar.tsx
@@ -1,11 +1,25 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import Modal from 'components/Modal';
+import Modal from './Modal';
 
 import 'styles/AddressToolbar.css';
 
-export default class AddressToolbar extends Component {
-  constructor(props) {
+export type AddressToolbarProps = {
+  onExportClick: () => void;
+  numOfAssocAddrs: number;
+  userAddr: {
+    housenumber: string;
+    streetname: string;
+    boro: string;
+  }
+};
+
+type State = {
+  showExportModal: boolean
+};
+
+export default class AddressToolbar extends Component<AddressToolbarProps, State> {
+  constructor(props: AddressToolbarProps) {
     super(props);
 
     this.state = {

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -3,7 +3,14 @@ import ReactModal from 'react-modal';
 
 import 'styles/Modal.css';
 
-const Modal = (props) => {
+type ModalProps = {
+  showModal: boolean;
+  onClose: (event: React.MouseEvent) => void;
+  children: any;
+  width?: number;
+};
+
+const Modal = (props: ModalProps) => {
 
   // style overrides are here. new stuff is in ReactModal.scss
   const styles = {

--- a/client/src/globals.d.ts
+++ b/client/src/globals.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  gtag: Gtag.Gtag;
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1016,6 +1016,16 @@
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-4.7.4.tgz#6de2f1e9890b8f64b669e4b47c09b20893063977"
   integrity sha1-beLx6YkLj2S2aeS0fAmyCJMGOXc=
 
+"@types/gtag.js@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.2.tgz#64620922012f6cdf2c3b13a84dde3686ab7d48d9"
+  integrity sha512-TwvMurpzM88wXreJNYr9nyiM/gPKF+o3jiPn+5kLWYBiucY8S5XmB0VWdVzvO6aiEdLy00g549URk45Cdw5xZg==
+
+"@types/history@*":
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
+  integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
+
 "@types/jest-diff@*":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
@@ -1048,6 +1058,30 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.4.tgz#7fb7ba368857c7aa0f4e4511c4710ca2c5a12a88"
   integrity sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-modal@^3.8.2":
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.8.2.tgz#401309e624cde522d65c3ef04918dbe325383598"
+  integrity sha512-/Drs+XfHg9M60fy2Q63UUlhECXSNknDu3tnwFnbOhcdDjq03VD3hLCfv3X+BBzRqgu4TOu+TwEwBhgI8qdVAAQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.4.tgz#63a7a8558129d2f4ff76e4bdd099bf4b98e25a0d"
+  integrity sha512-xrwaWHpnxKk/TTRe7pmoGy3E4SyF/ojFqNfFJacw7OLdfLXRvGfk4r/XePVaZNVfeJzL8fcnNilPN7xOdJ/vGw==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.0.3.tgz#855a1606e62de3f4d69ea34fb3c0e50e98e964d5"
+  integrity sha512-j2Gge5cvxca+5lK9wxovmGPgpVJMwjyu5lTA/Cd6fLGoPq7FXcUE1jFkEdxeyqGGz8VfHYSHCn5Lcn24BzaNKA==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.8.3":


### PR DESCRIPTION
This converts the `<AddressToolbar>` and `<Modal>` components to TypeScript.

The main benefit is that props for the components are now semi-documented--I say "semi" because I haven't added any comments documenting what each property is for, because I'm not very familiar with the code, but at least the name and type of the props are documented now.  Although even the types might be slightly inaccurate--since the consumers of these components haven't been converted yet, I'm just making educated guesses about the types, but we can revise them going forward.

Anyways, it's a start at least.  I think that as we make the types more explicit, it will become easier for folks to understand the code, and it should also uncover potential type errors, like our buddy `Cannot read property 'bbl' of undefined`.
