### PR TITLE
Ensure nodeJS is installed via nodesource.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,14 @@ ENV NODE_VERSION=8
 
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
 
+# https://github.com/nodejs/help/issues/554#issuecomment-429633801
+RUN printf 'Package: nodejs\n\
+Pin: origin deb.nodesource.com\n\
+Pin-Priority: 1001\n' \
+>> /etc/apt/preferences.d/nodejs
+
 RUN apt-get update \
+  && apt-cache policy nodejs \
   && apt-get install -y \
     nodejs \
     unzip \


### PR DESCRIPTION
For some bizarre reason, Labiba's computer (and possibly anyone who now tries using our Dockerfile from a freshly-installed Docker install, I'm not sure) was prioritizing Debian's default nodejs package over nodesource's, which meant that the wrong version of node was being installed _and_ npm wasn't being installed at all.

This ensures that node is installed from the correct package using the technique described at https://github.com/nodejs/help/issues/554#issuecomment-429633801.