### PR TITLE
Set the 'Access-Control-Allow-Origin' header on the dap api endpoint to *

### DIFF
--- a/server/controllers/address.js
+++ b/server/controllers/address.js
@@ -58,6 +58,7 @@ module.exports = {
   },
 
   dapAggregate: (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
     db.queryDapAggregate(req.query.bbl)
       .then(result => res.status(200).send({ result: result }) )
       .catch(err => {


### PR DESCRIPTION
This fix allows @0xStarcat to access the dap api in testing on their local machine.