### PR TITLE
Add 'yarn typecheck' and run it during CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           name: Build client and run tests
           command: |
             cd client
+            yarn lingui compile
             yarn typecheck
             # Note that CI=true in CircleCI, so this will fail if there are
             # any linter warnings.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           name: Build client and run tests
           command: |
             cd client
+            yarn typecheck
             # Note that CI=true in CircleCI, so this will fail if there are
             # any linter warnings.
             yarn build

--- a/client/package.json
+++ b/client/package.json
@@ -54,6 +54,7 @@
   },
   "scripts": {
     "lingui": "lingui",
+    "typecheck": "tsc",
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
     "watch-css": "yarn build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "start-js": "lingui compile && cross-env NODE_PATH=src:src/components:src/containers:src/styles react-scripts start",

--- a/client/src/components/AddressSearch.test.tsx
+++ b/client/src/components/AddressSearch.test.tsx
@@ -3,6 +3,7 @@ import { searchAddressToString } from "./AddressSearch";
 describe("searchAddressToString()", () => {
   it("works when housenumber is a string", () => {
     expect(searchAddressToString({
+      bbl: '1234567890',
       housenumber: '150',
       streetname: 'COURT STREET',
       boro: 'BROOKLYN'
@@ -11,6 +12,7 @@ describe("searchAddressToString()", () => {
 
   it("works when housenumber is undefined", () => {
     expect(searchAddressToString({
+      bbl: '1234567890',
       streetname: 'GOWANUS HOUSES',
       boro: 'BROOKLYN'
     })).toBe('GOWANUS HOUSES, BROOKLYN');


### PR DESCRIPTION
Oops, while `yarn build` type-checks all production code, it doesn't type-check tests and other things, so we actually had some test code that didn't type-check properly.  This adds a `yarn typecheck' command and runs it during CI, and also fixes the type errors in the test code.
