### PR TITLE
Upgrade evictions data to 2019

### DIFF
--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -105,8 +105,8 @@ export default class DetailView extends Component {
                                 <Trans render="label">Total Violations</Trans>
                                 { this.props.addr.totalviolations }
                               </div>
-                              <div title="Evictions executed by NYC Marshals in 2018. City Council, the Housing Data Coalition and Anti-Eviction Mapping Project cleaned, geocoded, and validated the data, originally sourced from DOI.">
-                                <Trans render="label">2018 Evictions</Trans>
+                              <div title="Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI.">
+                                <Trans render="label">2019 Evictions</Trans>
                                 { this.props.addr.evictions !== null ? this.props.addr.evictions : 'N/A' }
                               </div>
                               <div title="This tracks how rent stabilized units in the building have changed (i.e. &quot;&Delta;&quot;) from 2007 to 2017. If the number for 2017 is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills.">

--- a/client/src/components/EvictionsSummary.tsx
+++ b/client/src/components/EvictionsSummary.tsx
@@ -16,7 +16,7 @@ export const EvictionsSummary: React.FC<{
   const buildingTotalEvictions = helpers.coerceToInt(building && building.evictions, 0);
 
   return <p>
-    <Trans>In 2018, NYC Marshals scheduled <Plural value={totalEvictions} one="one eviction" other="# evictions" /> across this portfolio.</Trans>
+    <Trans>In 2019, NYC Marshals scheduled <Plural value={totalEvictions} one="one eviction" other="# evictions" /> across this portfolio.</Trans>
     {" "}
     {building && <Trans>
       The building with the most evictions was <b>{building.housenumber} {building.streetname}, {building.boro}</b> with <Plural value={buildingTotalEvictions} one="one eviction" other="# evictions" /> that year.

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -198,7 +198,7 @@ const PropertiesListWithoutI18n: React.FC<{
               Header: i18n._(t`Evictions`),
               columns: [
                 {
-                  Header: "2018",
+                  Header: "2019",
                   accessor: d => (d.evictions ? parseInt(d.evictions) : null),
                   id: 'evictions',
                   maxWidth: 75

--- a/client/src/containers/NychaPage.js
+++ b/client/src/containers/NychaPage.js
@@ -124,8 +124,8 @@ class NychaPageWithoutI18n extends Component {
                       <Trans render="label">Units</Trans>
                       { nycha.dev_unitsres }
                     </div>
-                    <div title={i18n._(t`Evictions executed in this development by NYC Marshals in 2018. City Council, the Housing Data Coalition and Anti-Eviction Mapping Project cleaned, geocoded, and validated the data, originally sourced from DOI.`)}>
-                      <Trans render="label">2018 Evictions</Trans>
+                    <div title={i18n._(t`Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI.`)}>
+                      <Trans render="label">2019 Evictions</Trans>
                       { nycha.dev_evictions }
                     </div>
                   </div>

--- a/client/src/data/nycha_bbls.json
+++ b/client/src/data/nycha_bbls.json
@@ -1,393 +1,639 @@
 [
   {
-    "bbl": 2023950001,
-    "development": "WEBSTER",
-    "dev_evictions": 10,
-    "dev_unitsres": 606
+    "bbl": 3003940001,
+    "development": "WYCKOFF GARDENS",
+    "dev_evictions": 5,
+    "dev_unitsres": 709
   },
   {
-    "bbl": 3014600001,
-    "development": "BROWN",
-    "dev_evictions": 2,
-    "dev_unitsres": 200
-  },
-  {
-    "bbl": 2025150006,
-    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
-  },
-  {
-    "bbl": 2025140073,
-    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
-  },
-  {
-    "bbl": 2025140072,
-    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
-  },
-  {
-    "bbl": 2025140070,
-    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
-  },
-  {
-    "bbl": 2025140067,
-    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
-  },
-  {
-    "bbl": 2025130050,
-    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
+    "bbl": 1012190001,
+    "development": "WSUR (SITE C) 589 AMSTERDAM AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 158
   },
   {
     "bbl": 1012050001,
     "development": "WSUR (SITE B) 74 WEST 92ND STREET",
-    "dev_evictions": 0,
+    "dev_evictions": "",
     "dev_unitsres": 168
   },
   {
-    "bbl": 3040290001,
-    "development": "BELMONT-SUTTER AREA",
-    "dev_evictions": 0,
-    "dev_unitsres": 72
+    "bbl": 1012240042,
+    "development": "WSUR (SITE A) 120 WEST 94TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 70
   },
   {
-    "bbl": 3037940001,
-    "development": "VAN DYKE II",
-    "dev_evictions": 0,
-    "dev_unitsres": 591
+    "bbl": 1012240016,
+    "development": "WSUR (BROWNSTONES)",
+    "dev_evictions": "",
+    "dev_unitsres": 227
   },
   {
-    "bbl": 3044810059,
-    "development": "EAST NEW YORK CITY LINE",
-    "dev_evictions": 0,
-    "dev_unitsres": 66
+    "bbl": 1012040056,
+    "development": "WSUR (BROWNSTONES)",
+    "dev_evictions": "",
+    "dev_unitsres": 227
   },
   {
-    "bbl": 3044810016,
-    "development": "EAST NEW YORK CITY LINE",
-    "dev_evictions": 0,
-    "dev_unitsres": 66
+    "bbl": 1012040021,
+    "development": "WSUR (BROWNSTONES)",
+    "dev_evictions": "",
+    "dev_unitsres": 227
   },
   {
-    "bbl": 3044810004,
-    "development": "EAST NEW YORK CITY LINE",
-    "dev_evictions": 0,
-    "dev_unitsres": 66
+    "bbl": 1012030013,
+    "development": "WSUR (BROWNSTONES)",
+    "dev_evictions": "",
+    "dev_unitsres": 227
   },
   {
-    "bbl": 3044800004,
-    "development": "EAST NEW YORK CITY LINE",
-    "dev_evictions": 0,
-    "dev_unitsres": 66
+    "bbl": 3037970001,
+    "development": "WOODSON",
+    "dev_evictions": 3,
+    "dev_unitsres": 407
   },
   {
-    "bbl": 3044580035,
-    "development": "EAST NEW YORK CITY LINE",
-    "dev_evictions": 0,
-    "dev_unitsres": 66
+    "bbl": 3037800001,
+    "development": "WOODSON",
+    "dev_evictions": 3,
+    "dev_unitsres": 407
   },
   {
-    "bbl": 3042630040,
-    "development": "EAST NEW YORK CITY LINE",
-    "dev_evictions": 0,
-    "dev_unitsres": 66
+    "bbl": 4007380050,
+    "development": "WOODSIDE",
+    "dev_evictions": 5,
+    "dev_unitsres": 1357
   },
   {
-    "bbl": 2029310086,
-    "development": "CLAREMONT PARKWAY-FRANKLIN AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 190
+    "bbl": 4007360002,
+    "development": "WOODSIDE",
+    "dev_evictions": 5,
+    "dev_unitsres": 1357
   },
   {
-    "bbl": 2029280028,
-    "development": "CLAREMONT PARKWAY-FRANKLIN AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 190
+    "bbl": 1012210007,
+    "development": "WISE TOWERS",
+    "dev_evictions": 3,
+    "dev_unitsres": 1197
   },
   {
-    "bbl": 2028690122,
-    "development": "HARRISON AVENUE REHAB (GROUP B)",
-    "dev_evictions": 0,
-    "dev_unitsres": 159
+    "bbl": 1016990001,
+    "development": "WILSON",
+    "dev_evictions": "",
+    "dev_unitsres": 398
   },
   {
-    "bbl": 2028690110,
-    "development": "HARRISON AVENUE REHAB (GROUP B)",
-    "dev_evictions": 0,
-    "dev_unitsres": 159
+    "bbl": 3030270001,
+    "development": "WILLIAMSBURG",
+    "dev_evictions": 6,
+    "dev_unitsres": 1635
   },
   {
-    "bbl": 2028690077,
-    "development": "HARRISON AVENUE REHAB (GROUP B)",
-    "dev_evictions": 0,
-    "dev_unitsres": 159
+    "bbl": 3030260001,
+    "development": "WILLIAMSBURG",
+    "dev_evictions": 6,
+    "dev_unitsres": 1635
   },
   {
-    "bbl": 2028680144,
-    "development": "HARRISON AVENUE REHAB (GROUP B)",
-    "dev_evictions": 0,
-    "dev_unitsres": 159
+    "bbl": 3030250070,
+    "development": "WILLIAMSBURG",
+    "dev_evictions": 6,
+    "dev_unitsres": 1635
   },
   {
-    "bbl": 2024130001,
-    "development": "MELROSE",
-    "dev_evictions": 8,
-    "dev_unitsres": 1023
+    "bbl": 3030250046,
+    "development": "WILLIAMSBURG",
+    "dev_evictions": 6,
+    "dev_unitsres": 1635
   },
   {
-    "bbl": 2026200036,
-    "development": "EAGLE AVENUE-EAST 163RD STREET",
+    "bbl": 3030240001,
+    "development": "WILLIAMSBURG",
+    "dev_evictions": 6,
+    "dev_unitsres": 1635
+  },
+  {
+    "bbl": 3021410019,
+    "development": "WILLIAMS PLAZA",
     "dev_evictions": 1,
-    "dev_unitsres": 66
+    "dev_unitsres": 577
   },
   {
-    "bbl": 2026260001,
-    "development": "SOUTH BRONX AREA (SITE 402)",
-    "dev_evictions": 0,
-    "dev_unitsres": 114
-  },
-  {
-    "bbl": 2025480042,
-    "development": "MILL BROOK EXTENSION",
-    "dev_evictions": 0,
-    "dev_unitsres": 125
-  },
-  {
-    "bbl": 1002560014,
-    "development": "LA GUARDIA ADDITION",
-    "dev_evictions": 0,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 1020110009,
-    "development": "SAMUEL (MHOP) III",
-    "dev_evictions": 0,
-    "dev_unitsres": 10
-  },
-  {
-    "bbl": 4097610036,
-    "development": "SHELTON HOUSE",
+    "bbl": 3021400026,
+    "development": "WILLIAMS PLAZA",
     "dev_evictions": 1,
-    "dev_unitsres": 156
-  },
-  {
-    "bbl": 3043770001,
-    "development": "BOULEVARD",
-    "dev_evictions": 9,
-    "dev_unitsres": 1316
-  },
-  {
-    "bbl": 3043550001,
-    "development": "BOULEVARD",
-    "dev_evictions": 9,
-    "dev_unitsres": 1316
-  },
-  {
-    "bbl": 4130330032,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4126090045,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4126090034,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4125220108,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4124820142,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4120270049,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4120140003,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4119640294,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4117950068,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4117810292,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4117590055,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4116980035,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4111130036,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4110580015,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4110520060,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4110390004,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4110120043,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4109940020,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4109850011,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4109810139,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4109230027,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4109150020,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4107720021,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4104150006,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4103650028,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4102010012,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4101970051,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4101730024,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4101670016,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 4100430019,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
-  },
-  {
-    "bbl": 3038740007,
-    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
-    "dev_evictions": 0,
-    "dev_unitsres": 37
+    "dev_unitsres": 577
   },
   {
     "bbl": 3020410001,
     "development": "WHITMAN",
-    "dev_evictions": 9,
+    "dev_evictions": 2,
     "dev_unitsres": 1050
   },
   {
     "bbl": 3020400001,
     "development": "WHITMAN",
-    "dev_evictions": 9,
+    "dev_evictions": 2,
     "dev_unitsres": 1050
+  },
+  {
+    "bbl": 1016540011,
+    "development": "WHITE",
+    "dev_evictions": "",
+    "dev_unitsres": 248
+  },
+  {
+    "bbl": 2028770497,
+    "development": "WEST TREMONT AVENUE-SEDGWICK AVENUE AREA",
+    "dev_evictions": "",
+    "dev_unitsres": 148
+  },
+  {
+    "bbl": 2027540046,
+    "development": "WEST FARMS SQUARE CONVENTIONAL",
+    "dev_evictions": "",
+    "dev_unitsres": 25
+  },
+  {
+    "bbl": 2030070036,
+    "development": "WEST FARMS ROAD REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 252
+  },
+  {
+    "bbl": 2027510033,
+    "development": "WEST FARMS ROAD REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 252
+  },
+  {
+    "bbl": 2027510030,
+    "development": "WEST FARMS ROAD REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 252
+  },
+  {
+    "bbl": 2027510015,
+    "development": "WEST FARMS ROAD REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 252
+  },
+  {
+    "bbl": 5001960001,
+    "development": "WEST BRIGHTON I / WEST BRIGHTON II",
+    "dev_evictions": 7,
+    "dev_unitsres": 634
+  },
+  {
+    "bbl": 3013410012,
+    "development": "WEEKSVILLE GARDENS",
+    "dev_evictions": 2,
+    "dev_unitsres": 274
+  },
+  {
+    "bbl": 3013410001,
+    "development": "WEEKSVILLE GARDENS",
+    "dev_evictions": 2,
+    "dev_unitsres": 274
+  },
+  {
+    "bbl": 2023950001,
+    "development": "WEBSTER",
+    "dev_evictions": "",
+    "dev_unitsres": 606
+  },
+  {
+    "bbl": 1021320082,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE IV (D)",
+    "dev_evictions": "",
+    "dev_unitsres": 40
+  },
+  {
+    "bbl": 1021320080,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE IV (D)",
+    "dev_evictions": "",
+    "dev_unitsres": 40
+  },
+  {
+    "bbl": 1021320106,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE IV (C)",
+    "dev_evictions": "",
+    "dev_unitsres": 40
+  },
+  {
+    "bbl": 1021320084,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE IV (C)",
+    "dev_evictions": "",
+    "dev_unitsres": 40
+  },
+  {
+    "bbl": 1021210051,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1021150060,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1021110042,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1021110041,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1021110040,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1021110038,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1021110006,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1021110005,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1021100071,
+    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1021320114,
+    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
+    "dev_evictions": "",
+    "dev_unitsres": 245
+  },
+  {
+    "bbl": 1021320110,
+    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
+    "dev_evictions": "",
+    "dev_unitsres": 245
+  },
+  {
+    "bbl": 1021320100,
+    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
+    "dev_evictions": "",
+    "dev_unitsres": 245
+  },
+  {
+    "bbl": 1021320094,
+    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
+    "dev_evictions": "",
+    "dev_unitsres": 245
+  },
+  {
+    "bbl": 1021320047,
+    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
+    "dev_evictions": "",
+    "dev_unitsres": 245
+  },
+  {
+    "bbl": 1016520001,
+    "development": "WASHINGTON",
+    "dev_evictions": 6,
+    "dev_unitsres": 1450
+  },
+  {
+    "bbl": 1016490001,
+    "development": "WASHINGTON",
+    "dev_evictions": 6,
+    "dev_unitsres": 1450
+  },
+  {
+    "bbl": 1016470001,
+    "development": "WASHINGTON",
+    "dev_evictions": 6,
+    "dev_unitsres": 1450
+  },
+  {
+    "bbl": 1003560001,
+    "development": "WALD",
+    "dev_evictions": 9,
+    "dev_unitsres": 1861
+  },
+  {
+    "bbl": 1018080001,
+    "development": "WAGNER",
+    "dev_evictions": 3,
+    "dev_unitsres": 2810
+  },
+  {
+    "bbl": 1018010100,
+    "development": "WAGNER",
+    "dev_evictions": 3,
+    "dev_unitsres": 2810
+  },
+  {
+    "bbl": 1018010005,
+    "development": "WAGNER",
+    "dev_evictions": 3,
+    "dev_unitsres": 2810
+  },
+  {
+    "bbl": 1017970001,
+    "development": "WAGNER",
+    "dev_evictions": 3,
+    "dev_unitsres": 2810
+  },
+  {
+    "bbl": 1002630001,
+    "development": "VLADECK II",
+    "dev_evictions": "",
+    "dev_unitsres": 236
+  },
+  {
+    "bbl": 1002670024,
+    "development": "VLADECK",
+    "dev_evictions": 3,
+    "dev_unitsres": 1487
+  },
+  {
+    "bbl": 1002600075,
+    "development": "VLADECK",
+    "dev_evictions": 3,
+    "dev_unitsres": 1487
+  },
+  {
+    "bbl": 1002600070,
+    "development": "VLADECK",
+    "dev_evictions": 3,
+    "dev_unitsres": 1487
+  },
+  {
+    "bbl": 1002600001,
+    "development": "VLADECK",
+    "dev_evictions": 3,
+    "dev_unitsres": 1487
+  },
+  {
+    "bbl": 3044310100,
+    "development": "VANDALIA AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 293
+  },
+  {
+    "bbl": 3037940001,
+    "development": "VAN DYKE II",
+    "dev_evictions": 1,
+    "dev_unitsres": 591
+  },
+  {
+    "bbl": 3037770001,
+    "development": "VAN DYKE I",
+    "dev_evictions": 3,
+    "dev_unitsres": 1153
+  },
+  {
+    "bbl": 3037600001,
+    "development": "VAN DYKE I",
+    "dev_evictions": 3,
+    "dev_unitsres": 1153
+  },
+  {
+    "bbl": 1017680012,
+    "development": "UPACA (SITE 6)",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 1017690005,
+    "development": "UPACA (SITE 5)",
+    "dev_evictions": "",
+    "dev_unitsres": 200
+  },
+  {
+    "bbl": 2028790043,
+    "development": "UNIVERSITY AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 230
+  },
+  {
+    "bbl": 2028790041,
+    "development": "UNIVERSITY AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 230
+  },
+  {
+    "bbl": 2028790033,
+    "development": "UNIVERSITY AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 230
+  },
+  {
+    "bbl": 2028790032,
+    "development": "UNIVERSITY AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 230
+  },
+  {
+    "bbl": 2028790030,
+    "development": "UNIVERSITY AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 230
+  },
+  {
+    "bbl": 3037700001,
+    "development": "UNITY PLAZA (SITES 17,24,25A)",
+    "dev_evictions": 5,
+    "dev_unitsres": 121
+  },
+  {
+    "bbl": 3037690030,
+    "development": "UNITY PLAZA (SITES 17,24,25A)",
+    "dev_evictions": 5,
+    "dev_unitsres": 121
+  },
+  {
+    "bbl": 3037870005,
+    "development": "UNITY PLAZA (SITES 4-27)",
+    "dev_evictions": 1,
+    "dev_unitsres": 600
+  },
+  {
+    "bbl": 3037850015,
+    "development": "UNITY PLAZA (SITES 4-27)",
+    "dev_evictions": 1,
+    "dev_unitsres": 600
+  },
+  {
+    "bbl": 3037840001,
+    "development": "UNITY PLAZA (SITES 4-27)",
+    "dev_evictions": 1,
+    "dev_unitsres": 600
+  },
+  {
+    "bbl": 2026800013,
+    "development": "UNION AVENUE-EAST 166TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 120
+  },
+  {
+    "bbl": 2026800001,
+    "development": "UNION AVENUE-EAST 166TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 120
+  },
+  {
+    "bbl": 2026780001,
+    "development": "UNION AVENUE-EAST 163RD STREET",
+    "dev_evictions": 1,
+    "dev_unitsres": 200
+  },
+  {
+    "bbl": 1002450001,
+    "development": "TWO BRIDGES URA (SITE 7)",
+    "dev_evictions": "",
+    "dev_unitsres": 250
+  },
+  {
+    "bbl": 2031430240,
+    "development": "TWIN PARKS WEST (SITES 1 & 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 312
+  },
+  {
+    "bbl": 2031430236,
+    "development": "TWIN PARKS WEST (SITES 1 & 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 312
+  },
+  {
+    "bbl": 2031430234,
+    "development": "TWIN PARKS WEST (SITES 1 & 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 312
+  },
+  {
+    "bbl": 2031430206,
+    "development": "TWIN PARKS WEST (SITES 1 & 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 312
+  },
+  {
+    "bbl": 2031430167,
+    "development": "TWIN PARKS WEST (SITES 1 & 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 312
+  },
+  {
+    "bbl": 2031430155,
+    "development": "TWIN PARKS WEST (SITES 1 & 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 312
+  },
+  {
+    "bbl": 2030940014,
+    "development": "TWIN PARKS EAST (SITE 9)",
+    "dev_evictions": "",
+    "dev_unitsres": 221
+  },
+  {
+    "bbl": 3017400001,
+    "development": "TOMPKINS",
+    "dev_evictions": 3,
+    "dev_unitsres": 1046
+  },
+  {
+    "bbl": 5007060001,
+    "development": "TODT HILL",
+    "dev_evictions": 4,
+    "dev_unitsres": 485
+  },
+  {
+    "bbl": 3035760001,
+    "development": "TILDEN",
+    "dev_evictions": 1,
+    "dev_unitsres": 997
+  },
+  {
+    "bbl": 2055670001,
+    "development": "THROGGS NECK / THROGGS NECK ADDITION",
+    "dev_evictions": 5,
+    "dev_unitsres": 1240
+  },
+  {
+    "bbl": 2055640001,
+    "development": "THROGGS NECK / THROGGS NECK ADDITION",
+    "dev_evictions": 5,
+    "dev_unitsres": 1240
+  },
+  {
+    "bbl": 2055820001,
+    "development": "THROGGS NECK",
+    "dev_evictions": 1,
+    "dev_unitsres": 424
+  },
+  {
+    "bbl": 1012210038,
+    "development": "THOMAS APARTMENTS",
+    "dev_evictions": "",
+    "dev_unitsres": 87
+  },
+  {
+    "bbl": 2024290001,
+    "development": "TELLER AVENUE-EAST 166TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 90
+  },
+  {
+    "bbl": 3021750090,
+    "development": "TAYLOR STREET-WYTHE AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 525
+  },
+  {
+    "bbl": 3021750080,
+    "development": "TAYLOR STREET-WYTHE AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 525
+  },
+  {
+    "bbl": 3021750075,
+    "development": "TAYLOR STREET-WYTHE AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 525
+  },
+  {
+    "bbl": 3021750070,
+    "development": "TAYLOR STREET-WYTHE AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 525
+  },
+  {
+    "bbl": 3021750060,
+    "development": "TAYLOR STREET-WYTHE AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 525
+  },
+  {
+    "bbl": 3021750030,
+    "development": "TAYLOR STREET-WYTHE AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 525
   },
   {
     "bbl": 3035500034,
@@ -450,5002 +696,298 @@
     "dev_unitsres": 193
   },
   {
-    "bbl": 2030620021,
-    "development": "EAST 180TH STREET-MONTEREY AVENUE",
-    "dev_evictions": 4,
-    "dev_unitsres": 239
-  },
-  {
-    "bbl": 2030620006,
-    "development": "EAST 180TH STREET-MONTEREY AVENUE",
-    "dev_evictions": 4,
-    "dev_unitsres": 239
-  },
-  {
-    "bbl": 2027570001,
-    "development": "EAST 165TH STREET-BRYANT AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 127
-  },
-  {
-    "bbl": 2027560010,
-    "development": "EAST 165TH STREET-BRYANT AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 127
-  },
-  {
-    "bbl": 2027500032,
-    "development": "EAST 165TH STREET-BRYANT AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 127
-  },
-  {
-    "bbl": 2027500016,
-    "development": "EAST 165TH STREET-BRYANT AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 127
-  },
-  {
-    "bbl": 2027490025,
-    "development": "EAST 165TH STREET-BRYANT AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 127
-  },
-  {
-    "bbl": 2027480025,
-    "development": "EAST 165TH STREET-BRYANT AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 127
-  },
-  {
-    "bbl": 1020070042,
-    "development": "SAMUEL (MHOP) II",
-    "dev_evictions": 0,
-    "dev_unitsres": 10
-  },
-  {
-    "bbl": 1003670001,
-    "development": "RIIS",
-    "dev_evictions": 10,
-    "dev_unitsres": 1204
-  },
-  {
-    "bbl": 1003620010,
-    "development": "RIIS",
-    "dev_evictions": 10,
-    "dev_unitsres": 1204
-  },
-  {
-    "bbl": 4133060180,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4127060038,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4126240061,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4120170049,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4117710045,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4112350046,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4111270044,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4110160026,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 1016840001,
-    "development": "JEFFERSON",
-    "dev_evictions": 6,
-    "dev_unitsres": 1491
-  },
-  {
-    "bbl": 1016620016,
-    "development": "JEFFERSON",
-    "dev_evictions": 6,
-    "dev_unitsres": 1491
-  },
-  {
-    "bbl": 1016620001,
-    "development": "JEFFERSON",
-    "dev_evictions": 6,
-    "dev_unitsres": 1491
-  },
-  {
-    "bbl": 2055820001,
-    "development": "THROGGS NECK",
-    "dev_evictions": 3,
-    "dev_unitsres": 1664
-  },
-  {
-    "bbl": 3035080054,
-    "development": "RALPH AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 124
-  },
-  {
-    "bbl": 3035080050,
-    "development": "RALPH AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 124
-  },
-  {
-    "bbl": 3035080046,
-    "development": "RALPH AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 124
-  },
-  {
-    "bbl": 3035080042,
-    "development": "RALPH AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 124
-  },
-  {
-    "bbl": 3035080041,
-    "development": "RALPH AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 124
-  },
-  {
-    "bbl": 3035080038,
-    "development": "RALPH AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 124
-  },
-  {
-    "bbl": 3035080036,
-    "development": "RALPH AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 124
-  },
-  {
-    "bbl": 3035080034,
-    "development": "RALPH AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 124
-  },
-  {
-    "bbl": 3083290225,
-    "development": "BAY VIEW",
-    "dev_evictions": 8,
-    "dev_unitsres": 1610
-  },
-  {
-    "bbl": 1021160033,
-    "development": "MARSHALL PLAZA",
-    "dev_evictions": 0,
-    "dev_unitsres": 180
-  },
-  {
-    "bbl": 1012210007,
-    "development": "WISE TOWERS",
-    "dev_evictions": 0,
-    "dev_unitsres": 1197
-  },
-  {
-    "bbl": 4049570024,
-    "development": "LEAVITT STREET-34TH AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 83
-  },
-  {
-    "bbl": 3069640002,
-    "development": "GRAVESEND",
-    "dev_evictions": 2,
-    "dev_unitsres": 634
-  },
-  {
-    "bbl": 1018740029,
-    "development": "DOUGLASS ADDITION",
-    "dev_evictions": 0,
-    "dev_unitsres": 135
-  },
-  {
-    "bbl": 3014710061,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710059,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710057,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710055,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710053,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710024,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710023,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710022,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710021,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710020,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710019,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710018,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710017,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710016,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710015,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710014,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710011,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710010,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710009,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710008,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710007,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710006,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710005,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710004,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014710001,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700160,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700073,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700059,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700058,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700055,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700053,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700051,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700050,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700049,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700048,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700041,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700039,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700038,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700037,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700036,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700035,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700033,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700025,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700024,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700023,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700022,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700020,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700019,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700018,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700017,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700015,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700011,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700010,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700009,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700008,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700003,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700001,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014660049,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014660047,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014660045,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014660044,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014660043,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014660042,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 3014700052,
-    "development": "HOWARD AVENUE-PARK PLACE",
-    "dev_evictions": 1,
-    "dev_unitsres": 154
-  },
-  {
-    "bbl": 1015730020,
-    "development": "HOLMES TOWERS",
-    "dev_evictions": 1,
-    "dev_unitsres": 537
-  },
-  {
-    "bbl": 2022870026,
-    "development": "BETANCES V",
-    "dev_evictions": 0,
-    "dev_unitsres": 304
-  },
-  {
-    "bbl": 2039630043,
-    "development": "GLEBE AVENUE-WESTCHESTER AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 132
-  },
-  {
-    "bbl": 2052630070,
-    "development": "BOSTON SECOR",
-    "dev_evictions": 3,
-    "dev_unitsres": 538
-  },
-  {
-    "bbl": 2052630040,
-    "development": "BOSTON SECOR",
-    "dev_evictions": 3,
-    "dev_unitsres": 538
-  },
-  {
-    "bbl": 1018360001,
-    "development": "DOUGLASS I",
-    "dev_evictions": 7,
-    "dev_unitsres": 896
-  },
-  {
-    "bbl": 1020150005,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020130026,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020130024,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020130022,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020130018,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020130016,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020130014,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120064,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120063,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120061,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120058,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120056,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120052,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120025,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120023,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120020,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120018,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120015,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120014,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120011,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120009,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120008,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120006,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120003,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020120001,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110063,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110061,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110033,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110031,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110022,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110015,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110014,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110013,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110011,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110008,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110007,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020110001,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020090064,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020090063,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020090044,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020070045,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020070044,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 1020070043,
-    "development": "SAMUEL (CITY)",
-    "dev_evictions": 3,
-    "dev_unitsres": 751
-  },
-  {
-    "bbl": 2028770497,
-    "development": "WEST TREMONT AVENUE-SEDGWICK AVENUE AREA",
-    "dev_evictions": 0,
-    "dev_unitsres": 148
-  },
-  {
-    "bbl": 2026280001,
-    "development": "SAINT MARY'S PARK",
-    "dev_evictions": 5,
-    "dev_unitsres": 1478
-  },
-  {
-    "bbl": 2026230135,
-    "development": "SAINT MARY'S PARK",
-    "dev_evictions": 5,
-    "dev_unitsres": 1478
-  },
-  {
-    "bbl": 3028670001,
-    "development": "COOPER PARK",
-    "dev_evictions": 0,
-    "dev_unitsres": 700
-  },
-  {
-    "bbl": 1003780017,
-    "development": "LOWER EAST SIDE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 59
-  },
-  {
-    "bbl": 2027540046,
-    "development": "WEST FARMS SQUARE CONVENTIONAL",
-    "dev_evictions": 0,
-    "dev_unitsres": 25
-  },
-  {
-    "bbl": 3070480015,
-    "development": "O'DWYER GARDENS",
-    "dev_evictions": 1,
-    "dev_unitsres": 573
-  },
-  {
-    "bbl": 3070470014,
-    "development": "O'DWYER GARDENS",
-    "dev_evictions": 1,
-    "dev_unitsres": 573
-  },
-  {
-    "bbl": 2022710001,
-    "development": "BETANCES II, 9A",
-    "dev_evictions": 1,
-    "dev_unitsres": 46
-  },
-  {
-    "bbl": 1012210038,
-    "development": "THOMAS APARTMENTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 87
-  },
-  {
-    "bbl": 2026960005,
-    "development": "STEBBINS AVENUE-HEWITT PLACE",
-    "dev_evictions": 0,
-    "dev_unitsres": 144
-  },
-  {
-    "bbl": 1016520001,
-    "development": "WASHINGTON",
-    "dev_evictions": 9,
-    "dev_unitsres": 1450
-  },
-  {
-    "bbl": 1016490001,
-    "development": "WASHINGTON",
-    "dev_evictions": 9,
-    "dev_unitsres": 1450
-  },
-  {
-    "bbl": 1016470001,
-    "development": "WASHINGTON",
-    "dev_evictions": 9,
-    "dev_unitsres": 1450
-  },
-  {
-    "bbl": 2049050001,
-    "development": "EDENWALD",
-    "dev_evictions": 16,
-    "dev_unitsres": 2039
-  },
-  {
-    "bbl": 4098020041,
-    "development": "INTERNATIONAL TOWER",
-    "dev_evictions": 0,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3013810013,
-    "development": "CROWN HEIGHTS",
-    "dev_evictions": 2,
-    "dev_unitsres": 138
-  },
-  {
-    "bbl": 3013750036,
-    "development": "CROWN HEIGHTS",
-    "dev_evictions": 2,
-    "dev_unitsres": 138
-  },
-  {
-    "bbl": 3013750034,
-    "development": "CROWN HEIGHTS",
-    "dev_evictions": 2,
-    "dev_unitsres": 138
-  },
-  {
-    "bbl": 3013750031,
-    "development": "CROWN HEIGHTS",
-    "dev_evictions": 2,
-    "dev_unitsres": 138
-  },
-  {
-    "bbl": 3013750029,
-    "development": "CROWN HEIGHTS",
-    "dev_evictions": 2,
-    "dev_unitsres": 138
-  },
-  {
-    "bbl": 3013690058,
-    "development": "CROWN HEIGHTS",
-    "dev_evictions": 2,
-    "dev_unitsres": 138
-  },
-  {
-    "bbl": 3013570068,
-    "development": "CROWN HEIGHTS",
-    "dev_evictions": 2,
-    "dev_unitsres": 138
-  },
-  {
-    "bbl": 3013570065,
-    "development": "CROWN HEIGHTS",
-    "dev_evictions": 2,
-    "dev_unitsres": 138
-  },
-  {
-    "bbl": 2055680100,
-    "development": "RANDALL AVENUE-BALCOM AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 230
-  },
-  {
-    "bbl": 2055680050,
-    "development": "RANDALL AVENUE-BALCOM AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 230
-  },
-  {
-    "bbl": 2055680001,
-    "development": "RANDALL AVENUE-BALCOM AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 230
-  },
-  {
-    "bbl": 1012240042,
-    "development": "WSUR (SITE A) 120 WEST 94TH STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 70
-  },
-  {
-    "bbl": 1012410025,
-    "development": "DE HOSTOS APARTMENTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 221
-  },
-  {
-    "bbl": 3017980020,
-    "development": "MARCY AVENUE-GREENE AVENUE SITE A",
-    "dev_evictions": 0,
-    "dev_unitsres": 48
-  },
-  {
-    "bbl": 2029900011,
-    "development": "HOE AVENUE-EAST 173RD STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 65
-  },
-  {
-    "bbl": 1016150023,
-    "development": "LEHMAN VILLAGE",
-    "dev_evictions": 2,
-    "dev_unitsres": 587
-  },
-  {
-    "bbl": 1016130023,
-    "development": "LEHMAN VILLAGE",
-    "dev_evictions": 2,
-    "dev_unitsres": 587
-  },
-  {
-    "bbl": 3005570001,
-    "development": "RED HOOK WEST",
-    "dev_evictions": 6,
-    "dev_unitsres": 1048
-  },
-  {
-    "bbl": 3005330001,
-    "development": "RED HOOK WEST",
-    "dev_evictions": 6,
-    "dev_unitsres": 1048
-  },
-  {
-    "bbl": 1018300056,
-    "development": "KING TOWERS",
-    "dev_evictions": 12,
-    "dev_unitsres": 527
-  },
-  {
-    "bbl": 1018290111,
-    "development": "KING TOWERS",
-    "dev_evictions": 12,
-    "dev_unitsres": 527
-  },
-  {
-    "bbl": 1015960001,
-    "development": "KING TOWERS",
-    "dev_evictions": 12,
-    "dev_unitsres": 527
-  },
-  {
-    "bbl": 2025140077,
-    "development": "HIGHBRIDGE REHABS (ANDERSON AVENUE)",
-    "dev_evictions": 1,
-    "dev_unitsres": 162
-  },
-  {
-    "bbl": 2025140020,
-    "development": "HIGHBRIDGE REHABS (ANDERSON AVENUE)",
-    "dev_evictions": 1,
-    "dev_unitsres": 162
-  },
-  {
-    "bbl": 2025140015,
-    "development": "HIGHBRIDGE REHABS (ANDERSON AVENUE)",
-    "dev_evictions": 1,
-    "dev_unitsres": 162
-  },
-  {
-    "bbl": 2025090018,
-    "development": "HIGHBRIDGE REHABS (ANDERSON AVENUE)",
-    "dev_evictions": 1,
-    "dev_unitsres": 162
-  },
-  {
-    "bbl": 5000710025,
-    "development": "CASSIDY-LAFAYETTE",
-    "dev_evictions": 0,
-    "dev_unitsres": 380
-  },
-  {
-    "bbl": 5000710011,
-    "development": "CASSIDY-LAFAYETTE",
-    "dev_evictions": 0,
-    "dev_unitsres": 380
-  },
-  {
-    "bbl": 5000710001,
-    "development": "CASSIDY-LAFAYETTE",
-    "dev_evictions": 0,
-    "dev_unitsres": 380
-  },
-  {
-    "bbl": 2022810055,
-    "development": "BETANCES III, 18",
-    "dev_evictions": 0,
-    "dev_unitsres": 68
-  },
-  {
-    "bbl": 3015850001,
-    "development": "303 VERNON AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 234
-  },
-  {
-    "bbl": 1017770005,
-    "development": "ROBINSON",
-    "dev_evictions": 0,
-    "dev_unitsres": 56
-  },
-  {
-    "bbl": 1016540011,
-    "development": "WHITE",
-    "dev_evictions": 0,
-    "dev_unitsres": 248
-  },
-  {
-    "bbl": 1018750057,
-    "development": "REHAB PROGRAM (DOUGLASS REHABS)",
-    "dev_evictions": 1,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1018750009,
-    "development": "REHAB PROGRAM (DOUGLASS REHABS)",
-    "dev_evictions": 1,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1018750005,
-    "development": "REHAB PROGRAM (DOUGLASS REHABS)",
-    "dev_evictions": 1,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1018730009,
-    "development": "REHAB PROGRAM (DOUGLASS REHABS)",
-    "dev_evictions": 1,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 4050370008,
-    "development": "BLAND",
-    "dev_evictions": 2,
-    "dev_unitsres": 400
-  },
-  {
-    "bbl": 1017710066,
-    "development": "PARK AVENUE-EAST 122ND, 123RD STREETS",
-    "dev_evictions": 0,
-    "dev_unitsres": 78
-  },
-  {
-    "bbl": 1017710065,
-    "development": "PARK AVENUE-EAST 122ND, 123RD STREETS",
-    "dev_evictions": 0,
-    "dev_unitsres": 78
-  },
-  {
-    "bbl": 1017710059,
-    "development": "PARK AVENUE-EAST 122ND, 123RD STREETS",
-    "dev_evictions": 0,
-    "dev_unitsres": 78
-  },
-  {
-    "bbl": 1017710010,
-    "development": "PARK AVENUE-EAST 122ND, 123RD STREETS",
-    "dev_evictions": 0,
-    "dev_unitsres": 78
-  },
-  {
-    "bbl": 4161140002,
-    "development": "HAMMEL",
-    "dev_evictions": 9,
-    "dev_unitsres": 712
-  },
-  {
-    "bbl": 2032610102,
-    "development": "FORT INDEPENDENCE STREET-HEATH AVENUE",
-    "dev_evictions": 1,
-    "dev_unitsres": 344
-  },
-  {
-    "bbl": 2031300100,
-    "development": "1010 EAST 178TH STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 224
-  },
-  {
-    "bbl": 3004010001,
-    "development": "572 WARREN STREET",
-    "dev_evictions": 1,
-    "dev_unitsres": 200
-  },
-  {
-    "bbl": 3035320030,
-    "development": "104-14 TAPSCOTT STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 32
-  },
-  {
-    "bbl": 2023250001,
-    "development": "PATTERSON",
-    "dev_evictions": 22,
-    "dev_unitsres": 1796
-  },
-  {
-    "bbl": 2023240001,
-    "development": "PATTERSON",
-    "dev_evictions": 22,
-    "dev_unitsres": 1796
-  },
-  {
-    "bbl": 2023110001,
-    "development": "MITCHEL",
-    "dev_evictions": 10,
-    "dev_unitsres": 1731
-  },
-  {
-    "bbl": 2022980062,
-    "development": "MITCHEL",
-    "dev_evictions": 10,
-    "dev_unitsres": 1731
-  },
-  {
-    "bbl": 2022980040,
-    "development": "MITCHEL",
-    "dev_evictions": 10,
-    "dev_unitsres": 1731
-  },
-  {
-    "bbl": 1011560020,
-    "development": "AMSTERDAM ADDITION",
-    "dev_evictions": 1,
-    "dev_unitsres": 175
-  },
-  {
-    "bbl": 1020080013,
-    "development": "PUBLIC SCHOOL 139 (CONVERSION)",
-    "dev_evictions": 0,
-    "dev_unitsres": 126
-  },
-  {
-    "bbl": 1014450023,
-    "development": "ROBBINS PLAZA",
-    "dev_evictions": 1,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 2022690100,
-    "development": "BETANCES I",
-    "dev_evictions": 2,
-    "dev_unitsres": 309
-  },
-  {
-    "bbl": 1004210052,
-    "development": "LOWER EAST SIDE I INFILL",
-    "dev_evictions": 0,
-    "dev_unitsres": 268
-  },
-  {
-    "bbl": 1004200062,
-    "development": "LOWER EAST SIDE I INFILL",
-    "dev_evictions": 0,
-    "dev_unitsres": 268
-  },
-  {
-    "bbl": 1004160001,
-    "development": "LOWER EAST SIDE I INFILL",
-    "dev_evictions": 0,
-    "dev_unitsres": 268
-  },
-  {
-    "bbl": 2022710020,
-    "development": "BETANCES III, 9A",
-    "dev_evictions": 0,
-    "dev_unitsres": 26
-  },
-  {
-    "bbl": 2026400001,
-    "development": "FOREST",
-    "dev_evictions": 4,
-    "dev_unitsres": 1350
-  },
-  {
-    "bbl": 2026390001,
-    "development": "FOREST",
-    "dev_evictions": 4,
-    "dev_unitsres": 1350
-  },
-  {
-    "bbl": 3017380001,
-    "development": "MARCY",
-    "dev_evictions": 4,
-    "dev_unitsres": 1372
-  },
-  {
-    "bbl": 3017190001,
-    "development": "MARCY",
-    "dev_evictions": 4,
-    "dev_unitsres": 1372
-  },
-  {
-    "bbl": 1017490010,
-    "development": "MORRIS PARK SENIOR CITIZENS HOME",
-    "dev_evictions": 0,
-    "dev_unitsres": 97
-  },
-  {
-    "bbl": 4160450015,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4128250102,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4121150028,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4120580205,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4119680050,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4116700040,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4111410070,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4109890105,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4109470041,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4102820058,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 4102410019,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 2035090025,
-    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
-    "dev_evictions": 0,
-    "dev_unitsres": 16
-  },
-  {
-    "bbl": 3037970001,
-    "development": "WOODSON",
-    "dev_evictions": 1,
-    "dev_unitsres": 407
-  },
-  {
-    "bbl": 3037800001,
-    "development": "WOODSON",
-    "dev_evictions": 1,
-    "dev_unitsres": 407
-  },
-  {
-    "bbl": 4007380050,
-    "development": "WOODSIDE",
-    "dev_evictions": 0,
-    "dev_unitsres": 1357
-  },
-  {
-    "bbl": 4007360002,
-    "development": "WOODSIDE",
-    "dev_evictions": 0,
-    "dev_unitsres": 1357
-  },
-  {
-    "bbl": 4004770049,
-    "development": "QUEENSBRIDGE SOUTH",
-    "dev_evictions": 8,
-    "dev_unitsres": 1607
-  },
-  {
-    "bbl": 4004650100,
-    "development": "QUEENSBRIDGE SOUTH",
-    "dev_evictions": 8,
-    "dev_unitsres": 1607
-  },
-  {
-    "bbl": 4004650001,
-    "development": "QUEENSBRIDGE SOUTH",
-    "dev_evictions": 8,
-    "dev_unitsres": 1607
-  },
-  {
-    "bbl": 2023720001,
-    "development": "1162-1176 WASHINGTON AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 65
-  },
-  {
-    "bbl": 3017980077,
-    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
-    "dev_evictions": 0,
-    "dev_unitsres": 30
-  },
-  {
-    "bbl": 3017980009,
-    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
-    "dev_evictions": 0,
-    "dev_unitsres": 30
-  },
-  {
-    "bbl": 3017980008,
-    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
-    "dev_evictions": 0,
-    "dev_unitsres": 30
-  },
-  {
-    "bbl": 3017980007,
-    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
-    "dev_evictions": 0,
-    "dev_unitsres": 30
-  },
-  {
-    "bbl": 3017980005,
-    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
-    "dev_evictions": 0,
-    "dev_unitsres": 30
-  },
-  {
-    "bbl": 3017980004,
-    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
-    "dev_evictions": 0,
-    "dev_unitsres": 30
-  },
-  {
-    "bbl": 3017980003,
-    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
-    "dev_evictions": 0,
-    "dev_unitsres": 30
-  },
-  {
-    "bbl": 3017980002,
-    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
-    "dev_evictions": 0,
-    "dev_unitsres": 30
-  },
-  {
-    "bbl": 1004300010,
-    "development": "FIRST HOUSES",
-    "dev_evictions": 0,
-    "dev_unitsres": 246
-  },
-  {
-    "bbl": 2038860002,
-    "development": "BRONX RIVER",
-    "dev_evictions": 0,
-    "dev_unitsres": 1250
-  },
-  {
-    "bbl": 1017680012,
-    "development": "UPACA (SITE 6)",
-    "dev_evictions": 1,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 2029350030,
-    "development": "FRANKLIN AVENUE III CONVENTIONAL",
-    "dev_evictions": 0,
-    "dev_unitsres": 15
-  },
-  {
-    "bbl": 2035980017,
-    "development": "SACK WERN",
-    "dev_evictions": 2,
-    "dev_unitsres": 351
-  },
-  {
-    "bbl": 2035940001,
-    "development": "SACK WERN",
-    "dev_evictions": 2,
-    "dev_unitsres": 351
-  },
-  {
-    "bbl": 2035930001,
-    "development": "SACK WERN",
-    "dev_evictions": 2,
-    "dev_unitsres": 351
-  },
-  {
-    "bbl": 2025570083,
-    "development": "MOORE",
-    "dev_evictions": 0,
-    "dev_unitsres": 463
-  },
-  {
-    "bbl": 1016400021,
-    "development": "JOHNSON",
-    "dev_evictions": 5,
-    "dev_unitsres": 1307
-  },
-  {
-    "bbl": 1016400001,
-    "development": "JOHNSON",
-    "dev_evictions": 5,
-    "dev_unitsres": 1307
-  },
-  {
-    "bbl": 4067920030,
-    "development": "POMONOK",
-    "dev_evictions": 9,
-    "dev_unitsres": 2080
-  },
-  {
-    "bbl": 4067920001,
-    "development": "POMONOK",
-    "dev_evictions": 9,
-    "dev_unitsres": 2080
-  },
-  {
-    "bbl": 1003440010,
-    "development": "STANTON STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 2028690116,
-    "development": "HARRISON AVENUE REHAB (GROUP A)",
-    "dev_evictions": 1,
-    "dev_unitsres": 34
-  },
-  {
-    "bbl": 3030270001,
-    "development": "WILLIAMSBURG",
-    "dev_evictions": 2,
-    "dev_unitsres": 1635
-  },
-  {
-    "bbl": 3030260001,
-    "development": "WILLIAMSBURG",
-    "dev_evictions": 2,
-    "dev_unitsres": 1635
-  },
-  {
-    "bbl": 3030250070,
-    "development": "WILLIAMSBURG",
-    "dev_evictions": 2,
-    "dev_unitsres": 1635
-  },
-  {
-    "bbl": 3030250046,
-    "development": "WILLIAMSBURG",
-    "dev_evictions": 2,
-    "dev_unitsres": 1635
-  },
-  {
-    "bbl": 3030240001,
-    "development": "WILLIAMSBURG",
-    "dev_evictions": 2,
-    "dev_unitsres": 1635
-  },
-  {
-    "bbl": 1009080027,
-    "development": "STRAUS",
-    "dev_evictions": 0,
-    "dev_unitsres": 267
-  },
-  {
-    "bbl": 1009080017,
-    "development": "STRAUS",
-    "dev_evictions": 0,
-    "dev_unitsres": 267
-  },
-  {
-    "bbl": 3070670001,
-    "development": "CONEY ISLAND",
-    "dev_evictions": 0,
-    "dev_unitsres": 534
-  },
-  {
-    "bbl": 3037870005,
-    "development": "UNITY PLAZA (SITES 4-27)",
-    "dev_evictions": 6,
-    "dev_unitsres": 600
-  },
-  {
-    "bbl": 3037850015,
-    "development": "UNITY PLAZA (SITES 4-27)",
-    "dev_evictions": 6,
-    "dev_unitsres": 600
-  },
-  {
-    "bbl": 3037840001,
-    "development": "UNITY PLAZA (SITES 4-27)",
-    "dev_evictions": 6,
-    "dev_unitsres": 600
-  },
-  {
-    "bbl": 3070490015,
-    "development": "SURFSIDE GARDENS",
-    "dev_evictions": 2,
-    "dev_unitsres": 637
-  },
-  {
-    "bbl": 3070070001,
-    "development": "SURFSIDE GARDENS",
-    "dev_evictions": 2,
-    "dev_unitsres": 637
-  },
-  {
-    "bbl": 3004040001,
-    "development": "GOWANUS",
-    "dev_evictions": 7,
-    "dev_unitsres": 1188
-  },
-  {
-    "bbl": 3003920001,
-    "development": "GOWANUS",
-    "dev_evictions": 7,
-    "dev_unitsres": 1188
-  },
-  {
-    "bbl": 2026780068,
-    "development": "PSS GRANDPARENT FAMILY APARTMENTS",
-    "dev_evictions": 1,
-    "dev_unitsres": 51
-  },
-  {
-    "bbl": 2024300030,
-    "development": "CLAREMONT REHAB (GROUP 2)",
-    "dev_evictions": 2,
-    "dev_unitsres": 118
-  },
-  {
-    "bbl": 2024290028,
-    "development": "CLAREMONT REHAB (GROUP 2)",
-    "dev_evictions": 2,
-    "dev_unitsres": 118
-  },
-  {
-    "bbl": 2024270022,
-    "development": "CLAREMONT REHAB (GROUP 2)",
-    "dev_evictions": 2,
-    "dev_unitsres": 118
-  },
-  {
-    "bbl": 2024270009,
-    "development": "CLAREMONT REHAB (GROUP 2)",
-    "dev_evictions": 2,
-    "dev_unitsres": 118
-  },
-  {
-    "bbl": 2024270006,
-    "development": "CLAREMONT REHAB (GROUP 2)",
-    "dev_evictions": 2,
-    "dev_unitsres": 118
-  },
-  {
-    "bbl": 2024270004,
-    "development": "CLAREMONT REHAB (GROUP 2)",
-    "dev_evictions": 2,
-    "dev_unitsres": 118
-  },
-  {
-    "bbl": 1022160001,
-    "development": "DYCKMAN",
-    "dev_evictions": 2,
-    "dev_unitsres": 1167
-  },
-  {
-    "bbl": 3014920006,
-    "development": "SARATOGA VILLAGE",
-    "dev_evictions": 0,
-    "dev_unitsres": 125
-  },
-  {
-    "bbl": 3014920001,
-    "development": "SARATOGA VILLAGE",
-    "dev_evictions": 0,
-    "dev_unitsres": 125
-  },
-  {
-    "bbl": 3070570012,
-    "development": "CAREY GARDENS",
-    "dev_evictions": 2,
-    "dev_unitsres": 683
-  },
-  {
-    "bbl": 3070560014,
-    "development": "CAREY GARDENS",
-    "dev_evictions": 2,
-    "dev_unitsres": 683
-  },
-  {
-    "bbl": 3070150015,
-    "development": "CAREY GARDENS",
-    "dev_evictions": 2,
-    "dev_unitsres": 683
-  },
-  {
-    "bbl": 3003940001,
-    "development": "WYCKOFF GARDENS",
-    "dev_evictions": 3,
-    "dev_unitsres": 709
-  },
-  {
-    "bbl": 1002550001,
-    "development": "RUTGERS",
-    "dev_evictions": 0,
-    "dev_unitsres": 721
-  },
-  {
-    "bbl": 3014390010,
-    "development": "OCEAN HILL-BROWNSVILLE",
-    "dev_evictions": 0,
-    "dev_unitsres": 126
-  },
-  {
-    "bbl": 3014390001,
-    "development": "OCEAN HILL-BROWNSVILLE",
-    "dev_evictions": 0,
-    "dev_unitsres": 126
-  },
-  {
-    "bbl": 3014310043,
-    "development": "OCEAN HILL-BROWNSVILLE",
-    "dev_evictions": 0,
-    "dev_unitsres": 126
-  },
-  {
-    "bbl": 3014310039,
-    "development": "OCEAN HILL-BROWNSVILLE",
-    "dev_evictions": 0,
-    "dev_unitsres": 126
-  },
-  {
-    "bbl": 3014310037,
-    "development": "OCEAN HILL-BROWNSVILLE",
-    "dev_evictions": 0,
-    "dev_unitsres": 126
-  },
-  {
-    "bbl": 1021360235,
-    "development": "FORT WASHINGTON AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 222
-  },
-  {
-    "bbl": 1019840033,
-    "development": "MANHATTANVILLE",
-    "dev_evictions": 3,
-    "dev_unitsres": 1272
-  },
-  {
-    "bbl": 1019840001,
-    "development": "MANHATTANVILLE",
-    "dev_evictions": 3,
-    "dev_unitsres": 1272
-  },
-  {
-    "bbl": 4005590002,
-    "development": "RAVENSWOOD",
-    "dev_evictions": 17,
-    "dev_unitsres": 1974
-  },
-  {
-    "bbl": 4005230002,
-    "development": "RAVENSWOOD",
-    "dev_evictions": 17,
-    "dev_unitsres": 1974
-  },
-  {
-    "bbl": 4003350002,
-    "development": "RAVENSWOOD",
-    "dev_evictions": 17,
-    "dev_unitsres": 1974
-  },
-  {
-    "bbl": 4003320002,
-    "development": "RAVENSWOOD",
-    "dev_evictions": 17,
-    "dev_unitsres": 1974
-  },
-  {
-    "bbl": 2037150027,
-    "development": "BOYNTON AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 82
-  },
-  {
-    "bbl": 2037150025,
-    "development": "BOYNTON AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 82
-  },
-  {
-    "bbl": 2037150023,
-    "development": "BOYNTON AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 82
-  },
-  {
-    "bbl": 2037140036,
-    "development": "BOYNTON AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 82
-  },
-  {
-    "bbl": 5000520078,
-    "development": "RICHMOND TERRACE",
-    "dev_evictions": 0,
-    "dev_unitsres": 502
-  },
-  {
-    "bbl": 5000510030,
-    "development": "RICHMOND TERRACE",
-    "dev_evictions": 0,
-    "dev_unitsres": 502
-  },
-  {
-    "bbl": 5000510001,
-    "development": "RICHMOND TERRACE",
-    "dev_evictions": 0,
-    "dev_unitsres": 502
-  },
-  {
-    "bbl": 2024160001,
-    "development": "JACKSON",
-    "dev_evictions": 0,
-    "dev_unitsres": 868
-  },
-  {
-    "bbl": 1020370001,
-    "development": "HARLEM RIVER II",
-    "dev_evictions": 4,
-    "dev_unitsres": 116
-  },
-  {
-    "bbl": 3035760001,
-    "development": "TILDEN",
-    "dev_evictions": 4,
-    "dev_unitsres": 997
-  },
-  {
-    "bbl": 3013810018,
-    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
-    "dev_evictions": 0,
-    "dev_unitsres": 147
-  },
-  {
-    "bbl": 3013790063,
-    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
-    "dev_evictions": 0,
-    "dev_unitsres": 147
-  },
-  {
-    "bbl": 3013790059,
-    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
-    "dev_evictions": 0,
-    "dev_unitsres": 147
-  },
-  {
-    "bbl": 3013790055,
-    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
-    "dev_evictions": 0,
-    "dev_unitsres": 147
-  },
-  {
-    "bbl": 3013790031,
-    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
-    "dev_evictions": 0,
-    "dev_unitsres": 147
-  },
-  {
-    "bbl": 3013730054,
-    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
-    "dev_evictions": 0,
-    "dev_unitsres": 147
-  },
-  {
-    "bbl": 1016830018,
-    "development": "335 EAST 111TH STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 66
-  },
-  {
-    "bbl": 3035100016,
-    "development": "SUTTER AVENUE-UNION STREET",
-    "dev_evictions": 1,
-    "dev_unitsres": 100
-  },
-  {
-    "bbl": 3035100011,
-    "development": "SUTTER AVENUE-UNION STREET",
-    "dev_evictions": 1,
-    "dev_unitsres": 100
-  },
-  {
-    "bbl": 3035100007,
-    "development": "SUTTER AVENUE-UNION STREET",
-    "dev_evictions": 1,
-    "dev_unitsres": 100
-  },
-  {
-    "bbl": 3035100006,
-    "development": "SUTTER AVENUE-UNION STREET",
-    "dev_evictions": 1,
-    "dev_unitsres": 100
-  },
-  {
-    "bbl": 3035100001,
-    "development": "SUTTER AVENUE-UNION STREET",
-    "dev_evictions": 1,
-    "dev_unitsres": 100
-  },
-  {
-    "bbl": 3035090059,
-    "development": "SUTTER AVENUE-UNION STREET",
-    "dev_evictions": 1,
-    "dev_unitsres": 100
-  },
-  {
-    "bbl": 1018080001,
-    "development": "WAGNER",
-    "dev_evictions": 11,
-    "dev_unitsres": 2810
-  },
-  {
-    "bbl": 1018010100,
-    "development": "WAGNER",
-    "dev_evictions": 11,
-    "dev_unitsres": 2810
-  },
-  {
-    "bbl": 1018010005,
-    "development": "WAGNER",
-    "dev_evictions": 11,
-    "dev_unitsres": 2810
-  },
-  {
-    "bbl": 1017970001,
-    "development": "WAGNER",
-    "dev_evictions": 11,
-    "dev_unitsres": 2810
-  },
-  {
-    "bbl": 2049050360,
-    "development": "BAYCHESTER",
-    "dev_evictions": 4,
-    "dev_unitsres": 441
-  },
-  {
-    "bbl": 2026800013,
-    "development": "UNION AVENUE-EAST 166TH STREET",
-    "dev_evictions": 1,
-    "dev_unitsres": 120
-  },
-  {
-    "bbl": 2026800001,
-    "development": "UNION AVENUE-EAST 166TH STREET",
-    "dev_evictions": 1,
-    "dev_unitsres": 120
-  },
-  {
-    "bbl": 1007240015,
-    "development": "ELLIOTT",
-    "dev_evictions": 2,
-    "dev_unitsres": 483
-  },
-  {
-    "bbl": 1007240001,
-    "development": "ELLIOTT",
-    "dev_evictions": 2,
-    "dev_unitsres": 483
-  },
-  {
-    "bbl": 1007230001,
-    "development": "ELLIOTT",
-    "dev_evictions": 2,
-    "dev_unitsres": 483
-  },
-  {
     "bbl": 1016200023,
     "development": "TAFT",
-    "dev_evictions": 10,
+    "dev_evictions": 8,
     "dev_unitsres": 1464
   },
   {
     "bbl": 1016180001,
     "development": "TAFT",
-    "dev_evictions": 10,
+    "dev_evictions": 8,
     "dev_unitsres": 1464
   },
   {
-    "bbl": 1003620001,
-    "development": "RIIS II",
-    "dev_evictions": 1,
-    "dev_unitsres": 586
-  },
-  {
-    "bbl": 2028770001,
-    "development": "SEDGWICK",
-    "dev_evictions": 4,
-    "dev_unitsres": 5502
-  },
-  {
-    "bbl": 2026650001,
-    "development": "ADAMS",
-    "dev_evictions": 2,
-    "dev_unitsres": 917
-  },
-  {
-    "bbl": 2026540002,
-    "development": "ADAMS",
-    "dev_evictions": 2,
-    "dev_unitsres": 917
-  },
-  {
-    "bbl": 3016010024,
-    "development": "ROOSEVELT I",
-    "dev_evictions": 0,
-    "dev_unitsres": 891
-  },
-  {
-    "bbl": 3015980001,
-    "development": "ROOSEVELT I",
-    "dev_evictions": 0,
-    "dev_unitsres": 891
-  },
-  {
-    "bbl": 3015970001,
-    "development": "ROOSEVELT I",
-    "dev_evictions": 0,
-    "dev_unitsres": 891
-  },
-  {
-    "bbl": 3005380001,
-    "development": "RED HOOK EAST",
-    "dev_evictions": 11,
-    "dev_unitsres": 1836
-  },
-  {
-    "bbl": 3045100001,
-    "development": "PINK",
-    "dev_evictions": 7,
-    "dev_unitsres": 1919
-  },
-  {
-    "bbl": 3045080001,
-    "development": "PINK",
-    "dev_evictions": 7,
-    "dev_unitsres": 1919
-  },
-  {
-    "bbl": 3044880001,
-    "development": "PINK",
-    "dev_evictions": 7,
-    "dev_unitsres": 1919
-  },
-  {
-    "bbl": 3044860001,
-    "development": "PINK",
-    "dev_evictions": 7,
-    "dev_unitsres": 1919
-  },
-  {
-    "bbl": 3037700001,
-    "development": "UNITY PLAZA (SITES 17,24,25A)",
-    "dev_evictions": 0,
-    "dev_unitsres": 121
-  },
-  {
-    "bbl": 3037690030,
-    "development": "UNITY PLAZA (SITES 17,24,25A)",
-    "dev_evictions": 0,
-    "dev_unitsres": 121
-  },
-  {
-    "bbl": 3035260021,
-    "development": "HUGHES APARTMENTS",
-    "dev_evictions": 1,
-    "dev_unitsres": 475
-  },
-  {
-    "bbl": 1003510001,
-    "development": "SEWARD PARK EXTENSION",
-    "dev_evictions": 1,
-    "dev_unitsres": 362
-  },
-  {
-    "bbl": 1003470080,
-    "development": "SEWARD PARK EXTENSION",
-    "dev_evictions": 1,
-    "dev_unitsres": 362
-  },
-  {
-    "bbl": 2024209078,
-    "development": "MORRISANIA AIR RIGHTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 666
-  },
-  {
-    "bbl": 2024209020,
-    "development": "MORRISANIA AIR RIGHTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 666
-  },
-  {
-    "bbl": 2024099059,
-    "development": "MORRISANIA AIR RIGHTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 666
-  },
-  {
-    "bbl": 4130420108,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4128170053,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4127780128,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4127320009,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4126460009,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4124380138,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4120250077,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4110550021,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4109990075,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4109620415,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4108410001,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 4096120068,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 2035120039,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
-    "dev_evictions": 1,
-    "dev_unitsres": 14
-  },
-  {
-    "bbl": 2026380090,
-    "development": "MCKINLEY",
-    "dev_evictions": 4,
-    "dev_unitsres": 619
-  },
-  {
-    "bbl": 2026310011,
-    "development": "MCKINLEY",
-    "dev_evictions": 4,
-    "dev_unitsres": 619
-  },
-  {
-    "bbl": 2044310001,
-    "development": "BOSTON ROAD PLAZA",
-    "dev_evictions": 0,
-    "dev_unitsres": 241
-  },
-  {
-    "bbl": 1018720029,
-    "development": "830 AMSTERDAM AVENUE",
-    "dev_evictions": 1,
-    "dev_unitsres": 159
-  },
-  {
-    "bbl": 3013520001,
-    "development": "ALBANY II",
-    "dev_evictions": 2,
-    "dev_unitsres": 400
-  },
-  {
-    "bbl": 3033340022,
-    "development": "BUSHWICK II CDA (GROUP E)",
-    "dev_evictions": 0,
-    "dev_unitsres": 276
-  },
-  {
-    "bbl": 3033340001,
-    "development": "BUSHWICK II CDA (GROUP E)",
-    "dev_evictions": 0,
-    "dev_unitsres": 276
-  },
-  {
-    "bbl": 3033250001,
-    "development": "BUSHWICK II CDA (GROUP E)",
-    "dev_evictions": 0,
-    "dev_unitsres": 276
-  },
-  {
-    "bbl": 3033160001,
-    "development": "BUSHWICK II CDA (GROUP E)",
-    "dev_evictions": 0,
-    "dev_unitsres": 276
-  },
-  {
-    "bbl": 4130990024,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
-    "dev_evictions": 1,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4126210018,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
-    "dev_evictions": 1,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4120480097,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
-    "dev_evictions": 1,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4119250082,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
-    "dev_evictions": 1,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4116100057,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
-    "dev_evictions": 1,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4110990062,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
-    "dev_evictions": 1,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4110700147,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
-    "dev_evictions": 1,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4110200021,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
-    "dev_evictions": 1,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4109540041,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
-    "dev_evictions": 1,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 5012480200,
-    "development": "MARINER'S HARBOR",
-    "dev_evictions": 6,
-    "dev_unitsres": 607
-  },
-  {
-    "bbl": 5012450001,
-    "development": "MARINER'S HARBOR",
-    "dev_evictions": 6,
-    "dev_unitsres": 607
-  },
-  {
-    "bbl": 1021320082,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE IV (D)",
-    "dev_evictions": 0,
-    "dev_unitsres": 40
-  },
-  {
-    "bbl": 1021320080,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE IV (D)",
-    "dev_evictions": 0,
-    "dev_unitsres": 40
-  },
-  {
-    "bbl": 3074051001,
-    "development": "SHEEPSHEAD BAY",
-    "dev_evictions": 6,
-    "dev_unitsres": 1056
-  },
-  {
-    "bbl": 3073870001,
-    "development": "SHEEPSHEAD BAY",
-    "dev_evictions": 6,
-    "dev_unitsres": 1056
-  },
-  {
-    "bbl": 3037870001,
-    "development": "LONG ISLAND BAPTIST HOUSES",
-    "dev_evictions": 4,
-    "dev_unitsres": 232
-  },
-  {
-    "bbl": 3037680018,
-    "development": "LONG ISLAND BAPTIST HOUSES",
-    "dev_evictions": 4,
-    "dev_unitsres": 232
-  },
-  {
-    "bbl": 3037670036,
-    "development": "LONG ISLAND BAPTIST HOUSES",
-    "dev_evictions": 4,
-    "dev_unitsres": 232
-  },
-  {
-    "bbl": 3037670032,
-    "development": "LONG ISLAND BAPTIST HOUSES",
-    "dev_evictions": 4,
-    "dev_unitsres": 232
-  },
-  {
-    "bbl": 3037670027,
-    "development": "LONG ISLAND BAPTIST HOUSES",
-    "dev_evictions": 4,
-    "dev_unitsres": 232
-  },
-  {
-    "bbl": 2029350007,
-    "development": "FRANKLIN AVENUE II CONVENTIONAL",
-    "dev_evictions": 0,
-    "dev_unitsres": 45
-  },
-  {
-    "bbl": 2029350005,
-    "development": "FRANKLIN AVENUE II CONVENTIONAL",
-    "dev_evictions": 0,
-    "dev_unitsres": 45
-  },
-  {
-    "bbl": 2029350003,
-    "development": "FRANKLIN AVENUE II CONVENTIONAL",
-    "dev_evictions": 0,
-    "dev_unitsres": 45
-  },
-  {
-    "bbl": 2029310064,
-    "development": "FRANKLIN AVENUE II CONVENTIONAL",
-    "dev_evictions": 0,
-    "dev_unitsres": 45
-  },
-  {
-    "bbl": 1001110100,
-    "development": "SMITH",
-    "dev_evictions": 9,
-    "dev_unitsres": 1934
-  },
-  {
-    "bbl": 2029310070,
-    "development": "FRANKLIN AVENUE I CONVENTIONAL",
-    "dev_evictions": 0,
-    "dev_unitsres": 61
-  },
-  {
-    "bbl": 2029310068,
-    "development": "FRANKLIN AVENUE I CONVENTIONAL",
-    "dev_evictions": 0,
-    "dev_unitsres": 61
-  },
-  {
-    "bbl": 2029310066,
-    "development": "FRANKLIN AVENUE I CONVENTIONAL",
-    "dev_evictions": 0,
-    "dev_unitsres": 61
-  },
-  {
-    "bbl": 4160830037,
-    "development": "CARLETON MANOR",
-    "dev_evictions": 4,
-    "dev_unitsres": 174
-  },
-  {
-    "bbl": 1019800001,
-    "development": "GRANT",
-    "dev_evictions": 14,
-    "dev_unitsres": 1941
-  },
-  {
-    "bbl": 1019640001,
-    "development": "GRANT",
-    "dev_evictions": 14,
-    "dev_unitsres": 1941
-  },
-  {
-    "bbl": 4121480100,
-    "development": "SOUTH JAMAICA II",
-    "dev_evictions": 3,
-    "dev_unitsres": 718
-  },
-  {
-    "bbl": 4101480001,
-    "development": "SOUTH JAMAICA II",
-    "dev_evictions": 3,
-    "dev_unitsres": 718
-  },
-  {
-    "bbl": 4101270001,
-    "development": "SOUTH JAMAICA II",
-    "dev_evictions": 3,
-    "dev_unitsres": 718
-  },
-  {
-    "bbl": 4101250063,
-    "development": "SOUTH JAMAICA II",
-    "dev_evictions": 3,
-    "dev_unitsres": 718
-  },
-  {
-    "bbl": 4101250012,
-    "development": "SOUTH JAMAICA II",
-    "dev_evictions": 3,
-    "dev_unitsres": 718
-  },
-  {
-    "bbl": 1016260021,
-    "development": "LEXINGTON",
-    "dev_evictions": 1,
-    "dev_unitsres": 448
-  },
-  {
-    "bbl": 1016260001,
-    "development": "LEXINGTON",
-    "dev_evictions": 1,
-    "dev_unitsres": 448
-  },
-  {
-    "bbl": 1018550001,
-    "development": "DOUGLASS II",
-    "dev_evictions": 2,
-    "dev_unitsres": 1162
-  },
-  {
-    "bbl": 2045420100,
-    "development": "PARKSIDE",
-    "dev_evictions": 0,
-    "dev_unitsres": 10005
-  },
-  {
-    "bbl": 2045070048,
-    "development": "PARKSIDE",
-    "dev_evictions": 0,
-    "dev_unitsres": 10005
-  },
-  {
-    "bbl": 2032390004,
-    "development": "BAILEY AVENUE-WEST 193RD STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 233
-  },
-  {
-    "bbl": 2029970030,
-    "development": "BRYANT AVENUE-EAST 174TH STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 111
-  },
-  {
-    "bbl": 3017400001,
-    "development": "TOMPKINS",
-    "dev_evictions": 6,
-    "dev_unitsres": 1046
-  },
-  {
-    "bbl": 3044310100,
-    "development": "VANDALIA AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 293
-  },
-  {
-    "bbl": 2037300001,
-    "development": "SOTOMAYOR HOUSES",
-    "dev_evictions": 6,
-    "dev_unitsres": 1506
-  },
-  {
-    "bbl": 2037250001,
-    "development": "SOTOMAYOR HOUSES",
-    "dev_evictions": 6,
-    "dev_unitsres": 1506
-  },
-  {
-    "bbl": 2037230001,
-    "development": "SOTOMAYOR HOUSES",
-    "dev_evictions": 6,
-    "dev_unitsres": 1506
-  },
-  {
-    "bbl": 4004900101,
-    "development": "ASTORIA",
-    "dev_evictions": 3,
-    "dev_unitsres": 1104
-  },
-  {
-    "bbl": 3039930001,
-    "development": "FIORENTINO PLAZA",
-    "dev_evictions": 4,
-    "dev_unitsres": 110
-  },
-  {
-    "bbl": 3037250001,
-    "development": "FIORENTINO PLAZA",
-    "dev_evictions": 4,
-    "dev_unitsres": 110
-  },
-  {
-    "bbl": 3037240029,
-    "development": "FIORENTINO PLAZA",
-    "dev_evictions": 4,
-    "dev_unitsres": 110
-  },
-  {
-    "bbl": 3037240027,
-    "development": "FIORENTINO PLAZA",
-    "dev_evictions": 4,
-    "dev_unitsres": 110
-  },
-  {
-    "bbl": 3013800034,
-    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
-    "dev_evictions": 1,
-    "dev_unitsres": 179
-  },
-  {
-    "bbl": 3013800031,
-    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
-    "dev_evictions": 1,
-    "dev_unitsres": 179
-  },
-  {
-    "bbl": 3013800028,
-    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
-    "dev_evictions": 1,
-    "dev_unitsres": 179
-  },
-  {
-    "bbl": 3013800025,
-    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
-    "dev_evictions": 1,
-    "dev_unitsres": 179
-  },
-  {
-    "bbl": 3013790011,
-    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
-    "dev_evictions": 1,
-    "dev_unitsres": 179
-  },
-  {
-    "bbl": 3013790008,
-    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
-    "dev_evictions": 1,
-    "dev_unitsres": 179
-  },
-  {
-    "bbl": 3013750002,
-    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
-    "dev_evictions": 1,
-    "dev_unitsres": 179
-  },
-  {
-    "bbl": 2029100001,
-    "development": "MORRIS I",
-    "dev_evictions": 5,
-    "dev_unitsres": 1085
-  },
-  {
-    "bbl": 2029010001,
-    "development": "MORRIS I",
-    "dev_evictions": 5,
-    "dev_unitsres": 1085
-  },
-  {
-    "bbl": 2023990010,
-    "development": "EAST 152ND STREET-COURTLANDT AVENUE",
-    "dev_evictions": 2,
-    "dev_unitsres": 221
-  },
-  {
-    "bbl": 2023980014,
-    "development": "EAST 152ND STREET-COURTLANDT AVENUE",
-    "dev_evictions": 2,
-    "dev_unitsres": 221
-  },
-  {
-    "bbl": 1003560001,
-    "development": "WALD",
-    "dev_evictions": 15,
-    "dev_unitsres": 1861
-  },
-  {
-    "bbl": 3021410019,
-    "development": "WILLIAMS PLAZA",
-    "dev_evictions": 0,
-    "dev_unitsres": 577
-  },
-  {
-    "bbl": 3021400026,
-    "development": "WILLIAMS PLAZA",
-    "dev_evictions": 0,
-    "dev_unitsres": 577
-  },
-  {
-    "bbl": 2044440001,
-    "development": "PELHAM PARKWAY",
-    "dev_evictions": 2,
-    "dev_unitsres": 1266
-  },
-  {
-    "bbl": 2043630001,
-    "development": "PELHAM PARKWAY",
-    "dev_evictions": 2,
-    "dev_unitsres": 1266
-  },
-  {
-    "bbl": 2043490001,
-    "development": "PELHAM PARKWAY",
-    "dev_evictions": 2,
-    "dev_unitsres": 1266
-  },
-  {
-    "bbl": 4130750067,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4120150164,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4111340046,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4110580007,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4110140027,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4103780041,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 4101620025,
-    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
-    "dev_evictions": 0,
-    "dev_unitsres": 9
-  },
-  {
-    "bbl": 1007230015,
-    "development": "CHELSEA",
-    "dev_evictions": 1,
-    "dev_unitsres": 425
-  },
-  {
-    "bbl": 3047950016,
-    "development": "REID APARTMENTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 230
-  },
-  {
-    "bbl": 1020090004,
-    "development": "SAMUEL (MHOP) I",
-    "dev_evictions": 0,
-    "dev_unitsres": 53
-  },
-  {
-    "bbl": 1020090003,
-    "development": "SAMUEL (MHOP) I",
-    "dev_evictions": 0,
-    "dev_unitsres": 53
-  },
-  {
-    "bbl": 1020090001,
-    "development": "SAMUEL (MHOP) I",
-    "dev_evictions": 0,
-    "dev_unitsres": 53
-  },
-  {
-    "bbl": 1020070057,
-    "development": "SAMUEL (MHOP) I",
-    "dev_evictions": 0,
-    "dev_unitsres": 53
-  },
-  {
-    "bbl": 1020070056,
-    "development": "SAMUEL (MHOP) I",
-    "dev_evictions": 0,
-    "dev_unitsres": 53
-  },
-  {
-    "bbl": 4132720054,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4131790027,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4121150033,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4119910017,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4116780060,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4111340022,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4111240053,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4110510023,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4109670159,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4108730024,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 4104200036,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 2047810029,
-    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 3033590029,
-    "development": "BUSHWICK II (GROUPS B & D)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3033510001,
-    "development": "BUSHWICK II (GROUPS B & D)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3033500028,
-    "development": "BUSHWICK II (GROUPS B & D)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3033420001,
-    "development": "BUSHWICK II (GROUPS B & D)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3033410001,
-    "development": "BUSHWICK II (GROUPS B & D)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3033320001,
-    "development": "BUSHWICK II (GROUPS B & D)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3016350126,
-    "development": "STUYVESANT GARDENS I",
-    "dev_evictions": 1,
-    "dev_unitsres": 329
-  },
-  {
-    "bbl": 3016350041,
-    "development": "STUYVESANT GARDENS I",
-    "dev_evictions": 1,
-    "dev_unitsres": 329
-  },
-  {
-    "bbl": 3016350003,
-    "development": "STUYVESANT GARDENS I",
-    "dev_evictions": 1,
-    "dev_unitsres": 329
-  },
-  {
-    "bbl": 3016310061,
-    "development": "STUYVESANT GARDENS I",
-    "dev_evictions": 1,
-    "dev_unitsres": 329
-  },
-  {
-    "bbl": 3016310060,
-    "development": "STUYVESANT GARDENS I",
-    "dev_evictions": 1,
-    "dev_unitsres": 329
-  },
-  {
-    "bbl": 3016310058,
-    "development": "STUYVESANT GARDENS I",
-    "dev_evictions": 1,
-    "dev_unitsres": 329
-  },
-  {
-    "bbl": 3016310031,
-    "development": "STUYVESANT GARDENS I",
-    "dev_evictions": 1,
-    "dev_unitsres": 329
-  },
-  {
-    "bbl": 3016310009,
-    "development": "STUYVESANT GARDENS I",
-    "dev_evictions": 1,
-    "dev_unitsres": 329
-  },
-  {
-    "bbl": 3016310001,
-    "development": "STUYVESANT GARDENS I",
-    "dev_evictions": 1,
-    "dev_unitsres": 329
-  },
-  {
-    "bbl": 3013440175,
-    "development": "KINGSBOROUGH EXTENSION",
-    "dev_evictions": 0,
-    "dev_unitsres": 184
-  },
-  {
-    "bbl": 2027570080,
-    "development": "LONGFELLOW AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 75
-  },
-  {
-    "bbl": 2027570020,
-    "development": "LONGFELLOW AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 75
-  },
-  {
-    "bbl": 1002580017,
-    "development": "LA GUARDIA",
-    "dev_evictions": 5,
-    "dev_unitsres": 1102
-  },
-  {
-    "bbl": 1002580001,
-    "development": "LA GUARDIA",
-    "dev_evictions": 5,
-    "dev_unitsres": 1102
-  },
-  {
-    "bbl": 1002560001,
-    "development": "LA GUARDIA",
-    "dev_evictions": 5,
-    "dev_unitsres": 1102
-  },
-  {
-    "bbl": 1019220041,
-    "development": "131 SAINT NICHOLAS AVENUE",
-    "dev_evictions": 0,
+    "bbl": 3035100016,
+    "development": "SUTTER AVENUE-UNION STREET",
+    "dev_evictions": "",
     "dev_unitsres": 100
   },
   {
-    "bbl": 3013410012,
-    "development": "WEEKSVILLE GARDENS",
-    "dev_evictions": 2,
-    "dev_unitsres": 274
+    "bbl": 3035100011,
+    "development": "SUTTER AVENUE-UNION STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 100
   },
   {
-    "bbl": 3013410001,
-    "development": "WEEKSVILLE GARDENS",
-    "dev_evictions": 2,
-    "dev_unitsres": 274
+    "bbl": 3035100007,
+    "development": "SUTTER AVENUE-UNION STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 100
   },
   {
-    "bbl": 1004290021,
-    "development": "MELTZER TOWER",
-    "dev_evictions": 0,
-    "dev_unitsres": 120
+    "bbl": 3035100006,
+    "development": "SUTTER AVENUE-UNION STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 100
   },
   {
-    "bbl": 2022910050,
-    "development": "BETANCES IV",
-    "dev_evictions": 0,
-    "dev_unitsres": 431
+    "bbl": 3035100001,
+    "development": "SUTTER AVENUE-UNION STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 100
   },
   {
-    "bbl": 2022870135,
-    "development": "BETANCES IV",
-    "dev_evictions": 0,
-    "dev_unitsres": 431
+    "bbl": 3035090059,
+    "development": "SUTTER AVENUE-UNION STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 100
   },
   {
-    "bbl": 5035320500,
-    "development": "BERRY",
-    "dev_evictions": 6,
-    "dev_unitsres": 506
-  },
-  {
-    "bbl": 3070530014,
-    "development": "CONEY ISLAND I (SITES 4 & 5)",
-    "dev_evictions": 2,
-    "dev_unitsres": 616
-  },
-  {
-    "bbl": 3070530013,
-    "development": "CONEY ISLAND I (SITES 4 & 5)",
-    "dev_evictions": 2,
-    "dev_unitsres": 616
-  },
-  {
-    "bbl": 3070530012,
-    "development": "CONEY ISLAND I (SITES 4 & 5)",
-    "dev_evictions": 2,
-    "dev_unitsres": 616
-  },
-  {
-    "bbl": 2028950001,
-    "development": "BUTLER",
-    "dev_evictions": 5,
-    "dev_unitsres": 1492
-  },
-  {
-    "bbl": 2028940001,
-    "development": "BUTLER",
-    "dev_evictions": 5,
-    "dev_unitsres": 1492
-  },
-  {
-    "bbl": 3021750090,
-    "development": "TAYLOR STREET-WYTHE AVENUE",
-    "dev_evictions": 2,
-    "dev_unitsres": 525
-  },
-  {
-    "bbl": 3021750080,
-    "development": "TAYLOR STREET-WYTHE AVENUE",
-    "dev_evictions": 2,
-    "dev_unitsres": 525
-  },
-  {
-    "bbl": 3021750075,
-    "development": "TAYLOR STREET-WYTHE AVENUE",
-    "dev_evictions": 2,
-    "dev_unitsres": 525
-  },
-  {
-    "bbl": 3021750070,
-    "development": "TAYLOR STREET-WYTHE AVENUE",
-    "dev_evictions": 2,
-    "dev_unitsres": 525
-  },
-  {
-    "bbl": 3021750060,
-    "development": "TAYLOR STREET-WYTHE AVENUE",
-    "dev_evictions": 2,
-    "dev_unitsres": 525
-  },
-  {
-    "bbl": 3021750030,
-    "development": "TAYLOR STREET-WYTHE AVENUE",
-    "dev_evictions": 2,
-    "dev_unitsres": 525
-  },
-  {
-    "bbl": 3019380001,
-    "development": "LAFAYETTE",
-    "dev_evictions": 8,
-    "dev_unitsres": 882
-  },
-  {
-    "bbl": 3033400020,
-    "development": "PALMETTO GARDENS",
-    "dev_evictions": 0,
-    "dev_unitsres": 115
-  },
-  {
-    "bbl": 2024340088,
-    "development": "CLAREMONT REHAB (GROUP 4)",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 2024340057,
-    "development": "CLAREMONT REHAB (GROUP 4)",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 2024340053,
-    "development": "CLAREMONT REHAB (GROUP 4)",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 2024280012,
-    "development": "CLAREMONT REHAB (GROUP 4)",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 2024280003,
-    "development": "CLAREMONT REHAB (GROUP 4)",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 2024270012,
-    "development": "CLAREMONT REHAB (GROUP 4)",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 2024270010,
-    "development": "CLAREMONT REHAB (GROUP 4)",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 2024270007,
-    "development": "CLAREMONT REHAB (GROUP 4)",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 2024270003,
-    "development": "CLAREMONT REHAB (GROUP 4)",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 1016370001,
-    "development": "CLINTON",
-    "dev_evictions": 7,
-    "dev_unitsres": 750
-  },
-  {
-    "bbl": 1016360001,
-    "development": "CLINTON",
-    "dev_evictions": 7,
-    "dev_unitsres": 750
-  },
-  {
-    "bbl": 1016330001,
-    "development": "CLINTON",
-    "dev_evictions": 7,
-    "dev_unitsres": 750
-  },
-  {
-    "bbl": 1016320001,
-    "development": "CLINTON",
-    "dev_evictions": 7,
-    "dev_unitsres": 750
-  },
-  {
-    "bbl": 2024290001,
-    "development": "TELLER AVENUE-EAST 166TH STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 90
-  },
-  {
-    "bbl": 3015960001,
-    "development": "ROOSEVELT II",
+    "bbl": 3070490015,
+    "development": "SURFSIDE GARDENS",
     "dev_evictions": 1,
-    "dev_unitsres": 1799
+    "dev_unitsres": 637
   },
   {
-    "bbl": 3015950024,
-    "development": "ROOSEVELT II",
+    "bbl": 3070070001,
+    "development": "SURFSIDE GARDENS",
     "dev_evictions": 1,
-    "dev_unitsres": 1799
-  },
-  {
-    "bbl": 3015950001,
-    "development": "ROOSEVELT II",
-    "dev_evictions": 1,
-    "dev_unitsres": 1799
-  },
-  {
-    "bbl": 5028320068,
-    "development": "NEW LANE AREA",
-    "dev_evictions": 0,
-    "dev_unitsres": 277
-  },
-  {
-    "bbl": 2026780001,
-    "development": "UNION AVENUE-EAST 163RD STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 200
-  },
-  {
-    "bbl": 4041700001,
-    "development": "REHAB PROGRAM (COLLEGE POINT)",
-    "dev_evictions": 0,
-    "dev_unitsres": 13
-  },
-  {
-    "bbl": 3000900001,
-    "development": "FARRAGUT",
-    "dev_evictions": 2,
-    "dev_unitsres": 1390
-  },
-  {
-    "bbl": 3000710001,
-    "development": "FARRAGUT",
-    "dev_evictions": 2,
-    "dev_unitsres": 1390
-  },
-  {
-    "bbl": 3000680001,
-    "development": "FARRAGUT",
-    "dev_evictions": 2,
-    "dev_unitsres": 1390
-  },
-  {
-    "bbl": 2023060009,
-    "development": "MOTT HAVEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 993
-  },
-  {
-    "bbl": 2023040001,
-    "development": "MOTT HAVEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 993
-  },
-  {
-    "bbl": 2023030021,
-    "development": "MOTT HAVEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 993
-  },
-  {
-    "bbl": 3020070001,
-    "development": "ATLANTIC TERMINAL SITE 4B",
-    "dev_evictions": 1,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3021760001,
-    "development": "INDEPENDENCE",
-    "dev_evictions": 3,
-    "dev_unitsres": 744
-  },
-  {
-    "bbl": 3021720001,
-    "development": "INDEPENDENCE",
-    "dev_evictions": 3,
-    "dev_unitsres": 744
-  },
-  {
-    "bbl": 2029890011,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029890001,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029880019,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029880018,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029820066,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029820048,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029820046,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029820045,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029820044,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029820038,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029820035,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029820032,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 2029820029,
-    "development": "EAST 173RD STREET-VYSE AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 1011540101,
-    "development": "AMSTERDAM",
-    "dev_evictions": 4,
-    "dev_unitsres": 1084
-  },
-  {
-    "bbl": 1012240016,
-    "development": "WSUR (BROWNSTONES)",
-    "dev_evictions": 1,
-    "dev_unitsres": 227
-  },
-  {
-    "bbl": 1012040056,
-    "development": "WSUR (BROWNSTONES)",
-    "dev_evictions": 1,
-    "dev_unitsres": 227
-  },
-  {
-    "bbl": 1012040021,
-    "development": "WSUR (BROWNSTONES)",
-    "dev_evictions": 1,
-    "dev_unitsres": 227
-  },
-  {
-    "bbl": 1012030013,
-    "development": "WSUR (BROWNSTONES)",
-    "dev_evictions": 1,
-    "dev_unitsres": 227
-  },
-  {
-    "bbl": 2046290050,
-    "development": "GUN HILL",
-    "dev_evictions": 4,
-    "dev_unitsres": 733
-  },
-  {
-    "bbl": 1019330050,
-    "development": "SAINT NICHOLAS",
-    "dev_evictions": 17,
-    "dev_unitsres": 1527
-  },
-  {
-    "bbl": 1019330001,
-    "development": "SAINT NICHOLAS",
-    "dev_evictions": 17,
-    "dev_unitsres": 1527
-  },
-  {
-    "bbl": 1003860033,
-    "development": "BRACETTI PLAZA",
-    "dev_evictions": 0,
-    "dev_unitsres": 108
-  },
-  {
-    "bbl": 2041710024,
-    "development": "MIDDLETOWN PLAZA",
-    "dev_evictions": 0,
-    "dev_unitsres": 179
-  },
-  {
-    "bbl": 4139360060,
-    "development": "157TH AVENUE-79TH STREET AREA",
-    "dev_evictions": 0,
-    "dev_unitsres": 0
-  },
-  {
-    "bbl": 4139350060,
-    "development": "157TH AVENUE-79TH STREET AREA",
-    "dev_evictions": 0,
-    "dev_unitsres": 0
+    "dev_unitsres": 637
   },
   {
     "bbl": 3017490015,
     "development": "SUMNER",
-    "dev_evictions": 1,
+    "dev_evictions": 2,
     "dev_unitsres": 1613
   },
   {
     "bbl": 3015800001,
     "development": "SUMNER",
-    "dev_evictions": 1,
+    "dev_evictions": 2,
     "dev_unitsres": 1613
   },
   {
-    "bbl": 2026800019,
-    "development": "DAVIDSON",
+    "bbl": 3016360024,
+    "development": "STUYVESANT GARDENS II",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3016310034,
+    "development": "STUYVESANT GARDENS II",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3016350126,
+    "development": "STUYVESANT GARDENS I",
+    "dev_evictions": 2,
+    "dev_unitsres": 329
+  },
+  {
+    "bbl": 3016350041,
+    "development": "STUYVESANT GARDENS I",
+    "dev_evictions": 2,
+    "dev_unitsres": 329
+  },
+  {
+    "bbl": 3016350003,
+    "development": "STUYVESANT GARDENS I",
+    "dev_evictions": 2,
+    "dev_unitsres": 329
+  },
+  {
+    "bbl": 3016310061,
+    "development": "STUYVESANT GARDENS I",
+    "dev_evictions": 2,
+    "dev_unitsres": 329
+  },
+  {
+    "bbl": 3016310060,
+    "development": "STUYVESANT GARDENS I",
+    "dev_evictions": 2,
+    "dev_unitsres": 329
+  },
+  {
+    "bbl": 3016310058,
+    "development": "STUYVESANT GARDENS I",
+    "dev_evictions": 2,
+    "dev_unitsres": 329
+  },
+  {
+    "bbl": 3016310031,
+    "development": "STUYVESANT GARDENS I",
+    "dev_evictions": 2,
+    "dev_unitsres": 329
+  },
+  {
+    "bbl": 3016310009,
+    "development": "STUYVESANT GARDENS I",
+    "dev_evictions": 2,
+    "dev_unitsres": 329
+  },
+  {
+    "bbl": 3016310001,
+    "development": "STUYVESANT GARDENS I",
+    "dev_evictions": 2,
+    "dev_unitsres": 329
+  },
+  {
+    "bbl": 1009080027,
+    "development": "STRAUS",
     "dev_evictions": 1,
-    "dev_unitsres": 175
+    "dev_unitsres": 267
   },
   {
-    "bbl": 1016730006,
-    "development": "METRO NORTH PLAZA",
-    "dev_evictions": 0,
-    "dev_unitsres": 268
-  },
-  {
-    "bbl": 1016730001,
-    "development": "METRO NORTH PLAZA",
-    "dev_evictions": 0,
-    "dev_unitsres": 268
-  },
-  {
-    "bbl": 3018080174,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080173,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080172,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080171,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080170,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080169,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080168,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080167,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080166,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080165,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080164,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080163,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080162,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080161,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080160,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018080059,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030124,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030123,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030122,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030121,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030120,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030119,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030118,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030117,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030116,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030115,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030114,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030113,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030112,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030042,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018020051,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018020044,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018020043,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940181,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940139,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940121,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940120,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940119,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940118,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940117,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940116,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940115,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940114,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940113,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940112,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940054,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3017940011,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030011,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 3018030027,
-    "development": "ARMSTRONG I",
-    "dev_evictions": 0,
-    "dev_unitsres": 416
-  },
-  {
-    "bbl": 4123350044,
-    "development": "BAISLEY PARK",
-    "dev_evictions": 5,
-    "dev_unitsres": 833
-  },
-  {
-    "bbl": 4122350022,
-    "development": "BAISLEY PARK",
-    "dev_evictions": 5,
-    "dev_unitsres": 833
-  },
-  {
-    "bbl": 3070700001,
-    "development": "HABER",
-    "dev_evictions": 0,
-    "dev_unitsres": 380
-  },
-  {
-    "bbl": 1004170001,
-    "development": "HERNANDEZ",
-    "dev_evictions": 0,
-    "dev_unitsres": 149
-  },
-  {
-    "bbl": 1002630001,
-    "development": "VLADECK II",
+    "bbl": 1009080017,
+    "development": "STRAUS",
     "dev_evictions": 1,
-    "dev_unitsres": 236
+    "dev_unitsres": 267
   },
   {
-    "bbl": 2024340042,
-    "development": "CLAREMONT REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 137
+    "bbl": 3013800034,
+    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
+    "dev_evictions": "",
+    "dev_unitsres": 179
   },
   {
-    "bbl": 2024340034,
-    "development": "CLAREMONT REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 137
+    "bbl": 3013800031,
+    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
+    "dev_evictions": "",
+    "dev_unitsres": 179
   },
   {
-    "bbl": 2024340030,
-    "development": "CLAREMONT REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 137
+    "bbl": 3013800028,
+    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
+    "dev_evictions": "",
+    "dev_unitsres": 179
   },
   {
-    "bbl": 2024340026,
-    "development": "CLAREMONT REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 137
+    "bbl": 3013800025,
+    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
+    "dev_evictions": "",
+    "dev_unitsres": 179
   },
   {
-    "bbl": 2024340018,
-    "development": "CLAREMONT REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 137
+    "bbl": 3013790011,
+    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
+    "dev_evictions": "",
+    "dev_unitsres": 179
   },
   {
-    "bbl": 1016960001,
-    "development": "EAST RIVER",
-    "dev_evictions": 12,
-    "dev_unitsres": 1170
+    "bbl": 3013790008,
+    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
+    "dev_evictions": "",
+    "dev_unitsres": 179
   },
   {
-    "bbl": 1021060003,
-    "development": "POLO GROUNDS TOWERS",
-    "dev_evictions": 19,
-    "dev_unitsres": 1614
+    "bbl": 3013750002,
+    "development": "STERLING PLACE REHABS (STERLING-BUFFALO)",
+    "dev_evictions": "",
+    "dev_unitsres": 179
+  },
+  {
+    "bbl": 3013810018,
+    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
+    "dev_evictions": "",
+    "dev_unitsres": 147
+  },
+  {
+    "bbl": 3013790063,
+    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
+    "dev_evictions": "",
+    "dev_unitsres": 147
+  },
+  {
+    "bbl": 3013790059,
+    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
+    "dev_evictions": "",
+    "dev_unitsres": 147
+  },
+  {
+    "bbl": 3013790055,
+    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
+    "dev_evictions": "",
+    "dev_unitsres": 147
+  },
+  {
+    "bbl": 3013790031,
+    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
+    "dev_evictions": "",
+    "dev_unitsres": 147
+  },
+  {
+    "bbl": 3013730054,
+    "development": "STERLING PLACE REHABS (SAINT JOHNS-STERLING)",
+    "dev_evictions": "",
+    "dev_unitsres": 147
+  },
+  {
+    "bbl": 2026960005,
+    "development": "STEBBINS AVENUE-HEWITT PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 144
+  },
+  {
+    "bbl": 5005450100,
+    "development": "STAPLETON",
+    "dev_evictions": 2,
+    "dev_unitsres": 693
+  },
+  {
+    "bbl": 1003440010,
+    "development": "STANTON STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4121480100,
+    "development": "SOUTH JAMAICA II",
+    "dev_evictions": 1,
+    "dev_unitsres": 718
+  },
+  {
+    "bbl": 4101480001,
+    "development": "SOUTH JAMAICA II",
+    "dev_evictions": 1,
+    "dev_unitsres": 718
+  },
+  {
+    "bbl": 4101270001,
+    "development": "SOUTH JAMAICA II",
+    "dev_evictions": 1,
+    "dev_unitsres": 718
+  },
+  {
+    "bbl": 4101250063,
+    "development": "SOUTH JAMAICA II",
+    "dev_evictions": 1,
+    "dev_unitsres": 718
+  },
+  {
+    "bbl": 4101250012,
+    "development": "SOUTH JAMAICA II",
+    "dev_evictions": 1,
+    "dev_unitsres": 718
   },
   {
     "bbl": 4101460051,
     "development": "SOUTH JAMAICA I",
-    "dev_evictions": 6,
+    "dev_evictions": 2,
     "dev_unitsres": 456
   },
   {
     "bbl": 4101250033,
     "development": "SOUTH JAMAICA I",
-    "dev_evictions": 6,
+    "dev_evictions": 2,
     "dev_unitsres": 456
   },
   {
-    "bbl": 3042920061,
-    "development": "CYPRESS HILLS",
-    "dev_evictions": 4,
-    "dev_unitsres": 1444
-  },
-  {
-    "bbl": 2030940014,
-    "development": "TWIN PARKS EAST (SITE 9)",
-    "dev_evictions": 2,
-    "dev_unitsres": 221
-  },
-  {
-    "bbl": 3013520080,
-    "development": "ALBANY",
-    "dev_evictions": 4,
-    "dev_unitsres": 829
-  },
-  {
-    "bbl": 2027610003,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400031,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400030,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400028,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400027,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400025,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400024,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400022,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400021,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400019,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400018,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400016,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400015,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2027400013,
-    "development": "HUNTS POINT AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 131
-  },
-  {
-    "bbl": 2038680033,
-    "development": "BRONX RIVER ADDITION",
-    "dev_evictions": 0,
-    "dev_unitsres": 231
-  },
-  {
-    "bbl": 2038660031,
-    "development": "BRONX RIVER ADDITION",
-    "dev_evictions": 0,
-    "dev_unitsres": 231
-  },
-  {
-    "bbl": 2036330001,
-    "development": "CLASON POINT GARDENS",
-    "dev_evictions": 5,
-    "dev_unitsres": 368
-  },
-  {
-    "bbl": 2035910001,
-    "development": "CLASON POINT GARDENS",
-    "dev_evictions": 5,
-    "dev_unitsres": 368
-  },
-  {
-    "bbl": 4159600060,
-    "development": "BEACH 41ST STREET-BEACH CHANNEL DRIVE",
-    "dev_evictions": 0,
-    "dev_unitsres": 712
-  },
-  {
-    "bbl": 4159550003,
-    "development": "BEACH 41ST STREET-BEACH CHANNEL DRIVE",
-    "dev_evictions": 0,
-    "dev_unitsres": 712
-  },
-  {
-    "bbl": 3018090062,
-    "development": "ARMSTRONG II",
+    "bbl": 2026260001,
+    "development": "SOUTH BRONX AREA (SITE 402)",
     "dev_evictions": 1,
-    "dev_unitsres": 248
-  },
-  {
-    "bbl": 3018090001,
-    "development": "ARMSTRONG II",
-    "dev_evictions": 1,
-    "dev_unitsres": 248
-  },
-  {
-    "bbl": 3018040010,
-    "development": "ARMSTRONG II",
-    "dev_evictions": 1,
-    "dev_unitsres": 248
-  },
-  {
-    "bbl": 3017990044,
-    "development": "ARMSTRONG II",
-    "dev_evictions": 1,
-    "dev_unitsres": 248
-  },
-  {
-    "bbl": 2036630001,
-    "development": "MONROE",
-    "dev_evictions": 5,
-    "dev_unitsres": 1103
-  },
-  {
-    "bbl": 2036370001,
-    "development": "MONROE",
-    "dev_evictions": 5,
-    "dev_unitsres": 1103
-  },
-  {
-    "bbl": 4102120033,
-    "development": "CONLON LIHFE TOWER",
-    "dev_evictions": 0,
-    "dev_unitsres": 216
-  },
-  {
-    "bbl": 3070460022,
-    "development": "CONEY ISLAND I (SITE 8)",
-    "dev_evictions": 0,
-    "dev_unitsres": 125
-  },
-  {
-    "bbl": 1002670024,
-    "development": "VLADECK",
-    "dev_evictions": 5,
-    "dev_unitsres": 1487
-  },
-  {
-    "bbl": 1002600075,
-    "development": "VLADECK",
-    "dev_evictions": 5,
-    "dev_unitsres": 1487
-  },
-  {
-    "bbl": 1002600070,
-    "development": "VLADECK",
-    "dev_evictions": 5,
-    "dev_unitsres": 1487
-  },
-  {
-    "bbl": 1002600001,
-    "development": "VLADECK",
-    "dev_evictions": 5,
-    "dev_unitsres": 1487
-  },
-  {
-    "bbl": 2035510001,
-    "development": "SOUNDVIEW",
-    "dev_evictions": 6,
-    "dev_unitsres": 1259
-  },
-  {
-    "bbl": 2035150001,
-    "development": "SOUNDVIEW",
-    "dev_evictions": 6,
-    "dev_unitsres": 1259
-  },
-  {
-    "bbl": 3015290001,
-    "development": "OCEAN HILL APARTMENTS",
-    "dev_evictions": 1,
-    "dev_unitsres": 238
-  },
-  {
-    "bbl": 3015280033,
-    "development": "OCEAN HILL APARTMENTS",
-    "dev_evictions": 1,
-    "dev_unitsres": 238
-  },
-  {
-    "bbl": 1012140055,
-    "development": "154 WEST 84TH STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 35
-  },
-  {
-    "bbl": 3045940064,
-    "development": "RUTLAND TOWERS",
-    "dev_evictions": 0,
-    "dev_unitsres": 60
-  },
-  {
-    "bbl": 4125910227,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 4123400068,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3046090013,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3044540030,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3040700024,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3040700021,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3040700019,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3040700016,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3040550012,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3020730046,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3019650075,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3018890036,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3018890034,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3018890022,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3018880177,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3009430069,
-    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
-    "dev_evictions": 0,
-    "dev_unitsres": 43
-  },
-  {
-    "bbl": 3035610001,
-    "development": "BROWNSVILLE",
-    "dev_evictions": 21,
-    "dev_unitsres": 1338
-  },
-  {
-    "bbl": 3035440001,
-    "development": "BROWNSVILLE",
-    "dev_evictions": 21,
-    "dev_unitsres": 1338
-  },
-  {
-    "bbl": 3081930001,
-    "development": "BREUKELEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 1620
-  },
-  {
-    "bbl": 3081910001,
-    "development": "BREUKELEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 1620
-  },
-  {
-    "bbl": 3081740001,
-    "development": "BREUKELEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 1620
-  },
-  {
-    "bbl": 3081580205,
-    "development": "BREUKELEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 1620
-  },
-  {
-    "bbl": 3081580150,
-    "development": "BREUKELEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 1620
-  },
-  {
-    "bbl": 3081580040,
-    "development": "BREUKELEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 1620
-  },
-  {
-    "bbl": 3081580001,
-    "development": "BREUKELEN",
-    "dev_evictions": 3,
-    "dev_unitsres": 1620
-  },
-  {
-    "bbl": 1021070059,
-    "development": "BETHUNE GARDENS",
-    "dev_evictions": 1,
-    "dev_unitsres": 170
-  },
-  {
-    "bbl": 1021320114,
-    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
-    "dev_evictions": 1,
-    "dev_unitsres": 245
-  },
-  {
-    "bbl": 1021320110,
-    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
-    "dev_evictions": 1,
-    "dev_unitsres": 245
-  },
-  {
-    "bbl": 1021320100,
-    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
-    "dev_evictions": 1,
-    "dev_unitsres": 245
-  },
-  {
-    "bbl": 1021320094,
-    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
-    "dev_evictions": 1,
-    "dev_unitsres": 245
-  },
-  {
-    "bbl": 1021320047,
-    "development": "WASHINGTON HEIGHTS REHAB (GROUPS 1&2)",
-    "dev_evictions": 1,
-    "dev_unitsres": 245
-  },
-  {
-    "bbl": 1020290001,
-    "development": "DREW-HAMILTON",
-    "dev_evictions": 6,
-    "dev_unitsres": 1217
-  },
-  {
-    "bbl": 1020280016,
-    "development": "DREW-HAMILTON",
-    "dev_evictions": 6,
-    "dev_unitsres": 1217
-  },
-  {
-    "bbl": 1020280001,
-    "development": "DREW-HAMILTON",
-    "dev_evictions": 6,
-    "dev_unitsres": 1217
-  },
-  {
-    "bbl": 1020270025,
-    "development": "DREW-HAMILTON",
-    "dev_evictions": 6,
-    "dev_unitsres": 1217
-  },
-  {
-    "bbl": 1020270001,
-    "development": "DREW-HAMILTON",
-    "dev_evictions": 6,
-    "dev_unitsres": 1217
-  },
-  {
-    "bbl": 1016880045,
-    "development": "CORSI HOUSES",
-    "dev_evictions": 1,
-    "dev_unitsres": 171
-  },
-  {
-    "bbl": 4155020003,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4155020002,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4130220085,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4129840026,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4129280078,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4127780124,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4126390054,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4124620019,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4123290038,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4122020019,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4121090066,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4121030071,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4119750142,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4119540078,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4116960016,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4116560067,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4111340018,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4111290028,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4110740054,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4110410030,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4110110060,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4109030042,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4108680026,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4104200080,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4103680060,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 4100410120,
-    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
-    "dev_evictions": 0,
-    "dev_unitsres": 29
-  },
-  {
-    "bbl": 1015730001,
-    "development": "ISAACS",
-    "dev_evictions": 4,
-    "dev_unitsres": 636
-  },
-  {
-    "bbl": 1003230001,
-    "development": "BARUCH",
-    "dev_evictions": 8,
-    "dev_unitsres": 2391
-  },
-  {
-    "bbl": 4158920001,
-    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 418
-  },
-  {
-    "bbl": 4158900066,
-    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 418
-  },
-  {
-    "bbl": 4158900064,
-    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 418
-  },
-  {
-    "bbl": 4158900062,
-    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 418
-  },
-  {
-    "bbl": 4158900058,
-    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 418
-  },
-  {
-    "bbl": 4158900055,
-    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 418
-  },
-  {
-    "bbl": 4158900054,
-    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
-    "dev_evictions": 0,
-    "dev_unitsres": 418
-  },
-  {
-    "bbl": 1003250001,
-    "development": "LAVANBURG HOMES",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 5007060001,
-    "development": "TODT HILL",
-    "dev_evictions": 3,
-    "dev_unitsres": 485
-  },
-  {
-    "bbl": 4049510008,
-    "development": "LATIMER GARDENS",
-    "dev_evictions": 1,
-    "dev_unitsres": 434
-  },
-  {
-    "bbl": 1003890041,
-    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 60
-  },
-  {
-    "bbl": 1003890040,
-    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 60
-  },
-  {
-    "bbl": 1003890038,
-    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 60
-  },
-  {
-    "bbl": 1003890036,
-    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 60
-  },
-  {
-    "bbl": 1003890032,
-    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
-    "dev_evictions": 0,
-    "dev_unitsres": 60
-  },
-  {
-    "bbl": 2031430240,
-    "development": "TWIN PARKS WEST (SITES 1 & 2)",
-    "dev_evictions": 0,
-    "dev_unitsres": 312
-  },
-  {
-    "bbl": 2031430236,
-    "development": "TWIN PARKS WEST (SITES 1 & 2)",
-    "dev_evictions": 0,
-    "dev_unitsres": 312
-  },
-  {
-    "bbl": 2031430234,
-    "development": "TWIN PARKS WEST (SITES 1 & 2)",
-    "dev_evictions": 0,
-    "dev_unitsres": 312
-  },
-  {
-    "bbl": 2031430206,
-    "development": "TWIN PARKS WEST (SITES 1 & 2)",
-    "dev_evictions": 0,
-    "dev_unitsres": 312
-  },
-  {
-    "bbl": 2031430167,
-    "development": "TWIN PARKS WEST (SITES 1 & 2)",
-    "dev_evictions": 0,
-    "dev_unitsres": 312
-  },
-  {
-    "bbl": 2031430155,
-    "development": "TWIN PARKS WEST (SITES 1 & 2)",
-    "dev_evictions": 0,
-    "dev_unitsres": 312
-  },
-  {
-    "bbl": 2024330001,
-    "development": "COLLEGE AVENUE-EAST 165TH STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 108
-  },
-  {
-    "bbl": 3014380001,
-    "development": "KINGSBOROUGH",
-    "dev_evictions": 12,
-    "dev_unitsres": 1264
-  },
-  {
-    "bbl": 3013440001,
-    "development": "KINGSBOROUGH",
-    "dev_evictions": 12,
-    "dev_unitsres": 1264
-  },
-  {
-    "bbl": 3014630041,
-    "development": "PROSPECT PLAZA II",
-    "dev_evictions": 2,
-    "dev_unitsres": 149
-  },
-  {
-    "bbl": 3014630016,
-    "development": "PROSPECT PLAZA II",
-    "dev_evictions": 2,
-    "dev_unitsres": 149
-  },
-  {
-    "bbl": 1003960010,
-    "development": "CAMPOS PLAZA II",
-    "dev_evictions": 0,
-    "dev_unitsres": 616
-  },
-  {
-    "bbl": 2035730001,
-    "development": "CASTLE HILL",
-    "dev_evictions": 1,
-    "dev_unitsres": 2033
-  },
-  {
-    "bbl": 2035700001,
-    "development": "CASTLE HILL",
-    "dev_evictions": 1,
-    "dev_unitsres": 2033
-  },
-  {
-    "bbl": 2035370001,
-    "development": "CASTLE HILL",
-    "dev_evictions": 1,
-    "dev_unitsres": 2033
-  },
-  {
-    "bbl": 2035340001,
-    "development": "CASTLE HILL",
-    "dev_evictions": 1,
-    "dev_unitsres": 2033
-  },
-  {
-    "bbl": 3031290001,
-    "development": "BUSHWICK",
-    "dev_evictions": 3,
-    "dev_unitsres": 1220
-  },
-  {
-    "bbl": 3031050109,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3031050001,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3030960030,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3030960014,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3030960001,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3030890134,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3030800070,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3030800050,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3030800040,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3030800020,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 3030800010,
-    "development": "BORINQUEN PLAZA I",
-    "dev_evictions": 0,
-    "dev_unitsres": 699
-  },
-  {
-    "bbl": 1017570020,
-    "development": "LINCOLN",
-    "dev_evictions": 11,
-    "dev_unitsres": 1237
-  },
-  {
-    "bbl": 1017570001,
-    "development": "LINCOLN",
-    "dev_evictions": 11,
-    "dev_unitsres": 1237
-  },
-  {
-    "bbl": 1003380001,
-    "development": "GOMPERS",
-    "dev_evictions": 1,
-    "dev_unitsres": 711
-  },
-  {
-    "bbl": 1016990001,
-    "development": "WILSON",
-    "dev_evictions": 3,
-    "dev_unitsres": 398
-  },
-  {
-    "bbl": 3020500001,
-    "development": "INGERSOLL",
-    "dev_evictions": 13,
-    "dev_unitsres": 1142
-  },
-  {
-    "bbl": 3020340001,
-    "development": "INGERSOLL",
-    "dev_evictions": 13,
-    "dev_unitsres": 1142
-  },
-  {
-    "bbl": 3020250150,
-    "development": "INGERSOLL",
-    "dev_evictions": 13,
-    "dev_unitsres": 1142
-  },
-  {
-    "bbl": 1016100023,
-    "development": "CARVER",
-    "dev_evictions": 6,
-    "dev_unitsres": 1254
-  },
-  {
-    "bbl": 1016080023,
-    "development": "CARVER",
-    "dev_evictions": 6,
-    "dev_unitsres": 1254
-  },
-  {
-    "bbl": 1016050024,
-    "development": "CARVER",
-    "dev_evictions": 6,
-    "dev_unitsres": 1254
-  },
-  {
-    "bbl": 1020680046,
-    "development": "AUDUBON",
-    "dev_evictions": 0,
-    "dev_unitsres": 168
-  },
-  {
-    "bbl": 1012070050,
-    "development": "REHAB PROGRAM (WISE REHAB)",
-    "dev_evictions": 0,
-    "dev_unitsres": 40
-  },
-  {
-    "bbl": 3030810080,
-    "development": "BORINQUEN PLAZA II",
-    "dev_evictions": 0,
-    "dev_unitsres": 441
-  },
-  {
-    "bbl": 3030810075,
-    "development": "BORINQUEN PLAZA II",
-    "dev_evictions": 0,
-    "dev_unitsres": 441
-  },
-  {
-    "bbl": 3030810070,
-    "development": "BORINQUEN PLAZA II",
-    "dev_evictions": 0,
-    "dev_unitsres": 441
-  },
-  {
-    "bbl": 3030810060,
-    "development": "BORINQUEN PLAZA II",
-    "dev_evictions": 0,
-    "dev_unitsres": 441
-  },
-  {
-    "bbl": 3030810050,
-    "development": "BORINQUEN PLAZA II",
-    "dev_evictions": 0,
-    "dev_unitsres": 441
-  },
-  {
-    "bbl": 3030810040,
-    "development": "BORINQUEN PLAZA II",
-    "dev_evictions": 0,
-    "dev_unitsres": 441
-  },
-  {
-    "bbl": 3030810035,
-    "development": "BORINQUEN PLAZA II",
-    "dev_evictions": 0,
-    "dev_unitsres": 441
-  },
-  {
-    "bbl": 3030810001,
-    "development": "BORINQUEN PLAZA II",
-    "dev_evictions": 0,
-    "dev_unitsres": 441
-  },
-  {
-    "bbl": 3033240019,
-    "development": "HOPE GARDENS",
-    "dev_evictions": 0,
-    "dev_unitsres": 436
-  },
-  {
-    "bbl": 3033150001,
-    "development": "HOPE GARDENS",
-    "dev_evictions": 0,
-    "dev_unitsres": 436
-  },
-  {
-    "bbl": 3034150039,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3034100033,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3034100001,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3034090032,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3034030001,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3032970001,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3032960046,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3032860001,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3032850049,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3032760001,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
-  },
-  {
-    "bbl": 3032750047,
-    "development": "BUSHWICK II (GROUPS A & C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 300
+    "dev_unitsres": 114
   },
   {
     "bbl": 5032430100,
@@ -5454,370 +996,856 @@
     "dev_unitsres": 422
   },
   {
-    "bbl": 1019880031,
-    "development": "MANHATTANVILLE REHAB (GROUP 2)",
-    "dev_evictions": 0,
-    "dev_unitsres": 46
+    "bbl": 2035510001,
+    "development": "SOUNDVIEW",
+    "dev_evictions": 12,
+    "dev_unitsres": 1259
   },
   {
-    "bbl": 1019880022,
-    "development": "MANHATTANVILLE REHAB (GROUP 2)",
-    "dev_evictions": 0,
-    "dev_unitsres": 46
+    "bbl": 2035150001,
+    "development": "SOUNDVIEW",
+    "dev_evictions": 12,
+    "dev_unitsres": 1259
   },
   {
-    "bbl": 1019880020,
-    "development": "MANHATTANVILLE REHAB (GROUP 2)",
-    "dev_evictions": 0,
-    "dev_unitsres": 46
+    "bbl": 2037300001,
+    "development": "SOTOMAYOR HOUSES",
+    "dev_evictions": 4,
+    "dev_unitsres": 1506
   },
   {
-    "bbl": 3035120051,
-    "development": "HOWARD AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 150
+    "bbl": 2037250001,
+    "development": "SOTOMAYOR HOUSES",
+    "dev_evictions": 4,
+    "dev_unitsres": 1506
   },
   {
-    "bbl": 3035120021,
-    "development": "HOWARD AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 150
+    "bbl": 2037230001,
+    "development": "SOTOMAYOR HOUSES",
+    "dev_evictions": 4,
+    "dev_unitsres": 1506
   },
   {
-    "bbl": 3035110046,
-    "development": "HOWARD AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 150
+    "bbl": 1001110100,
+    "development": "SMITH",
+    "dev_evictions": 6,
+    "dev_unitsres": 1934
   },
   {
-    "bbl": 3035110022,
-    "development": "HOWARD AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 150
+    "bbl": 4097610036,
+    "development": "SHELTON HOUSE",
+    "dev_evictions": "",
+    "dev_unitsres": 156
   },
   {
-    "bbl": 3035110013,
-    "development": "HOWARD AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 150
+    "bbl": 3074051001,
+    "development": "SHEEPSHEAD BAY",
+    "dev_evictions": 5,
+    "dev_unitsres": 1056
   },
   {
-    "bbl": 1017690005,
-    "development": "UPACA (SITE 5)",
-    "dev_evictions": 1,
-    "dev_unitsres": 200
+    "bbl": 3073870001,
+    "development": "SHEEPSHEAD BAY",
+    "dev_evictions": 5,
+    "dev_unitsres": 1056
   },
   {
-    "bbl": 1021060320,
-    "development": "RANGEL",
-    "dev_evictions": 0,
-    "dev_unitsres": 984
+    "bbl": 1003510001,
+    "development": "SEWARD PARK EXTENSION",
+    "dev_evictions": "",
+    "dev_unitsres": 362
   },
   {
-    "bbl": 2024340080,
-    "development": "CLAREMONT REHAB (GROUP 3)",
-    "dev_evictions": 1,
-    "dev_unitsres": 117
+    "bbl": 1003470080,
+    "development": "SEWARD PARK EXTENSION",
+    "dev_evictions": "",
+    "dev_unitsres": 362
   },
   {
-    "bbl": 2024340074,
-    "development": "CLAREMONT REHAB (GROUP 3)",
-    "dev_evictions": 1,
-    "dev_unitsres": 117
-  },
-  {
-    "bbl": 2024280015,
-    "development": "CLAREMONT REHAB (GROUP 3)",
-    "dev_evictions": 1,
-    "dev_unitsres": 117
-  },
-  {
-    "bbl": 2024280009,
-    "development": "CLAREMONT REHAB (GROUP 3)",
-    "dev_evictions": 1,
-    "dev_unitsres": 117
-  },
-  {
-    "bbl": 2024280004,
-    "development": "CLAREMONT REHAB (GROUP 3)",
-    "dev_evictions": 1,
-    "dev_unitsres": 117
-  },
-  {
-    "bbl": 2029110001,
-    "development": "MORRIS II",
-    "dev_evictions": 10,
-    "dev_unitsres": 802
-  },
-  {
-    "bbl": 2029020036,
-    "development": "MORRIS II",
-    "dev_evictions": 10,
-    "dev_unitsres": 802
-  },
-  {
-    "bbl": 1009330025,
-    "development": "344 EAST 28TH STREET",
+    "bbl": 2028770001,
+    "development": "SEDGWICK",
     "dev_evictions": 3,
-    "dev_unitsres": 225
+    "dev_unitsres": 5502
   },
   {
-    "bbl": 1002450001,
-    "development": "TWO BRIDGES URA (SITE 7)",
+    "bbl": 3014920006,
+    "development": "SARATOGA VILLAGE",
+    "dev_evictions": "",
+    "dev_unitsres": 125
+  },
+  {
+    "bbl": 3014920001,
+    "development": "SARATOGA VILLAGE",
+    "dev_evictions": "",
+    "dev_unitsres": 125
+  },
+  {
+    "bbl": 1020110009,
+    "development": "SAMUEL (MHOP) III",
+    "dev_evictions": "",
+    "dev_unitsres": 10
+  },
+  {
+    "bbl": 1020070042,
+    "development": "SAMUEL (MHOP) II",
+    "dev_evictions": "",
+    "dev_unitsres": 10
+  },
+  {
+    "bbl": 1020090004,
+    "development": "SAMUEL (MHOP) I",
+    "dev_evictions": "",
+    "dev_unitsres": 53
+  },
+  {
+    "bbl": 1020090003,
+    "development": "SAMUEL (MHOP) I",
+    "dev_evictions": "",
+    "dev_unitsres": 53
+  },
+  {
+    "bbl": 1020090001,
+    "development": "SAMUEL (MHOP) I",
+    "dev_evictions": "",
+    "dev_unitsres": 53
+  },
+  {
+    "bbl": 1020070057,
+    "development": "SAMUEL (MHOP) I",
+    "dev_evictions": "",
+    "dev_unitsres": 53
+  },
+  {
+    "bbl": 1020070056,
+    "development": "SAMUEL (MHOP) I",
+    "dev_evictions": "",
+    "dev_unitsres": 53
+  },
+  {
+    "bbl": 1020150005,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020130026,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020130024,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020130022,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020130018,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020130016,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020130014,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120064,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120063,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120061,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120058,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120056,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120052,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120025,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120023,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120020,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120018,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120015,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120014,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120011,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120009,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120008,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120006,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120003,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020120001,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110063,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110061,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110033,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110031,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110022,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110015,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110014,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110013,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110011,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110008,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110007,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020110001,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020090064,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020090063,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020090044,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020070045,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020070044,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1020070043,
+    "development": "SAMUEL (CITY)",
+    "dev_evictions": 5,
+    "dev_unitsres": 751
+  },
+  {
+    "bbl": 1019330050,
+    "development": "SAINT NICHOLAS",
+    "dev_evictions": 5,
+    "dev_unitsres": 1527
+  },
+  {
+    "bbl": 1019330001,
+    "development": "SAINT NICHOLAS",
+    "dev_evictions": 5,
+    "dev_unitsres": 1527
+  },
+  {
+    "bbl": 2026280001,
+    "development": "SAINT MARY'S PARK",
+    "dev_evictions": 4,
+    "dev_unitsres": 1478
+  },
+  {
+    "bbl": 2026230135,
+    "development": "SAINT MARY'S PARK",
+    "dev_evictions": 4,
+    "dev_unitsres": 1478
+  },
+  {
+    "bbl": 2035980017,
+    "development": "SACK WERN",
     "dev_evictions": 1,
-    "dev_unitsres": 250
+    "dev_unitsres": 351
   },
   {
-    "bbl": 2057020001,
-    "development": "MARBLE HILL",
+    "bbl": 2035940001,
+    "development": "SACK WERN",
     "dev_evictions": 1,
-    "dev_unitsres": 619
+    "dev_unitsres": 351
   },
   {
-    "bbl": 2032650001,
-    "development": "MARBLE HILL",
+    "bbl": 2035930001,
+    "development": "SACK WERN",
     "dev_evictions": 1,
-    "dev_unitsres": 619
+    "dev_unitsres": 351
   },
   {
-    "bbl": 2022150623,
-    "development": "MARBLE HILL",
+    "bbl": 3045940064,
+    "development": "RUTLAND TOWERS",
     "dev_evictions": 1,
-    "dev_unitsres": 619
+    "dev_unitsres": 60
   },
   {
-    "bbl": 2022150116,
-    "development": "MARBLE HILL",
+    "bbl": 1002550001,
+    "development": "RUTGERS",
+    "dev_evictions": 3,
+    "dev_unitsres": 721
+  },
+  {
+    "bbl": 3015960001,
+    "development": "ROOSEVELT II",
+    "dev_evictions": "",
+    "dev_unitsres": 1799
+  },
+  {
+    "bbl": 3015950024,
+    "development": "ROOSEVELT II",
+    "dev_evictions": "",
+    "dev_unitsres": 1799
+  },
+  {
+    "bbl": 3015950001,
+    "development": "ROOSEVELT II",
+    "dev_evictions": "",
+    "dev_unitsres": 1799
+  },
+  {
+    "bbl": 3016010024,
+    "development": "ROOSEVELT I",
+    "dev_evictions": "",
+    "dev_unitsres": 891
+  },
+  {
+    "bbl": 3015980001,
+    "development": "ROOSEVELT I",
+    "dev_evictions": "",
+    "dev_unitsres": 891
+  },
+  {
+    "bbl": 3015970001,
+    "development": "ROOSEVELT I",
+    "dev_evictions": "",
+    "dev_unitsres": 891
+  },
+  {
+    "bbl": 1017770005,
+    "development": "ROBINSON",
+    "dev_evictions": "",
+    "dev_unitsres": 56
+  },
+  {
+    "bbl": 1014450023,
+    "development": "ROBBINS PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 1003620001,
+    "development": "RIIS II",
+    "dev_evictions": "",
+    "dev_unitsres": 586
+  },
+  {
+    "bbl": 1003670001,
+    "development": "RIIS",
+    "dev_evictions": 4,
+    "dev_unitsres": 1204
+  },
+  {
+    "bbl": 1003620010,
+    "development": "RIIS",
+    "dev_evictions": 4,
+    "dev_unitsres": 1204
+  },
+  {
+    "bbl": 5000520078,
+    "development": "RICHMOND TERRACE",
+    "dev_evictions": 4,
+    "dev_unitsres": 502
+  },
+  {
+    "bbl": 5000510030,
+    "development": "RICHMOND TERRACE",
+    "dev_evictions": 4,
+    "dev_unitsres": 502
+  },
+  {
+    "bbl": 5000510001,
+    "development": "RICHMOND TERRACE",
+    "dev_evictions": 4,
+    "dev_unitsres": 502
+  },
+  {
+    "bbl": 3047950016,
+    "development": "REID APARTMENTS",
     "dev_evictions": 1,
-    "dev_unitsres": 619
+    "dev_unitsres": 230
   },
   {
-    "bbl": 3037770001,
-    "development": "VAN DYKE I",
-    "dev_evictions": 7,
-    "dev_unitsres": 1153
-  },
-  {
-    "bbl": 3037600001,
-    "development": "VAN DYKE I",
-    "dev_evictions": 7,
-    "dev_unitsres": 1153
-  },
-  {
-    "bbl": 3034890001,
-    "development": "HOWARD",
-    "dev_evictions": 6,
-    "dev_unitsres": 815
-  },
-  {
-    "bbl": 3043970001,
-    "development": "LINDEN",
-    "dev_evictions": 6,
-    "dev_unitsres": 1579
-  },
-  {
-    "bbl": 3043930001,
-    "development": "LINDEN",
-    "dev_evictions": 6,
-    "dev_unitsres": 1579
-  },
-  {
-    "bbl": 3043750050,
-    "development": "LINDEN",
-    "dev_evictions": 6,
-    "dev_unitsres": 1579
-  },
-  {
-    "bbl": 3043710001,
-    "development": "LINDEN",
-    "dev_evictions": 6,
-    "dev_unitsres": 1579
+    "bbl": 1012070050,
+    "development": "REHAB PROGRAM (WISE REHAB)",
+    "dev_evictions": "",
+    "dev_unitsres": 40
   },
   {
     "bbl": 1019230029,
     "development": "REHAB PROGRAM (TAFT REHABS)",
-    "dev_evictions": 3,
+    "dev_evictions": 2,
     "dev_unitsres": 120
   },
   {
     "bbl": 1018270042,
     "development": "REHAB PROGRAM (TAFT REHABS)",
-    "dev_evictions": 3,
+    "dev_evictions": 2,
     "dev_unitsres": 120
   },
   {
     "bbl": 1017180001,
     "development": "REHAB PROGRAM (TAFT REHABS)",
-    "dev_evictions": 3,
+    "dev_evictions": 2,
     "dev_unitsres": 120
   },
   {
-    "bbl": 3074080001,
-    "development": "NOSTRAND",
-    "dev_evictions": 4,
-    "dev_unitsres": 1148
+    "bbl": 1018750057,
+    "development": "REHAB PROGRAM (DOUGLASS REHABS)",
+    "dev_evictions": "",
+    "dev_unitsres": 112
   },
   {
-    "bbl": 3073890001,
-    "development": "NOSTRAND",
-    "dev_evictions": 4,
-    "dev_unitsres": 1148
+    "bbl": 1018750009,
+    "development": "REHAB PROGRAM (DOUGLASS REHABS)",
+    "dev_evictions": "",
+    "dev_unitsres": 112
   },
   {
-    "bbl": 2025480001,
-    "development": "MILL BROOK",
+    "bbl": 1018750005,
+    "development": "REHAB PROGRAM (DOUGLASS REHABS)",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 1018730009,
+    "development": "REHAB PROGRAM (DOUGLASS REHABS)",
+    "dev_evictions": "",
+    "dev_unitsres": 112
+  },
+  {
+    "bbl": 4041700001,
+    "development": "REHAB PROGRAM (COLLEGE POINT)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4155010002,
+    "development": "REDFERN",
+    "dev_evictions": 8,
+    "dev_unitsres": 604
+  },
+  {
+    "bbl": 3005570001,
+    "development": "RED HOOK WEST",
+    "dev_evictions": 2,
+    "dev_unitsres": 1048
+  },
+  {
+    "bbl": 3005330001,
+    "development": "RED HOOK WEST",
+    "dev_evictions": 2,
+    "dev_unitsres": 1048
+  },
+  {
+    "bbl": 3005380001,
+    "development": "RED HOOK EAST",
+    "dev_evictions": 2,
+    "dev_unitsres": 1836
+  },
+  {
+    "bbl": 4005590002,
+    "development": "RAVENSWOOD",
     "dev_evictions": 6,
-    "dev_unitsres": 1945
+    "dev_unitsres": 1974
   },
   {
-    "bbl": 2022630019,
-    "development": "MILL BROOK",
+    "bbl": 4005230002,
+    "development": "RAVENSWOOD",
     "dev_evictions": 6,
-    "dev_unitsres": 1945
+    "dev_unitsres": 1974
   },
   {
-    "bbl": 5005450100,
-    "development": "STAPLETON",
-    "dev_evictions": 5,
-    "dev_unitsres": 693
+    "bbl": 4003350002,
+    "development": "RAVENSWOOD",
+    "dev_evictions": 6,
+    "dev_unitsres": 1974
   },
   {
-    "bbl": 3037090017,
-    "development": "GLENMORE PLAZA",
-    "dev_evictions": 2,
-    "dev_unitsres": 468
+    "bbl": 4003320002,
+    "development": "RAVENSWOOD",
+    "dev_evictions": 6,
+    "dev_unitsres": 1974
   },
   {
-    "bbl": 3037090016,
-    "development": "GLENMORE PLAZA",
-    "dev_evictions": 2,
-    "dev_unitsres": 468
-  },
-  {
-    "bbl": 3037090001,
-    "development": "GLENMORE PLAZA",
-    "dev_evictions": 2,
-    "dev_unitsres": 468
-  },
-  {
-    "bbl": 3035070001,
-    "development": "GLENMORE PLAZA",
-    "dev_evictions": 2,
-    "dev_unitsres": 468
-  },
-  {
-    "bbl": 1020370011,
-    "development": "HARLEM RIVER",
-    "dev_evictions": 1,
-    "dev_unitsres": 573
-  },
-  {
-    "bbl": 1020160060,
-    "development": "HARLEM RIVER",
-    "dev_evictions": 1,
-    "dev_unitsres": 573
-  },
-  {
-    "bbl": 1012190001,
-    "development": "WSUR (SITE C) 589 AMSTERDAM AVENUE",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
-  },
-  {
-    "bbl": 2045810001,
-    "development": "EASTCHESTER GARDENS",
+    "bbl": 1021060320,
+    "development": "RANGEL",
     "dev_evictions": 3,
-    "dev_unitsres": 877
+    "dev_unitsres": 984
   },
   {
-    "bbl": 3079780001,
-    "development": "GLENWOOD",
+    "bbl": 2055680100,
+    "development": "RANDALL AVENUE-BALCOM AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 230
+  },
+  {
+    "bbl": 2055680050,
+    "development": "RANDALL AVENUE-BALCOM AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 230
+  },
+  {
+    "bbl": 2055680001,
+    "development": "RANDALL AVENUE-BALCOM AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 230
+  },
+  {
+    "bbl": 3035080054,
+    "development": "RALPH AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 124
+  },
+  {
+    "bbl": 3035080050,
+    "development": "RALPH AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 124
+  },
+  {
+    "bbl": 3035080046,
+    "development": "RALPH AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 124
+  },
+  {
+    "bbl": 3035080042,
+    "development": "RALPH AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 124
+  },
+  {
+    "bbl": 3035080041,
+    "development": "RALPH AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 124
+  },
+  {
+    "bbl": 3035080038,
+    "development": "RALPH AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 124
+  },
+  {
+    "bbl": 3035080036,
+    "development": "RALPH AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 124
+  },
+  {
+    "bbl": 3035080034,
+    "development": "RALPH AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 124
+  },
+  {
+    "bbl": 4004770049,
+    "development": "QUEENSBRIDGE SOUTH",
     "dev_evictions": 6,
-    "dev_unitsres": 1188
+    "dev_unitsres": 1607
   },
   {
-    "bbl": 2022910030,
-    "development": "BETANCES VI",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
+    "bbl": 4004650100,
+    "development": "QUEENSBRIDGE SOUTH",
+    "dev_evictions": 6,
+    "dev_unitsres": 1607
   },
   {
-    "bbl": 2022910001,
-    "development": "BETANCES VI",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
+    "bbl": 4004650001,
+    "development": "QUEENSBRIDGE SOUTH",
+    "dev_evictions": 6,
+    "dev_unitsres": 1607
   },
   {
-    "bbl": 2022720119,
-    "development": "BETANCES VI",
-    "dev_evictions": 0,
-    "dev_unitsres": 158
+    "bbl": 4004700200,
+    "development": "QUEENSBRIDGE NORTH",
+    "dev_evictions": 8,
+    "dev_unitsres": 1542
   },
   {
-    "bbl": 1003870144,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 4004700100,
+    "development": "QUEENSBRIDGE NORTH",
+    "dev_evictions": 8,
+    "dev_unitsres": 1542
   },
   {
-    "bbl": 1003870131,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 4004700001,
+    "development": "QUEENSBRIDGE NORTH",
+    "dev_evictions": 8,
+    "dev_unitsres": 1542
   },
   {
-    "bbl": 1003870129,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 1020080013,
+    "development": "PUBLIC SCHOOL 139 (CONVERSION)",
+    "dev_evictions": "",
+    "dev_unitsres": 126
   },
   {
-    "bbl": 1003870020,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 2026780068,
+    "development": "PSS GRANDPARENT FAMILY APARTMENTS",
+    "dev_evictions": "",
+    "dev_unitsres": 51
   },
   {
-    "bbl": 1003750063,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 3014630041,
+    "development": "PROSPECT PLAZA II",
+    "dev_evictions": 4,
+    "dev_unitsres": 149
   },
   {
-    "bbl": 1003750045,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 3014630016,
+    "development": "PROSPECT PLAZA II",
+    "dev_evictions": 4,
+    "dev_unitsres": 149
   },
   {
-    "bbl": 1003750035,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 4067920030,
+    "development": "POMONOK",
+    "dev_evictions": 14,
+    "dev_unitsres": 2080
   },
   {
-    "bbl": 1003750034,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 4067920001,
+    "development": "POMONOK",
+    "dev_evictions": 14,
+    "dev_unitsres": 2080
   },
   {
-    "bbl": 1003750033,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 1021060003,
+    "development": "POLO GROUNDS TOWERS",
+    "dev_evictions": 6,
+    "dev_unitsres": 1614
   },
   {
-    "bbl": 1003750001,
-    "development": "LOWER EAST SIDE II",
-    "dev_evictions": 2,
-    "dev_unitsres": 213
+    "bbl": 3045100001,
+    "development": "PINK",
+    "dev_evictions": 11,
+    "dev_unitsres": 1919
   },
   {
-    "bbl": 3016880001,
-    "development": "BREVOORT",
+    "bbl": 3045080001,
+    "development": "PINK",
+    "dev_evictions": 11,
+    "dev_unitsres": 1919
+  },
+  {
+    "bbl": 3044880001,
+    "development": "PINK",
+    "dev_evictions": 11,
+    "dev_unitsres": 1919
+  },
+  {
+    "bbl": 3044860001,
+    "development": "PINK",
+    "dev_evictions": 11,
+    "dev_unitsres": 1919
+  },
+  {
+    "bbl": 3043690001,
+    "development": "PENNSYLVANIA AVENUE-WORTMAN AVENUE",
     "dev_evictions": 1,
-    "dev_unitsres": 896
+    "dev_unitsres": 336
+  },
+  {
+    "bbl": 2044440001,
+    "development": "PELHAM PARKWAY",
+    "dev_evictions": 1,
+    "dev_unitsres": 1266
+  },
+  {
+    "bbl": 2043630001,
+    "development": "PELHAM PARKWAY",
+    "dev_evictions": 1,
+    "dev_unitsres": 1266
+  },
+  {
+    "bbl": 2043490001,
+    "development": "PELHAM PARKWAY",
+    "dev_evictions": 1,
+    "dev_unitsres": 1266
+  },
+  {
+    "bbl": 2023250001,
+    "development": "PATTERSON",
+    "dev_evictions": 24,
+    "dev_unitsres": 1796
+  },
+  {
+    "bbl": 2023240001,
+    "development": "PATTERSON",
+    "dev_evictions": 24,
+    "dev_unitsres": 1796
+  },
+  {
+    "bbl": 2045420100,
+    "development": "PARKSIDE",
+    "dev_evictions": 1,
+    "dev_unitsres": 10005
+  },
+  {
+    "bbl": 2045070048,
+    "development": "PARKSIDE",
+    "dev_evictions": 1,
+    "dev_unitsres": 10005
   },
   {
     "bbl": 3013790043,
@@ -5874,586 +1902,328 @@
     "dev_unitsres": 138
   },
   {
-    "bbl": 1003070001,
-    "development": "45 ALLEN STREET",
-    "dev_evictions": 0,
-    "dev_unitsres": 104
+    "bbl": 1017710066,
+    "development": "PARK AVENUE-EAST 122ND, 123RD STREETS",
+    "dev_evictions": "",
+    "dev_unitsres": 78
   },
   {
-    "bbl": 3016360024,
-    "development": "STUYVESANT GARDENS II",
-    "dev_evictions": 0,
-    "dev_unitsres": 150
+    "bbl": 1017710065,
+    "development": "PARK AVENUE-EAST 122ND, 123RD STREETS",
+    "dev_evictions": "",
+    "dev_unitsres": 78
   },
   {
-    "bbl": 3016310034,
-    "development": "STUYVESANT GARDENS II",
-    "dev_evictions": 0,
-    "dev_unitsres": 150
+    "bbl": 1017710059,
+    "development": "PARK AVENUE-EAST 122ND, 123RD STREETS",
+    "dev_evictions": "",
+    "dev_unitsres": 78
   },
   {
-    "bbl": 1010840009,
-    "development": "HARBORVIEW TERRACE",
-    "dev_evictions": 0,
-    "dev_unitsres": 377
+    "bbl": 1017710010,
+    "development": "PARK AVENUE-EAST 122ND, 123RD STREETS",
+    "dev_evictions": "",
+    "dev_unitsres": 78
   },
   {
-    "bbl": 1010830015,
-    "development": "HARBORVIEW TERRACE",
-    "dev_evictions": 0,
-    "dev_unitsres": 377
+    "bbl": 3033400020,
+    "development": "PALMETTO GARDENS",
+    "dev_evictions": "",
+    "dev_unitsres": 115
   },
   {
-    "bbl": 3034960013,
-    "development": "GARVEY (GROUP A)",
-    "dev_evictions": 3,
-    "dev_unitsres": 318
+    "bbl": 3014390010,
+    "development": "OCEAN HILL-BROWNSVILLE",
+    "dev_evictions": "",
+    "dev_unitsres": 126
   },
   {
-    "bbl": 3034940010,
-    "development": "GARVEY (GROUP A)",
-    "dev_evictions": 3,
-    "dev_unitsres": 318
+    "bbl": 3014390001,
+    "development": "OCEAN HILL-BROWNSVILLE",
+    "dev_evictions": "",
+    "dev_unitsres": 126
   },
   {
-    "bbl": 3021570022,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "bbl": 3014310043,
+    "development": "OCEAN HILL-BROWNSVILLE",
+    "dev_evictions": "",
+    "dev_unitsres": 126
+  },
+  {
+    "bbl": 3014310039,
+    "development": "OCEAN HILL-BROWNSVILLE",
+    "dev_evictions": "",
+    "dev_unitsres": 126
+  },
+  {
+    "bbl": 3014310037,
+    "development": "OCEAN HILL-BROWNSVILLE",
+    "dev_evictions": "",
+    "dev_unitsres": 126
+  },
+  {
+    "bbl": 3015290001,
+    "development": "OCEAN HILL APARTMENTS",
     "dev_evictions": 2,
-    "dev_unitsres": 150
+    "dev_unitsres": 238
   },
   {
-    "bbl": 3021570021,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "bbl": 3015280033,
+    "development": "OCEAN HILL APARTMENTS",
     "dev_evictions": 2,
-    "dev_unitsres": 150
+    "dev_unitsres": 238
   },
   {
-    "bbl": 3021570020,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
+    "bbl": 4158920001,
+    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
+    "dev_evictions": "",
+    "dev_unitsres": 418
   },
   {
-    "bbl": 3021570019,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
+    "bbl": 4158900066,
+    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
+    "dev_evictions": "",
+    "dev_unitsres": 418
   },
   {
-    "bbl": 3021570006,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
+    "bbl": 4158900064,
+    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
+    "dev_evictions": "",
+    "dev_unitsres": 418
   },
   {
-    "bbl": 3021570005,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
+    "bbl": 4158900062,
+    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
+    "dev_evictions": "",
+    "dev_unitsres": 418
   },
   {
-    "bbl": 3021570004,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
+    "bbl": 4158900058,
+    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
+    "dev_evictions": "",
+    "dev_unitsres": 418
   },
   {
-    "bbl": 3021570003,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
+    "bbl": 4158900055,
+    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
+    "dev_evictions": "",
+    "dev_unitsres": 418
   },
   {
-    "bbl": 3021570002,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
+    "bbl": 4158900054,
+    "development": "OCEAN BAY APARTMENTS (OCEANSIDE)",
+    "dev_evictions": "",
+    "dev_unitsres": 418
   },
   {
-    "bbl": 3021570001,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021560022,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021560021,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021560007,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450036,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450035,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450034,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450033,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450032,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450031,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450030,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450029,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450028,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450026,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450018,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450017,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450008,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 3021450001,
-    "development": "BERRY STREET-SOUTH 9TH STREET",
-    "dev_evictions": 2,
-    "dev_unitsres": 150
-  },
-  {
-    "bbl": 4159020046,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4157820054,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4157820051,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4126700008,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4126650031,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4126340029,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4124690156,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4122080005,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4121700023,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4119760022,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4119750032,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4119600020,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4117810285,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4112080049,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4111200001,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4110990076,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4109660222,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4109220017,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4102840018,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 4100190011,
-    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
-    "dev_evictions": 1,
-    "dev_unitsres": 24
-  },
-  {
-    "bbl": 1007170019,
-    "development": "FULTON",
-    "dev_evictions": 1,
-    "dev_unitsres": 974
-  },
-  {
-    "bbl": 1007160017,
-    "development": "FULTON",
-    "dev_evictions": 1,
-    "dev_unitsres": 974
-  },
-  {
-    "bbl": 1007150010,
-    "development": "FULTON",
-    "dev_evictions": 1,
-    "dev_unitsres": 974
-  },
-  {
-    "bbl": 1007140031,
-    "development": "FULTON",
-    "dev_evictions": 1,
-    "dev_unitsres": 974
-  },
-  {
-    "bbl": 3070590026,
-    "development": "CONEY ISLAND I (SITE 1B)",
-    "dev_evictions": 1,
-    "dev_unitsres": 193
-  },
-  {
-    "bbl": 3048180136,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180135,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180134,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180133,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180033,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180031,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180030,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180029,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180028,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180027,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180026,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3048180025,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3013300012,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3013300011,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3013300010,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3013300009,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3013300008,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 3013300007,
-    "development": "FENIMORE-LEFFERTS",
-    "dev_evictions": 0,
-    "dev_unitsres": 36
-  },
-  {
-    "bbl": 1021210051,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1021150060,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1021110042,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1021110041,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1021110040,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1021110038,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1021110006,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1021110005,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1021100071,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE III",
-    "dev_evictions": 0,
-    "dev_unitsres": 112
-  },
-  {
-    "bbl": 1019870017,
-    "development": "MANHATTANVILLE REHAB (GROUP 3)",
-    "dev_evictions": 0,
-    "dev_unitsres": 51
-  },
-  {
-    "bbl": 2025270032,
-    "development": "HIGHBRIDGE GARDENS",
+    "bbl": 3070480015,
+    "development": "O'DWYER GARDENS",
     "dev_evictions": 4,
-    "dev_unitsres": 700
+    "dev_unitsres": 573
+  },
+  {
+    "bbl": 3070470014,
+    "development": "O'DWYER GARDENS",
+    "dev_evictions": 4,
+    "dev_unitsres": 573
+  },
+  {
+    "bbl": 3074080001,
+    "development": "NOSTRAND",
+    "dev_evictions": 6,
+    "dev_unitsres": 1148
+  },
+  {
+    "bbl": 3073890001,
+    "development": "NOSTRAND",
+    "dev_evictions": 6,
+    "dev_unitsres": 1148
+  },
+  {
+    "bbl": 5028320068,
+    "development": "NEW LANE AREA",
+    "dev_evictions": "",
+    "dev_unitsres": 277
   },
   {
     "bbl": 2029440001,
     "development": "MURPHY",
-    "dev_evictions": 0,
+    "dev_evictions": "",
     "dev_unitsres": 281
   },
   {
-    "bbl": 2037370001,
-    "development": "1471 WATSON AVENUE",
+    "bbl": 2023060009,
+    "development": "MOTT HAVEN",
+    "dev_evictions": 9,
+    "dev_unitsres": 993
+  },
+  {
+    "bbl": 2023040001,
+    "development": "MOTT HAVEN",
+    "dev_evictions": 9,
+    "dev_unitsres": 993
+  },
+  {
+    "bbl": 2023030021,
+    "development": "MOTT HAVEN",
+    "dev_evictions": 9,
+    "dev_unitsres": 993
+  },
+  {
+    "bbl": 2024209078,
+    "development": "MORRISANIA AIR RIGHTS",
+    "dev_evictions": "",
+    "dev_unitsres": 666
+  },
+  {
+    "bbl": 2024209020,
+    "development": "MORRISANIA AIR RIGHTS",
+    "dev_evictions": "",
+    "dev_unitsres": 666
+  },
+  {
+    "bbl": 2024099059,
+    "development": "MORRISANIA AIR RIGHTS",
+    "dev_evictions": "",
+    "dev_unitsres": 666
+  },
+  {
+    "bbl": 2023900024,
+    "development": "MORRISANIA",
+    "dev_evictions": "",
+    "dev_unitsres": 206
+  },
+  {
+    "bbl": 1017490010,
+    "development": "MORRIS PARK SENIOR CITIZENS HOME",
+    "dev_evictions": "",
+    "dev_unitsres": 97
+  },
+  {
+    "bbl": 2029110001,
+    "development": "MORRIS II",
+    "dev_evictions": 3,
+    "dev_unitsres": 802
+  },
+  {
+    "bbl": 2029020036,
+    "development": "MORRIS II",
+    "dev_evictions": 3,
+    "dev_unitsres": 802
+  },
+  {
+    "bbl": 2029100001,
+    "development": "MORRIS I",
+    "dev_evictions": 11,
+    "dev_unitsres": 1085
+  },
+  {
+    "bbl": 2029010001,
+    "development": "MORRIS I",
+    "dev_evictions": 11,
+    "dev_unitsres": 1085
+  },
+  {
+    "bbl": 2025570083,
+    "development": "MOORE",
+    "dev_evictions": 2,
+    "dev_unitsres": 463
+  },
+  {
+    "bbl": 2036630001,
+    "development": "MONROE",
+    "dev_evictions": 9,
+    "dev_unitsres": 1103
+  },
+  {
+    "bbl": 2036370001,
+    "development": "MONROE",
+    "dev_evictions": 9,
+    "dev_unitsres": 1103
+  },
+  {
+    "bbl": 2023110001,
+    "development": "MITCHEL",
+    "dev_evictions": 3,
+    "dev_unitsres": 1731
+  },
+  {
+    "bbl": 2022980062,
+    "development": "MITCHEL",
+    "dev_evictions": 3,
+    "dev_unitsres": 1731
+  },
+  {
+    "bbl": 2022980040,
+    "development": "MITCHEL",
+    "dev_evictions": 3,
+    "dev_unitsres": 1731
+  },
+  {
+    "bbl": 2025480042,
+    "development": "MILL BROOK EXTENSION",
+    "dev_evictions": "",
+    "dev_unitsres": 125
+  },
+  {
+    "bbl": 2025480001,
+    "development": "MILL BROOK",
     "dev_evictions": 1,
-    "dev_unitsres": 100
+    "dev_unitsres": 1945
   },
   {
-    "bbl": 3017690078,
-    "development": "BEDFORD-STUYVESANT REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
+    "bbl": 2022630019,
+    "development": "MILL BROOK",
+    "dev_evictions": 1,
+    "dev_unitsres": 1945
   },
   {
-    "bbl": 3017690001,
-    "development": "BEDFORD-STUYVESANT REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
+    "bbl": 2041710024,
+    "development": "MIDDLETOWN PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 179
   },
   {
-    "bbl": 3017610063,
-    "development": "BEDFORD-STUYVESANT REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
+    "bbl": 1016730006,
+    "development": "METRO NORTH PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 268
   },
   {
-    "bbl": 3017610061,
-    "development": "BEDFORD-STUYVESANT REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
+    "bbl": 1016730001,
+    "development": "METRO NORTH PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 268
   },
   {
-    "bbl": 3017610045,
-    "development": "BEDFORD-STUYVESANT REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 80
+    "bbl": 1004290021,
+    "development": "MELTZER TOWER",
+    "dev_evictions": "",
+    "dev_unitsres": 120
   },
   {
-    "bbl": 3037450001,
-    "development": "LOW HOUSES",
-    "dev_evictions": 4,
-    "dev_unitsres": 667
+    "bbl": 2024130001,
+    "development": "MELROSE",
+    "dev_evictions": 1,
+    "dev_unitsres": 1023
   },
   {
-    "bbl": 3037270001,
-    "development": "LOW HOUSES",
-    "dev_evictions": 4,
-    "dev_unitsres": 667
+    "bbl": 2026380090,
+    "development": "MCKINLEY",
+    "dev_evictions": 3,
+    "dev_unitsres": 619
+  },
+  {
+    "bbl": 2026310011,
+    "development": "MCKINLEY",
+    "dev_evictions": 3,
+    "dev_unitsres": 619
+  },
+  {
+    "bbl": 1021160033,
+    "development": "MARSHALL PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 180
   },
   {
     "bbl": 3071400016,
@@ -6468,195 +2238,4425 @@
     "dev_unitsres": 1765
   },
   {
-    "bbl": 2022820057,
-    "development": "BETANCES II, 18",
-    "dev_evictions": 0,
-    "dev_unitsres": 100
+    "bbl": 5012480200,
+    "development": "MARINER'S HARBOR",
+    "dev_evictions": 6,
+    "dev_unitsres": 607
   },
   {
-    "bbl": 2030070036,
-    "development": "WEST FARMS ROAD REHAB",
-    "dev_evictions": 2,
-    "dev_unitsres": 252
+    "bbl": 5012450001,
+    "development": "MARINER'S HARBOR",
+    "dev_evictions": 6,
+    "dev_unitsres": 607
   },
   {
-    "bbl": 2027510033,
-    "development": "WEST FARMS ROAD REHAB",
-    "dev_evictions": 2,
-    "dev_unitsres": 252
+    "bbl": 3017980077,
+    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
+    "dev_evictions": "",
+    "dev_unitsres": 30
   },
   {
-    "bbl": 2027510030,
-    "development": "WEST FARMS ROAD REHAB",
-    "dev_evictions": 2,
-    "dev_unitsres": 252
+    "bbl": 3017980009,
+    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
+    "dev_evictions": "",
+    "dev_unitsres": 30
   },
   {
-    "bbl": 2027510015,
-    "development": "WEST FARMS ROAD REHAB",
-    "dev_evictions": 2,
-    "dev_unitsres": 252
+    "bbl": 3017980008,
+    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
+    "dev_evictions": "",
+    "dev_unitsres": 30
   },
   {
-    "bbl": 3030980001,
-    "development": "HYLAN",
-    "dev_evictions": 0,
-    "dev_unitsres": 205
+    "bbl": 3017980007,
+    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
+    "dev_evictions": "",
+    "dev_unitsres": 30
   },
   {
-    "bbl": 1021320106,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE IV (C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 40
+    "bbl": 3017980005,
+    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
+    "dev_evictions": "",
+    "dev_unitsres": 30
   },
   {
-    "bbl": 1021320084,
-    "development": "WASHINGTON HEIGHTS REHAB PHASE IV (C)",
-    "dev_evictions": 0,
-    "dev_unitsres": 40
+    "bbl": 3017980004,
+    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
+    "dev_evictions": "",
+    "dev_unitsres": 30
   },
   {
-    "bbl": 3043690001,
-    "development": "PENNSYLVANIA AVENUE-WORTMAN AVENUE",
+    "bbl": 3017980003,
+    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
+    "dev_evictions": "",
+    "dev_unitsres": 30
+  },
+  {
+    "bbl": 3017980002,
+    "development": "MARCY AVENUE-GREENE AVENUE SITE B",
+    "dev_evictions": "",
+    "dev_unitsres": 30
+  },
+  {
+    "bbl": 3017980020,
+    "development": "MARCY AVENUE-GREENE AVENUE SITE A",
+    "dev_evictions": "",
+    "dev_unitsres": 48
+  },
+  {
+    "bbl": 3017380001,
+    "development": "MARCY",
+    "dev_evictions": 5,
+    "dev_unitsres": 1372
+  },
+  {
+    "bbl": 3017190001,
+    "development": "MARCY",
+    "dev_evictions": 5,
+    "dev_unitsres": 1372
+  },
+  {
+    "bbl": 2057020001,
+    "development": "MARBLE HILL",
     "dev_evictions": 1,
-    "dev_unitsres": 336
+    "dev_unitsres": 619
   },
   {
-    "bbl": 2023900024,
-    "development": "MORRISANIA",
-    "dev_evictions": 4,
-    "dev_unitsres": 206
+    "bbl": 2032650001,
+    "development": "MARBLE HILL",
+    "dev_evictions": 1,
+    "dev_unitsres": 619
+  },
+  {
+    "bbl": 2022150623,
+    "development": "MARBLE HILL",
+    "dev_evictions": 1,
+    "dev_unitsres": 619
+  },
+  {
+    "bbl": 2022150116,
+    "development": "MARBLE HILL",
+    "dev_evictions": 1,
+    "dev_unitsres": 619
+  },
+  {
+    "bbl": 1019870017,
+    "development": "MANHATTANVILLE REHAB (GROUP 3)",
+    "dev_evictions": "",
+    "dev_unitsres": 51
+  },
+  {
+    "bbl": 1019880031,
+    "development": "MANHATTANVILLE REHAB (GROUP 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 46
+  },
+  {
+    "bbl": 1019880022,
+    "development": "MANHATTANVILLE REHAB (GROUP 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 46
+  },
+  {
+    "bbl": 1019880020,
+    "development": "MANHATTANVILLE REHAB (GROUP 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 46
+  },
+  {
+    "bbl": 1019840033,
+    "development": "MANHATTANVILLE",
+    "dev_evictions": 6,
+    "dev_unitsres": 1272
+  },
+  {
+    "bbl": 1019840001,
+    "development": "MANHATTANVILLE",
+    "dev_evictions": 6,
+    "dev_unitsres": 1272
+  },
+  {
+    "bbl": 1003890041,
+    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 60
+  },
+  {
+    "bbl": 1003890040,
+    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 60
+  },
+  {
+    "bbl": 1003890038,
+    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 60
+  },
+  {
+    "bbl": 1003890036,
+    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 60
+  },
+  {
+    "bbl": 1003890032,
+    "development": "LOWER EAST SIDE REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 60
+  },
+  {
+    "bbl": 1003780017,
+    "development": "LOWER EAST SIDE III",
+    "dev_evictions": "",
+    "dev_unitsres": 59
+  },
+  {
+    "bbl": 1003870144,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1003870131,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1003870129,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1003870020,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1003750063,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1003750045,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1003750035,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1003750034,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1003750033,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1003750001,
+    "development": "LOWER EAST SIDE II",
+    "dev_evictions": "",
+    "dev_unitsres": 213
+  },
+  {
+    "bbl": 1004210052,
+    "development": "LOWER EAST SIDE I INFILL",
+    "dev_evictions": "",
+    "dev_unitsres": 268
+  },
+  {
+    "bbl": 1004200062,
+    "development": "LOWER EAST SIDE I INFILL",
+    "dev_evictions": "",
+    "dev_unitsres": 268
+  },
+  {
+    "bbl": 1004160001,
+    "development": "LOWER EAST SIDE I INFILL",
+    "dev_evictions": "",
+    "dev_unitsres": 268
+  },
+  {
+    "bbl": 3037450001,
+    "development": "LOW HOUSES",
+    "dev_evictions": 1,
+    "dev_unitsres": 667
+  },
+  {
+    "bbl": 3037270001,
+    "development": "LOW HOUSES",
+    "dev_evictions": 1,
+    "dev_unitsres": 667
+  },
+  {
+    "bbl": 2027570080,
+    "development": "LONGFELLOW AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 75
+  },
+  {
+    "bbl": 2027570020,
+    "development": "LONGFELLOW AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 75
+  },
+  {
+    "bbl": 3037870001,
+    "development": "LONG ISLAND BAPTIST HOUSES",
+    "dev_evictions": "",
+    "dev_unitsres": 232
+  },
+  {
+    "bbl": 3037680018,
+    "development": "LONG ISLAND BAPTIST HOUSES",
+    "dev_evictions": "",
+    "dev_unitsres": 232
+  },
+  {
+    "bbl": 3037670036,
+    "development": "LONG ISLAND BAPTIST HOUSES",
+    "dev_evictions": "",
+    "dev_unitsres": 232
+  },
+  {
+    "bbl": 3037670032,
+    "development": "LONG ISLAND BAPTIST HOUSES",
+    "dev_evictions": "",
+    "dev_unitsres": 232
+  },
+  {
+    "bbl": 3037670027,
+    "development": "LONG ISLAND BAPTIST HOUSES",
+    "dev_evictions": "",
+    "dev_unitsres": 232
+  },
+  {
+    "bbl": 3043970001,
+    "development": "LINDEN",
+    "dev_evictions": 16,
+    "dev_unitsres": 1579
+  },
+  {
+    "bbl": 3043930001,
+    "development": "LINDEN",
+    "dev_evictions": 16,
+    "dev_unitsres": 1579
+  },
+  {
+    "bbl": 3043750050,
+    "development": "LINDEN",
+    "dev_evictions": 16,
+    "dev_unitsres": 1579
+  },
+  {
+    "bbl": 3043710001,
+    "development": "LINDEN",
+    "dev_evictions": 16,
+    "dev_unitsres": 1579
+  },
+  {
+    "bbl": 1017570020,
+    "development": "LINCOLN",
+    "dev_evictions": 6,
+    "dev_unitsres": 1237
+  },
+  {
+    "bbl": 1017570001,
+    "development": "LINCOLN",
+    "dev_evictions": 6,
+    "dev_unitsres": 1237
+  },
+  {
+    "bbl": 1016260021,
+    "development": "LEXINGTON",
+    "dev_evictions": 5,
+    "dev_unitsres": 448
+  },
+  {
+    "bbl": 1016260001,
+    "development": "LEXINGTON",
+    "dev_evictions": 5,
+    "dev_unitsres": 448
   },
   {
     "bbl": 3046720001,
     "development": "LENOX ROAD-ROCKAWAY PARKWAY",
-    "dev_evictions": 0,
+    "dev_evictions": 3,
     "dev_unitsres": 83
   },
   {
     "bbl": 3046710007,
     "development": "LENOX ROAD-ROCKAWAY PARKWAY",
-    "dev_evictions": 0,
+    "dev_evictions": 3,
     "dev_unitsres": 83
   },
   {
     "bbl": 3046520045,
     "development": "LENOX ROAD-ROCKAWAY PARKWAY",
-    "dev_evictions": 0,
+    "dev_evictions": 3,
     "dev_unitsres": 83
   },
   {
-    "bbl": 1007240010,
-    "development": "CHELSEA ADDITION",
+    "bbl": 1016150023,
+    "development": "LEHMAN VILLAGE",
+    "dev_evictions": 1,
+    "dev_unitsres": 587
+  },
+  {
+    "bbl": 1016130023,
+    "development": "LEHMAN VILLAGE",
+    "dev_evictions": 1,
+    "dev_unitsres": 587
+  },
+  {
+    "bbl": 4049570024,
+    "development": "LEAVITT STREET-34TH AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 83
+  },
+  {
+    "bbl": 1003250001,
+    "development": "LAVANBURG HOMES",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 4049510008,
+    "development": "LATIMER GARDENS",
+    "dev_evictions": 3,
+    "dev_unitsres": 434
+  },
+  {
+    "bbl": 3019380001,
+    "development": "LAFAYETTE",
+    "dev_evictions": 3,
+    "dev_unitsres": 882
+  },
+  {
+    "bbl": 1002560014,
+    "development": "LA GUARDIA ADDITION",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 1002580017,
+    "development": "LA GUARDIA",
+    "dev_evictions": 3,
+    "dev_unitsres": 1102
+  },
+  {
+    "bbl": 1002580001,
+    "development": "LA GUARDIA",
+    "dev_evictions": 3,
+    "dev_unitsres": 1102
+  },
+  {
+    "bbl": 1002560001,
+    "development": "LA GUARDIA",
+    "dev_evictions": 3,
+    "dev_unitsres": 1102
+  },
+  {
+    "bbl": 3013440175,
+    "development": "KINGSBOROUGH EXTENSION",
+    "dev_evictions": 1,
+    "dev_unitsres": 184
+  },
+  {
+    "bbl": 3014380001,
+    "development": "KINGSBOROUGH",
+    "dev_evictions": 1,
+    "dev_unitsres": 1264
+  },
+  {
+    "bbl": 3013440001,
+    "development": "KINGSBOROUGH",
+    "dev_evictions": 1,
+    "dev_unitsres": 1264
+  },
+  {
+    "bbl": 1018300056,
+    "development": "KING TOWERS",
+    "dev_evictions": 13,
+    "dev_unitsres": 527
+  },
+  {
+    "bbl": 1018290111,
+    "development": "KING TOWERS",
+    "dev_evictions": 13,
+    "dev_unitsres": 527
+  },
+  {
+    "bbl": 1015960001,
+    "development": "KING TOWERS",
+    "dev_evictions": 13,
+    "dev_unitsres": 527
+  },
+  {
+    "bbl": 1016400021,
+    "development": "JOHNSON",
+    "dev_evictions": 5,
+    "dev_unitsres": 1307
+  },
+  {
+    "bbl": 1016400001,
+    "development": "JOHNSON",
+    "dev_evictions": 5,
+    "dev_unitsres": 1307
+  },
+  {
+    "bbl": 1016840001,
+    "development": "JEFFERSON",
+    "dev_evictions": 7,
+    "dev_unitsres": 1491
+  },
+  {
+    "bbl": 1016620016,
+    "development": "JEFFERSON",
+    "dev_evictions": 7,
+    "dev_unitsres": 1491
+  },
+  {
+    "bbl": 1016620001,
+    "development": "JEFFERSON",
+    "dev_evictions": 7,
+    "dev_unitsres": 1491
+  },
+  {
+    "bbl": 2024160001,
+    "development": "JACKSON",
+    "dev_evictions": 5,
+    "dev_unitsres": 868
+  },
+  {
+    "bbl": 1015730001,
+    "development": "ISAACS",
+    "dev_evictions": 6,
+    "dev_unitsres": 636
+  },
+  {
+    "bbl": 4098020041,
+    "development": "INTERNATIONAL TOWER",
     "dev_evictions": 2,
-    "dev_unitsres": 94
+    "dev_unitsres": 150
   },
   {
-    "bbl": 4004700200,
-    "development": "QUEENSBRIDGE NORTH",
-    "dev_evictions": 5,
-    "dev_unitsres": 1542
+    "bbl": 3020500001,
+    "development": "INGERSOLL",
+    "dev_evictions": 16,
+    "dev_unitsres": 1142
   },
   {
-    "bbl": 4004700100,
-    "development": "QUEENSBRIDGE NORTH",
-    "dev_evictions": 5,
-    "dev_unitsres": 1542
+    "bbl": 3020340001,
+    "development": "INGERSOLL",
+    "dev_evictions": 16,
+    "dev_unitsres": 1142
   },
   {
-    "bbl": 4004700001,
-    "development": "QUEENSBRIDGE NORTH",
+    "bbl": 3020250150,
+    "development": "INGERSOLL",
+    "dev_evictions": 16,
+    "dev_unitsres": 1142
+  },
+  {
+    "bbl": 3021760001,
+    "development": "INDEPENDENCE",
+    "dev_evictions": 1,
+    "dev_unitsres": 744
+  },
+  {
+    "bbl": 3021720001,
+    "development": "INDEPENDENCE",
+    "dev_evictions": 1,
+    "dev_unitsres": 744
+  },
+  {
+    "bbl": 3030980001,
+    "development": "HYLAN",
+    "dev_evictions": "",
+    "dev_unitsres": 205
+  },
+  {
+    "bbl": 2027610003,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400031,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400030,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400028,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400027,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400025,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400024,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400022,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400021,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400019,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400018,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400016,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400015,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 2027400013,
+    "development": "HUNTS POINT AVENUE REHAB",
+    "dev_evictions": 1,
+    "dev_unitsres": 131
+  },
+  {
+    "bbl": 3035260021,
+    "development": "HUGHES APARTMENTS",
+    "dev_evictions": 3,
+    "dev_unitsres": 475
+  },
+  {
+    "bbl": 3014710061,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710059,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710057,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710055,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710053,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710024,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710023,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710022,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710021,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710020,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710019,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710018,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710017,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710016,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710015,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710014,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710011,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710010,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710009,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710008,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710007,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710006,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710005,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710004,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014710001,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700160,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700073,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700059,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700058,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700055,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700053,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700051,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700050,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700049,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700048,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700041,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700039,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700038,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700037,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700036,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700035,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700033,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700025,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700024,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700023,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700022,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700020,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700019,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700018,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700017,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700015,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700011,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700010,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700009,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700008,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700003,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700001,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014660049,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014660047,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014660045,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014660044,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014660043,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014660042,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3014700052,
+    "development": "HOWARD AVENUE-PARK PLACE",
+    "dev_evictions": "",
+    "dev_unitsres": 154
+  },
+  {
+    "bbl": 3035120051,
+    "development": "HOWARD AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3035120021,
+    "development": "HOWARD AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3035110046,
+    "development": "HOWARD AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3035110022,
+    "development": "HOWARD AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3035110013,
+    "development": "HOWARD AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3034890001,
+    "development": "HOWARD",
     "dev_evictions": 5,
-    "dev_unitsres": 1542
+    "dev_unitsres": 815
+  },
+  {
+    "bbl": 3033240019,
+    "development": "HOPE GARDENS",
+    "dev_evictions": "",
+    "dev_unitsres": 436
+  },
+  {
+    "bbl": 3033150001,
+    "development": "HOPE GARDENS",
+    "dev_evictions": "",
+    "dev_unitsres": 436
+  },
+  {
+    "bbl": 1015730020,
+    "development": "HOLMES TOWERS",
+    "dev_evictions": 3,
+    "dev_unitsres": 537
+  },
+  {
+    "bbl": 2029900011,
+    "development": "HOE AVENUE-EAST 173RD STREET",
+    "dev_evictions": 1,
+    "dev_unitsres": 65
+  },
+  {
+    "bbl": 2025150006,
+    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 2025140073,
+    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 2025140072,
+    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 2025140070,
+    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 2025140067,
+    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 2025130050,
+    "development": "HIGHBRIDGE REHABS (NELSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 2025140077,
+    "development": "HIGHBRIDGE REHABS (ANDERSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 162
+  },
+  {
+    "bbl": 2025140020,
+    "development": "HIGHBRIDGE REHABS (ANDERSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 162
+  },
+  {
+    "bbl": 2025140015,
+    "development": "HIGHBRIDGE REHABS (ANDERSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 162
+  },
+  {
+    "bbl": 2025090018,
+    "development": "HIGHBRIDGE REHABS (ANDERSON AVENUE)",
+    "dev_evictions": "",
+    "dev_unitsres": 162
+  },
+  {
+    "bbl": 2025270032,
+    "development": "HIGHBRIDGE GARDENS",
+    "dev_evictions": "",
+    "dev_unitsres": 700
+  },
+  {
+    "bbl": 1004170001,
+    "development": "HERNANDEZ",
+    "dev_evictions": 1,
+    "dev_unitsres": 149
+  },
+  {
+    "bbl": 2028690122,
+    "development": "HARRISON AVENUE REHAB (GROUP B)",
+    "dev_evictions": 2,
+    "dev_unitsres": 159
+  },
+  {
+    "bbl": 2028690110,
+    "development": "HARRISON AVENUE REHAB (GROUP B)",
+    "dev_evictions": 2,
+    "dev_unitsres": 159
+  },
+  {
+    "bbl": 2028690077,
+    "development": "HARRISON AVENUE REHAB (GROUP B)",
+    "dev_evictions": 2,
+    "dev_unitsres": 159
+  },
+  {
+    "bbl": 2028680144,
+    "development": "HARRISON AVENUE REHAB (GROUP B)",
+    "dev_evictions": 2,
+    "dev_unitsres": 159
+  },
+  {
+    "bbl": 2028690116,
+    "development": "HARRISON AVENUE REHAB (GROUP A)",
+    "dev_evictions": 1,
+    "dev_unitsres": 34
+  },
+  {
+    "bbl": 1020370001,
+    "development": "HARLEM RIVER II",
+    "dev_evictions": "",
+    "dev_unitsres": 116
+  },
+  {
+    "bbl": 1020370011,
+    "development": "HARLEM RIVER",
+    "dev_evictions": 1,
+    "dev_unitsres": 573
+  },
+  {
+    "bbl": 1020160060,
+    "development": "HARLEM RIVER",
+    "dev_evictions": 1,
+    "dev_unitsres": 573
+  },
+  {
+    "bbl": 1010840009,
+    "development": "HARBORVIEW TERRACE",
+    "dev_evictions": "",
+    "dev_unitsres": 377
+  },
+  {
+    "bbl": 1010830015,
+    "development": "HARBORVIEW TERRACE",
+    "dev_evictions": "",
+    "dev_unitsres": 377
+  },
+  {
+    "bbl": 4161140002,
+    "development": "HAMMEL",
+    "dev_evictions": 2,
+    "dev_unitsres": 712
+  },
+  {
+    "bbl": 3070700001,
+    "development": "HABER",
+    "dev_evictions": 2,
+    "dev_unitsres": 380
+  },
+  {
+    "bbl": 2046290050,
+    "development": "GUN HILL",
+    "dev_evictions": 1,
+    "dev_unitsres": 733
+  },
+  {
+    "bbl": 3069640002,
+    "development": "GRAVESEND",
+    "dev_evictions": 5,
+    "dev_unitsres": 634
+  },
+  {
+    "bbl": 1019800001,
+    "development": "GRANT",
+    "dev_evictions": 8,
+    "dev_unitsres": 1941
+  },
+  {
+    "bbl": 1019640001,
+    "development": "GRANT",
+    "dev_evictions": 8,
+    "dev_unitsres": 1941
   },
   {
     "bbl": 1019250015,
     "development": "GRAMPION",
-    "dev_evictions": 0,
+    "dev_evictions": 2,
     "dev_unitsres": 38
   },
   {
-    "bbl": 2028790043,
-    "development": "UNIVERSITY AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 230
+    "bbl": 3004040001,
+    "development": "GOWANUS",
+    "dev_evictions": 5,
+    "dev_unitsres": 1188
   },
   {
-    "bbl": 2028790041,
-    "development": "UNIVERSITY AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 230
+    "bbl": 3003920001,
+    "development": "GOWANUS",
+    "dev_evictions": 5,
+    "dev_unitsres": 1188
   },
   {
-    "bbl": 2028790033,
-    "development": "UNIVERSITY AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 230
+    "bbl": 1003380001,
+    "development": "GOMPERS",
+    "dev_evictions": "",
+    "dev_unitsres": 711
   },
   {
-    "bbl": 2028790032,
-    "development": "UNIVERSITY AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 230
+    "bbl": 3079780001,
+    "development": "GLENWOOD",
+    "dev_evictions": 4,
+    "dev_unitsres": 1188
   },
   {
-    "bbl": 2028790030,
-    "development": "UNIVERSITY AVENUE REHAB",
-    "dev_evictions": 0,
-    "dev_unitsres": 230
-  },
-  {
-    "bbl": 4155010002,
-    "development": "REDFERN",
+    "bbl": 3037090017,
+    "development": "GLENMORE PLAZA",
     "dev_evictions": 1,
-    "dev_unitsres": 604
+    "dev_unitsres": 468
   },
   {
-    "bbl": 2025680012,
-    "development": "BETANCES II, 13 / BETANCES III, 13",
-    "dev_evictions": "",
-    "dev_unitsres": ""
+    "bbl": 3037090016,
+    "development": "GLENMORE PLAZA",
+    "dev_evictions": 1,
+    "dev_unitsres": 468
   },
   {
-    "bbl": 5001960001,
-    "development": "WEST BRIGHTON I / WEST BRIGHTON II",
+    "bbl": 3037090001,
+    "development": "GLENMORE PLAZA",
+    "dev_evictions": 1,
+    "dev_unitsres": 468
+  },
+  {
+    "bbl": 3035070001,
+    "development": "GLENMORE PLAZA",
+    "dev_evictions": 1,
+    "dev_unitsres": 468
+  },
+  {
+    "bbl": 2039630043,
+    "development": "GLEBE AVENUE-WESTCHESTER AVENUE",
     "dev_evictions": "",
-    "dev_unitsres": ""
+    "dev_unitsres": 132
+  },
+  {
+    "bbl": 3034960013,
+    "development": "GARVEY (GROUP A)",
+    "dev_evictions": 6,
+    "dev_unitsres": 318
+  },
+  {
+    "bbl": 3034940010,
+    "development": "GARVEY (GROUP A)",
+    "dev_evictions": 6,
+    "dev_unitsres": 318
+  },
+  {
+    "bbl": 1007170019,
+    "development": "FULTON",
+    "dev_evictions": 4,
+    "dev_unitsres": 974
+  },
+  {
+    "bbl": 1007160017,
+    "development": "FULTON",
+    "dev_evictions": 4,
+    "dev_unitsres": 974
+  },
+  {
+    "bbl": 1007150010,
+    "development": "FULTON",
+    "dev_evictions": 4,
+    "dev_unitsres": 974
+  },
+  {
+    "bbl": 1007140031,
+    "development": "FULTON",
+    "dev_evictions": 4,
+    "dev_unitsres": 974
+  },
+  {
+    "bbl": 2029350030,
+    "development": "FRANKLIN AVENUE III CONVENTIONAL",
+    "dev_evictions": "",
+    "dev_unitsres": 15
+  },
+  {
+    "bbl": 2029350007,
+    "development": "FRANKLIN AVENUE II CONVENTIONAL",
+    "dev_evictions": "",
+    "dev_unitsres": 45
+  },
+  {
+    "bbl": 2029350005,
+    "development": "FRANKLIN AVENUE II CONVENTIONAL",
+    "dev_evictions": "",
+    "dev_unitsres": 45
+  },
+  {
+    "bbl": 2029350003,
+    "development": "FRANKLIN AVENUE II CONVENTIONAL",
+    "dev_evictions": "",
+    "dev_unitsres": 45
+  },
+  {
+    "bbl": 2029310064,
+    "development": "FRANKLIN AVENUE II CONVENTIONAL",
+    "dev_evictions": "",
+    "dev_unitsres": 45
+  },
+  {
+    "bbl": 2029310070,
+    "development": "FRANKLIN AVENUE I CONVENTIONAL",
+    "dev_evictions": "",
+    "dev_unitsres": 61
+  },
+  {
+    "bbl": 2029310068,
+    "development": "FRANKLIN AVENUE I CONVENTIONAL",
+    "dev_evictions": "",
+    "dev_unitsres": 61
+  },
+  {
+    "bbl": 2029310066,
+    "development": "FRANKLIN AVENUE I CONVENTIONAL",
+    "dev_evictions": "",
+    "dev_unitsres": 61
+  },
+  {
+    "bbl": 1021360235,
+    "development": "FORT WASHINGTON AVENUE REHAB",
+    "dev_evictions": "",
+    "dev_unitsres": 222
+  },
+  {
+    "bbl": 2032610102,
+    "development": "FORT INDEPENDENCE STREET-HEATH AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 344
+  },
+  {
+    "bbl": 2026400001,
+    "development": "FOREST",
+    "dev_evictions": 8,
+    "dev_unitsres": 1350
+  },
+  {
+    "bbl": 2026390001,
+    "development": "FOREST",
+    "dev_evictions": 8,
+    "dev_unitsres": 1350
+  },
+  {
+    "bbl": 1004300010,
+    "development": "FIRST HOUSES",
+    "dev_evictions": "",
+    "dev_unitsres": 246
+  },
+  {
+    "bbl": 3039930001,
+    "development": "FIORENTINO PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 110
+  },
+  {
+    "bbl": 3037250001,
+    "development": "FIORENTINO PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 110
+  },
+  {
+    "bbl": 3037240029,
+    "development": "FIORENTINO PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 110
+  },
+  {
+    "bbl": 3037240027,
+    "development": "FIORENTINO PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 110
+  },
+  {
+    "bbl": 4159020046,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4157820054,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4157820051,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4126700008,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4126650031,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4126340029,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4124690156,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4122080005,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4121700023,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4119760022,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4119750032,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4119600020,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4117810285,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4112080049,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4111200001,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4110990076,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4109660222,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4109220017,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4102840018,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4100190011,
+    "development": "FHA REPOSSESSED HOUSES (GROUP X)",
+    "dev_evictions": "",
+    "dev_unitsres": 24
+  },
+  {
+    "bbl": 4130990024,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4126210018,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4120480097,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4119250082,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4116100057,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4110990062,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4110700147,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4110200021,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4109540041,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VIII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4133060180,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4127060038,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4126240061,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4120170049,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4117710045,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4112350046,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4111270044,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4110160026,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VII)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4130750067,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4120150164,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4111340046,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4110580007,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4110140027,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4103780041,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4101620025,
+    "development": "FHA REPOSSESSED HOUSES (GROUP VI)",
+    "dev_evictions": "",
+    "dev_unitsres": 9
+  },
+  {
+    "bbl": 4130330032,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4126090045,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4126090034,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4125220108,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4124820142,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4120270049,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4120140003,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4119640294,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4117950068,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4117810292,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4117590055,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4116980035,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4111130036,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4110580015,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4110520060,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4110390004,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4110120043,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4109940020,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4109850011,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4109810139,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4109230027,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4109150020,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4107720021,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4104150006,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4103650028,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4102010012,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4101970051,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4101730024,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4101670016,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4100430019,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 3038740007,
+    "development": "FHA REPOSSESSED HOUSES (GROUP V)",
+    "dev_evictions": 1,
+    "dev_unitsres": 37
+  },
+  {
+    "bbl": 4125910227,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 4123400068,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3046090013,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3044540030,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3040700024,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3040700021,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3040700019,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3040700016,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3040550012,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3020730046,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3019650075,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3018890036,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3018890034,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3018890022,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3018880177,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 3009430069,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IX)",
+    "dev_evictions": "",
+    "dev_unitsres": 43
+  },
+  {
+    "bbl": 4130420108,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4128170053,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4127780128,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4127320009,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4126460009,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4124380138,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4120250077,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4110550021,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4109990075,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4109620415,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4108410001,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4096120068,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 2035120039,
+    "development": "FHA REPOSSESSED HOUSES (GROUP IV)",
+    "dev_evictions": "",
+    "dev_unitsres": 14
+  },
+  {
+    "bbl": 4132720054,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4131790027,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4121150033,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4119910017,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4116780060,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4111340022,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4111240053,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4110510023,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4109670159,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4108730024,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4104200036,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 2047810029,
+    "development": "FHA REPOSSESSED HOUSES (GROUP III)",
+    "dev_evictions": "",
+    "dev_unitsres": 13
+  },
+  {
+    "bbl": 4160450015,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4128250102,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4121150028,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4120580205,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4119680050,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4116700040,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4111410070,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4109890105,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4109470041,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4102820058,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4102410019,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 2035090025,
+    "development": "FHA REPOSSESSED HOUSES (GROUP II)",
+    "dev_evictions": 1,
+    "dev_unitsres": 16
+  },
+  {
+    "bbl": 4155020003,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4155020002,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4130220085,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4129840026,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4129280078,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4127780124,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4126390054,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4124620019,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4123290038,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4122020019,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4121090066,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4121030071,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4119750142,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4119540078,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4116960016,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4116560067,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4111340018,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4111290028,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4110740054,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4110410030,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4110110060,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4109030042,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4108680026,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4104200080,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4103680060,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 4100410120,
+    "development": "FHA REPOSSESSED HOUSES (GROUP I)",
+    "dev_evictions": 2,
+    "dev_unitsres": 29
+  },
+  {
+    "bbl": 3048180136,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180135,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180134,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180133,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180033,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180031,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180030,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180029,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180028,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180027,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180026,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3048180025,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3013300012,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3013300011,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3013300010,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3013300009,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3013300008,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3013300007,
+    "development": "FENIMORE-LEFFERTS",
+    "dev_evictions": "",
+    "dev_unitsres": 36
+  },
+  {
+    "bbl": 3000900001,
+    "development": "FARRAGUT",
+    "dev_evictions": 8,
+    "dev_unitsres": 1390
+  },
+  {
+    "bbl": 3000710001,
+    "development": "FARRAGUT",
+    "dev_evictions": 8,
+    "dev_unitsres": 1390
+  },
+  {
+    "bbl": 3000680001,
+    "development": "FARRAGUT",
+    "dev_evictions": 8,
+    "dev_unitsres": 1390
+  },
+  {
+    "bbl": 1007240015,
+    "development": "ELLIOTT",
+    "dev_evictions": 7,
+    "dev_unitsres": 483
+  },
+  {
+    "bbl": 1007240001,
+    "development": "ELLIOTT",
+    "dev_evictions": 7,
+    "dev_unitsres": 483
+  },
+  {
+    "bbl": 1007230001,
+    "development": "ELLIOTT",
+    "dev_evictions": 7,
+    "dev_unitsres": 483
+  },
+  {
+    "bbl": 2049050001,
+    "development": "EDENWALD",
+    "dev_evictions": 14,
+    "dev_unitsres": 2039
+  },
+  {
+    "bbl": 2045810001,
+    "development": "EASTCHESTER GARDENS",
+    "dev_evictions": 8,
+    "dev_unitsres": 877
+  },
+  {
+    "bbl": 1016960001,
+    "development": "EAST RIVER",
+    "dev_evictions": 9,
+    "dev_unitsres": 1170
+  },
+  {
+    "bbl": 3044810059,
+    "development": "EAST NEW YORK CITY LINE",
+    "dev_evictions": "",
+    "dev_unitsres": 66
+  },
+  {
+    "bbl": 3044810016,
+    "development": "EAST NEW YORK CITY LINE",
+    "dev_evictions": "",
+    "dev_unitsres": 66
+  },
+  {
+    "bbl": 3044810004,
+    "development": "EAST NEW YORK CITY LINE",
+    "dev_evictions": "",
+    "dev_unitsres": 66
+  },
+  {
+    "bbl": 3044800004,
+    "development": "EAST NEW YORK CITY LINE",
+    "dev_evictions": "",
+    "dev_unitsres": 66
+  },
+  {
+    "bbl": 3044580035,
+    "development": "EAST NEW YORK CITY LINE",
+    "dev_evictions": "",
+    "dev_unitsres": 66
+  },
+  {
+    "bbl": 3042630040,
+    "development": "EAST NEW YORK CITY LINE",
+    "dev_evictions": "",
+    "dev_unitsres": 66
+  },
+  {
+    "bbl": 2030620021,
+    "development": "EAST 180TH STREET-MONTEREY AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 239
+  },
+  {
+    "bbl": 2030620006,
+    "development": "EAST 180TH STREET-MONTEREY AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 239
+  },
+  {
+    "bbl": 2029890011,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029890001,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029880019,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029880018,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029820066,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029820048,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029820046,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029820045,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029820044,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029820038,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029820035,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029820032,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2029820029,
+    "development": "EAST 173RD STREET-VYSE AVENUE",
+    "dev_evictions": 2,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 2027570001,
+    "development": "EAST 165TH STREET-BRYANT AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 127
+  },
+  {
+    "bbl": 2027560010,
+    "development": "EAST 165TH STREET-BRYANT AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 127
+  },
+  {
+    "bbl": 2027500032,
+    "development": "EAST 165TH STREET-BRYANT AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 127
+  },
+  {
+    "bbl": 2027500016,
+    "development": "EAST 165TH STREET-BRYANT AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 127
+  },
+  {
+    "bbl": 2027490025,
+    "development": "EAST 165TH STREET-BRYANT AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 127
+  },
+  {
+    "bbl": 2027480025,
+    "development": "EAST 165TH STREET-BRYANT AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 127
+  },
+  {
+    "bbl": 2023990010,
+    "development": "EAST 152ND STREET-COURTLANDT AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 221
+  },
+  {
+    "bbl": 2023980014,
+    "development": "EAST 152ND STREET-COURTLANDT AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 221
+  },
+  {
+    "bbl": 2026200036,
+    "development": "EAGLE AVENUE-EAST 163RD STREET",
+    "dev_evictions": 2,
+    "dev_unitsres": 66
+  },
+  {
+    "bbl": 1022160001,
+    "development": "DYCKMAN",
+    "dev_evictions": 3,
+    "dev_unitsres": 1167
+  },
+  {
+    "bbl": 1020290001,
+    "development": "DREW-HAMILTON",
+    "dev_evictions": 7,
+    "dev_unitsres": 1217
+  },
+  {
+    "bbl": 1020280016,
+    "development": "DREW-HAMILTON",
+    "dev_evictions": 7,
+    "dev_unitsres": 1217
+  },
+  {
+    "bbl": 1020280001,
+    "development": "DREW-HAMILTON",
+    "dev_evictions": 7,
+    "dev_unitsres": 1217
+  },
+  {
+    "bbl": 1020270025,
+    "development": "DREW-HAMILTON",
+    "dev_evictions": 7,
+    "dev_unitsres": 1217
+  },
+  {
+    "bbl": 1020270001,
+    "development": "DREW-HAMILTON",
+    "dev_evictions": 7,
+    "dev_unitsres": 1217
+  },
+  {
+    "bbl": 1018550001,
+    "development": "DOUGLASS II",
+    "dev_evictions": 3,
+    "dev_unitsres": 1162
+  },
+  {
+    "bbl": 1018360001,
+    "development": "DOUGLASS I",
+    "dev_evictions": 1,
+    "dev_unitsres": 896
+  },
+  {
+    "bbl": 1018740029,
+    "development": "DOUGLASS ADDITION",
+    "dev_evictions": "",
+    "dev_unitsres": 135
+  },
+  {
+    "bbl": 1012410025,
+    "development": "DE HOSTOS APARTMENTS",
+    "dev_evictions": "",
+    "dev_unitsres": 221
+  },
+  {
+    "bbl": 2026800019,
+    "development": "DAVIDSON",
+    "dev_evictions": "",
+    "dev_unitsres": 175
+  },
+  {
+    "bbl": 3042920061,
+    "development": "CYPRESS HILLS",
+    "dev_evictions": 3,
+    "dev_unitsres": 1444
+  },
+  {
+    "bbl": 3013810013,
+    "development": "CROWN HEIGHTS",
+    "dev_evictions": 1,
+    "dev_unitsres": 138
+  },
+  {
+    "bbl": 3013750036,
+    "development": "CROWN HEIGHTS",
+    "dev_evictions": 1,
+    "dev_unitsres": 138
+  },
+  {
+    "bbl": 3013750034,
+    "development": "CROWN HEIGHTS",
+    "dev_evictions": 1,
+    "dev_unitsres": 138
+  },
+  {
+    "bbl": 3013750031,
+    "development": "CROWN HEIGHTS",
+    "dev_evictions": 1,
+    "dev_unitsres": 138
+  },
+  {
+    "bbl": 3013750029,
+    "development": "CROWN HEIGHTS",
+    "dev_evictions": 1,
+    "dev_unitsres": 138
+  },
+  {
+    "bbl": 3013690058,
+    "development": "CROWN HEIGHTS",
+    "dev_evictions": 1,
+    "dev_unitsres": 138
+  },
+  {
+    "bbl": 3013570068,
+    "development": "CROWN HEIGHTS",
+    "dev_evictions": 1,
+    "dev_unitsres": 138
+  },
+  {
+    "bbl": 3013570065,
+    "development": "CROWN HEIGHTS",
+    "dev_evictions": 1,
+    "dev_unitsres": 138
+  },
+  {
+    "bbl": 1016880045,
+    "development": "CORSI HOUSES",
+    "dev_evictions": "",
+    "dev_unitsres": 171
+  },
+  {
+    "bbl": 3028670001,
+    "development": "COOPER PARK",
+    "dev_evictions": 4,
+    "dev_unitsres": 700
+  },
+  {
+    "bbl": 4102120033,
+    "development": "CONLON LIHFE TOWER",
+    "dev_evictions": "",
+    "dev_unitsres": 216
+  },
+  {
+    "bbl": 3070530014,
+    "development": "CONEY ISLAND I (SITES 4 & 5)",
+    "dev_evictions": 6,
+    "dev_unitsres": 616
+  },
+  {
+    "bbl": 3070530013,
+    "development": "CONEY ISLAND I (SITES 4 & 5)",
+    "dev_evictions": 6,
+    "dev_unitsres": 616
+  },
+  {
+    "bbl": 3070530012,
+    "development": "CONEY ISLAND I (SITES 4 & 5)",
+    "dev_evictions": 6,
+    "dev_unitsres": 616
+  },
+  {
+    "bbl": 3070460022,
+    "development": "CONEY ISLAND I (SITE 8)",
+    "dev_evictions": 2,
+    "dev_unitsres": 125
+  },
+  {
+    "bbl": 3070590026,
+    "development": "CONEY ISLAND I (SITE 1B)",
+    "dev_evictions": "",
+    "dev_unitsres": 193
+  },
+  {
+    "bbl": 3070670001,
+    "development": "CONEY ISLAND",
+    "dev_evictions": 3,
+    "dev_unitsres": 534
+  },
+  {
+    "bbl": 2024330001,
+    "development": "COLLEGE AVENUE-EAST 165TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 108
+  },
+  {
+    "bbl": 1016370001,
+    "development": "CLINTON",
+    "dev_evictions": 4,
+    "dev_unitsres": 750
+  },
+  {
+    "bbl": 1016360001,
+    "development": "CLINTON",
+    "dev_evictions": 4,
+    "dev_unitsres": 750
+  },
+  {
+    "bbl": 1016330001,
+    "development": "CLINTON",
+    "dev_evictions": 4,
+    "dev_unitsres": 750
+  },
+  {
+    "bbl": 1016320001,
+    "development": "CLINTON",
+    "dev_evictions": 4,
+    "dev_unitsres": 750
+  },
+  {
+    "bbl": 2036330001,
+    "development": "CLASON POINT GARDENS",
+    "dev_evictions": "",
+    "dev_unitsres": 368
+  },
+  {
+    "bbl": 2035910001,
+    "development": "CLASON POINT GARDENS",
+    "dev_evictions": "",
+    "dev_unitsres": 368
+  },
+  {
+    "bbl": 2024340042,
+    "development": "CLAREMONT REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 137
+  },
+  {
+    "bbl": 2024340034,
+    "development": "CLAREMONT REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 137
+  },
+  {
+    "bbl": 2024340030,
+    "development": "CLAREMONT REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 137
+  },
+  {
+    "bbl": 2024340026,
+    "development": "CLAREMONT REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 137
+  },
+  {
+    "bbl": 2024340018,
+    "development": "CLAREMONT REHAB (GROUP 5)",
+    "dev_evictions": 1,
+    "dev_unitsres": 137
+  },
+  {
+    "bbl": 2024340088,
+    "development": "CLAREMONT REHAB (GROUP 4)",
+    "dev_evictions": "",
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2024340057,
+    "development": "CLAREMONT REHAB (GROUP 4)",
+    "dev_evictions": "",
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2024340053,
+    "development": "CLAREMONT REHAB (GROUP 4)",
+    "dev_evictions": "",
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2024280012,
+    "development": "CLAREMONT REHAB (GROUP 4)",
+    "dev_evictions": "",
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2024280003,
+    "development": "CLAREMONT REHAB (GROUP 4)",
+    "dev_evictions": "",
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2024270012,
+    "development": "CLAREMONT REHAB (GROUP 4)",
+    "dev_evictions": "",
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2024270010,
+    "development": "CLAREMONT REHAB (GROUP 4)",
+    "dev_evictions": "",
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2024270007,
+    "development": "CLAREMONT REHAB (GROUP 4)",
+    "dev_evictions": "",
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2024270003,
+    "development": "CLAREMONT REHAB (GROUP 4)",
+    "dev_evictions": "",
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2024340080,
+    "development": "CLAREMONT REHAB (GROUP 3)",
+    "dev_evictions": "",
+    "dev_unitsres": 117
+  },
+  {
+    "bbl": 2024340074,
+    "development": "CLAREMONT REHAB (GROUP 3)",
+    "dev_evictions": "",
+    "dev_unitsres": 117
+  },
+  {
+    "bbl": 2024280015,
+    "development": "CLAREMONT REHAB (GROUP 3)",
+    "dev_evictions": "",
+    "dev_unitsres": 117
+  },
+  {
+    "bbl": 2024280009,
+    "development": "CLAREMONT REHAB (GROUP 3)",
+    "dev_evictions": "",
+    "dev_unitsres": 117
+  },
+  {
+    "bbl": 2024280004,
+    "development": "CLAREMONT REHAB (GROUP 3)",
+    "dev_evictions": "",
+    "dev_unitsres": 117
+  },
+  {
+    "bbl": 2024300030,
+    "development": "CLAREMONT REHAB (GROUP 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 118
+  },
+  {
+    "bbl": 2024290028,
+    "development": "CLAREMONT REHAB (GROUP 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 118
+  },
+  {
+    "bbl": 2024270022,
+    "development": "CLAREMONT REHAB (GROUP 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 118
+  },
+  {
+    "bbl": 2024270009,
+    "development": "CLAREMONT REHAB (GROUP 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 118
+  },
+  {
+    "bbl": 2024270006,
+    "development": "CLAREMONT REHAB (GROUP 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 118
+  },
+  {
+    "bbl": 2024270004,
+    "development": "CLAREMONT REHAB (GROUP 2)",
+    "dev_evictions": "",
+    "dev_unitsres": 118
+  },
+  {
+    "bbl": 2029310086,
+    "development": "CLAREMONT PARKWAY-FRANKLIN AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 190
+  },
+  {
+    "bbl": 2029280028,
+    "development": "CLAREMONT PARKWAY-FRANKLIN AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 190
+  },
+  {
+    "bbl": 1007240010,
+    "development": "CHELSEA ADDITION",
+    "dev_evictions": 1,
+    "dev_unitsres": 94
+  },
+  {
+    "bbl": 1007230015,
+    "development": "CHELSEA",
+    "dev_evictions": 1,
+    "dev_unitsres": 425
+  },
+  {
+    "bbl": 2035730001,
+    "development": "CASTLE HILL",
+    "dev_evictions": 6,
+    "dev_unitsres": 2033
+  },
+  {
+    "bbl": 2035700001,
+    "development": "CASTLE HILL",
+    "dev_evictions": 6,
+    "dev_unitsres": 2033
+  },
+  {
+    "bbl": 2035370001,
+    "development": "CASTLE HILL",
+    "dev_evictions": 6,
+    "dev_unitsres": 2033
+  },
+  {
+    "bbl": 2035340001,
+    "development": "CASTLE HILL",
+    "dev_evictions": 6,
+    "dev_unitsres": 2033
+  },
+  {
+    "bbl": 5000710025,
+    "development": "CASSIDY-LAFAYETTE",
+    "dev_evictions": 1,
+    "dev_unitsres": 380
+  },
+  {
+    "bbl": 5000710011,
+    "development": "CASSIDY-LAFAYETTE",
+    "dev_evictions": 1,
+    "dev_unitsres": 380
+  },
+  {
+    "bbl": 5000710001,
+    "development": "CASSIDY-LAFAYETTE",
+    "dev_evictions": 1,
+    "dev_unitsres": 380
+  },
+  {
+    "bbl": 1016100023,
+    "development": "CARVER",
+    "dev_evictions": 9,
+    "dev_unitsres": 1254
+  },
+  {
+    "bbl": 1016080023,
+    "development": "CARVER",
+    "dev_evictions": 9,
+    "dev_unitsres": 1254
+  },
+  {
+    "bbl": 1016050024,
+    "development": "CARVER",
+    "dev_evictions": 9,
+    "dev_unitsres": 1254
+  },
+  {
+    "bbl": 4160830037,
+    "development": "CARLETON MANOR",
+    "dev_evictions": 1,
+    "dev_unitsres": 174
+  },
+  {
+    "bbl": 3070570012,
+    "development": "CAREY GARDENS",
+    "dev_evictions": 1,
+    "dev_unitsres": 683
+  },
+  {
+    "bbl": 3070560014,
+    "development": "CAREY GARDENS",
+    "dev_evictions": 1,
+    "dev_unitsres": 683
+  },
+  {
+    "bbl": 3070150015,
+    "development": "CAREY GARDENS",
+    "dev_evictions": 1,
+    "dev_unitsres": 683
+  },
+  {
+    "bbl": 1003960010,
+    "development": "CAMPOS PLAZA II",
+    "dev_evictions": "",
+    "dev_unitsres": 616
+  },
+  {
+    "bbl": 2028950001,
+    "development": "BUTLER",
+    "dev_evictions": 1,
+    "dev_unitsres": 1492
+  },
+  {
+    "bbl": 2028940001,
+    "development": "BUTLER",
+    "dev_evictions": 1,
+    "dev_unitsres": 1492
+  },
+  {
+    "bbl": 3033340022,
+    "development": "BUSHWICK II CDA (GROUP E)",
+    "dev_evictions": "",
+    "dev_unitsres": 276
+  },
+  {
+    "bbl": 3033340001,
+    "development": "BUSHWICK II CDA (GROUP E)",
+    "dev_evictions": "",
+    "dev_unitsres": 276
+  },
+  {
+    "bbl": 3033250001,
+    "development": "BUSHWICK II CDA (GROUP E)",
+    "dev_evictions": "",
+    "dev_unitsres": 276
+  },
+  {
+    "bbl": 3033160001,
+    "development": "BUSHWICK II CDA (GROUP E)",
+    "dev_evictions": "",
+    "dev_unitsres": 276
+  },
+  {
+    "bbl": 3033590029,
+    "development": "BUSHWICK II (GROUPS B & D)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3033510001,
+    "development": "BUSHWICK II (GROUPS B & D)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3033500028,
+    "development": "BUSHWICK II (GROUPS B & D)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3033420001,
+    "development": "BUSHWICK II (GROUPS B & D)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3033410001,
+    "development": "BUSHWICK II (GROUPS B & D)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3033320001,
+    "development": "BUSHWICK II (GROUPS B & D)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3034150039,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3034100033,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3034100001,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3034090032,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3034030001,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3032970001,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3032960046,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3032860001,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3032850049,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3032760001,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3032750047,
+    "development": "BUSHWICK II (GROUPS A & C)",
+    "dev_evictions": "",
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 3031290001,
+    "development": "BUSHWICK",
+    "dev_evictions": 3,
+    "dev_unitsres": 1220
+  },
+  {
+    "bbl": 2029970030,
+    "development": "BRYANT AVENUE-EAST 174TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 111
+  },
+  {
+    "bbl": 3035610001,
+    "development": "BROWNSVILLE",
+    "dev_evictions": 6,
+    "dev_unitsres": 1338
+  },
+  {
+    "bbl": 3035440001,
+    "development": "BROWNSVILLE",
+    "dev_evictions": 6,
+    "dev_unitsres": 1338
+  },
+  {
+    "bbl": 3014600001,
+    "development": "BROWN",
+    "dev_evictions": "",
+    "dev_unitsres": 200
+  },
+  {
+    "bbl": 2038680033,
+    "development": "BRONX RIVER ADDITION",
+    "dev_evictions": 2,
+    "dev_unitsres": 231
+  },
+  {
+    "bbl": 2038660031,
+    "development": "BRONX RIVER ADDITION",
+    "dev_evictions": 2,
+    "dev_unitsres": 231
+  },
+  {
+    "bbl": 2038860002,
+    "development": "BRONX RIVER",
+    "dev_evictions": 7,
+    "dev_unitsres": 1250
+  },
+  {
+    "bbl": 3016880001,
+    "development": "BREVOORT",
+    "dev_evictions": 3,
+    "dev_unitsres": 896
+  },
+  {
+    "bbl": 3081930001,
+    "development": "BREUKELEN",
+    "dev_evictions": 3,
+    "dev_unitsres": 1620
+  },
+  {
+    "bbl": 3081910001,
+    "development": "BREUKELEN",
+    "dev_evictions": 3,
+    "dev_unitsres": 1620
+  },
+  {
+    "bbl": 3081740001,
+    "development": "BREUKELEN",
+    "dev_evictions": 3,
+    "dev_unitsres": 1620
+  },
+  {
+    "bbl": 3081580205,
+    "development": "BREUKELEN",
+    "dev_evictions": 3,
+    "dev_unitsres": 1620
+  },
+  {
+    "bbl": 3081580150,
+    "development": "BREUKELEN",
+    "dev_evictions": 3,
+    "dev_unitsres": 1620
+  },
+  {
+    "bbl": 3081580040,
+    "development": "BREUKELEN",
+    "dev_evictions": 3,
+    "dev_unitsres": 1620
+  },
+  {
+    "bbl": 3081580001,
+    "development": "BREUKELEN",
+    "dev_evictions": 3,
+    "dev_unitsres": 1620
+  },
+  {
+    "bbl": 1003860033,
+    "development": "BRACETTI PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 108
+  },
+  {
+    "bbl": 2037150027,
+    "development": "BOYNTON AVENUE REHAB",
+    "dev_evictions": 2,
+    "dev_unitsres": 82
+  },
+  {
+    "bbl": 2037150025,
+    "development": "BOYNTON AVENUE REHAB",
+    "dev_evictions": 2,
+    "dev_unitsres": 82
+  },
+  {
+    "bbl": 2037150023,
+    "development": "BOYNTON AVENUE REHAB",
+    "dev_evictions": 2,
+    "dev_unitsres": 82
+  },
+  {
+    "bbl": 2037140036,
+    "development": "BOYNTON AVENUE REHAB",
+    "dev_evictions": 2,
+    "dev_unitsres": 82
+  },
+  {
+    "bbl": 3043770001,
+    "development": "BOULEVARD",
+    "dev_evictions": 3,
+    "dev_unitsres": 1316
+  },
+  {
+    "bbl": 3043550001,
+    "development": "BOULEVARD",
+    "dev_evictions": 3,
+    "dev_unitsres": 1316
+  },
+  {
+    "bbl": 2052630070,
+    "development": "BOSTON SECOR",
+    "dev_evictions": 3,
+    "dev_unitsres": 538
+  },
+  {
+    "bbl": 2052630040,
+    "development": "BOSTON SECOR",
+    "dev_evictions": 3,
+    "dev_unitsres": 538
+  },
+  {
+    "bbl": 2044310001,
+    "development": "BOSTON ROAD PLAZA",
+    "dev_evictions": "",
+    "dev_unitsres": 241
+  },
+  {
+    "bbl": 3030810080,
+    "development": "BORINQUEN PLAZA II",
+    "dev_evictions": "",
+    "dev_unitsres": 441
+  },
+  {
+    "bbl": 3030810075,
+    "development": "BORINQUEN PLAZA II",
+    "dev_evictions": "",
+    "dev_unitsres": 441
+  },
+  {
+    "bbl": 3030810070,
+    "development": "BORINQUEN PLAZA II",
+    "dev_evictions": "",
+    "dev_unitsres": 441
+  },
+  {
+    "bbl": 3030810060,
+    "development": "BORINQUEN PLAZA II",
+    "dev_evictions": "",
+    "dev_unitsres": 441
+  },
+  {
+    "bbl": 3030810050,
+    "development": "BORINQUEN PLAZA II",
+    "dev_evictions": "",
+    "dev_unitsres": 441
+  },
+  {
+    "bbl": 3030810040,
+    "development": "BORINQUEN PLAZA II",
+    "dev_evictions": "",
+    "dev_unitsres": 441
+  },
+  {
+    "bbl": 3030810035,
+    "development": "BORINQUEN PLAZA II",
+    "dev_evictions": "",
+    "dev_unitsres": 441
+  },
+  {
+    "bbl": 3030810001,
+    "development": "BORINQUEN PLAZA II",
+    "dev_evictions": "",
+    "dev_unitsres": 441
+  },
+  {
+    "bbl": 3031050109,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3031050001,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3030960030,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3030960014,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3030960001,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3030890134,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3030800070,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3030800050,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3030800040,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3030800020,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 3030800010,
+    "development": "BORINQUEN PLAZA I",
+    "dev_evictions": 2,
+    "dev_unitsres": 699
+  },
+  {
+    "bbl": 4050370008,
+    "development": "BLAND",
+    "dev_evictions": 1,
+    "dev_unitsres": 400
+  },
+  {
+    "bbl": 1021070059,
+    "development": "BETHUNE GARDENS",
+    "dev_evictions": "",
+    "dev_unitsres": 170
+  },
+  {
+    "bbl": 2022910030,
+    "development": "BETANCES VI",
+    "dev_evictions": 2,
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2022910001,
+    "development": "BETANCES VI",
+    "dev_evictions": 2,
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2022720119,
+    "development": "BETANCES VI",
+    "dev_evictions": 2,
+    "dev_unitsres": 158
+  },
+  {
+    "bbl": 2022870026,
+    "development": "BETANCES V",
+    "dev_evictions": "",
+    "dev_unitsres": 0
   },
   {
     "bbl": 2022910023,
     "development": "BETANCES IV / BETANCES V",
-    "dev_evictions": "",
-    "dev_unitsres": ""
+    "dev_evictions": 6,
+    "dev_unitsres": 304
   },
   {
     "bbl": 2022720038,
     "development": "BETANCES IV / BETANCES V",
-    "dev_evictions": "",
-    "dev_unitsres": ""
+    "dev_evictions": 6,
+    "dev_unitsres": 304
   },
   {
     "bbl": 2022720005,
     "development": "BETANCES IV / BETANCES V",
+    "dev_evictions": 6,
+    "dev_unitsres": 304
+  },
+  {
+    "bbl": 2022910050,
+    "development": "BETANCES IV",
+    "dev_evictions": 1,
+    "dev_unitsres": 127
+  },
+  {
+    "bbl": 2022870135,
+    "development": "BETANCES IV",
+    "dev_evictions": 1,
+    "dev_unitsres": 127
+  },
+  {
+    "bbl": 2022810055,
+    "development": "BETANCES III, 18",
     "dev_evictions": "",
-    "dev_unitsres": ""
+    "dev_unitsres": 0
+  },
+  {
+    "bbl": 2022710020,
+    "development": "BETANCES III, 9A",
+    "dev_evictions": "",
+    "dev_unitsres": 26
   },
   {
     "bbl": 2022810010,
     "development": "BETANCES II, 18 / BETANCES III, 18",
     "dev_evictions": "",
-    "dev_unitsres": ""
+    "dev_unitsres": 68
   },
   {
-    "bbl": 2055670001,
-    "development": "THROGGS NECK / THROGGS NECK ADDITION",
+    "bbl": 2022820057,
+    "development": "BETANCES II, 18",
     "dev_evictions": "",
-    "dev_unitsres": ""
+    "dev_unitsres": 32
   },
   {
-    "bbl": 2055640001,
-    "development": "THROGGS NECK / THROGGS NECK ADDITION",
+    "bbl": 2025680012,
+    "development": "BETANCES II, 13 / BETANCES III, 13",
+    "dev_evictions": 1,
+    "dev_unitsres": 200
+  },
+  {
+    "bbl": 2022710001,
+    "development": "BETANCES II, 9A",
     "dev_evictions": "",
-    "dev_unitsres": ""
+    "dev_unitsres": 46
+  },
+  {
+    "bbl": 2022690100,
+    "development": "BETANCES I",
+    "dev_evictions": 2,
+    "dev_unitsres": 309
+  },
+  {
+    "bbl": 3021570022,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021570021,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021570020,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021570019,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021570006,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021570005,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021570004,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021570003,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021570002,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021570001,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021560022,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021560021,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021560007,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450036,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450035,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450034,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450033,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450032,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450031,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450030,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450029,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450028,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450026,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450018,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450017,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450008,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 3021450001,
+    "development": "BERRY STREET-SOUTH 9TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 150
+  },
+  {
+    "bbl": 5035320500,
+    "development": "BERRY",
+    "dev_evictions": 1,
+    "dev_unitsres": 506
+  },
+  {
+    "bbl": 3040290001,
+    "development": "BELMONT-SUTTER AREA",
+    "dev_evictions": "",
+    "dev_unitsres": 72
+  },
+  {
+    "bbl": 3017690078,
+    "development": "BEDFORD-STUYVESANT REHAB",
+    "dev_evictions": 2,
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 3017690001,
+    "development": "BEDFORD-STUYVESANT REHAB",
+    "dev_evictions": 2,
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 3017610063,
+    "development": "BEDFORD-STUYVESANT REHAB",
+    "dev_evictions": 2,
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 3017610061,
+    "development": "BEDFORD-STUYVESANT REHAB",
+    "dev_evictions": 2,
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 3017610045,
+    "development": "BEDFORD-STUYVESANT REHAB",
+    "dev_evictions": 2,
+    "dev_unitsres": 80
+  },
+  {
+    "bbl": 4159600060,
+    "development": "BEACH 41ST STREET-BEACH CHANNEL DRIVE",
+    "dev_evictions": 4,
+    "dev_unitsres": 712
+  },
+  {
+    "bbl": 4159550003,
+    "development": "BEACH 41ST STREET-BEACH CHANNEL DRIVE",
+    "dev_evictions": 4,
+    "dev_unitsres": 712
+  },
+  {
+    "bbl": 2049050360,
+    "development": "BAYCHESTER",
+    "dev_evictions": "",
+    "dev_unitsres": 441
+  },
+  {
+    "bbl": 3083290225,
+    "development": "BAY VIEW",
+    "dev_evictions": 8,
+    "dev_unitsres": 1610
+  },
+  {
+    "bbl": 1003230001,
+    "development": "BARUCH",
+    "dev_evictions": 4,
+    "dev_unitsres": 2391
+  },
+  {
+    "bbl": 4123350044,
+    "development": "BAISLEY PARK",
+    "dev_evictions": 3,
+    "dev_unitsres": 833
+  },
+  {
+    "bbl": 4122350022,
+    "development": "BAISLEY PARK",
+    "dev_evictions": 3,
+    "dev_unitsres": 833
+  },
+  {
+    "bbl": 2032390004,
+    "development": "BAILEY AVENUE-WEST 193RD STREET",
+    "dev_evictions": 1,
+    "dev_unitsres": 233
+  },
+  {
+    "bbl": 1020680046,
+    "development": "AUDUBON",
+    "dev_evictions": 1,
+    "dev_unitsres": 168
+  },
+  {
+    "bbl": 3020070001,
+    "development": "ATLANTIC TERMINAL SITE 4B",
+    "dev_evictions": 1,
+    "dev_unitsres": 300
+  },
+  {
+    "bbl": 4004900101,
+    "development": "ASTORIA",
+    "dev_evictions": 7,
+    "dev_unitsres": 1104
+  },
+  {
+    "bbl": 3018090062,
+    "development": "ARMSTRONG II",
+    "dev_evictions": 2,
+    "dev_unitsres": 248
+  },
+  {
+    "bbl": 3018090001,
+    "development": "ARMSTRONG II",
+    "dev_evictions": 2,
+    "dev_unitsres": 248
+  },
+  {
+    "bbl": 3018040010,
+    "development": "ARMSTRONG II",
+    "dev_evictions": 2,
+    "dev_unitsres": 248
+  },
+  {
+    "bbl": 3017990044,
+    "development": "ARMSTRONG II",
+    "dev_evictions": 2,
+    "dev_unitsres": 248
+  },
+  {
+    "bbl": 3018080174,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080173,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080172,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080171,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080170,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080169,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080168,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080167,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080166,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080165,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080164,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080163,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080162,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080161,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080160,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018080059,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030124,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030123,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030122,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030121,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030120,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030119,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030118,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030117,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030116,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030115,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030114,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030113,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030112,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030042,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018020051,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018020044,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018020043,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940181,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940139,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940121,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940120,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940119,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940118,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940117,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940116,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940115,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940114,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940113,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940112,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940054,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3017940011,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030011,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 3018030027,
+    "development": "ARMSTRONG I",
+    "dev_evictions": 3,
+    "dev_unitsres": 416
+  },
+  {
+    "bbl": 1011560020,
+    "development": "AMSTERDAM ADDITION",
+    "dev_evictions": "",
+    "dev_unitsres": 175
+  },
+  {
+    "bbl": 1011540101,
+    "development": "AMSTERDAM",
+    "dev_evictions": 4,
+    "dev_unitsres": 1084
+  },
+  {
+    "bbl": 3013520001,
+    "development": "ALBANY II",
+    "dev_evictions": 2,
+    "dev_unitsres": 400
+  },
+  {
+    "bbl": 3013520080,
+    "development": "ALBANY",
+    "dev_evictions": 5,
+    "dev_unitsres": 829
+  },
+  {
+    "bbl": 2026650001,
+    "development": "ADAMS",
+    "dev_evictions": 2,
+    "dev_unitsres": 917
+  },
+  {
+    "bbl": 2026540002,
+    "development": "ADAMS",
+    "dev_evictions": 2,
+    "dev_unitsres": 917
+  },
+  {
+    "bbl": 2037370001,
+    "development": "1471 WATSON AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 100
+  },
+  {
+    "bbl": 2023720001,
+    "development": "1162-1176 WASHINGTON AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 65
+  },
+  {
+    "bbl": 2031300100,
+    "development": "1010 EAST 178TH STREET",
+    "dev_evictions": 1,
+    "dev_unitsres": 224
+  },
+  {
+    "bbl": 1018720029,
+    "development": "830 AMSTERDAM AVENUE",
+    "dev_evictions": "",
+    "dev_unitsres": 159
+  },
+  {
+    "bbl": 3004010001,
+    "development": "572 WARREN STREET",
+    "dev_evictions": 1,
+    "dev_unitsres": 200
+  },
+  {
+    "bbl": 1009330025,
+    "development": "344 EAST 28TH STREET",
+    "dev_evictions": 1,
+    "dev_unitsres": 225
+  },
+  {
+    "bbl": 1016830018,
+    "development": "335 EAST 111TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 66
+  },
+  {
+    "bbl": 3015850001,
+    "development": "303 VERNON AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 234
+  },
+  {
+    "bbl": 4139360060,
+    "development": "157TH AVENUE-79TH STREET AREA",
+    "dev_evictions": "",
+    "dev_unitsres": 0
+  },
+  {
+    "bbl": 4139350060,
+    "development": "157TH AVENUE-79TH STREET AREA",
+    "dev_evictions": "",
+    "dev_unitsres": 0
+  },
+  {
+    "bbl": 1012140055,
+    "development": "154 WEST 84TH STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 35
+  },
+  {
+    "bbl": 1019220041,
+    "development": "131 SAINT NICHOLAS AVENUE",
+    "dev_evictions": 1,
+    "dev_unitsres": 100
+  },
+  {
+    "bbl": 3035320030,
+    "development": "104-14 TAPSCOTT STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 32
+  },
+  {
+    "bbl": 1003070001,
+    "development": "45 ALLEN STREET",
+    "dev_evictions": "",
+    "dev_unitsres": 104
   }
 ]

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,15 +13,15 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/DetailView.js:155
+#: src/components/DetailView.js:156
 msgid "(expired {0})"
 msgstr "(expired {0})"
 
-#: src/components/DetailView.js:156
+#: src/components/DetailView.js:157
 msgid "(expires {0})"
 msgstr "(expires {0})"
 
-#: src/components/DetailView.js:123
+#: src/components/DetailView.js:124
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
@@ -33,17 +33,19 @@ msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
-#: src/components/DetailView.js:108
+#: src/components/DetailView.js:109
 #: src/containers/NychaPage.js:128
-msgid "2018 Evictions"
-msgstr "2018 Evictions"
+msgid "2019 Evictions"
+msgstr "2019 Evictions"
 
-#: src/components/DetailView.js:196
+#: src/components/DetailView.js:197
 #: src/components/Indicators.js:392
+#: src/containers/NotRegisteredPage.js:161
+#: src/containers/NychaPage.js:186
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
 
-#: src/containers/App.js:55
+#: src/containers/App.js:56
 msgid "About"
 msgstr "About"
 
@@ -51,7 +53,7 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 
-#: src/components/DetailView.js:178
+#: src/components/DetailView.js:179
 #: src/components/PropertiesSummary.js:97
 msgid "Additional links"
 msgstr "Additional links"
@@ -64,8 +66,8 @@ msgstr "Address"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: src/components/DetailView.js:162
-#: src/components/DetailView.js:202
+#: src/components/DetailView.js:163
+#: src/components/DetailView.js:203
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -73,7 +75,7 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/components/DetailView.js:74
+#: src/components/DetailView.js:75
 #: src/components/Indicators.js:289
 msgid "BUILDING:"
 msgstr "BUILDING:"
@@ -114,14 +116,14 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.js:138
-#: src/components/DetailView.js:251
-#: src/components/DetailView.js:257
+#: src/components/DetailView.js:139
+#: src/components/DetailView.js:252
+#: src/components/DetailView.js:258
 #: src/components/OwnersTable.tsx:19
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.js:132
+#: src/components/DetailView.js:133
 msgid "Business Entities"
 msgstr "Business Entities"
 
@@ -153,20 +155,19 @@ msgstr "Close legend"
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
-#: src/components/DetailView.js:190
+#: src/components/DetailView.js:191
 #: src/components/Indicators.js:384
 #: src/containers/NotRegisteredPage.js:160
-#: src/containers/NychaPage.js:186
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
-#: src/components/DetailView.js:193
+#: src/components/DetailView.js:194
 #: src/components/Indicators.js:389
 #: src/containers/NotRegisteredPage.js:157
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
-#: src/containers/App.js:50
+#: src/containers/App.js:51
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -175,7 +176,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
 #: src/components/LegalFooter.tsx:19
-#: src/containers/App.js:57
+#: src/containers/App.js:58
 msgid "Donate"
 msgstr "Donate"
 
@@ -205,8 +206,8 @@ msgid "Evictions"
 msgstr "Evictions"
 
 #: src/containers/NychaPage.js:127
-msgid "Evictions executed in this development by NYC Marshals in 2018. City Council, the Housing Data Coalition and Anti-Eviction Mapping Project cleaned, geocoded, and validated the data, originally sourced from DOI."
-msgstr "Evictions executed in this development by NYC Marshals in 2018. City Council, the Housing Data Coalition and Anti-Eviction Mapping Project cleaned, geocoded, and validated the data, originally sourced from DOI."
+msgid "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
+msgstr "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
 #: src/components/AddressToolbar.tsx:25
 msgid "Export Data"
@@ -220,7 +221,7 @@ msgstr "Failure to register a building with HPD"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/DetailView.js:187
+#: src/components/DetailView.js:188
 #: src/components/Indicators.js:379
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
@@ -232,10 +233,6 @@ msgstr "HPD Complaints"
 #: src/components/IndicatorsDatasets.tsx:12
 msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
-
-#: src/containers/NotRegisteredPage.js:161
-msgid "HPD Complaints/Violations"
-msgstr "HPD Complaints/Violations"
 
 #: src/components/IndicatorsDatasets.tsx:24
 #: src/components/PropertiesList.tsx:149
@@ -254,22 +251,22 @@ msgstr "HUD Complaint Form 958"
 msgid "Have thoughts about this page?"
 msgstr "Have thoughts about this page?"
 
-#: src/containers/App.js:54
+#: src/containers/App.js:55
 msgid "Home"
 msgstr "Home"
 
-#: src/components/DetailView.js:78
-#: src/components/DetailView.js:223
+#: src/components/DetailView.js:79
+#: src/components/DetailView.js:224
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.js:56
+#: src/containers/App.js:57
 msgid "How to use"
 msgstr "How to use"
 
 #: src/components/EvictionsSummary.tsx:9
-msgid "In 2018, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
-msgstr "In 2018, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
+msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
+msgstr "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
 #: src/containers/NotRegisteredPage.js:196
 msgid "Ineligible to certify violations"
@@ -300,7 +297,7 @@ msgstr "Landlord"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.js:153
+#: src/components/DetailView.js:154
 msgid "Last registered:"
 msgstr "Last registered:"
 
@@ -362,11 +359,6 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/DetailView.js:196
-#: src/components/Indicators.js:392
-msgid "New!"
-msgstr "New!"
-
 #: src/containers/NotRegisteredPage.js:117
 #: src/containers/NychaPage.js:97
 msgid "No address found"
@@ -392,7 +384,7 @@ msgstr "Non-Emergency"
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
-#: src/components/DetailView.js:181
+#: src/components/DetailView.js:182
 #: src/components/Indicators.js:369
 msgid "Official building pages"
 msgstr "Official building pages"
@@ -405,7 +397,7 @@ msgstr "Oops! That email is invalid."
 msgid "Open"
 msgstr "Open"
 
-#: src/components/DetailView.js:100
+#: src/components/DetailView.js:101
 msgid "Open Violations"
 msgstr "Open Violations"
 
@@ -421,9 +413,9 @@ msgstr "Owners submit Building Permit Applications to the Department of Building
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
 
-#: src/components/DetailView.js:145
-#: src/components/DetailView.js:265
-#: src/components/DetailView.js:271
+#: src/components/DetailView.js:146
+#: src/components/DetailView.js:266
+#: src/components/DetailView.js:272
 #: src/components/OwnersTable.tsx:31
 msgid "People"
 msgstr "People"
@@ -448,7 +440,7 @@ msgstr "Public Housing Development"
 msgid "Quarter"
 msgstr "Quarter"
 
-#: src/components/DetailView.js:112
+#: src/components/DetailView.js:113
 #: src/components/PropertiesList.tsx:128
 msgid "RS Units"
 msgstr "RS Units"
@@ -482,22 +474,22 @@ msgstr "Send us a data request"
 msgid "Send us feedback!"
 msgstr "Send us feedback!"
 
-#: src/containers/App.js:60
+#: src/containers/App.js:61
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.js:167
-#: src/components/DetailView.js:207
+#: src/components/DetailView.js:168
+#: src/components/DetailView.js:208
 #: src/components/EngagementPanel.tsx:15
 #: src/components/PropertiesSummary.js:107
-#: src/containers/App.js:67
+#: src/containers/App.js:68
 #: src/containers/NotRegisteredPage.js:168
 #: src/containers/NychaPage.js:197
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
 
-#: src/components/DetailView.js:237
-#: src/components/DetailView.js:243
+#: src/components/DetailView.js:238
+#: src/components/DetailView.js:244
 #: src/components/OwnersTable.tsx:25
 msgid "Shell Companies"
 msgstr "Shell Companies"
@@ -526,8 +518,8 @@ msgstr "Source code"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/components/DetailView.js:163
-#: src/components/DetailView.js:203
+#: src/components/DetailView.js:164
+#: src/components/DetailView.js:204
 #: src/containers/NychaPage.js:193
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
@@ -641,7 +633,7 @@ msgstr "Timeline"
 msgid "Total"
 msgstr "Total"
 
-#: src/components/DetailView.js:104
+#: src/components/DetailView.js:105
 msgid "Total Violations"
 msgstr "Total Violations"
 
@@ -653,7 +645,7 @@ msgstr "Unable to initiate a court action for nonpayment of rent."
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
-#: src/components/DetailView.js:94
+#: src/components/DetailView.js:95
 #: src/components/PropertiesList.tsx:82
 #: src/containers/NychaPage.js:124
 msgid "Units"
@@ -664,7 +656,7 @@ msgstr "Units"
 msgid "Useful links:"
 msgstr "Useful links:"
 
-#: src/components/DetailView.js:126
+#: src/components/DetailView.js:127
 msgid "View data over time"
 msgstr "View data over time"
 
@@ -672,7 +664,7 @@ msgstr "View data over time"
 msgid "View detail"
 msgstr "View detail"
 
-#: src/components/DetailView.js:184
+#: src/components/DetailView.js:185
 #: src/components/Indicators.js:374
 #: src/containers/NotRegisteredPage.js:156
 msgid "View documents on ACRIS"
@@ -688,7 +680,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.js:65
+#: src/components/DetailView.js:66
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -700,11 +692,11 @@ msgstr "Violations Issued"
 msgid "Visit our website"
 msgstr "Visit our website"
 
-#: src/containers/App.js:42
+#: src/containers/App.js:43
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
-#: src/components/DetailView.js:224
+#: src/components/DetailView.js:225
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -712,7 +704,7 @@ msgstr "We compare your search address with a database of over 200k buildings to
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 
-#: src/containers/App.js:46
+#: src/containers/App.js:47
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 
@@ -720,7 +712,7 @@ msgstr "Who owns what in nyc?"
 msgid "Year"
 msgstr "Year"
 
-#: src/components/DetailView.js:90
+#: src/components/DetailView.js:91
 msgid "Year Built"
 msgstr "Year Built"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -13,15 +13,15 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/DetailView.js:155
+#: src/components/DetailView.js:156
 msgid "(expired {0})"
 msgstr ""
 
-#: src/components/DetailView.js:156
+#: src/components/DetailView.js:157
 msgid "(expires {0})"
 msgstr ""
 
-#: src/components/DetailView.js:123
+#: src/components/DetailView.js:124
 msgid "(hover over a box to learn more)"
 msgstr ""
 
@@ -33,17 +33,19 @@ msgstr ""
 msgid "... or view some sample portfolios:"
 msgstr ""
 
-#: src/components/DetailView.js:108
+#: src/components/DetailView.js:109
 #: src/containers/NychaPage.js:128
-msgid "2018 Evictions"
+msgid "2019 Evictions"
 msgstr ""
 
-#: src/components/DetailView.js:196
+#: src/components/DetailView.js:197
 #: src/components/Indicators.js:392
+#: src/containers/NotRegisteredPage.js:161
+#: src/containers/NychaPage.js:186
 msgid "ANHD DAP Portal"
 msgstr ""
 
-#: src/containers/App.js:55
+#: src/containers/App.js:56
 msgid "About"
 msgstr ""
 
@@ -51,7 +53,7 @@ msgstr ""
 msgid "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 msgstr ""
 
-#: src/components/DetailView.js:178
+#: src/components/DetailView.js:179
 #: src/components/PropertiesSummary.js:97
 msgid "Additional links"
 msgstr ""
@@ -64,8 +66,8 @@ msgstr ""
 msgid "All set! Thanks for subscribing!"
 msgstr ""
 
-#: src/components/DetailView.js:162
-#: src/components/DetailView.js:202
+#: src/components/DetailView.js:163
+#: src/components/DetailView.js:203
 msgid "Are you having issues in this building?"
 msgstr ""
 
@@ -73,7 +75,7 @@ msgstr ""
 msgid "Are you having issues in this development?"
 msgstr ""
 
-#: src/components/DetailView.js:74
+#: src/components/DetailView.js:75
 #: src/components/Indicators.js:289
 msgid "BUILDING:"
 msgstr ""
@@ -114,14 +116,14 @@ msgstr ""
 msgid "Built"
 msgstr ""
 
-#: src/components/DetailView.js:138
-#: src/components/DetailView.js:251
-#: src/components/DetailView.js:257
+#: src/components/DetailView.js:139
+#: src/components/DetailView.js:252
+#: src/components/DetailView.js:258
 #: src/components/OwnersTable.tsx:19
 msgid "Business Addresses"
 msgstr ""
 
-#: src/components/DetailView.js:132
+#: src/components/DetailView.js:133
 msgid "Business Entities"
 msgstr ""
 
@@ -153,20 +155,19 @@ msgstr ""
 msgid "Complaints Issued"
 msgstr ""
 
-#: src/components/DetailView.js:190
+#: src/components/DetailView.js:191
 #: src/components/Indicators.js:384
 #: src/containers/NotRegisteredPage.js:160
-#: src/containers/NychaPage.js:186
 msgid "DOB Building Profile"
 msgstr ""
 
-#: src/components/DetailView.js:193
+#: src/components/DetailView.js:194
 #: src/components/Indicators.js:389
 #: src/containers/NotRegisteredPage.js:157
 msgid "DOF Property Tax Bills"
 msgstr ""
 
-#: src/containers/App.js:50
+#: src/containers/App.js:51
 msgid "Demo Site"
 msgstr ""
 
@@ -175,7 +176,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr ""
 
 #: src/components/LegalFooter.tsx:19
-#: src/containers/App.js:57
+#: src/containers/App.js:58
 msgid "Donate"
 msgstr ""
 
@@ -205,7 +206,7 @@ msgid "Evictions"
 msgstr ""
 
 #: src/containers/NychaPage.js:127
-msgid "Evictions executed in this development by NYC Marshals in 2018. City Council, the Housing Data Coalition and Anti-Eviction Mapping Project cleaned, geocoded, and validated the data, originally sourced from DOI."
+msgid "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr ""
 
 #: src/components/AddressToolbar.tsx:25
@@ -220,7 +221,7 @@ msgstr ""
 msgid "General info"
 msgstr ""
 
-#: src/components/DetailView.js:187
+#: src/components/DetailView.js:188
 #: src/components/Indicators.js:379
 msgid "HPD Building Profile"
 msgstr ""
@@ -231,10 +232,6 @@ msgstr ""
 
 #: src/components/IndicatorsDatasets.tsx:12
 msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
-msgstr ""
-
-#: src/containers/NotRegisteredPage.js:161
-msgid "HPD Complaints/Violations"
 msgstr ""
 
 #: src/components/IndicatorsDatasets.tsx:24
@@ -254,21 +251,21 @@ msgstr ""
 msgid "Have thoughts about this page?"
 msgstr ""
 
-#: src/containers/App.js:54
+#: src/containers/App.js:55
 msgid "Home"
 msgstr ""
 
-#: src/components/DetailView.js:78
-#: src/components/DetailView.js:223
+#: src/components/DetailView.js:79
+#: src/components/DetailView.js:224
 msgid "How is this building associated to this portfolio?"
 msgstr ""
 
-#: src/containers/App.js:56
+#: src/containers/App.js:57
 msgid "How to use"
 msgstr ""
 
 #: src/components/EvictionsSummary.tsx:9
-msgid "In 2018, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
+msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr ""
 
 #: src/containers/NotRegisteredPage.js:196
@@ -300,7 +297,7 @@ msgstr ""
 msgid "Last Sale Unknown"
 msgstr ""
 
-#: src/components/DetailView.js:153
+#: src/components/DetailView.js:154
 msgid "Last registered:"
 msgstr ""
 
@@ -362,11 +359,6 @@ msgstr ""
 msgid "New York Regional Office:"
 msgstr ""
 
-#: src/components/DetailView.js:196
-#: src/components/Indicators.js:392
-msgid "New!"
-msgstr ""
-
 #: src/containers/NotRegisteredPage.js:117
 #: src/containers/NychaPage.js:97
 msgid "No address found"
@@ -392,7 +384,7 @@ msgstr ""
 msgid "Officer/Owner"
 msgstr ""
 
-#: src/components/DetailView.js:181
+#: src/components/DetailView.js:182
 #: src/components/Indicators.js:369
 msgid "Official building pages"
 msgstr ""
@@ -405,7 +397,7 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: src/components/DetailView.js:100
+#: src/components/DetailView.js:101
 msgid "Open Violations"
 msgstr ""
 
@@ -421,9 +413,9 @@ msgstr ""
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
 msgstr ""
 
-#: src/components/DetailView.js:145
-#: src/components/DetailView.js:265
-#: src/components/DetailView.js:271
+#: src/components/DetailView.js:146
+#: src/components/DetailView.js:266
+#: src/components/DetailView.js:272
 #: src/components/OwnersTable.tsx:31
 msgid "People"
 msgstr ""
@@ -448,7 +440,7 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: src/components/DetailView.js:112
+#: src/components/DetailView.js:113
 #: src/components/PropertiesList.tsx:128
 msgid "RS Units"
 msgstr ""
@@ -482,22 +474,22 @@ msgstr ""
 msgid "Send us feedback!"
 msgstr ""
 
-#: src/containers/App.js:60
+#: src/containers/App.js:61
 msgid "Share"
 msgstr ""
 
-#: src/components/DetailView.js:167
-#: src/components/DetailView.js:207
+#: src/components/DetailView.js:168
+#: src/components/DetailView.js:208
 #: src/components/EngagementPanel.tsx:15
 #: src/components/PropertiesSummary.js:107
-#: src/containers/App.js:67
+#: src/containers/App.js:68
 #: src/containers/NotRegisteredPage.js:168
 #: src/containers/NychaPage.js:197
 msgid "Share this page with your neighbors"
 msgstr ""
 
-#: src/components/DetailView.js:237
-#: src/components/DetailView.js:243
+#: src/components/DetailView.js:238
+#: src/components/DetailView.js:244
 #: src/components/OwnersTable.tsx:25
 msgid "Shell Companies"
 msgstr ""
@@ -526,8 +518,8 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
-#: src/components/DetailView.js:163
-#: src/components/DetailView.js:203
+#: src/components/DetailView.js:164
+#: src/components/DetailView.js:204
 #: src/containers/NychaPage.js:193
 msgid "Take action on JustFix.nyc!"
 msgstr ""
@@ -641,7 +633,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: src/components/DetailView.js:104
+#: src/components/DetailView.js:105
 msgid "Total Violations"
 msgstr ""
 
@@ -653,7 +645,7 @@ msgstr ""
 msgid "Unable to request Code Violation Dismissals"
 msgstr ""
 
-#: src/components/DetailView.js:94
+#: src/components/DetailView.js:95
 #: src/components/PropertiesList.tsx:82
 #: src/containers/NychaPage.js:124
 msgid "Units"
@@ -664,7 +656,7 @@ msgstr ""
 msgid "Useful links:"
 msgstr ""
 
-#: src/components/DetailView.js:126
+#: src/components/DetailView.js:127
 msgid "View data over time"
 msgstr ""
 
@@ -672,7 +664,7 @@ msgstr ""
 msgid "View detail"
 msgstr ""
 
-#: src/components/DetailView.js:184
+#: src/components/DetailView.js:185
 #: src/components/Indicators.js:374
 #: src/containers/NotRegisteredPage.js:156
 msgid "View documents on ACRIS"
@@ -688,7 +680,7 @@ msgstr ""
 msgid "View portfolio"
 msgstr ""
 
-#: src/components/DetailView.js:65
+#: src/components/DetailView.js:66
 msgid "View portfolio map"
 msgstr ""
 
@@ -700,11 +692,11 @@ msgstr ""
 msgid "Visit our website"
 msgstr ""
 
-#: src/containers/App.js:42
+#: src/containers/App.js:43
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr ""
 
-#: src/components/DetailView.js:224
+#: src/components/DetailView.js:225
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr ""
 
@@ -712,7 +704,7 @@ msgstr ""
 msgid "What happens if the landlord has failed to register?"
 msgstr ""
 
-#: src/containers/App.js:46
+#: src/containers/App.js:47
 msgid "Who owns what in nyc?"
 msgstr "¿Quién posee qué en Nueva York?"
 
@@ -720,7 +712,7 @@ msgstr "¿Quién posee qué en Nueva York?"
 msgid "Year"
 msgstr ""
 
-#: src/components/DetailView.js:90
+#: src/components/DetailView.js:91
 msgid "Year Built"
 msgstr ""
 

--- a/sql/create_bldgs_table.sql
+++ b/sql/create_bldgs_table.sql
@@ -37,8 +37,8 @@ LEFT JOIN (
   SELECT
     bbl,
     count(*) as evictions
-  FROM marshal_evictions_18
-  WHERE residentialcommercialind = 'Residential'
+  FROM marshal_evictions_19
+  WHERE residentialcommercialind = 'RESIDENTIAL'
   GROUP BY bbl
 ) evictions ON (registrations.bbl = evictions.bbl)
 LEFT JOIN (

--- a/sql/nycha_stats.sql
+++ b/sql/nycha_stats.sql
@@ -1,0 +1,27 @@
+with evictions_by_bbl as (
+	select 
+		bbl,
+		count(*) as evictions
+	from marshal_evictions_19
+	where bbl is not null
+	and residentialcommercialind = any('{R, Residential, RESIDENTIAL}')
+	group by bbl
+),
+dev_stats as (
+    select 
+        development,
+        sum(evictions) dev_evictions,
+        sum(unitsres) dev_unitsres
+    from "nycha_developments_TEMPORARY"
+    left join evictions_by_bbl using(bbl)
+    left join pluto_19v2 using(bbl)
+    group by development 
+)
+
+select 
+	t.bbl,
+	t.development,
+	d.dev_evictions,
+	d.dev_unitsres
+from "nycha_developments_TEMPORARY" t
+left join dev_stats d using(development)


### PR DESCRIPTION
I updated our wow buildings sql to include the new 2019 evictions data we have, changed relevant text throughout the site to match, and also updated our nycha data with new eviction and res unit counts. 