### PR TITLE
Upgrade react-google-maps to 9.4.5

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
     "react-device-detect": "^1.7.5",
     "react-dom": "16.8.6",
     "react-draggable": "^3.0.5",
-    "react-google-maps": "7.1.0",
+    "react-google-maps": "9.4.5",
     "react-leaflet": "^1.4.0",
     "react-mapbox-gl": "^3.8.0",
     "react-modal": "^3.0.0",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -122,7 +122,7 @@
     <link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet">
 
     <!-- <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAFVvznsJR8hocex0DUNDI7YkUIDDuF-Yw&libraries=places"></script> -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCuf0Ca1EvxogvbZQKOBl_40y0UWm4Fk30&libraries=places,geometry"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_STREETVIEW_API_KEY%&libraries=places,geometry"></script>
 
   </head>
   <body>

--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import { LocaleLink as Link } from '../i18n';
-import { StreetViewPanorama } from 'react-google-maps';
+import { StreetView } from './StreetView';
 import Helpers from 'util/helpers';
 import Browser from 'util/browser';
 import Modal from 'components/Modal';
@@ -14,8 +14,6 @@ export default class DetailView extends Component {
     super(props);
 
     this.state = {
-      coordinates: null,
-      heading: 0,
       showCompareModal: false,
       todaysDate: new Date()
     }
@@ -23,31 +21,9 @@ export default class DetailView extends Component {
     this.detailSlideLength = 300;
   }
 
-  // we need to trigger an ajax call (the streetViewService) when props
-  // receives a new address. this computes the street view heading
-  // srsly tho google, why not point to the latlng automatically?
   componentDidUpdate(prevProps, prevState) {
-
     // scroll to top of wrapper div:
     document.querySelector('.DetailView__wrapper').scrollTop = 0;
-
-    // this says: if the component is getting the addr for the first time OR
-    //            if the component already has an addr but is getting a new one
-    if( (!prevProps.addr && this.props.addr) || (prevProps.addr && this.props.addr && (prevProps.addr.bbl !== this.props.addr.bbl))) {
-
-      let coordinates = new window.google.maps.LatLng(this.props.addr.lat, this.props.addr.lng);
-      let streetViewService = new window.google.maps.StreetViewService();
-
-      streetViewService.getPanoramaByLocation(coordinates, 50, (panoData) => {
-        if (panoData !== null) {
-          let panoCoordinates = panoData.location.latLng;
-          this.setState({
-            heading: window.google.maps.geometry.spherical.computeHeading(panoCoordinates, coordinates),
-            coordinates: coordinates
-          });
-        }
-      });
-    }
   }
 
   formatDate(dateString) {
@@ -72,6 +48,8 @@ export default class DetailView extends Component {
 
     const bblDash = <span className="unselectable" unselectable="on">-</span>;
 
+    const streetView = <StreetView addr={this.props.addr} />;
+
     // console.log(showContent);
 
     return (
@@ -87,17 +65,7 @@ export default class DetailView extends Component {
                     </button>
                   </div>
                   <div className="card-image show-lg">
-                    <StreetViewPanorama
-                      containerElement={<div style={{ width: `100%`, height: `${isMobile ? '180px' : '300px'}` }} />}
-                      position={this.state.coordinates}
-                      pov={{ heading: this.state.heading, pitch: 15 }}
-                      zoom={0.5}
-                      options={{
-                        disableDefaultUI: true,
-                        panControl: true,
-                        fullscreenControl: true
-                      }}
-                    />
+                    {streetView}
                   </div>
                   <div className="columns main-content-columns">
                     <div className="column col-lg-12 col-7">
@@ -207,17 +175,7 @@ export default class DetailView extends Component {
                     </div>
                     <div className="column col-lg-12 col-5">
                       <div className="card-image hide-lg">
-                        <StreetViewPanorama
-                          containerElement={<div style={{ width: `100%`, height: `${isMobile ? '180px' : '300px'}` }} />}
-                          position={this.state.coordinates}
-                          pov={{ heading: this.state.heading, pitch: 15 }}
-                          zoom={0.5}
-                          options={{
-                            disableDefaultUI: true,
-                            panControl: true,
-                            fullscreenControl: true
-                          }}
-                        />
+                        {streetView}
                       </div>
                       <div className="card-body column-right">
                         <div className="card-body-resources">

--- a/client/src/components/StreetView.tsx
+++ b/client/src/components/StreetView.tsx
@@ -3,7 +3,6 @@ import { withGoogleMap, StreetViewPanorama } from 'react-google-maps';
 import Browser from '../util/browser';
 
 export type StreetViewAddr = {
-  bbl: string,
   lat: number,
   lng: number
 };
@@ -12,14 +11,14 @@ export type StreetViewProps = {
   addr: StreetViewAddr|null|undefined,
 };
 
-type ImplProps = {
+type HeadingAndCoords = {
   heading: number,
   coordinates: google.maps.LatLng|undefined
 };
 
-type State = ImplProps;
+type State = HeadingAndCoords;
 
-const UnwrappedStreetViewImpl: React.FC<ImplProps> = props => {
+const UnwrappedStreetViewImpl: React.FC<HeadingAndCoords> = props => {
   return (
     <StreetViewPanorama
       visible
@@ -39,15 +38,20 @@ const UnwrappedStreetViewImpl: React.FC<ImplProps> = props => {
 
 const StreetViewImpl = withGoogleMap(UnwrappedStreetViewImpl);
 
+const NULL_HEADING_AND_COORDS: HeadingAndCoords = { heading: 0, coordinates: undefined };
+
+function getAddrHash(addr: StreetViewAddr|null|undefined): string {
+  return addr ? `${addr.lat},${addr.lng}` : '';
+}
+
 export class StreetView extends React.Component<StreetViewProps, State> {
   _isMounted: boolean = false;
+  _currAddrHash: string;
 
   constructor(props: StreetViewProps) {
     super(props);
-    this.state = {
-      heading: 0,
-      coordinates: undefined
-    };
+    this._currAddrHash = getAddrHash(null);
+    this.state = {...NULL_HEADING_AND_COORDS};
   }
 
   componentDidMount() {
@@ -60,39 +64,39 @@ export class StreetView extends React.Component<StreetViewProps, State> {
   }
 
   updateHeadingAndCoordinates() {
-    if (!this.props.addr) {
-      this.setState({
-        heading: 0,
-        coordinates: undefined  
-      });
+    const addrHash = getAddrHash(this.props.addr);
+    if (addrHash === this._currAddrHash) {
+      // Nothing changed, no need to recompute anything.
       return;
     }
 
-    let coordinates = new window.google.maps.LatLng(this.props.addr.lat, this.props.addr.lng);
-    let streetViewService = new window.google.maps.StreetViewService();
+    this._currAddrHash = addrHash;
 
-    streetViewService.getPanoramaByLocation(coordinates, 50, (panoData) => {
-      if (!this._isMounted) return;
-      if (panoData && panoData.location && panoData.location.latLng) {
-        // this computes the street view heading
-        // srsly tho google, why not point to the latlng automatically?
-        let panoCoordinates = panoData.location.latLng;
-        this.setState({
-          heading: window.google.maps.geometry.spherical.computeHeading(panoCoordinates, coordinates),
-          coordinates: coordinates
-        });
-      }
-    });
+    if (this.props.addr) {
+      let coordinates = new window.google.maps.LatLng(this.props.addr.lat, this.props.addr.lng);
+      let streetViewService = new window.google.maps.StreetViewService();
+
+      streetViewService.getPanoramaByLocation(coordinates, 50, (panoData) => {
+        if (!(this._isMounted && addrHash === this._currAddrHash)) return;
+        if (panoData && panoData.location && panoData.location.latLng) {
+          // this computes the street view heading
+          // srsly tho google, why not point to the latlng automatically?
+          let panoCoordinates = panoData.location.latLng;
+          this.setState({
+            heading: window.google.maps.geometry.spherical.computeHeading(panoCoordinates, coordinates),
+            coordinates: coordinates
+          });
+        } else {
+          this.setState(NULL_HEADING_AND_COORDS);
+        }
+      });
+    } else {
+      this.setState(NULL_HEADING_AND_COORDS);
+    }
   }
 
-  // we need to trigger an ajax call (the streetViewService) when props
-  // receives a new address.
-  componentDidUpdate(prevProps: StreetViewProps) {
-    // this says: if the component is getting the addr for the first time OR
-    //            if the component already has an addr but is getting a new one
-    if( (!prevProps.addr && this.props.addr) || (prevProps.addr && this.props.addr && (prevProps.addr.bbl !== this.props.addr.bbl))) {
-      this.updateHeadingAndCoordinates();
-    }
+  componentDidUpdate() {
+    this.updateHeadingAndCoordinates();
   }
 
   render() {

--- a/client/src/components/StreetView.tsx
+++ b/client/src/components/StreetView.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { withGoogleMap, StreetViewPanorama } from 'react-google-maps';
+import Browser from '../util/browser';
+
+export type StreetViewAddr = {
+  bbl: string,
+  lat: number,
+  lng: number
+};
+
+export type StreetViewProps = {
+  addr: StreetViewAddr|null|undefined,
+};
+
+type ImplProps = {
+  heading: number,
+  coordinates: google.maps.LatLng|undefined
+};
+
+type State = ImplProps;
+
+const UnwrappedStreetViewImpl: React.FC<ImplProps> = props => {
+  return (
+    <StreetViewPanorama
+      visible
+      defaultPosition={props.coordinates}
+      position={props.coordinates}
+      pov={{ heading: props.heading, pitch: 15 }}
+      zoom={0.5}
+      options={{
+        disableDefaultUI: true,
+        enableCloseButton: false,
+        panControl: true,
+        fullscreenControl: true
+      }}
+    />
+  );
+};
+
+const StreetViewImpl = withGoogleMap(UnwrappedStreetViewImpl);
+
+export class StreetView extends React.Component<StreetViewProps, State> {
+  _isMounted: boolean = false;
+
+  constructor(props: StreetViewProps) {
+    super(props);
+    this.state = {
+      heading: 0,
+      coordinates: undefined
+    };
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+    this.updateHeadingAndCoordinates();
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  updateHeadingAndCoordinates() {
+    if (!this.props.addr) {
+      this.setState({
+        heading: 0,
+        coordinates: undefined  
+      });
+      return;
+    }
+
+    let coordinates = new window.google.maps.LatLng(this.props.addr.lat, this.props.addr.lng);
+    let streetViewService = new window.google.maps.StreetViewService();
+
+    streetViewService.getPanoramaByLocation(coordinates, 50, (panoData) => {
+      if (!this._isMounted) return;
+      if (panoData && panoData.location && panoData.location.latLng) {
+        // this computes the street view heading
+        // srsly tho google, why not point to the latlng automatically?
+        let panoCoordinates = panoData.location.latLng;
+        this.setState({
+          heading: window.google.maps.geometry.spherical.computeHeading(panoCoordinates, coordinates),
+          coordinates: coordinates
+        });
+      }
+    });
+  }
+
+  // we need to trigger an ajax call (the streetViewService) when props
+  // receives a new address.
+  componentDidUpdate(prevProps: StreetViewProps) {
+    // this says: if the component is getting the addr for the first time OR
+    //            if the component already has an addr but is getting a new one
+    if( (!prevProps.addr && this.props.addr) || (prevProps.addr && this.props.addr && (prevProps.addr.bbl !== this.props.addr.bbl))) {
+      this.updateHeadingAndCoordinates();
+    }
+  }
+
+  render() {
+    const { heading, coordinates } = this.state;
+    const isMobile = Browser.isMobile();
+
+    return (
+      <StreetViewImpl
+        heading={heading}
+        coordinates={coordinates}
+        containerElement={<div style={{ width: `100%`, height: `${isMobile ? '180px' : '300px'}` }} />}
+        mapElement={<div style={{height: '100%'}} />}
+      />
+    );
+  }
+}

--- a/client/src/globals.d.ts
+++ b/client/src/globals.d.ts
@@ -1,3 +1,8 @@
-interface Window {
-  gtag: Gtag.Gtag;
+import { google } from "google-maps";
+
+declare global {
+  interface Window {
+    gtag: Gtag.Gtag;
+    google: google;
+  }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2741,6 +2741,11 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+change-emitter@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
+  integrity sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
@@ -3268,7 +3273,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2, create-react-class@^15.6.0:
+create-react-class@^15.6.0:
   version "15.6.3"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
@@ -4574,7 +4579,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -5114,10 +5119,10 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-google-maps-infobox@^1.1.13:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/google-maps-infobox/-/google-maps-infobox-1.1.15.tgz#22a28a97cf72a2cd8493eef755c71fc1a2995170"
-  integrity sha1-IqKKl89yos2Ek+73VccfwaKZUXA=
+google-maps-infobox@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/google-maps-infobox/-/google-maps-infobox-2.0.0.tgz#1ea6de93c0cdf4138c2d586331835c83dcc59dc2"
+  integrity sha512-hTuWmWZZSOxf5D/z7l3/hTF1grgRvLG53BEKMdjiKOG+FcK/kH7vqseUeyIU9Zj2ZIqKTOaro0nknxpAuRq4Vw==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
@@ -5352,6 +5357,11 @@ hoist-non-react-statics@3.3.0:
   integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
   dependencies:
     react-is "^16.7.0"
+
+hoist-non-react-statics@^2.3.1:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
 hoist-non-react-statics@^3.1.0:
   version "3.3.1"
@@ -7185,6 +7195,11 @@ marker-clusterer-plus@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz#f8eff74d599dab3b7d0e3fed5264ea0e704f5d67"
   integrity sha1-+O/3TVmdqzt9Dj/tUmTqDnBPXWc=
+
+markerwithlabel@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/markerwithlabel/-/markerwithlabel-2.0.2.tgz#fa6aee4abb0ee553e24e2b708226858f58b8729e"
+  integrity sha512-C/cbm1A0h/u54gwHk5ZJNdUU3V3+1BbCpRPMsMyFA7vF4yL+aB4rWpxACz29TpQ+cTg6/iQroExh0PMSRGtQFg==
 
 math-random@^1.0.1:
   version "1.0.4"
@@ -9471,11 +9486,6 @@ react-device-detect@^1.7.5:
   resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-1.7.5.tgz#04c8a6475d67b5ac4f984c8d912ec11134f5b893"
   integrity sha512-ccgJuTHVCI3yfqvgU56gQDvjueFyaHVAXsa5rJuzWRasvsd0IalzfyccSECIlygjv3E+DmAGcwNYWUarUA82Fw==
 
-react-display-name@^0.2.0:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.5.tgz#304c7cbfb59ee40389d436e1a822c17fe27936c6"
-  integrity sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg==
-
 react-dom@16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -9499,21 +9509,20 @@ react-error-overlay@^5.1.4:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
   integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
 
-react-google-maps@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/react-google-maps/-/react-google-maps-7.1.0.tgz#4bd06efc869cbcb6a978c6dbf04daf725e1afd68"
-  integrity sha512-QLFN0Pa+OqX81sIYF3luNfu7if3HfGCuUOt3OjsxyafAE22AHTEle+3BhlsOm980JgLkh4VCIEQjra/U7lFYlg==
+react-google-maps@9.4.5:
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/react-google-maps/-/react-google-maps-9.4.5.tgz#920c199bdc925e0ce93880edffb09428d263aafa"
+  integrity sha512-8z5nX9DxIcBCXuEiurmRT1VXVwnzx0C6+3Es6lxB2/OyY2SLax2/LcDu6Aldxnl3HegefTL7NJzGeaKAJ61pOA==
   dependencies:
     babel-runtime "^6.11.6"
     can-use-dom "^0.1.0"
-    create-react-class "^15.5.2"
-    google-maps-infobox "^1.1.13"
+    google-maps-infobox "^2.0.0"
     invariant "^2.2.1"
     lodash "^4.16.2"
     marker-clusterer-plus "^2.1.4"
+    markerwithlabel "^2.0.1"
     prop-types "^15.5.8"
-    react-display-name "^0.2.0"
-    react-prop-types-element-of-type "^2.2.0"
+    recompose "^0.26.0"
     scriptjs "^2.5.8"
     warning "^3.0.0"
 
@@ -9565,11 +9574,6 @@ react-modal@^3.0.0:
     prop-types "^15.5.10"
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
-
-react-prop-types-element-of-type@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-prop-types-element-of-type/-/react-prop-types-element-of-type-2.2.0.tgz#bcc332d3903c2259cf68c28a81c4a663faba59ac"
-  integrity sha1-vMMy05A8IlnPaMKKgcSmY/q6Waw=
 
 react-router-dom@^5.1.2:
   version "5.1.2"
@@ -9770,6 +9774,16 @@ realpath-native@^1.0.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+recompose@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
+  integrity sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==
+  dependencies:
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    symbol-observable "^1.0.4"
 
 recursive-readdir@2.2.2:
   version "2.2.2"
@@ -10974,6 +10988,11 @@ svgo@^1.0.0, svgo@^1.0.5:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
Fixes #197.

It also fixes a bug whereby our `<script>` tag that loaded the Google Maps API was hard-coded to use our current API key, rather than pulling from `process.env.REACT_APP_STREETVIEW_API_KEY`.

It also explicitly makes us use v3 of the Google Maps API (I think we were using v1 before but I'm not sure).
