### PR TITLE
Return 404 for nonexistent static files

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -37,6 +37,14 @@ if (process.env.NODE_ENV === 'production') {
 
 app.use('/api', routes);
 
+const return404 = function(req, res) {
+  res.status(404).end();
+};
+
+// These will help prevent https://github.com/JustFixNYC/who-owns-what/issues/169.
+app.get(/^\/static\/.*/, return404);
+app.get(/^\/[0-9A-Za-z_.\-]+\.(js|json|ico|html)$/, return404);
+
 app.get('*', function(req, res) {
   res.sendFile(path.resolve(__dirname + '/../client/build/index.html'));
 });


### PR DESCRIPTION
This should fix #169 by making the server return 404 for any paths that miss express' `static` middleware and look like static files.
