### PR TITLE
Only create StreetView when we know it's visible.

### DIFF
--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import { LocaleLink as Link } from '../i18n';
 import { StreetView } from './StreetView';
+import { LazyLoadWhenVisible } from './LazyLoadWhenVisible';
 import Helpers from 'util/helpers';
 import Browser from 'util/browser';
 import Modal from 'components/Modal';
@@ -48,7 +49,7 @@ export default class DetailView extends Component {
 
     const bblDash = <span className="unselectable" unselectable="on">-</span>;
 
-    const streetView = <StreetView addr={this.props.addr} />;
+    const streetView = <LazyLoadWhenVisible><StreetView addr={this.props.addr} /></LazyLoadWhenVisible>;
 
     // console.log(showContent);
 

--- a/client/src/components/LazyLoadWhenVisible.tsx
+++ b/client/src/components/LazyLoadWhenVisible.tsx
@@ -1,0 +1,31 @@
+import React, { useRef, useState, useEffect } from 'react';
+
+
+export const LazyLoadWhenVisible: React.FC = props => {
+  if (!('IntersectionObserver' in window)) {
+    return <div>{props.children}</div>;
+  }
+
+  const ref = useRef<HTMLDivElement>(null);
+  const [hasBeenVisible, setHasBeenVisible] = useState(false);
+
+  useEffect(() => {
+    const { current } = ref;
+    if (!current) return;
+
+    const obs = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          setHasBeenVisible(true);
+        }
+      });
+    });
+    obs.observe(current);
+
+    return () => {
+      obs.unobserve(current);
+    };
+  }, [ref]);
+
+  return <div ref={ref}>{hasBeenVisible && props.children}</div>
+};


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/JustFixNYC/who-owns-what/pull/200#issuecomment-561656193 whereby we actually fully render _two_ street view widgets per detail page--one for the mobile view and one for the desktop view.

This uses an [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to only instantiate the widget if we know it's going to be visible.

However, Intersection Observer is a newer browser API that's not available on all browsers, such as IE11.  If it's not available, we simply fall back to the old behavior of just rendering the street view widget.  Since a small minority of browsers won't have the API, I think this will still be a net win.
