### PR TITLE
Add urls and focus styles to address page tabs

### DIFF
--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -9,7 +9,7 @@ import Modal from 'components/Modal';
 import 'styles/DetailView.css';
 import { Trans } from '@lingui/macro';
 import { SocialSharePortfolio } from './SocialShare';
-import { NavLink } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 
 export default class DetailView extends Component {
   constructor(props) {
@@ -123,9 +123,9 @@ export default class DetailView extends Component {
                         </div>
                         <span className="card-body-table-prompt float-right"><Trans render="i">(hover over a box to learn more)</Trans></span>
                         <div className="card-body-timeline-link">
-                          <button className="btn btn-primary btn-block" onClick={() => {this.props.onLinkToTimeline(); window.gtag('event', 'view-data-over-time-overview-tab');}}>
+                          <Link to={this.props.generateBaseUrl() + "/timeline"} className="btn btn-primary btn-block" onClick={() => {window.gtag('event', 'view-data-over-time-overview-tab');}}>
                             <Trans render="span">View data over time</Trans>{' '}&#8599;&#xFE0E;
-                          </button>
+                          </Link>
                         </div>
                         <div className="card-body-landlord">
                             <div className="columns">

--- a/client/src/components/Indicators.js
+++ b/client/src/components/Indicators.js
@@ -1,66 +1,67 @@
-import React, { Component } from 'react';
+import React, { Component } from "react";
 
-import Helpers from 'util/helpers';
+import Helpers from "util/helpers";
 
-import IndicatorsViz from 'components/IndicatorsViz';
-import Loader from 'components/Loader';
-import LegalFooter from 'components/LegalFooter';
-import APIClient from 'components/APIClient';
-import { withI18n } from '@lingui/react';
-import { Trans } from '@lingui/macro';
+import IndicatorsViz from "components/IndicatorsViz";
+import Loader from "components/Loader";
+import LegalFooter from "components/LegalFooter";
+import APIClient from "components/APIClient";
+import { withI18n } from "@lingui/react";
+import { Trans } from "@lingui/macro";
 
-import 'styles/Indicators.css';
-import { IndicatorsDatasetRadio, INDICATORS_DATASETS } from './IndicatorsDatasets';
+import "styles/Indicators.css";
+import {
+  IndicatorsDatasetRadio,
+  INDICATORS_DATASETS,
+} from "./IndicatorsDatasets";
+import { Link } from "react-router-dom";
 
+const initialState = {
+  saleHistory: null,
 
-const initialState = { 
+  lastSale: {
+    date: null,
+    label: null,
+    documentid: null,
+  },
 
-      saleHistory: null,
+  indicatorHistory: null,
 
-      lastSale: {
-        date: null,
-        label: null, 
-        documentid: null 
-      },
+  violsData: {
+    labels: null,
+    values: {
+      class_a: null,
+      class_b: null,
+      class_c: null,
+      total: null,
+    },
+  },
 
-      indicatorHistory: null,
+  complaintsData: {
+    labels: null,
+    values: {
+      emergency: null,
+      nonemergency: null,
+      total: null,
+    },
+  },
 
-      violsData: {
-        labels: null,
-        values: {
-          class_a: null,
-          class_b: null,
-          class_c: null,
-          total: null
-        }
-      },
+  permitsData: {
+    labels: null,
+    values: {
+      total: null,
+    },
+  },
 
-      complaintsData: {
-        labels: null,
-        values: {
-          emergency: null,
-          nonemergency: null,
-          total: null
-        }
-      },
-
-      permitsData: {
-        labels: null,
-        values: {
-          total: null
-        }
-      },
-
-      indicatorList: ['complaints','viols','permits'],
-      defaultVis: 'complaints',
-      activeVis: 'complaints',
-      timeSpanList: ['month','quarter','year'],
-      activeTimeSpan: 'quarter',
-      monthsInGroup: 3,
-      xAxisStart: 0,
-      xAxisViewableColumns: 20,
-      currentAddr: null
-
+  indicatorList: ["complaints", "viols", "permits"],
+  defaultVis: "complaints",
+  activeVis: "complaints",
+  timeSpanList: ["month", "quarter", "year"],
+  activeTimeSpan: "quarter",
+  monthsInGroup: 3,
+  xAxisStart: 0,
+  xAxisViewableColumns: 20,
+  currentAddr: null,
 };
 
 class IndicatorsWithoutI18n extends Component {
@@ -77,82 +78,92 @@ class IndicatorsWithoutI18n extends Component {
 
   /** Shifts the X-axis 'left' or 'right', or 'reset' the X-axis to default */
   handleXAxisChange(shift) {
-
     const span = this.state.xAxisViewableColumns;
-    const labelsArray = this.state[(this.state.activeVis + 'Data')].labels;
+    const labelsArray = this.state[this.state.activeVis + "Data"].labels;
 
-    if(!labelsArray || labelsArray.length < span) { 
+    if (!labelsArray || labelsArray.length < span) {
       return;
     }
 
-    const groupedLabelsLength = Math.floor(labelsArray.length / this.state.monthsInGroup);
+    const groupedLabelsLength = Math.floor(
+      labelsArray.length / this.state.monthsInGroup
+    );
 
     const xAxisMax = Math.max(groupedLabelsLength - span, 0);
     const currentPosition = this.state.xAxisStart;
     const offset = Math.ceil(6 / this.state.monthsInGroup);
 
-    if (shift === 'left') {
+    if (shift === "left") {
       const newPosition = Math.max(currentPosition - offset, 0);
       this.setState({
-          xAxisStart: newPosition
-        });
+        xAxisStart: newPosition,
+      });
     }
 
-    if (shift === 'right') {
+    if (shift === "right") {
       const newPosition = Math.min(currentPosition + offset, xAxisMax);
       this.setState({
-          xAxisStart: newPosition
-        });
+        xAxisStart: newPosition,
+      });
     }
 
-    if (shift === 'reset') {
+    if (shift === "reset") {
       this.setState({
-          xAxisStart: xAxisMax
-        });
+        xAxisStart: xAxisMax,
+      });
     }
-
   }
 
   handleVisChange(selectedVis) {
     this.setState({
-      activeVis: selectedVis
+      activeVis: selectedVis,
     });
   }
 
   /** Changes viewing timespan to be by 'year', 'quarter', or 'month' */
   handleTimeSpanChange(selectedTimeSpan) {
-    var monthsInGroup = (selectedTimeSpan === 'quarter' ? 3 : selectedTimeSpan === 'year' ? 12 : 1)
+    var monthsInGroup =
+      selectedTimeSpan === "quarter" ? 3 : selectedTimeSpan === "year" ? 12 : 1;
 
     this.setState({
       activeTimeSpan: selectedTimeSpan,
-      monthsInGroup: monthsInGroup
+      monthsInGroup: monthsInGroup,
     });
   }
 
   /** Fetches data for Indicators component via 2 API calls and saves the raw data in state */
   fetchData(detailAddr) {
-      APIClient.getSaleHistory(detailAddr.bbl)
-        .then(results => this.setState({ saleHistory: results.result }))
-        .catch(err => {window.Rollbar.error("API error on Indicators: Sale History", err, detailAddr.bbl);}
-      );
-
-      APIClient.getIndicatorHistory(detailAddr.bbl)
-        .then(results => this.setState({ indicatorHistory: results.result }))
-        .catch(err => {window.Rollbar.error("API error on Indicators: Indicator History", err, detailAddr.bbl);}
-      );
-
-      this.setState({
-        currentAddr: detailAddr
+    APIClient.getSaleHistory(detailAddr.bbl)
+      .then((results) => this.setState({ saleHistory: results.result }))
+      .catch((err) => {
+        window.Rollbar.error(
+          "API error on Indicators: Sale History",
+          err,
+          detailAddr.bbl
+        );
       });
+
+    APIClient.getIndicatorHistory(detailAddr.bbl)
+      .then((results) => this.setState({ indicatorHistory: results.result }))
+      .catch((err) => {
+        window.Rollbar.error(
+          "API error on Indicators: Indicator History",
+          err,
+          detailAddr.bbl
+        );
+      });
+
+    this.setState({
+      currentAddr: detailAddr,
+    });
   }
 
   /** Reorganizes raw data from API call and then returns an object that matches the data stucture in state  */
   createVizData(rawJSON, vizType) {
-
     // Generate object to hold data for viz
     // Note: keys in "values" object need to match exact key names in data from API call
-    var vizData = Object.assign({},initialState[(vizType + 'Data')]);
-    
+    var vizData = Object.assign({}, initialState[vizType + "Data"]);
+
     vizData.labels = [];
     for (const column in vizData.values) {
       vizData.values[column] = [];
@@ -162,202 +173,339 @@ class IndicatorsWithoutI18n extends Component {
     // Default grouping is by MONTH
 
     const rawJSONLength = rawJSON.length;
-     
-    for (let i = 0; i < rawJSONLength; i++) {
 
+    for (let i = 0; i < rawJSONLength; i++) {
       vizData.labels.push(rawJSON[i].month);
 
       for (const column in vizData.values) {
-        const vizTypePlusColumn = vizType + '_' + column
+        const vizTypePlusColumn = vizType + "_" + column;
         vizData.values[column].push(parseInt(rawJSON[i][vizTypePlusColumn]));
       }
-
     }
     return vizData;
-  } 
+  }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-
     // make the api call when we have a new detail address from the Address Page
-    if(nextProps.detailAddr && nextProps.detailAddr.bbl && // will be receiving a detailAddr prop AND
-        (!this.props.detailAddr || // either we don't have one now 
-         (this.props.detailAddr && this.props.detailAddr.bbl && // OR we have a different one
-          !Helpers.addrsAreEqual(this.props.detailAddr, nextProps.detailAddr)))) { 
+    if (
+      nextProps.detailAddr &&
+      nextProps.detailAddr.bbl && // will be receiving a detailAddr prop AND
+      (!this.props.detailAddr || // either we don't have one now
+        (this.props.detailAddr &&
+        this.props.detailAddr.bbl && // OR we have a different one
+          !Helpers.addrsAreEqual(this.props.detailAddr, nextProps.detailAddr)))
+    ) {
       this.reset();
       this.fetchData(nextProps.detailAddr);
     }
   }
 
   componentDidUpdate(prevProps, prevState) {
-
     const indicatorList = this.state.indicatorList;
 
-    // process viz data from incoming API calls: 
-    
-    if(this.state.indicatorHistory && !Helpers.jsonEqual(prevState.indicatorHistory, this.state.indicatorHistory)) {
-     
-      for (const indicator of indicatorList) {
+    // process viz data from incoming API calls:
 
-        var inputData = this.createVizData(this.state.indicatorHistory, indicator);
-        
+    if (
+      this.state.indicatorHistory &&
+      !Helpers.jsonEqual(
+        prevState.indicatorHistory,
+        this.state.indicatorHistory
+      )
+    ) {
+      for (const indicator of indicatorList) {
+        var inputData = this.createVizData(
+          this.state.indicatorHistory,
+          indicator
+        );
+
         this.setState({
-          [(indicator + 'Data')]: inputData
+          [indicator + "Data"]: inputData,
         });
       }
     }
 
     // reset chart positions when:
-    // 1. default dataset loads or 
+    // 1. default dataset loads or
     // 2. when activeTimeSpan changes:
 
-    if((!prevState[(this.state.defaultVis + 'Data')].labels && this.state[(this.state.defaultVis + 'Data')].labels) ||
-    (prevState.activeTimeSpan !== this.state.activeTimeSpan)) {
-      this.handleXAxisChange('reset');
+    if (
+      (!prevState[this.state.defaultVis + "Data"].labels &&
+        this.state[this.state.defaultVis + "Data"].labels) ||
+      prevState.activeTimeSpan !== this.state.activeTimeSpan
+    ) {
+      this.handleXAxisChange("reset");
     }
 
     // process sale history data when:
-    // 1. default dataset loads or 
-    // 2. when activeTimeSpan changes 
+    // 1. default dataset loads or
+    // 2. when activeTimeSpan changes
 
-    if(this.state.saleHistory && 
-        (!Helpers.jsonEqual(prevState.saleHistory, this.state.saleHistory) ||
-        (prevState.activeTimeSpan !== this.state.activeTimeSpan))) {
-
-      if (this.state.saleHistory.length > 0 && 
-          (this.state.saleHistory[0].docdate || this.state.saleHistory[0].recordedfiled) &&
-          this.state.saleHistory[0].documentid ) {
-        
-        var lastSaleDate = this.state.saleHistory[0].docdate || this.state.saleHistory[0].recordedfiled; 
-        var lastSaleYear = lastSaleDate.slice(0,4);
-        var lastSaleQuarter = lastSaleYear + '-Q' + Math.ceil(parseInt(lastSaleDate.slice(5,7)) / 3);
-        var lastSaleMonth = lastSaleDate.slice(0,7);
+    if (
+      this.state.saleHistory &&
+      (!Helpers.jsonEqual(prevState.saleHistory, this.state.saleHistory) ||
+        prevState.activeTimeSpan !== this.state.activeTimeSpan)
+    ) {
+      if (
+        this.state.saleHistory.length > 0 &&
+        (this.state.saleHistory[0].docdate ||
+          this.state.saleHistory[0].recordedfiled) &&
+        this.state.saleHistory[0].documentid
+      ) {
+        var lastSaleDate =
+          this.state.saleHistory[0].docdate ||
+          this.state.saleHistory[0].recordedfiled;
+        var lastSaleYear = lastSaleDate.slice(0, 4);
+        var lastSaleQuarter =
+          lastSaleYear +
+          "-Q" +
+          Math.ceil(parseInt(lastSaleDate.slice(5, 7)) / 3);
+        var lastSaleMonth = lastSaleDate.slice(0, 7);
 
         this.setState({
           lastSale: {
             date: lastSaleDate,
-            label: (this.state.activeTimeSpan === 'year' ? lastSaleYear :
-                    this.state.activeTimeSpan === 'quarter' ? lastSaleQuarter :
-                    lastSaleMonth),
-            documentid: this.state.saleHistory[0].documentid
-          }
+            label:
+              this.state.activeTimeSpan === "year"
+                ? lastSaleYear
+                : this.state.activeTimeSpan === "quarter"
+                ? lastSaleQuarter
+                : lastSaleMonth,
+            documentid: this.state.saleHistory[0].documentid,
+          },
         });
-
-      }
-
-      else {
+      } else {
         this.setState({
-          lastSale: initialState.lastSale
+          lastSale: initialState.lastSale,
         });
       }
-
     }
   }
 
   render() {
+    const boro = this.props.detailAddr
+      ? this.props.detailAddr.bbl.slice(0, 1)
+      : null;
+    const block = this.props.detailAddr
+      ? this.props.detailAddr.bbl.slice(1, 6)
+      : null;
+    const lot = this.props.detailAddr
+      ? this.props.detailAddr.bbl.slice(6, 10)
+      : null;
+    const housenumber = this.props.detailAddr
+      ? this.props.detailAddr.housenumber
+      : null;
+    const streetname = this.props.detailAddr
+      ? this.props.detailAddr.streetname
+      : null;
 
+    const indicatorData = this.state.activeVis + "Data";
+    const xAxisLength = this.state[indicatorData].labels
+      ? Math.floor(
+          this.state[indicatorData].labels.length / this.state.monthsInGroup
+        )
+      : 0;
+    const indicatorDataTotal = this.state[indicatorData].values.total
+      ? this.state[indicatorData].values.total.reduce(
+          (total, sum) => total + sum
+        )
+      : null;
 
-  const boro = (this.props.detailAddr ? this.props.detailAddr.bbl.slice(0, 1) : null);
-  const block = (this.props.detailAddr ? this.props.detailAddr.bbl.slice(1, 6) : null);
-  const lot = (this.props.detailAddr ? this.props.detailAddr.bbl.slice(6, 10) : null);
-  const housenumber = (this.props.detailAddr ? this.props.detailAddr.housenumber : null);
-  const streetname = (this.props.detailAddr ? this.props.detailAddr.streetname : null);
+    const i18n = this.props.i18n;
+    const detailAddrStr =
+      this.props.detailAddr &&
+      `${this.props.detailAddr.housenumber} ${Helpers.titleCase(
+        this.props.detailAddr.streetname
+      )}, ${Helpers.titleCase(this.props.detailAddr.boro)}`;
 
-  const indicatorData = this.state.activeVis + 'Data'; 
-  const xAxisLength = (this.state[indicatorData].labels ? Math.floor(this.state[indicatorData].labels.length / this.state.monthsInGroup) : 0);
-  const indicatorDataTotal = (this.state[indicatorData].values.total ? (this.state[indicatorData].values.total).reduce((total, sum) => (total + sum)) : null);
-  
-  const i18n = this.props.i18n;
-  const detailAddrStr = this.props.detailAddr && `${this.props.detailAddr.housenumber} ${Helpers.titleCase(this.props.detailAddr.streetname)}, ${Helpers.titleCase(this.props.detailAddr.boro)}`;
-  
-  const dataset = INDICATORS_DATASETS[this.state.activeVis];
+    const dataset = INDICATORS_DATASETS[this.state.activeVis];
 
     return (
       <div className="Page Indicators">
         <div className="Indicators__content Page__content">
-          { !(this.props.isVisible && 
-              this.state.saleHistory && this.state.indicatorHistory &&
-              this.state[this.state.defaultVis + 'Data'].labels) ? 
-            (
-              <Loader loading={true} classNames="Loader-map"><Trans>Loading</Trans></Loader>
-            ) : 
-          (
+          {!(
+            this.props.isVisible &&
+            this.state.saleHistory &&
+            this.state.indicatorHistory &&
+            this.state[this.state.defaultVis + "Data"].labels
+          ) ? (
+            <Loader loading={true} classNames="Loader-map">
+              <Trans>Loading</Trans>
+            </Loader>
+          ) : (
             <div className="columns">
               <div className="column col-8 col-lg-12">
-
                 <div className="title-card">
-                  <h4 className="title">{(this.props.detailAddr ? 
-                    <span><Trans>BUILDING:</Trans> <b>{detailAddrStr}</b></span> :
-                        <span></span>)}
+                  <h4 className="title">
+                    {this.props.detailAddr ? (
+                      <span>
+                        <Trans>BUILDING:</Trans> <b>{detailAddrStr}</b>
+                      </span>
+                    ) : (
+                      <span />
+                    )}
                   </h4>
-                  <br/>
-                  <button onClick={() => this.props.onBackToOverview(this.props.detailAddr)}><Trans>Back to Overview</Trans></button>
+                  <br />
+                  <Link
+                    to={this.props.generateBaseUrl()}
+                    onClick={() =>
+                      this.props.onBackToOverview(this.props.detailAddr)
+                    }
+                  >
+                    <Trans>Back to Overview</Trans>
+                  </Link>
                 </div>
 
                 <div className="Indicators__links">
                   <div className="Indicators__linksContainer">
-                    <em className="Indicators__linksTitle"><Trans>Select a Dataset:</Trans></em> <br/>
-                    <IndicatorsDatasetRadio id="complaints" activeId={this.state.activeVis} onChange={this.handleVisChange} />
-                    <IndicatorsDatasetRadio id="viols" activeId={this.state.activeVis} onChange={this.handleVisChange} />
-                    <IndicatorsDatasetRadio id="permits" activeId={this.state.activeVis} onChange={this.handleVisChange} />
+                    <em className="Indicators__linksTitle">
+                      <Trans>Select a Dataset:</Trans>
+                    </em>{" "}
+                    <br />
+                    <IndicatorsDatasetRadio
+                      id="complaints"
+                      activeId={this.state.activeVis}
+                      onChange={this.handleVisChange}
+                    />
+                    <IndicatorsDatasetRadio
+                      id="viols"
+                      activeId={this.state.activeVis}
+                      onChange={this.handleVisChange}
+                    />
+                    <IndicatorsDatasetRadio
+                      id="permits"
+                      activeId={this.state.activeVis}
+                      onChange={this.handleVisChange}
+                    />
                   </div>
                   <div className="Indicators__linksContainer">
-                    <em className="Indicators__linksTitle">View by:</em> <br/>
+                    <em className="Indicators__linksTitle">View by:</em> <br />
                     <li className="menu-item">
-                        <label className={"form-radio" + (this.state.activeTimeSpan === "month" ? " active" : "")} onClick={() => {window.gtag('event', 'month-timeline-tab');}}>
-                          <input type="radio"
-                            name="Time" 
-                            checked={(this.state.activeTimeSpan === "month" ? true : false)}
-                            onChange={() => this.handleTimeSpanChange("month")} />
-                          <i className="form-icon"></i> <Trans>Month</Trans>
-                        </label>
+                      <label
+                        className={
+                          "form-radio" +
+                          (this.state.activeTimeSpan === "month"
+                            ? " active"
+                            : "")
+                        }
+                        onClick={() => {
+                          window.gtag("event", "month-timeline-tab");
+                        }}
+                      >
+                        <input
+                          type="radio"
+                          name="Time"
+                          checked={
+                            this.state.activeTimeSpan === "month" ? true : false
+                          }
+                          onChange={() => this.handleTimeSpanChange("month")}
+                        />
+                        <i className="form-icon" /> <Trans>Month</Trans>
+                      </label>
                     </li>
                     <li className="menu-item">
-                        <label className={"form-radio" + (this.state.activeTimeSpan === "quarter" ? " active" : "")} onClick={() => {window.gtag('event', 'quarter-timeline-tab');}}>
-                          <input type="radio"
-                            name= "Time" 
-                            checked={(this.state.activeTimeSpan === "quarter" ? true : false)}
-                            onChange={() => this.handleTimeSpanChange("quarter")} />
-                          <i className="form-icon"></i> <Trans>Quarter</Trans>
-                        </label>
+                      <label
+                        className={
+                          "form-radio" +
+                          (this.state.activeTimeSpan === "quarter"
+                            ? " active"
+                            : "")
+                        }
+                        onClick={() => {
+                          window.gtag("event", "quarter-timeline-tab");
+                        }}
+                      >
+                        <input
+                          type="radio"
+                          name="Time"
+                          checked={
+                            this.state.activeTimeSpan === "quarter"
+                              ? true
+                              : false
+                          }
+                          onChange={() => this.handleTimeSpanChange("quarter")}
+                        />
+                        <i className="form-icon" /> <Trans>Quarter</Trans>
+                      </label>
                     </li>
                     <li className="menu-item">
-                        <label className={"form-radio" + (this.state.activeTimeSpan === "year" ? " active" : "")} onClick={() => {window.gtag('event', 'year-timeline-tab');}}>
-                          <input type="radio"
-                            name="Time" 
-                            checked={(this.state.activeTimeSpan === "year" ? true : false)}
-                            onChange={() => this.handleTimeSpanChange("year")} />
-                          <i className="form-icon"></i> <Trans>Year</Trans>
-                        </label>
+                      <label
+                        className={
+                          "form-radio" +
+                          (this.state.activeTimeSpan === "year"
+                            ? " active"
+                            : "")
+                        }
+                        onClick={() => {
+                          window.gtag("event", "year-timeline-tab");
+                        }}
+                      >
+                        <input
+                          type="radio"
+                          name="Time"
+                          checked={
+                            this.state.activeTimeSpan === "year" ? true : false
+                          }
+                          onChange={() => this.handleTimeSpanChange("year")}
+                        />
+                        <i className="form-icon" /> <Trans>Year</Trans>
+                      </label>
                     </li>
                   </div>
-                </div>  
+                </div>
 
-                <span className="title viz-title"> 
+                <span className="title viz-title">
                   {dataset && dataset.quantity(i18n, indicatorDataTotal)}
                 </span>
 
                 <div className="Indicators__viz">
-                  <button className={(this.state.xAxisStart === 0 || this.state.activeTimeSpan === 'year' ? 
-                    "btn btn-off btn-axis-shift" : "btn btn-axis-shift")}
-                    onClick={() => {this.handleXAxisChange("left"); window.gtag('event', 'graph-back-button');}}>‹</button>
+                  <button
+                    className={
+                      this.state.xAxisStart === 0 ||
+                      this.state.activeTimeSpan === "year"
+                        ? "btn btn-off btn-axis-shift"
+                        : "btn btn-axis-shift"
+                    }
+                    onClick={() => {
+                      this.handleXAxisChange("left");
+                      window.gtag("event", "graph-back-button");
+                    }}
+                  >
+                    ‹
+                  </button>
                   <IndicatorsViz {...this.state} />
-                  <button className={(this.state.xAxisStart + this.state.xAxisViewableColumns >= xAxisLength || this.state.activeTimeSpan === 'year'? 
-                    "btn btn-off btn-axis-shift" : "btn btn-axis-shift")}
-                    onClick={() => this.handleXAxisChange("right")}>›</button>
-                </div> 
-
-                <div className="Indicators__feedback hide-lg">
-                  <Trans render="i">Have thoughts about this page?</Trans> 
-                  <nobr><a href="https://airtable.com/shrZ9uL3id6oWEn8T" target="_blank" rel="noopener noreferrer"><Trans>Send us feedback!</Trans></a></nobr>
+                  <button
+                    className={
+                      this.state.xAxisStart + this.state.xAxisViewableColumns >=
+                        xAxisLength || this.state.activeTimeSpan === "year"
+                        ? "btn btn-off btn-axis-shift"
+                        : "btn btn-axis-shift"
+                    }
+                    onClick={() => this.handleXAxisChange("right")}
+                  >
+                    ›
+                  </button>
                 </div>
 
+                <div className="Indicators__feedback hide-lg">
+                  <Trans render="i">Have thoughts about this page?</Trans>
+                  <nobr>
+                    <a
+                      href="https://airtable.com/shrZ9uL3id6oWEn8T"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <Trans>Send us feedback!</Trans>
+                    </a>
+                  </nobr>
+                </div>
               </div>
               <div className="column column-context col-4 col-lg-12">
-                
                 <div className="card">
                   <div className="card-header">
-                    <div className="card-title h5">What are {dataset && dataset.name(i18n)}?</div>
-                    <div className="card-subtitle text-gray"></div>
+                    <div className="card-title h5">
+                      What are {dataset && dataset.name(i18n)}?
+                    </div>
+                    <div className="card-subtitle text-gray" />
                   </div>
                   <div className="card-body">
                     {dataset && dataset.explanation(i18n)}
@@ -369,42 +517,95 @@ class IndicatorsWithoutI18n extends Component {
                     <Trans render="h6">Official building pages</Trans>
                     <div className="columns">
                       <div className="column col-12">
-                        <a onClick={() => {window.gtag('event', 'acris-timeline-tab');}} 
-                           href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`} target="_blank" rel="noopener noreferrer" 
-                           className="btn btn-block"><Trans>View documents on ACRIS</Trans> &#8599;&#xFE0E;</a>
+                        <a
+                          onClick={() => {
+                            window.gtag("event", "acris-timeline-tab");
+                          }}
+                          href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn btn-block"
+                        >
+                          <Trans>View documents on ACRIS</Trans> &#8599;&#xFE0E;
+                        </a>
                       </div>
                       <div className="column col-12">
-                        <a onClick={() => {window.gtag('event', 'hpd-timeline-tab');}} 
-                           href={(housenumber && streetname ? `https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${housenumber}&p3=${Helpers.formatStreetNameForHpdLink(streetname)}&SearchButton=Search` : `https://hpdonline.hpdnyc.org/HPDonline/provide_address.aspx`)} target="_blank" rel="noopener noreferrer" 
-                           className="btn btn-block"><Trans>HPD Building Profile</Trans> &#8599;&#xFE0E;</a>
+                        <a
+                          onClick={() => {
+                            window.gtag("event", "hpd-timeline-tab");
+                          }}
+                          href={
+                            housenumber && streetname
+                              ? `https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${housenumber}&p3=${Helpers.formatStreetNameForHpdLink(
+                                  streetname
+                                )}&SearchButton=Search`
+                              : `https://hpdonline.hpdnyc.org/HPDonline/provide_address.aspx`
+                          }
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn btn-block"
+                        >
+                          <Trans>HPD Building Profile</Trans> &#8599;&#xFE0E;
+                        </a>
                       </div>
                       <div className="column col-12">
-                        <a onClick={() => {window.gtag('event', 'dob-timeline-tab');}} 
-                           href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`} target="_blank" rel="noopener noreferrer" 
-                           className="btn btn-block"><Trans>DOB Building Profile</Trans> &#8599;&#xFE0E;</a>
+                        <a
+                          onClick={() => {
+                            window.gtag("event", "dob-timeline-tab");
+                          }}
+                          href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn btn-block"
+                        >
+                          <Trans>DOB Building Profile</Trans> &#8599;&#xFE0E;
+                        </a>
                       </div>
                       <div className="column col-12">
-                        <a onClick={() => {window.gtag('event', 'dof-timeline-tab');}} 
-                           href={`https://a836-pts-access.nyc.gov/care/search/commonsearch.aspx?mode=persprop`} target="_blank" rel="noopener noreferrer" 
-                           className="btn btn-block"><Trans>DOF Property Tax Bills</Trans> &#8599;&#xFE0E;</a>
+                        <a
+                          onClick={() => {
+                            window.gtag("event", "dof-timeline-tab");
+                          }}
+                          href={`https://a836-pts-access.nyc.gov/care/search/commonsearch.aspx?mode=persprop`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn btn-block"
+                        >
+                          <Trans>DOF Property Tax Bills</Trans> &#8599;&#xFE0E;
+                        </a>
                       </div>
                       <div className="column col-12">
-                          <a onClick={() => {window.gtag('event', 'dap-timeline-tab');}} href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`} target="_blank" rel="noopener noreferrer" className="btn btn-block"><Trans>ANHD DAP Portal</Trans> &#8599;&#xFE0E;</a>
+                        <a
+                          onClick={() => {
+                            window.gtag("event", "dap-timeline-tab");
+                          }}
+                          href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn btn-block"
+                        >
+                          <Trans>ANHD DAP Portal</Trans> &#8599;&#xFE0E;
+                        </a>
                       </div>
                     </div>
                   </div>
                 </div>
 
                 <div className="Indicators__feedback show-lg">
-                  <i>Have thoughts about this page?</i> 
-                  <nobr><a href="https://airtable.com/shrZ9uL3id6oWEn8T" target="_blank" rel="noopener noreferrer">Send us feedback!</a></nobr>
+                  <i>Have thoughts about this page?</i>
+                  <nobr>
+                    <a
+                      href="https://airtable.com/shrZ9uL3id6oWEn8T"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Send us feedback!
+                    </a>
+                  </nobr>
                 </div>
-
               </div>
-
             </div>
-            )
-          }
+          )}
         </div>
         <LegalFooter position="inside" />
       </div>

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -1,39 +1,41 @@
-import React from 'react';
-import ReactTable from 'react-table';
-import Browser from '../util/browser';
+import React from "react";
+import ReactTable from "react-table";
+import Browser from "../util/browser";
 
-import 'react-table/react-table.css';
-import 'styles/PropertiesList.css';
-import { I18n } from '@lingui/core';
-import { withI18n } from '@lingui/react';
-import { t } from '@lingui/macro';
+import "react-table/react-table.css";
+import "styles/PropertiesList.css";
+import { I18n } from "@lingui/core";
+import { withI18n } from "@lingui/react";
+import { t } from "@lingui/macro";
+import { Link } from "react-router-dom";
 
 type Addr = {
-  housenumber: string,
-  streetname: string,
-  zip: string,
-  boro: string,
-  bbl: string,
-  yearbuilt: number,
-  unitsres: number,
-  rsunits2007: number,
-  rsunits2017: number,
-  openviolations: number,
-  totalviolations: number,
-  evictions: string|null,
-  ownernames: {title: string, value: string}[],
+  housenumber: string;
+  streetname: string;
+  zip: string;
+  boro: string;
+  bbl: string;
+  yearbuilt: number;
+  unitsres: number;
+  rsunits2007: number;
+  rsunits2017: number;
+  openviolations: number;
+  totalviolations: number;
+  evictions: string | null;
+  ownernames: { title: string; value: string }[];
 };
 
 const PropertiesListWithoutI18n: React.FC<{
-  i18n: I18n,
-  addrs: Addr[],
-  onOpenDetail: (addr: Addr) => void,
+  i18n: I18n;
+  addrs: Addr[];
+  onOpenDetail: (addr: Addr) => void;
+  generateBaseUrl: () => string;
 }> = (props) => {
   const { i18n } = props;
   // console.log(props.addrs);
 
-  if(!props.addrs.length) {
-    return ( null );
+  if (!props.addrs.length) {
+    return null;
   } else {
     return (
       <div className="PropertiesList">
@@ -41,7 +43,7 @@ const PropertiesListWithoutI18n: React.FC<{
           data={props.addrs}
           minRows={Browser.isMobile() ? 5 : 10}
           defaultPageSize={props.addrs.length}
-          showPagination = {false}
+          showPagination={false}
           columns={[
             // {
             //   Header: () => {
@@ -73,46 +75,46 @@ const PropertiesListWithoutI18n: React.FC<{
                 // },
                 {
                   Header: i18n._(t`Address`),
-                  accessor: d => `${d.housenumber} ${d.streetname}`,
-                  id: 'address',
+                  accessor: (d) => `${d.housenumber} ${d.streetname}`,
+                  id: "address",
                   minWidth: 150,
                   style: {
-                    textAlign: "left"
-                  }
+                    textAlign: "left",
+                  },
                 },
                 {
                   Header: i18n._(t`Zipcode`),
-                  accessor: d => d.zip,
-                  id: 'zip',
-                  width: 75
+                  accessor: (d) => d.zip,
+                  id: "zip",
+                  width: 75,
                 },
                 {
                   Header: i18n._(t`Borough`),
-                  accessor: d => d.boro,
-                  id: 'boro',
+                  accessor: (d) => d.boro,
+                  id: "boro",
                 },
                 {
-                  Header: 'BBL',
-                  accessor: d => d.bbl,
-                  id: 'bbl',
-                }
-              ]
+                  Header: "BBL",
+                  accessor: (d) => d.bbl,
+                  id: "bbl",
+                },
+              ],
             },
             {
               Header: i18n._(t`Information`),
               columns: [
                 {
                   Header: i18n._(t`Built`),
-                  accessor: d => d.yearbuilt,
-                  id: 'yearbuilt',
-                  maxWidth: 75
+                  accessor: (d) => d.yearbuilt,
+                  id: "yearbuilt",
+                  maxWidth: 75,
                 },
                 {
                   Header: i18n._(t`Units`),
-                  accessor: d => d.unitsres,
-                  id: 'unitsres',
-                  maxWidth: 75
-                }
+                  accessor: (d) => d.unitsres,
+                  id: "unitsres",
+                  maxWidth: 75,
+                },
                 // ,
                 // {
                 //   Header: '421-a',
@@ -126,7 +128,7 @@ const PropertiesListWithoutI18n: React.FC<{
                 //   Header: 'J-51',
                 //   accessor: 'subsidyj51'
                 // },
-              ]
+              ],
             },
             // {
             //   Header: 'Shell Companies',
@@ -158,98 +160,111 @@ const PropertiesListWithoutI18n: React.FC<{
               columns: [
                 {
                   Header: "2007",
-                  accessor: d => d.rsunits2007,
-                  id: 'rsunits2007',
-                  maxWidth: 75
+                  accessor: (d) => d.rsunits2007,
+                  id: "rsunits2007",
+                  maxWidth: 75,
                 },
                 {
                   Header: "2017",
-                  accessor: d => d.rsunits2017,
-                  id: 'rsunits2017',
-                  Cell: row => {
+                  accessor: (d) => d.rsunits2017,
+                  id: "rsunits2017",
+                  Cell: (row) => {
                     return (
-                      <span className={`${row.original.rsunits2017 < row.original.rsunits2007 ? 'text-danger' : ''}`}
-                        >{row.original.rsunits2017}
+                      <span
+                        className={`${
+                          row.original.rsunits2017 < row.original.rsunits2007
+                            ? "text-danger"
+                            : ""
+                        }`}
+                      >
+                        {row.original.rsunits2017}
                       </span>
                     );
                   },
-                  maxWidth: 75
-                }
-              ]
+                  maxWidth: 75,
+                },
+              ],
             },
             {
               Header: i18n._(t`HPD Violations`),
               columns: [
                 {
                   Header: i18n._(t`Open`),
-                  accessor: d => d.openviolations,
-                  id: 'openviolations',
-                  maxWidth: 75
+                  accessor: (d) => d.openviolations,
+                  id: "openviolations",
+                  maxWidth: 75,
                 },
                 {
                   Header: i18n._(t`Total`),
-                  accessor: d => d.totalviolations,
-                  id: 'totalviolations',
-                  maxWidth: 75
-                }
-              ]
+                  accessor: (d) => d.totalviolations,
+                  id: "totalviolations",
+                  maxWidth: 75,
+                },
+              ],
             },
             {
               Header: i18n._(t`Evictions`),
               columns: [
                 {
                   Header: "2019",
-                  accessor: d => (d.evictions ? parseInt(d.evictions) : null),
-                  id: 'evictions',
-                  maxWidth: 75
-                }
-              ]
+                  accessor: (d) => (d.evictions ? parseInt(d.evictions) : null),
+                  id: "evictions",
+                  maxWidth: 75,
+                },
+              ],
             },
             {
               Header: i18n._(t`Landlord`),
               columns: [
                 {
                   Header: i18n._(t`Officer/Owner`),
-                  accessor: d => {
-                    var owner = d.ownernames.find(o => o.title === 'HeadOfficer' || o.title === 'IndividualOwner'); 
-                    return (owner ? owner.value : '');
+                  accessor: (d) => {
+                    var owner = d.ownernames.find(
+                      (o) =>
+                        o.title === "HeadOfficer" ||
+                        o.title === "IndividualOwner"
+                    );
+                    return owner ? owner.value : "";
                   },
                   id: "ownernames",
-                  minWidth: 150
-                }
+                  minWidth: 150,
+                },
                 // ,
                 // {
                 //   Header: "Change in RS",
                 //   accessor: "totalviolations"
                 // }
-              ]
+              ],
             },
             {
               Header: i18n._(t`View detail`),
-              accessor: d => d.bbl,
+              accessor: (d) => d.bbl,
               columns: [
                 {
-                    Cell: row => {
-                      return (
-                        <button className="btn" onClick={() => props.onOpenDetail(row.original)}>
-                          <span style={{ padding: '0 3px' }}>&#10142;</span>
-                        </button>);
-                    }
-                }
-              ]
-            }
+                  Cell: (row) => {
+                    return (
+                      <Link
+                        to={props.generateBaseUrl()}
+                        className="btn"
+                        onClick={() => props.onOpenDetail(row.original)}
+                      >
+                        <span style={{ padding: "0 3px" }}>&#10142;</span>
+                      </Link>
+                    );
+                  },
+                },
+              ],
+            },
           ]}
           style={{
-            height: "100%"
+            height: "100%",
           }}
-          className='-striped -highlight'
+          className="-striped -highlight"
         />
       </div>
     );
   }
-
-
-}
+};
 
 const PropertiesList = withI18n()(PropertiesListWithoutI18n);
 

--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -1,84 +1,115 @@
-import React from 'react';
-import { FacebookButton, TwitterButton, EmailButton } from 'react-social';
-import {isMobile, isAndroid} from "react-device-detect";
+import React from "react";
+import { FacebookButton, TwitterButton, EmailButton } from "react-social";
+import { isMobile, isAndroid } from "react-device-detect";
 
-import fbIcon from '../assets/img/fb.svg';
-import twitterIcon from '../assets/img/twitter.svg';
-import { I18n } from '@lingui/core';
-import { t, Trans } from '@lingui/macro';
-import { withI18n } from '@lingui/react';
-import helpers, { MaybeStringyNumber } from '../util/helpers';
+import fbIcon from "../assets/img/fb.svg";
+import twitterIcon from "../assets/img/twitter.svg";
+import { I18n } from "@lingui/core";
+import { t, Trans } from "@lingui/macro";
+import { withI18n } from "@lingui/react";
+import helpers, { MaybeStringyNumber } from "../util/helpers";
 
 const SocialShareWithoutI18n: React.FC<{
-  i18n: I18n,
-  location?: string,
-  url?: string,
-  twitterMessage?: string,
-  emailMessage?: string,
+  i18n: I18n;
+  location?: string;
+  url?: string;
+  twitterMessage?: string;
+  emailMessage?: string;
 }> = (props) => {
   const { i18n } = props;
 
   return (
     <div className="btn-group btns-social btn-group-block">
-     <FacebookButton
-       onClick={() => {window.gtag('event', 'facebook-' + props.location);}}
-       className="btn btn-steps"
-       sharer={true}
-       windowOptions={['width=400', 'height=200']}
-       url={(props.url || 'https://whoownswhat.justfix.nyc/')}
-       appId={`247990609143668`}>
-       <img src={fbIcon} className="icon mx-1" alt="Facebook" />
-       <span>Facebook</span>
-     </FacebookButton>
-     <TwitterButton
-       onClick={() => {window.gtag('event', 'twitter-' + props.location);}}
-       className="btn btn-steps"
-       windowOptions={['width=400', 'height=200']}
-       url={(props.url || 'https://whoownswhat.justfix.nyc/')}
-       message={(props.twitterMessage || `#WhoOwnsWhat @JustFixNYC`)}
-       >
-       <img src={twitterIcon} className="icon mx-1" alt="Twitter" />
-       <span>Twitter</span>
-     </TwitterButton>
-     <EmailButton
-       onClick={() => {window.gtag('event', 'email-' + props.location);}}
-       className="btn btn-steps"
-       url={(props.url || 'https://whoownswhat.justfix.nyc/')}
-       target="_blank"
-       message={(props.emailMessage || i18n._(t`New JustFix.nyc tool helps research on NYC landlords`))}>
-       <i className="icon icon-mail mx-2" />
-       <Trans render="span">Email</Trans>
-     </EmailButton>
-     {isMobile && 
-     <a className="btn btn-steps" 
-      onClick={() => {window.gtag('event', 'twitter-' + props.location);}}
-      href={"sms: " + (isAndroid ? "?" : "&") + "body=" + encodeURIComponent(props.url || "https://whoownswhat.justfix.nyc/")}
-      target="_blank" rel="noopener noreferrer">
-       SMS
-    </a>}
+      <FacebookButton
+        onClick={() => {
+          window.gtag("event", "facebook-" + props.location);
+        }}
+        className="btn btn-steps"
+        sharer={true}
+        windowOptions={["width=400", "height=200"]}
+        url={props.url || "https://whoownswhat.justfix.nyc/"}
+        appId={`247990609143668`}
+      >
+        <img src={fbIcon} className="icon mx-1" alt="Facebook" />
+        <span>Facebook</span>
+      </FacebookButton>
+      <TwitterButton
+        onClick={() => {
+          window.gtag("event", "twitter-" + props.location);
+        }}
+        className="btn btn-steps"
+        windowOptions={["width=400", "height=200"]}
+        url={props.url || "https://whoownswhat.justfix.nyc/"}
+        message={props.twitterMessage || `#WhoOwnsWhat @JustFixNYC`}
+      >
+        <img src={twitterIcon} className="icon mx-1" alt="Twitter" />
+        <span>Twitter</span>
+      </TwitterButton>
+      <EmailButton
+        onClick={() => {
+          window.gtag("event", "email-" + props.location);
+        }}
+        className="btn btn-steps"
+        url={props.url || "https://whoownswhat.justfix.nyc/"}
+        target="_blank"
+        message={
+          props.emailMessage ||
+          i18n._(t`New JustFix.nyc tool helps research on NYC landlords`)
+        }
+      >
+        <i className="icon icon-mail mx-2" />
+        <Trans render="span">Email</Trans>
+      </EmailButton>
+      {isMobile && (
+        <a
+          className="btn btn-steps"
+          onClick={() => {
+            window.gtag("event", "twitter-" + props.location);
+          }}
+          href={
+            "sms: " +
+            (isAndroid ? "?" : "&") +
+            "body=" +
+            encodeURIComponent(props.url || "https://whoownswhat.justfix.nyc/")
+          }
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          SMS
+        </a>
+      )}
     </div>
   );
-
-}
+};
 
 const SocialShare = withI18n()(SocialShareWithoutI18n);
 
 export default SocialShare;
 
 const SocialSharePortfolioWithoutI18n: React.FC<{
-  i18n: I18n,
-  location?: string,
-  addr: {boro: any, housenumber: any, streetname: any},
-  buildings: MaybeStringyNumber,
-}> = ({i18n, location, addr, buildings}) => {
+  i18n: I18n;
+  location?: string;
+  addr: { boro: any; housenumber: any; streetname: any };
+  buildings: MaybeStringyNumber;
+}> = ({ i18n, location, addr, buildings }) => {
   const buildingCount = helpers.coerceToInt(buildings, 0);
-  return <SocialShareWithoutI18n
-    i18n={i18n}
-    location={location}
-    url={encodeURI('https://whoownswhat.justfix.nyc/address/' + addr.boro + '/' + addr.housenumber + '/' + addr.streetname).replace(" ", "%20")} // Support for Android
-    twitterMessage={i18n._(t`The ${buildingCount} buildings that my landlord "owns" 👀... #WhoOwnsWhat @JustFixNYC`)}
-    emailMessage={i18n._(t`The ${buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)`)}
-  />;
+  return (
+    <SocialShareWithoutI18n
+      i18n={i18n}
+      location={location}
+      url={encodeURI(
+        `https://whoownswhat.justfix.nyc/address/${addr.boro}/${
+          addr.housenumber
+        }/${addr.streetname}${location === "summary-tab" ? "/summary" : ""}`
+      ).replace(" ", "%20")} // Support for Android
+      twitterMessage={i18n._(
+        t`The ${buildingCount} buildings that my landlord "owns" 👀... #WhoOwnsWhat @JustFixNYC`
+      )}
+      emailMessage={i18n._(
+        t`The ${buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)`
+      )}
+    />
+  );
 };
 
 export const SocialSharePortfolio = withI18n()(SocialSharePortfolioWithoutI18n);

--- a/client/src/containers/AddressPage.js
+++ b/client/src/containers/AddressPage.js
@@ -181,6 +181,7 @@ export default class AddressPage extends Component {
                   >
                     <Link
                       to={this.generateBaseUrl()}
+                      tabIndex={this.props.currentTab === 0 ? -1 : 0}
                       onClick={() => {
                         if (
                           Browser.isMobile() &&
@@ -200,6 +201,7 @@ export default class AddressPage extends Component {
                   >
                     <Link
                       to={this.generateBaseUrl() + "/timeline"}
+                      tabIndex={this.props.currentTab === 1 ? -1 : 0}
                       onClick={() => {
                         window.gtag("event", "timeline-tab");
                       }}
@@ -214,6 +216,7 @@ export default class AddressPage extends Component {
                   >
                     <Link
                       to={this.generateBaseUrl() + "/portfolio"}
+                      tabIndex={this.props.currentTab === 2 ? -1 : 0}
                       onClick={() => {
                         window.gtag("event", "portfolio-tab");
                       }}
@@ -228,6 +231,7 @@ export default class AddressPage extends Component {
                   >
                     <Link
                       to={this.generateBaseUrl() + "/summary"}
+                      tabIndex={this.props.currentTab === 3 ? -1 : 0}
                       onClick={() => {
                         window.gtag("event", "summary-tab");
                       }}

--- a/client/src/containers/AddressPage.js
+++ b/client/src/containers/AddressPage.js
@@ -98,13 +98,6 @@ export default class AddressPage extends Component {
     this.setState({
       detailAddr: addr,
       detailMobileSlide: true,
-      currentTab: 0,
-    });
-  };
-
-  handleTimelineLink = () => {
-    this.setState({
-      currentTab: 1,
     });
   };
 
@@ -176,8 +169,9 @@ export default class AddressPage extends Component {
                       value={this.state.assocAddrs.length}
                       one="building"
                       other="buildings"
-                    />:
+                    />
                   </Trans>
+                  :
                 </h5>
                 <ul className="tab tab-block">
                   <li
@@ -263,7 +257,7 @@ export default class AddressPage extends Component {
               mobileShow={this.state.detailMobileSlide}
               userAddr={this.state.userAddr}
               onCloseDetail={this.handleCloseDetail}
-              onLinkToTimeline={this.handleTimelineLink}
+              generateBaseUrl={this.generateBaseUrl}
             />
           </div>
           <div
@@ -275,6 +269,7 @@ export default class AddressPage extends Component {
               isVisible={this.props.currentTab === 1}
               detailAddr={this.state.detailAddr}
               onBackToOverview={this.handleAddrChange}
+              generateBaseUrl={this.generateBaseUrl}
             />
           </div>
           <div
@@ -286,6 +281,7 @@ export default class AddressPage extends Component {
               <PropertiesList
                 addrs={this.state.assocAddrs}
                 onOpenDetail={this.handleAddrChange}
+                generateBaseUrl={this.generateBaseUrl}
               />
             }
           </div>

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -72,7 +72,10 @@ render() {
               <div className="App__body">
                 <Switch>
                   <Route exact path="/:locale/" component={HomePage} />
-                  <Route path="/:locale/address/:boro/:housenumber/:streetname" component={AddressPage} />
+                  <Route path="/:locale/address/:boro/:housenumber/:streetname" render={(props) => <AddressPage currentTab={0} {...props} />} exact />
+                  <Route path="/:locale/address/:boro/:housenumber/:streetname/timeline" render={(props) => <AddressPage currentTab={1} {...props} />} />
+                  <Route path="/:locale/address/:boro/:housenumber/:streetname/portfolio" render={(props) => <AddressPage currentTab={2} {...props} />} />
+                  <Route path="/:locale/address/:boro/:housenumber/:streetname/summary" render={(props) => <AddressPage currentTab={3} {...props} />} />
                   <Route path="/:locale/bbl/:boro/:block/:lot" component={BBLPage} />
                   <Route path="/:locale/bbl/:bbl" component={BBLPage} />
                   <Route path="/:locale/about" component={AboutPage} />

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -1,17 +1,13 @@
-@import '_vars.scss';
-@import '_scrollbar.scss';
-@import '_button.scss';
+@import "_vars.scss";
+@import "_scrollbar.scss";
+@import "_button.scss";
 
 .Indicators {
-
-
-
   // @include for-phone-only() {
   //   padding-right: 30px;
   // };
 
   .Indicators__content {
-
     padding: 30px 30px 30px 30px;
 
     @include for-tablet-portrait-up() {
@@ -20,7 +16,7 @@
 
     & > div > h6 {
       font-size: 1.4rem;
-      margin-bottom: .6rem;
+      margin-bottom: 0.6rem;
       text-decoration: underline;
       font-weight: bold;
     }
@@ -39,22 +35,21 @@
     }
 
     .title {
-        font-size: 2rem;
-        text-decoration: none;    
-        padding-left: 1.5rem;
-        margin-bottom: 0px;
+      font-size: 2rem;
+      text-decoration: none;
+      padding-left: 1.5rem;
+      margin-bottom: 0px;
 
-        &.viz-title {
-          display: block;
-          text-align: center;
-        }
+      &.viz-title {
+        display: block;
+        text-align: center;
       }
+    }
 
     .title-card {
-
       padding-bottom: 2.5rem;
 
-      button {
+      a {
         color: #454d5d;
         margin-left: 1.5rem;
         text-decoration: underline;
@@ -74,7 +69,7 @@
         h6 {
           font-weight: bold;
           margin-bottom: 0.75rem;
-          width: 100%
+          width: 100%;
         }
         .chip {
           background-color: $gray-light;
@@ -86,29 +81,28 @@
     }
 
     .control-panel {
-      justify-content: space-evenly; 
+      justify-content: space-evenly;
       padding-top: 15px;
     }
 
     .btn-data-select {
-        flex: 1 1 0;
+      flex: 1 1 0;
     }
 
-    .btn-data-select.selected, .btn-data-select.selected:hover {
+    .btn-data-select.selected,
+    .btn-data-select.selected:hover {
       color: #fff;
       background-color: #727e96;
       box-shadow: inset 1px 1px 0px 0px #4f596c;
     }
 
     aside {
-
       @include for-tablet-portrait-up() {
         width: 32%;
         margin-left: 40px;
         margin-top: 0;
         margin-bottom: 0;
       }
-
     }
   }
 
@@ -117,7 +111,6 @@
     position: relative;
 
     .Indicators__linksContainer {
-
       &:first-child {
         padding-bottom: 1rem;
       }
@@ -136,9 +129,7 @@
           color: #000;
         }
       }
-
     }
-
   }
 
   .Indicators__viz {
@@ -157,11 +148,13 @@
       font-size: 20px;
       align-self: center;
 
-      // button placement offset: 
+      // button placement offset:
       margin-bottom: 75px;
     }
 
-    .btn-off, .btn-off:hover, .btn-off:active {
+    .btn-off,
+    .btn-off:hover,
+    .btn-off:active {
       opacity: 0.25;
       cursor: default;
       color: #454d5d;
@@ -169,11 +162,9 @@
       background-color: #f8f9fa;
       box-shadow: inset -1px -1px 0px 0px #acb3c2, inset 2px 2px 0px 0px #fff;
     }
-
   }
 
   .Indicators__feedback {
-    
     text-align: center;
 
     @include for-tablet-landscape-up() {
@@ -190,5 +181,4 @@
       }
     }
   }
-
 }

--- a/client/src/styles/_tabs.scss
+++ b/client/src/styles/_tabs.scss
@@ -1,7 +1,6 @@
-@import '_vars.scss';
+@import "_vars.scss";
 
 @mixin tabs() {
-
   // .tab li {
   //   position: relative;
   // }
@@ -68,8 +67,6 @@
   //   right: -20px;
   // }
 
-
-
   .tab {
     margin-bottom: 0;
     border-bottom: none;
@@ -80,10 +77,11 @@
     }
 
     li.tab-item {
-
       height: 26px;
 
-      background: #ffffff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAHElEQVQYV2NMS0v7P2vWLEYGKIAzMARgKjFUAABWhQgF0A6r6AAAAABJRU5ErkJggg==) repeat;
+      background: #ffffff
+        url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAHElEQVQYV2NMS0v7P2vWLEYGKIAzMARgKjFUAABWhQgF0A6r6AAAAABJRU5ErkJggg==)
+        repeat;
 
       border: 1px solid $gray-dark;
       border-bottom: none;
@@ -105,21 +103,24 @@
         cursor: pointer;
       }
 
-      &:before, &:after {
+      &:before,
+      &:after {
         // content:'';
-        width:9px;
-        height:7px;
-        position:absolute;
-        z-index:2;
-        bottom:0;
-        background: #ffffff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAHElEQVQYV2NMS0v7P2vWLEYGKIAzMARgKjFUAABWhQgF0A6r6AAAAABJRU5ErkJggg==) repeat;
+        width: 9px;
+        height: 7px;
+        position: absolute;
+        z-index: 2;
+        bottom: 0;
+        background: #ffffff
+          url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAHElEQVQYV2NMS0v7P2vWLEYGKIAzMARgKjFUAABWhQgF0A6r6AAAAABJRU5ErkJggg==)
+          repeat;
       }
 
       &:before {
-        left:-8px;
+        left: -8px;
       }
       &:after {
-        right:-8px;
+        right: -8px;
       }
 
       &.active {
@@ -129,20 +130,26 @@
         background: #fff;
         z-index: 3;
 
-        &:before, &:after {
-          background:#fff;
-          bottom:0;
+        &:before,
+        &:after {
+          background: #fff;
+          bottom: 0;
         }
 
         a {
-          &:before, &:after {
-            border-bottom:1px solid $dark;
+          &:before,
+          &:after {
+            border-bottom: 1px solid $dark;
           }
           &:before {
-            border-right:1px solid $dark;
+            border-right: 1px solid $dark;
           }
           &:after {
-            border-left:1px solid $dark;
+            border-left: 1px solid $dark;
+          }
+
+          &:focus {
+            box-shadow: none;
           }
         }
       }
@@ -157,37 +164,33 @@
         position: relative;
 
         &:focus {
-          box-shadow: none;
+          box-shadow: 0 0 0 2px $dark;
         }
 
-        &:before, &:after {
-          // content:'';
-          width:10px;
-          height:9px;
-          position:absolute;
-          z-index:3;
-          bottom:-1px;
-          background:#fff;
-          overflow:hidden;
-          border-bottom:1px solid $gray-dark;
+        &:before,
+        &:after {
+          // content:   '';
+          width: 10px;
+          height: 9px;
+          position: absolute;
+          z-index: 3;
+          bottom: -1px;
+          background: #fff;
+          overflow: hidden;
+          border-bottom: 1px solid $gray-dark;
         }
 
         &:before {
-          left:-10px;
-          border-bottom-right-radius:8px;
-          border-right:1px solid $gray-dark;
+          left: -10px;
+          border-bottom-right-radius: 8px;
+          border-right: 1px solid $gray-dark;
         }
         &:after {
-          right:-10px;
-          border-bottom-left-radius:8px;
-          border-left:1px solid $gray-dark;
+          right: -10px;
+          border-bottom-left-radius: 8px;
+          border-left: 1px solid $gray-dark;
         }
-
       }
-
     }
   }
-
-
-
 }


### PR DESCRIPTION
This PR improved the accessibility and usability of Who Owns What by assigning a specific url path to each of the four tabs we include on the address page. Now users can tab through links to navigate between these pages as well as share each individual URL allowing another user to have a direct link to that page. 

Specifically, this PR:
- [x] Adds unique URL paths to each address page tab
- [x] Verifies that direct links (and direct links via bbl) still work
- [x] Converts all previous tab changes to internal links
- [x] Adds focus class for tabs