### PR TITLE
Added new helper function to correctly format street names for outbound HPD links

### DIFF
--- a/client/src/components/AddressToolbar.tsx
+++ b/client/src/components/AddressToolbar.tsx
@@ -43,19 +43,6 @@ export default class AddressToolbar extends Component<AddressToolbarProps, State
     return (
       <div className="AddressToolbar">
         <div className="btn-group float-right">
-          {
-            // <div className="dropdown">
-            //   <button className="btn dropdown-toggle" tabIndex="0">
-            //     Property Links &#8964;
-            //   </button>
-            //   <ul className="menu">
-            //     <li><a href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`} target="_blank">View documents on ACRIS &#8599;</a></li>
-            //     <li><a href={`http://webapps.nyc.gov:8084/CICS/fin1/find001i?FFUNC=C&FBORO=${boro}&FBLOCK=${block}&FLOT=${lot}`} target="_blank">DOF Property Tax Bills &#8599;</a></li>
-            //     <li><a href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`} target="_blank">DOB Property Profile &#8599;</a></li>
-            //     <li><a href={`https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${this.props.userAddr.housenumber}&p3=${this.props.userAddr.streetname}&SearchButton=Search`} target="_blank">HPD Complaints/Violations &#8599;</a></li>
-            //   </ul>
-            // </div>
-          }
           <button className="btn" onClick={() => this.setState({ showExportModal: true })}>
             <Trans>Export Data</Trans>
           </button>

--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -185,7 +185,7 @@ export default class DetailView extends Component {
                                 <a onClick={() => {window.gtag('event', 'acris-overview-tab');}} href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`} target="_blank" rel="noopener noreferrer" className="btn btn-block"><Trans>View documents on ACRIS</Trans> &#8599;&#xFE0E;</a>
                               </div>
                               <div className="column col-12">
-                                <a onClick={() => {window.gtag('event', 'hpd-overview-tab');}} href={`https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${this.props.addr.housenumber}&p3=${this.props.addr.streetname}&SearchButton=Search`} target="_blank" rel="noopener noreferrer" className="btn btn-block"><Trans>HPD Building Profile</Trans> &#8599;&#xFE0E;</a>
+                                <a onClick={() => {window.gtag('event', 'hpd-overview-tab');}} href={`https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${this.props.addr.housenumber}&p3=${Helpers.formatStreetNameForHpdLink(this.props.addr.streetname)}&SearchButton=Search`} target="_blank" rel="noopener noreferrer" className="btn btn-block"><Trans>HPD Building Profile</Trans> &#8599;&#xFE0E;</a>
                               </div>
                               <div className="column col-12">
                                 <a onClick={() => {window.gtag('event', 'dob-overview-tab');}} href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`} target="_blank" rel="noopener noreferrer" className="btn btn-block"><Trans>DOB Building Profile</Trans> &#8599;&#xFE0E;</a>

--- a/client/src/components/Indicators.js
+++ b/client/src/components/Indicators.js
@@ -375,7 +375,7 @@ class IndicatorsWithoutI18n extends Component {
                       </div>
                       <div className="column col-12">
                         <a onClick={() => {window.gtag('event', 'hpd-timeline-tab');}} 
-                           href={(housenumber && streetname ? `https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${housenumber}&p3=${streetname}&SearchButton=Search` : `https://hpdonline.hpdnyc.org/HPDonline/provide_address.aspx`)} target="_blank" rel="noopener noreferrer" 
+                           href={(housenumber && streetname ? `https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${housenumber}&p3=${Helpers.formatStreetNameForHpdLink(streetname)}&SearchButton=Search` : `https://hpdonline.hpdnyc.org/HPDonline/provide_address.aspx`)} target="_blank" rel="noopener noreferrer" 
                            className="btn btn-block"><Trans>HPD Building Profile</Trans> &#8599;&#xFE0E;</a>
                       </div>
                       <div className="column col-12">

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -103,3 +103,19 @@ test("titleCase() works", () => {
 test("formatDate() works", () => {
   expect(helpers.formatDate('2008-01-05')).toBe('January 2008');
 });
+
+test("formatStreetNameForHpdLink() works", () => {
+  expect(helpers.formatStreetNameForHpdLink('East 21st Street')).toBe('E 21ST STREET');
+});
+
+test("formatStreetNameForHpdLink() doesn't change anything but the streetname prefix", () => {
+  expect(helpers.formatStreetNameForHpdLink('Easton Avenue')).toBe('EASTON AVENUE');
+});
+
+test("formatStreetNameForHpdLink() still works for one-word streetnames", () => {
+  expect(helpers.formatStreetNameForHpdLink('Broadway')).toBe('BROADWAY');
+});
+
+test("formatStreetNameForHpdLink() still works for empty streetnames", () => {
+  expect(helpers.formatStreetNameForHpdLink('')).toBe('');
+});

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -105,15 +105,15 @@ test("formatDate() works", () => {
 });
 
 test("formatStreetNameForHpdLink() works", () => {
-  expect(helpers.formatStreetNameForHpdLink('East 21st Street')).toBe('E 21ST STREET');
+  expect(helpers.formatStreetNameForHpdLink('East 21st Street')).toBe('E 21st Street');
 });
 
 test("formatStreetNameForHpdLink() doesn't change anything but the streetname prefix", () => {
-  expect(helpers.formatStreetNameForHpdLink('Easton Avenue')).toBe('EASTON AVENUE');
+  expect(helpers.formatStreetNameForHpdLink('Easton Avenue')).toBe('Easton Avenue');
 });
 
 test("formatStreetNameForHpdLink() still works for one-word streetnames", () => {
-  expect(helpers.formatStreetNameForHpdLink('Broadway')).toBe('BROADWAY');
+  expect(helpers.formatStreetNameForHpdLink('Broadway')).toBe('Broadway');
 });
 
 test("formatStreetNameForHpdLink() still works for empty streetnames", () => {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -125,7 +125,7 @@ export default {
   },
 
   formatStreetNameForHpdLink(streetName: string): string {
-    const streetNamePrefix = streetName.slice(0,streetName.indexOf(' '));
+    const streetNamePrefix = streetName.toUpperCase().slice(0,streetName.indexOf(' '));
     const newStreetNamePrefix = 
       (streetNamePrefix === 'NORTH' ? 'N'
       : streetNamePrefix === 'SOUTH' ? 'S'

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -125,12 +125,12 @@ export default {
   },
 
   formatStreetNameForHpdLink(streetName: string): string {
-    const streetNamePrefix = streetName.toUpperCase().slice(0,streetName.indexOf(' '));
+    const streetNamePrefix = streetName.slice(0,streetName.indexOf(' '));
     const newStreetNamePrefix = 
-      (streetNamePrefix === 'NORTH' ? 'N'
-      : streetNamePrefix === 'SOUTH' ? 'S'
-      : streetNamePrefix === 'EAST' ? 'E'
-      : streetNamePrefix === 'WEST' ? 'W'
+      (streetNamePrefix.toUpperCase() === 'NORTH' ? 'N'
+      : streetNamePrefix.toUpperCase() === 'SOUTH' ? 'S'
+      : streetNamePrefix.toUpperCase() === 'EAST' ? 'E'
+      : streetNamePrefix.toUpperCase() === 'WEST' ? 'W'
       : streetNamePrefix); 
     const streetNameRest = streetName.slice(streetName.indexOf(' '));
     return newStreetNamePrefix + streetNameRest; 

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -122,6 +122,18 @@ export default {
     var date = new Date(dateString);
     var options = {year: 'numeric', month: 'long'};
     return date.toLocaleDateString("en-US", options);
+  },
+
+  formatStreetNameForHpdLink(streetName: string): string {
+    const streetNamePrefix = streetName.slice(0,streetName.indexOf(' '));
+    const newStreetNamePrefix = 
+      (streetNamePrefix === 'NORTH' ? 'N'
+      : streetNamePrefix === 'SOUTH' ? 'S'
+      : streetNamePrefix === 'EAST' ? 'E'
+      : streetNamePrefix === 'WEST' ? 'W'
+      : streetNamePrefix); 
+    const streetNameRest = streetName.slice(streetName.indexOf(' '));
+    return newStreetNamePrefix + streetNameRest; 
   }
 
 };


### PR DESCRIPTION
Seems that [HPD's Online Portal](https://hpdonline.hpdnyc.org/HPDonline/select_application.aspx) doesn't like when streetname prefixes are spelled out (when E 21st is 'EAST 21ST'). This PR adds a helper function that tries to format these street prefixes in the preferred way to limit broken links to HPD Building Profile pages.