### PR TITLE
Factor out i18n-base.ts, rename Locale to SupportedLocale

### DIFF
--- a/client/src/i18n-base.test.ts
+++ b/client/src/i18n-base.test.ts
@@ -1,0 +1,6 @@
+import { isSupportedLocale } from "./i18n-base";
+
+test("isSupportedLocale() works", () => {
+  expect(isSupportedLocale('en')).toBe(true);
+  expect(isSupportedLocale('zz')).toBe(false);
+});

--- a/client/src/i18n-base.ts
+++ b/client/src/i18n-base.ts
@@ -1,0 +1,32 @@
+/** Our supported locales. */
+export type SupportedLocale = 'en'|'es';
+
+/** A type that maps locales to language names. */
+type LocaleLanguages = {
+  [P in SupportedLocale]: string
+};
+
+/**
+ * A mapping from supported locale codes to their user-facing names, in their
+ * respective languages.
+ */
+export const languageNames: LocaleLanguages = {
+  en: 'English',
+  es: 'Español'
+};
+
+/** Return a list of all supported locales. */
+export function getSupportedLocales(): SupportedLocale[] {
+  return Object.keys(languageNames) as SupportedLocale[];
+}
+
+/**
+ * The fallback default locale to use if we don't support the
+ * browser's preferred locale.
+ */
+export const defaultLocale: SupportedLocale = 'en';
+
+/** Return whether the given string is a supported locale. */
+export function isSupportedLocale(code: string): code is SupportedLocale {
+  return code in languageNames;
+}

--- a/client/src/i18n.test.tsx
+++ b/client/src/i18n.test.tsx
@@ -1,4 +1,4 @@
-import { removeLocalePrefix, parseLocaleFromPath, isSupportedLocale, localeFromRouter, localePrefixPath } from "./i18n";
+import { removeLocalePrefix, parseLocaleFromPath, localeFromRouter, localePrefixPath } from "./i18n";
 
 function routerProps(pathname: string): any {
   return { location: { pathname }};
@@ -15,11 +15,6 @@ describe("i18n", () => {
 
   it("parses nothing from paths when locale is not present", () => {
     expect(parseLocaleFromPath("/blarf")).toBe(null);
-  });
-
-  it("tells us whether a locale is supported or not", () => {
-    expect(isSupportedLocale('en')).toBe(true);
-    expect(isSupportedLocale('zz')).toBe(false);
   });
 
   it("extracts locale from router path", () => {

--- a/client/src/i18n.tsx
+++ b/client/src/i18n.tsx
@@ -15,6 +15,7 @@ import { I18nProvider } from '@lingui/react';
 import catalogEn from './locales/en/messages';
 import catalogEs from './locales/es/messages';
 import { LocationDescriptorObject, History } from 'history';
+import { SupportedLocale, languageNames, defaultLocale, isSupportedLocale } from './i18n-base';
 
 /**
  * This feature flag determines whether to actively "promote"
@@ -29,12 +30,9 @@ import { LocationDescriptorObject, History } from 'history';
  */
 const ENABLE_PUBLIC_FACING_I18N = !!process.env.REACT_APP_ENABLE_PUBLIC_FACING_I18N;
 
-/** Our supported locales. */
-type Locale = 'en'|'es';
-
 /** The structure for message catalogs that lingui expects. */
 type LocaleCatalog = {
-  [P in Locale]: any
+  [P in SupportedLocale]: any
 };
 
 /** Message catalogs for our supported locales. */
@@ -43,28 +41,12 @@ const catalogs: LocaleCatalog = {
   es: catalogEs,
 };
 
-/** A type that maps locales to language names. */
-type LocaleLanguages = {
-  [P in Locale]: string
-};
-
-const languages: LocaleLanguages = {
-  en: 'English',
-  es: 'Español'
-};
-
-/**
- * The fallback default locale to use if we don't support the
- * browser's preferred locale.
- */
-const defaultLocale: Locale = 'en';
-
 /**
  * Return the best possible guess at what the default locale
  * should be, taking into account the current browser's language
  * preferences and the locales we support.
  */
-function getBestDefaultLocale(): Locale {
+function getBestDefaultLocale(): SupportedLocale {
   const preferredLocale = navigator.language.slice(0, 2);
 
   if (isSupportedLocale(preferredLocale) && ENABLE_PUBLIC_FACING_I18N) {
@@ -74,18 +56,13 @@ function getBestDefaultLocale(): Locale {
   return defaultLocale;
 }
 
-/** Return whether the given string is a supported locale. */
-export function isSupportedLocale(code: string): code is Locale {
-  return code in catalogs;
-}
-
 /**
  * Given a path (e.g. `/en/boop`), return the locale of the first
  * component of the path if it's a supported locale.
  * 
  * Return null if there is no locale, or if it's an unsupported one.
  */
-export function parseLocaleFromPath(path: string): Locale|null {
+export function parseLocaleFromPath(path: string): SupportedLocale|null {
   const localeMatch = path.match(/^\/([a-z][a-z])\//);
   if (localeMatch) {
     const code = localeMatch[1];
@@ -102,7 +79,7 @@ export function parseLocaleFromPath(path: string): Locale|null {
  * assertion failure if the current pathname doesn't have a
  * locale prefix.
  */
-export function localeFromRouter(routerProps: RouteComponentProps): Locale {
+export function localeFromRouter(routerProps: RouteComponentProps): SupportedLocale {
   const { pathname } = routerProps.location;
   const locale = parseLocaleFromPath(pathname);
 
@@ -169,11 +146,11 @@ export function removeLocalePrefix(path: string): string {
  */
 export const LocaleSwitcher = withRouter(function LocaleSwitcher(props: RouteComponentProps) {
   const locale = localeFromRouter(props);
-  const toLocale: Locale = locale === 'en' ? 'es' : 'en';
+  const toLocale: SupportedLocale = locale === 'en' ? 'es' : 'en';
   const to = `/${toLocale}${removeLocalePrefix(props.location.pathname)}`;
 
   return ENABLE_PUBLIC_FACING_I18N
-    ? <NavLink to={to}>{languages[toLocale]}</NavLink>
+    ? <NavLink to={to}>{languageNames[toLocale]}</NavLink>
     : null;
 });
 


### PR DESCRIPTION
This factors out a separate TypeScript-only (no TSX/React) module called `i18n-base` that has no dependencies, does not assume a browser runtime, and can be used by node scripts with minimal transpiler configurations (e.g. #203).

It also renames the `Locale` typing to `SupportedLocale`, as this is more accurate and also doesn't conflict with other third-party type names (in particular, Contentful's packages define their own `Locale` type).