### PR TITLE
I18n tweaks

### DIFF
--- a/client/src/components/AddressToolbar.tsx
+++ b/client/src/components/AddressToolbar.tsx
@@ -42,11 +42,8 @@ export default class AddressToolbar extends Component<AddressToolbarProps, State
     return (
       <div className="AddressToolbar">
         <div className="btn-group float-right">
-          <button className="btn" onClick={() => this.setState({ showExportModal: true })}>
-            <Trans>Export Data</Trans>
-          </button>
           <Link
-            className="btn"
+            className="btn btn-primary"
             onClick={() => {
               window.gtag("event", "new-search");
             }}
@@ -54,6 +51,9 @@ export default class AddressToolbar extends Component<AddressToolbarProps, State
           >
             <Trans>New Search</Trans>
           </Link>
+          <button className="btn" onClick={() => this.setState({ showExportModal: true })}>
+            <Trans>Export Data</Trans>
+          </button>
         </div>
         <Modal
           showModal={this.state.showExportModal}

--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -11,7 +11,7 @@ import { withI18n } from "@lingui/react";
 import { t } from "@lingui/macro";
 import { Trans } from "@lingui/macro";
 import { SocialSharePortfolio } from "./SocialShare";
-import { NavLink, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { LocaleLink } from "../i18n";
 
 class DetailViewWithoutI18n extends Component {

--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -295,12 +295,12 @@ class DetailViewWithoutI18n extends Component {
                     <div className="card-body column-right">
                       <div className="card-body-resources">
                         <span className="card-body-resources__title show-lg">
-                          <Trans render="em">Additional links</Trans>
+                          <Trans render="em">Useful links</Trans>
                         </span>
 
                         <div className="card-body-links">
-                          <h6 className="DetailView__subtitle">
-                            <Trans>Official building pages</Trans>
+                          <h6 className="DetailView__subtitle hide-lg">
+                            <Trans>Useful links</Trans>
                           </h6>
                           <div className="columns">
                             <div className="column col-12">

--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -34,7 +34,7 @@ class DetailViewWithoutI18n extends Component {
   formatDate(dateString) {
     var date = new Date(dateString);
     var options = { year: "numeric", month: "short", day: "numeric" };
-    return date.toLocaleDateString("en-US", options);
+    return date.toLocaleDateString(this.props.i18n._language || "en", options);
   }
 
   render() {

--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -12,6 +12,7 @@ import { t } from "@lingui/macro";
 import { Trans } from "@lingui/macro";
 import { SocialSharePortfolio } from "./SocialShare";
 import { NavLink, Link } from "react-router-dom";
+import { LocaleLink } from "../i18n";
 
 class DetailViewWithoutI18n extends Component {
   constructor(props) {
@@ -416,7 +417,7 @@ class DetailViewWithoutI18n extends Component {
                 <Trans render="p">
                   We compare your search address with a database of over 200k buildings to identify
                   a landlord or management company's portfolio. To learn more, check out{" "}
-                  <NavLink to="/how-it-works">our methodology</NavLink>.
+                  <LocaleLink to="/how-it-works">our methodology</LocaleLink>.
                 </Trans>
                 <table className="DetailView__compareTable">
                   <thead>

--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -7,11 +7,13 @@ import Browser from "util/browser";
 import Modal from "components/Modal";
 
 import "styles/DetailView.css";
+import { withI18n } from "@lingui/react";
+import { t } from "@lingui/macro";
 import { Trans } from "@lingui/macro";
 import { SocialSharePortfolio } from "./SocialShare";
 import { NavLink, Link } from "react-router-dom";
 
-export default class DetailView extends Component {
+class DetailViewWithoutI18n extends Component {
   constructor(props) {
     super(props);
 
@@ -35,6 +37,7 @@ export default class DetailView extends Component {
   }
 
   render() {
+    const { i18n } = this.props;
     let boro, block, lot, ownernames, userOwnernames, takeActionURL;
     if (this.props.addr) {
       ({ boro, block, lot } = Helpers.splitBBL(this.props.addr.bbl));
@@ -97,7 +100,9 @@ export default class DetailView extends Component {
                         <div className="table-row">
                           <div
                             className="double"
-                            title="This is the official identifer for the building according to the Dept. of Finance tax records."
+                            title={i18n._(
+                              t`This is the official identifer for the building according to the Dept. of Finance tax records.`
+                            )}
                           >
                             <label>
                               Boro{bblDash}Block{bblDash}Lot (BBL)
@@ -108,29 +113,53 @@ export default class DetailView extends Component {
                             {bblDash}
                             {lot}
                           </div>
-                          <div title="The year that this building was originally constructed, according to the Dept. of City Planning.">
+                          <div
+                            title={i18n._(
+                              t`The year that this building was originally constructed, according to the Dept. of City Planning.`
+                            )}
+                          >
                             <Trans render="label">Year Built</Trans>
                             {this.props.addr.yearbuilt !== 0 ? this.props.addr.yearbuilt : "N/A"}
                           </div>
-                          <div title="The number of residential units in this building, according to the Dept. of City Planning.">
+                          <div
+                            title={i18n._(
+                              t`The number of residential units in this building, according to the Dept. of City Planning.`
+                            )}
+                          >
                             <Trans render="label">Units</Trans>
                             {this.props.addr.unitsres}
                           </div>
                         </div>
                         <div className="table-row">
-                          <div title="The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information.">
+                          <div
+                            title={i18n._(
+                              t`The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information.`
+                            )}
+                          >
                             <Trans render="label">Open Violations</Trans>
                             {this.props.addr.openviolations}
                           </div>
-                          <div title="This represents the total number of HPD Violations (both open & closed) recorded by the city.">
+                          <div
+                            title={i18n._(
+                              t`This represents the total number of HPD Violations (both open & closed) recorded by the city.`
+                            )}
+                          >
                             <Trans render="label">Total Violations</Trans>
                             {this.props.addr.totalviolations}
                           </div>
-                          <div title="Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI.">
+                          <div
+                            title={i18n._(
+                              t`Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI.`
+                            )}
+                          >
                             <Trans render="label">2019 Evictions</Trans>
                             {this.props.addr.evictions !== null ? this.props.addr.evictions : "N/A"}
                           </div>
-                          <div title='This tracks how rent stabilized units in the building have changed (i.e. "&Delta;") from 2007 to 2017. If the number for 2017 is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills.'>
+                          <div
+                            title={i18n._(
+                              t`This tracks how rent stabilized units in the building have changed (i.e. "&Delta;") from 2007 to 2017. If the number for 2017 is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills.`
+                            )}
+                          >
                             <label>
                               &Delta; <Trans>RS Units</Trans>
                             </label>
@@ -485,3 +514,7 @@ export default class DetailView extends Component {
     );
   }
 }
+
+const DetailView = withI18n()(DetailViewWithoutI18n);
+
+export default DetailView;

--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -435,7 +435,7 @@ class DetailViewWithoutI18n extends Component {
                     <tr>
                       <td>
                         <div>
-                          <Trans>Shell Companies</Trans>
+                          <Trans>Business Entities</Trans>
                         </div>
                         <ul>
                           {this.props.userAddr.corpnames &&
@@ -446,7 +446,7 @@ class DetailViewWithoutI18n extends Component {
                       </td>
                       <td>
                         <div>
-                          <Trans>Shell Companies</Trans>
+                          <Trans>Business Entities</Trans>
                         </div>
                         <ul>
                           {this.props.addr.corpnames &&

--- a/client/src/components/Indicators.js
+++ b/client/src/components/Indicators.js
@@ -444,7 +444,9 @@ class IndicatorsWithoutI18n extends Component {
               <div className="column column-context col-4 col-lg-12">
                 <div className="card">
                   <div className="card-header">
-                    <div className="card-title h5">What are {dataset && dataset.name(i18n)}?</div>
+                    <div className="card-title h5">
+                      <Trans>What are {dataset && dataset.name(i18n)}?</Trans>
+                    </div>
                     <div className="card-subtitle text-gray" />
                   </div>
                   <div className="card-body">{dataset && dataset.explanation(i18n)}</div>

--- a/client/src/components/Indicators.js
+++ b/client/src/components/Indicators.js
@@ -454,7 +454,7 @@ class IndicatorsWithoutI18n extends Component {
 
                 <div className="card card-links">
                   <div className="card-body card-body-links">
-                    <Trans render="h6">Official building pages</Trans>
+                    <Trans render="h6">Useful links</Trans>
                     <div className="columns">
                       <div className="column col-12">
                         <a

--- a/client/src/components/IndicatorsViz.js
+++ b/client/src/components/IndicatorsViz.js
@@ -131,6 +131,8 @@ class IndicatorsVizImplementation extends Component {
 
     const { i18n } = this.props;
     const locale = i18n._language || "en";
+    console.log(Helpers.formatDateForTimeline("2010-03-05"));
+    console.log(Helpers.formatDateForTimeline("2010-03-05", "es"));
 
     switch (this.props.activeVis) {
       case "viols":
@@ -272,8 +274,8 @@ class IndicatorsVizImplementation extends Component {
                 if (timeSpan === "month") {
                   var fullDate = value.concat("-15"); // Make date value include a day so it can be parsed
                   return (
-                    (value.slice(5, 7) === "01" ? value.slice(0, 4) + "  " : "") +
-                    Helpers.formatDateForTimeline(fullDate).slice(0, 3) // Include special year label for January
+                    (value.slice(5, 7) === "01" ? value.slice(0, 4) + "  " : "") + // Include special year label for January
+                    Helpers.formatMonthSnippetForTimeline(fullDate, locale)
                   );
                 } else if (timeSpan === "quarter") {
                   return (
@@ -297,24 +299,15 @@ class IndicatorsVizImplementation extends Component {
           title: function (tooltipItem) {
             if (timeSpan === "quarter") {
               const quarter = this._data.labels[tooltipItem[0].index].slice(-1);
-              var monthRange;
-
-              switch (quarter) {
-                case "1":
-                  monthRange = "Jan - Mar";
-                  break;
-                case "2":
-                  monthRange = "Apr - Jun";
-                  break;
-                case "3":
-                  monthRange = "Jul - Sep";
-                  break;
-                case "4":
-                  monthRange = "Oct - Dec";
-                  break;
-                default:
-                  monthRange = "";
-              }
+              const numOfLastMonthInQuarter = parseInt(quarter) * 3;
+              /** A quarter year written out as it's range of months (ex: "Jan - Mar")  */
+              const monthRange = `${Helpers.formatMonthSnippetForTimeline(
+                "2020/0" + (numOfLastMonthInQuarter - 2),
+                locale
+              )} - ${Helpers.formatMonthSnippetForTimeline(
+                "2020/0" + numOfLastMonthInQuarter,
+                locale
+              )}`;
 
               return monthRange + " " + this._data.labels[tooltipItem[0].index].slice(0, 4);
             } else if (timeSpan === "year") {

--- a/client/src/components/IndicatorsViz.js
+++ b/client/src/components/IndicatorsViz.js
@@ -273,7 +273,7 @@ class IndicatorsVizImplementation extends Component {
                   var fullDate = value.concat("-15"); // Make date value include a day so it can be parsed
                   return (
                     (value.slice(5, 7) === "01" ? value.slice(0, 4) + "  " : "") + // Include special year label for January
-                    Helpers.formatMonthSnippetForTimeline(fullDate, locale)
+                    Helpers.formatMonthAbbreviationForTimeline(fullDate, locale)
                   );
                 } else if (timeSpan === "quarter") {
                   return (
@@ -299,10 +299,10 @@ class IndicatorsVizImplementation extends Component {
               const quarter = this._data.labels[tooltipItem[0].index].slice(-1);
               const numOfLastMonthInQuarter = parseInt(quarter) * 3;
               /** The quarter year written out as it's range of months (ex: "Jan - Mar")  */
-              const monthRange = `${Helpers.formatMonthSnippetForTimeline(
+              const monthRange = `${Helpers.formatMonthAbbreviationForTimeline(
                 "2020/0" + (numOfLastMonthInQuarter - 2),
                 locale
-              )} - ${Helpers.formatMonthSnippetForTimeline(
+              )} - ${Helpers.formatMonthAbbreviationForTimeline(
                 "2020/0" + numOfLastMonthInQuarter,
                 locale
               )}`;

--- a/client/src/components/IndicatorsViz.js
+++ b/client/src/components/IndicatorsViz.js
@@ -130,6 +130,7 @@ class IndicatorsVizImplementation extends Component {
     var datasets;
 
     const { i18n } = this.props;
+    const locale = i18n._language || "en";
 
     switch (this.props.activeVis) {
       case "viols":
@@ -272,7 +273,7 @@ class IndicatorsVizImplementation extends Component {
                   var fullDate = value.concat("-15"); // Make date value include a day so it can be parsed
                   return (
                     (value.slice(5, 7) === "01" ? value.slice(0, 4) + "  " : "") +
-                    Helpers.formatDate(fullDate).slice(0, 3) // Include special year label for January
+                    Helpers.formatDateForTimeline(fullDate).slice(0, 3) // Include special year label for January
                   );
                 } else if (timeSpan === "quarter") {
                   return (
@@ -321,7 +322,7 @@ class IndicatorsVizImplementation extends Component {
             } else if (timeSpan === "month") {
               // Make date value include day:
               var fullDate = this._data.labels[tooltipItem[0].index].concat("-15");
-              return Helpers.formatDate(fullDate);
+              return Helpers.formatDateForTimeline(fullDate, locale);
             } else {
               return "";
             }
@@ -402,7 +403,7 @@ class IndicatorsVizImplementation extends Component {
                 label: {
                   content:
                     (dateLocation === "past" ? "← " : "") +
-                    Helpers.formatDate(this.props.lastSale.date) +
+                    Helpers.formatDateForTimeline(this.props.lastSale.date, locale) +
                     (dateLocation === "future" ? " →" : ""),
                   fontFamily: "Inconsolata, monospace",
                   fontColor: "#fff",

--- a/client/src/components/IndicatorsViz.js
+++ b/client/src/components/IndicatorsViz.js
@@ -131,8 +131,6 @@ class IndicatorsVizImplementation extends Component {
 
     const { i18n } = this.props;
     const locale = i18n._language || "en";
-    console.log(Helpers.formatDateForTimeline("2010-03-05"));
-    console.log(Helpers.formatDateForTimeline("2010-03-05", "es"));
 
     switch (this.props.activeVis) {
       case "viols":
@@ -300,7 +298,7 @@ class IndicatorsVizImplementation extends Component {
             if (timeSpan === "quarter") {
               const quarter = this._data.labels[tooltipItem[0].index].slice(-1);
               const numOfLastMonthInQuarter = parseInt(quarter) * 3;
-              /** A quarter year written out as it's range of months (ex: "Jan - Mar")  */
+              /** The quarter year written out as it's range of months (ex: "Jan - Mar")  */
               const monthRange = `${Helpers.formatMonthSnippetForTimeline(
                 "2020/0" + (numOfLastMonthInQuarter - 2),
                 locale

--- a/client/src/components/OwnersTable.tsx
+++ b/client/src/components/OwnersTable.tsx
@@ -35,7 +35,7 @@ const OwnersTable: React.FC<{
               )}
             </div>
             <div className="column col-3">
-              <Trans render="p">Shell Companies</Trans>
+              <Trans render="p">Business Entities</Trans>
               {props.addr.corpnames && props.addr.corpnames.length && (
                 <ul>
                   {props.addr.corpnames.map((corp, idx) => (

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -131,7 +131,7 @@ const PropertiesListWithoutI18n: React.FC<{
               ],
             },
             // {
-            //   Header: 'Shell Companies',
+            //   Header: 'Business Entities',
             //   accessor: 'corpnames',
             //   Cell: row => {
             //     return (<span>{row.original.corpnames ? row.original.corpnames.join(', ') : ''}</span>);

--- a/client/src/containers/NotRegisteredPage.js
+++ b/client/src/containers/NotRegisteredPage.js
@@ -241,7 +241,7 @@ export default class NotRegisteredPage extends Component {
                 buildingInfo.housenumber &&
                 buildingInfo.streetname && (
                   <div>
-                    <Trans render="p">Useful links:</Trans>
+                    <Trans render="p">Useful links</Trans>:
                     <div>
                       <div className="btn-group btn-group-block">
                         <a

--- a/client/src/containers/NychaPage.js
+++ b/client/src/containers/NychaPage.js
@@ -260,12 +260,12 @@ class NychaPageWithoutI18n extends Component {
                       <Trans>HUD Complaint Form 958</Trans> &#8599;
                     </a>
                     <a
-                      href="https://www1.nyc.gov/assets/nycha/downloads/pdf/Development-Guide-01142019.pdf"
+                      href="https://www1.nyc.gov/assets/nycha/downloads/pdf/Development-Guide-04-23-2020.pdf"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="btn"
                     >
-                      <Trans>NYCHA Facility Directory</Trans> &#8599;
+                      <Trans>NYCHA Directory</Trans> &#8599;
                     </a>
                   </div>
                   <div className="btn-group btn-group-block">

--- a/client/src/containers/NychaPage.js
+++ b/client/src/containers/NychaPage.js
@@ -248,7 +248,7 @@ class NychaPageWithoutI18n extends Component {
               <br />
 
               <div>
-                <Trans render="p">Useful links:</Trans>
+                <Trans render="p">Useful links</Trans>:
                 <div>
                   <div className="btn-group btn-group-block">
                     <a

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -128,6 +128,9 @@ msgid "Business Addresses"
 msgstr "Business Addresses"
 
 #: src/components/DetailView.js:204
+#: src/components/DetailView.js:438
+#: src/components/DetailView.js:449
+#: src/components/OwnersTable.tsx:25
 msgid "Business Entities"
 msgstr "Business Entities"
 
@@ -511,8 +514,8 @@ msgstr "Share this page with your neighbors"
 #: src/components/DetailView.js:438
 #: src/components/DetailView.js:449
 #: src/components/OwnersTable.tsx:25
-msgid "Shell Companies"
-msgstr "Shell Companies"
+#~ msgid "Shell Companies"
+#~ msgstr "Shell Companies"
 
 #: src/components/Subscribe.tsx:52
 msgid "Sign up"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -57,7 +57,6 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 
-#: src/components/DetailView.js:298
 #: src/components/PropertiesSummary.js:161
 msgid "Additional links"
 msgstr "Additional links"
@@ -395,11 +394,6 @@ msgstr "Non-Emergency"
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
-#: src/components/DetailView.js:303
-#: src/components/Indicators.js:457
-msgid "Official building pages"
-msgstr "Official building pages"
-
 #: src/components/Subscribe.tsx:34
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
@@ -680,10 +674,13 @@ msgstr "Unable to request Code Violation Dismissals"
 msgid "Units"
 msgstr "Units"
 
+#: src/components/DetailView.js:298
+#: src/components/DetailView.js:303
+#: src/components/Indicators.js:457
 #: src/containers/NotRegisteredPage.js:244
 #: src/containers/NychaPage.js:251
-msgid "Useful links:"
-msgstr "Useful links:"
+msgid "Useful links"
+msgstr "Useful links"
 
 #: src/components/DetailView.js:198
 msgid "View data over time"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,52 +13,52 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/DetailView.js:156
+#: src/components/DetailView.js:248
 msgid "(expired {0})"
 msgstr "(expired {0})"
 
-#: src/components/DetailView.js:157
+#: src/components/DetailView.js:255
 msgid "(expires {0})"
 msgstr "(expires {0})"
 
-#: src/components/DetailView.js:124
+#: src/components/DetailView.js:187
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
-#: src/components/PropertiesMap.js:228
+#: src/components/PropertiesMap.js:278
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 
-#: src/containers/HomePage.tsx:108
+#: src/containers/HomePage.tsx:128
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
-#: src/components/DetailView.js:109
-#: src/containers/NychaPage.js:128
+#: src/components/DetailView.js:155
+#: src/containers/NychaPage.js:149
 msgid "2019 Evictions"
 msgstr "2019 Evictions"
 
-#: src/containers/HomePage.tsx:25
+#: src/containers/HomePage.tsx:27
 msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 msgstr "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 
-#: src/components/DetailView.js:197
-#: src/components/Indicators.js:587
-#: src/containers/NotRegisteredPage.js:161
-#: src/containers/NychaPage.js:186
+#: src/components/DetailView.js:371
+#: src/components/Indicators.js:525
+#: src/containers/NotRegisteredPage.js:279
+#: src/containers/NychaPage.js:286
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
 
-#: src/containers/App.js:56
+#: src/containers/App.js:62
 msgid "About"
 msgstr "About"
 
-#: src/components/PropertiesSummary.js:89
+#: src/components/PropertiesSummary.js:149
 msgid "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 
-#: src/components/DetailView.js:179
-#: src/components/PropertiesSummary.js:97
+#: src/components/DetailView.js:297
+#: src/components/PropertiesSummary.js:161
 msgid "Additional links"
 msgstr "Additional links"
 
@@ -70,49 +70,49 @@ msgstr "Address"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: src/components/DetailView.js:163
-#: src/components/DetailView.js:203
+#: src/components/DetailView.js:265
+#: src/components/DetailView.js:379
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
-#: src/containers/NychaPage.js:192
+#: src/containers/NychaPage.js:293
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/components/DetailView.js:75
-#: src/components/Indicators.js:341
+#: src/components/DetailView.js:84
+#: src/components/Indicators.js:303
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/Indicators.js:354
+#: src/components/Indicators.js:314
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
 #: src/components/PropertiesList.tsx:62
-#: src/containers/NychaPage.js:120
+#: src/containers/NychaPage.js:133
 msgid "Borough"
 msgstr "Borough"
 
-#: src/containers/NychaPage.js:137
+#: src/containers/NychaPage.js:162
 msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
-#: src/containers/NotRegisteredPage.js:78
-#: src/containers/NotRegisteredPage.js:91
-#: src/containers/NotRegisteredPage.js:102
+#: src/containers/NotRegisteredPage.js:100
+#: src/containers/NotRegisteredPage.js:130
+#: src/containers/NotRegisteredPage.js:159
 msgid "Building Classification"
 msgstr "Building Classification"
 
-#: src/components/IndicatorsDatasets.tsx:44
+#: src/components/IndicatorsDatasets.tsx:61
 msgid "Building Permit Applications"
 msgstr "Building Permit Applications"
 
-#: src/components/IndicatorsViz.js:185
-#: src/components/IndicatorsViz.js:247
+#: src/components/IndicatorsViz.js:181
+#: src/components/IndicatorsViz.js:256
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
-#: src/containers/NotRegisteredPage.js:190
+#: src/containers/NotRegisteredPage.js:322
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
@@ -120,58 +120,58 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.js:139
-#: src/components/DetailView.js:252
-#: src/components/DetailView.js:258
+#: src/components/DetailView.js:215
+#: src/components/DetailView.js:460
+#: src/components/DetailView.js:471
 #: src/components/OwnersTable.tsx:19
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.js:133
+#: src/components/DetailView.js:204
 msgid "Business Entities"
 msgstr "Business Entities"
 
-#: src/containers/NotRegisteredPage.js:194
+#: src/containers/NotRegisteredPage.js:326
 msgid "Civil penalties of $250-$500"
 msgstr "Civil penalties of $250-$500"
 
-#: src/components/IndicatorsViz.js:158
+#: src/components/IndicatorsViz.js:152
 msgid "Class A"
 msgstr "Class A"
 
-#: src/components/IndicatorsViz.js:151
+#: src/components/IndicatorsViz.js:145
 msgid "Class B"
 msgstr "Class B"
 
-#: src/components/IndicatorsViz.js:144
+#: src/components/IndicatorsViz.js:138
 msgid "Class C"
 msgstr "Class C"
 
-#: src/containers/NotRegisteredPage.js:200
+#: src/containers/NotRegisteredPage.js:338
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
-#: src/components/PropertiesMap.js:220
+#: src/components/PropertiesMap.js:260
 msgid "Close legend"
 msgstr "Close legend"
 
-#: src/components/IndicatorsViz.js:246
+#: src/components/IndicatorsViz.js:253
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
-#: src/components/DetailView.js:191
-#: src/components/Indicators.js:561
-#: src/containers/NotRegisteredPage.js:160
+#: src/components/DetailView.js:345
+#: src/components/Indicators.js:499
+#: src/containers/NotRegisteredPage.js:271
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
-#: src/components/DetailView.js:194
-#: src/components/Indicators.js:574
-#: src/containers/NotRegisteredPage.js:157
+#: src/components/DetailView.js:358
+#: src/components/Indicators.js:512
+#: src/containers/NotRegisteredPage.js:261
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
-#: src/containers/App.js:51
+#: src/containers/App.js:54
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -179,24 +179,24 @@ msgstr "Demo Site"
 msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
-#: src/components/LegalFooter.tsx:19
-#: src/containers/App.js:58
+#: src/components/LegalFooter.tsx:31
+#: src/containers/App.js:68
 msgid "Donate"
 msgstr "Donate"
 
-#: src/components/AddressToolbar.tsx:34
+#: src/components/AddressToolbar.tsx:46
 msgid "Download"
 msgstr "Download"
 
-#: src/components/SocialShare.tsx:29
+#: src/components/SocialShare.tsx:28
 msgid "Email"
 msgstr "Email"
 
-#: src/components/IndicatorsViz.js:168
+#: src/components/IndicatorsViz.js:163
 msgid "Emergency"
 msgstr "Emergency"
 
-#: src/containers/HomePage.tsx:97
+#: src/containers/HomePage.tsx:108
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Enter an NYC address and find other buildings your landlord might own:"
 
@@ -204,12 +204,16 @@ msgstr "Enter an NYC address and find other buildings your landlord might own:"
 msgid "Enter email"
 msgstr "Enter email"
 
-#: src/components/PropertiesList.tsx:157
-#: src/components/PropertiesSummary.js:91
+#: src/components/PropertiesList.tsx:155
+#: src/components/PropertiesSummary.js:154
 msgid "Evictions"
 msgstr "Evictions"
 
-#: src/containers/NychaPage.js:127
+#: src/components/DetailView.js:152
+msgid "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
+msgstr "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
+
+#: src/containers/NychaPage.js:146
 msgid "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
@@ -217,16 +221,16 @@ msgstr "Evictions executed in this development by NYC Marshals in 2019. ANHD and
 msgid "Export Data"
 msgstr "Export Data"
 
-#: src/containers/NotRegisteredPage.js:189
+#: src/containers/NotRegisteredPage.js:321
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PropertiesSummary.js:53
+#: src/components/PropertiesSummary.js:54
 msgid "General info"
 msgstr "General info"
 
-#: src/components/DetailView.js:188
-#: src/components/Indicators.js:548
+#: src/components/DetailView.js:332
+#: src/components/Indicators.js:486
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
@@ -235,36 +239,40 @@ msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
 #: src/components/IndicatorsDatasets.tsx:12
-msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
-msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
+#~ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
+#~ msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
-#: src/components/IndicatorsDatasets.tsx:24
-#: src/components/PropertiesList.tsx:140
+#: src/components/IndicatorsDatasets.tsx:12
+msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
+msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
+
+#: src/components/IndicatorsDatasets.tsx:32
+#: src/components/PropertiesList.tsx:138
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
-#: src/components/IndicatorsDatasets.tsx:31
+#: src/components/IndicatorsDatasets.tsx:39
 msgid "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner— however, HPD violations are notoriously unenforced by the City. These Violations fall into three categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8/>Read more about HPD Violations at the <9>official HPD page</9>."
 msgstr "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner— however, HPD violations are notoriously unenforced by the City. These Violations fall into three categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8/>Read more about HPD Violations at the <9>official HPD page</9>."
 
-#: src/containers/NychaPage.js:181
+#: src/containers/NychaPage.js:260
 msgid "HUD Complaint Form 958"
 msgstr "HUD Complaint Form 958"
 
-#: src/components/Indicators.js:490
+#: src/components/Indicators.js:432
 msgid "Have thoughts about this page?"
 msgstr "Have thoughts about this page?"
 
-#: src/containers/App.js:55
+#: src/containers/App.js:59
 msgid "Home"
 msgstr "Home"
 
-#: src/components/DetailView.js:79
-#: src/components/DetailView.js:224
+#: src/components/DetailView.js:92
+#: src/components/DetailView.js:414
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.js:57
+#: src/containers/App.js:65
 msgid "How to use"
 msgstr "How to use"
 
@@ -272,7 +280,7 @@ msgstr "How to use"
 msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/containers/NotRegisteredPage.js:196
+#: src/containers/NotRegisteredPage.js:328
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
@@ -280,7 +288,7 @@ msgstr "Ineligible to certify violations"
 msgid "Information"
 msgstr "Information"
 
-#: src/containers/NotRegisteredPage.js:101
+#: src/containers/NotRegisteredPage.js:146
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "It doesn't seem like this property is required to register with HPD."
 
@@ -288,12 +296,12 @@ msgstr "It doesn't seem like this property is required to register with HPD."
 msgid "Join the fight for tenant rights!"
 msgstr "Join the fight for tenant rights!"
 
-#: src/components/LegalFooter.tsx:13
+#: src/components/LegalFooter.tsx:19
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 
-#: src/components/PropertiesList.tsx:168
-#: src/components/PropertiesSummary.js:71
+#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesSummary.js:104
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -301,17 +309,17 @@ msgstr "Landlord"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.js:154
+#: src/components/DetailView.js:242
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/PropertiesMap.js:220
+#: src/components/PropertiesMap.js:265
 msgid "Legend"
 msgstr "Legend"
 
-#: src/components/Indicators.js:332
-#: src/components/PropertiesMap.js:177
-#: src/containers/AddressPage.js:307
+#: src/components/Indicators.js:294
+#: src/components/PropertiesMap.js:191
+#: src/containers/AddressPage.js:274
 msgid "Loading"
 msgstr "Loading"
 
@@ -319,77 +327,77 @@ msgstr "Loading"
 msgid "Location"
 msgstr "Location"
 
-#: src/components/PropertiesSummary.js:99
+#: src/components/PropertiesSummary.js:165
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
-#: src/components/LegalFooter.tsx:17
+#: src/components/LegalFooter.tsx:25
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 
-#: src/components/PropertiesSummary.js:81
+#: src/components/PropertiesSummary.js:127
 msgid "Maintenance code violations"
 msgstr "Maintenance code violations"
 
-#: src/containers/NotRegisteredPage.js:195
+#: src/containers/NotRegisteredPage.js:327
 msgid "May be issued official Orders"
 msgstr "May be issued official Orders"
 
-#: src/components/LegalFooter.tsx:23
+#: src/components/LegalFooter.tsx:41
 msgid "Methodology"
 msgstr "Methodology"
 
-#: src/components/Indicators.js:402
+#: src/components/Indicators.js:357
 msgid "Month"
 msgstr "Month"
 
-#: src/containers/NychaPage.js:185
+#: src/containers/NychaPage.js:278
 msgid "MyNYCHA App"
 msgstr "MyNYCHA App"
 
-#: src/containers/NychaPage.js:182
+#: src/containers/NychaPage.js:268
 msgid "NYCHA Facility Directory"
 msgstr "NYCHA Facility Directory"
 
-#: src/components/SocialShare.tsx:27
+#: src/components/SocialShare.tsx:26
 msgid "New JustFix.nyc tool helps research on NYC landlords"
 msgstr "New JustFix.nyc tool helps research on NYC landlords"
 
-#: src/components/AddressToolbar.tsx:27
+#: src/components/AddressToolbar.tsx:29
 msgid "New Search"
 msgstr "New Search"
 
-#: src/containers/NychaPage.js:151
+#: src/containers/NychaPage.js:188
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/containers/NotRegisteredPage.js:117
-#: src/containers/NychaPage.js:97
+#: src/containers/NotRegisteredPage.js:179
+#: src/containers/NychaPage.js:110
 msgid "No address found"
 msgstr "No address found"
 
-#: src/components/IndicatorsViz.js:430
+#: src/components/IndicatorsViz.js:435
 msgid "No data available"
 msgstr "No data available"
 
-#: src/containers/NotRegisteredPage.js:136
+#: src/containers/NotRegisteredPage.js:201
 msgid "No registration found for {usersInputAddressFragment}!"
 msgstr "No registration found for {usersInputAddressFragment}!"
 
-#: src/containers/NotRegisteredPage.js:138
+#: src/containers/NotRegisteredPage.js:203
 msgid "No registration found!"
 msgstr "No registration found!"
 
-#: src/components/IndicatorsViz.js:175
+#: src/components/IndicatorsViz.js:170
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/PropertiesList.tsx:171
+#: src/components/PropertiesList.tsx:169
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
-#: src/components/DetailView.js:182
-#: src/components/Indicators.js:517
+#: src/components/DetailView.js:302
+#: src/components/Indicators.js:455
 msgid "Official building pages"
 msgstr "Official building pages"
 
@@ -397,23 +405,27 @@ msgstr "Official building pages"
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:143
+#: src/components/PropertiesList.tsx:141
 msgid "Open"
 msgstr "Open"
 
-#: src/components/DetailView.js:101
+#: src/components/DetailView.js:139
 msgid "Open Violations"
 msgstr "Open Violations"
 
-#: src/containers/AddressPage.js:194
+#: src/containers/AddressPage.js:173
 msgid "Overview"
 msgstr "Overview"
 
 #: src/components/IndicatorsDatasets.tsx:50
-msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/> Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
-msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/> Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
+#~ msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/> Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
+#~ msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/> Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 
-#: src/containers/AddressPage.js:165
+#: src/components/IndicatorsDatasets.tsx:67
+msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
+msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
+
+#: src/containers/AddressPage.js:155
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
@@ -421,9 +433,9 @@ msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural,
 #~ msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
 #~ msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
 
-#: src/components/DetailView.js:146
-#: src/components/DetailView.js:266
-#: src/components/DetailView.js:272
+#: src/components/DetailView.js:227
+#: src/components/DetailView.js:484
+#: src/components/DetailView.js:496
 #: src/components/OwnersTable.tsx:31
 msgid "People"
 msgstr "People"
@@ -432,72 +444,72 @@ msgstr "People"
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/containers/AddressPage.js:224
+#: src/containers/AddressPage.js:195
 msgid "Portfolio"
 msgstr "Portfolio"
 
-#: src/components/LegalFooter.tsx:21
+#: src/components/LegalFooter.tsx:37
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
-#: src/containers/NychaPage.js:110
+#: src/containers/NychaPage.js:123
 msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
-#: src/components/Indicators.js:427
+#: src/components/Indicators.js:375
 msgid "Quarter"
 msgstr "Quarter"
 
-#: src/components/DetailView.js:113
+#: src/components/DetailView.js:164
 #: src/components/PropertiesList.tsx:116
 msgid "RS Units"
 msgstr "RS Units"
 
-#: src/components/PropertiesSummary.js:93
+#: src/components/PropertiesSummary.js:156
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/containers/NotRegisteredPage.js:182
-#: src/containers/NychaPage.js:212
+#: src/containers/NotRegisteredPage.js:313
+#: src/containers/NychaPage.js:334
 msgid "Search for a different address"
 msgstr "Search for a different address"
 
-#: src/containers/BBLPage.tsx:131
+#: src/containers/BBLPage.tsx:141
 msgid "Searching"
 msgstr "Searching"
 
-#: src/containers/HomePage.tsx:102
+#: src/containers/HomePage.tsx:114
 msgid "Searching for <0>{0} {1}, {2}</0>"
 msgstr "Searching for <0>{0} {1}, {2}</0>"
 
-#: src/components/Indicators.js:361
+#: src/components/Indicators.js:321
 msgid "Select a Dataset:"
 msgstr "Select a Dataset:"
 
-#: src/components/PropertiesSummary.js:102
+#: src/components/PropertiesSummary.js:179
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/components/Indicators.js:497
+#: src/components/Indicators.js:439
 msgid "Send us feedback!"
 msgstr "Send us feedback!"
 
-#: src/containers/App.js:61
+#: src/containers/App.js:72
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.js:168
-#: src/components/DetailView.js:208
-#: src/components/EngagementPanel.tsx:15
-#: src/components/PropertiesSummary.js:107
-#: src/containers/App.js:68
-#: src/containers/NotRegisteredPage.js:168
-#: src/containers/NychaPage.js:197
+#: src/components/DetailView.js:282
+#: src/components/DetailView.js:393
+#: src/components/EngagementPanel.tsx:18
+#: src/components/PropertiesSummary.js:185
+#: src/containers/App.js:81
+#: src/containers/NotRegisteredPage.js:288
+#: src/containers/NychaPage.js:309
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
 
-#: src/components/DetailView.js:238
-#: src/components/DetailView.js:244
+#: src/components/DetailView.js:438
+#: src/components/DetailView.js:449
 #: src/components/OwnersTable.tsx:25
 msgid "Shell Companies"
 msgstr "Shell Companies"
@@ -506,225 +518,249 @@ msgstr "Shell Companies"
 msgid "Sign up"
 msgstr "Sign up"
 
-#: src/components/EngagementPanel.tsx:11
+#: src/components/EngagementPanel.tsx:12
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/IndicatorsViz.js:376
+#: src/components/IndicatorsViz.js:375
 msgid "Sold to Current Owner"
 msgstr "Sold to Current Owner"
 
-#: src/components/PropertiesMap.js:187
+#: src/components/PropertiesMap.js:202
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 
-#: src/components/LegalFooter.tsx:24
+#: src/components/LegalFooter.tsx:44
 msgid "Source code"
 msgstr "Source code"
 
-#: src/containers/AddressPage.js:239
+#: src/containers/AddressPage.js:206
 msgid "Summary"
 msgstr "Summary"
 
-#: src/components/DetailView.js:164
-#: src/components/DetailView.js:204
-#: src/containers/NychaPage.js:193
+#: src/components/DetailView.js:276
+#: src/components/DetailView.js:387
+#: src/containers/NychaPage.js:303
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
 
-#: src/components/LegalFooter.tsx:20
+#: src/components/LegalFooter.tsx:34
 msgid "Terms of use"
 msgstr "Terms of use"
 
-#: src/containers/NychaPage.js:136
+#: src/containers/NychaPage.js:159
 msgid "The NYCHA office overseeing your borough. Some experts suggest reaching out to Borough Management Offices to advocate for repairs, as they tend to have more administrative power than local management offices."
 msgstr "The NYCHA office overseeing your borough. Some experts suggest reaching out to Borough Management Offices to advocate for repairs, as they tend to have more administrative power than local management offices."
 
-#: src/components/RentstabSummary.tsx:22
+#: src/components/RentstabSummary.tsx:27
 msgid "The building that has lost the most units is <0>{0} {1}, {2}</0>, which has lost <1>{absRsLossAddrDiff}</1> {absRsLossAddrDiff, plural, one {unit} other {units}} in the past 10 years."
 msgstr "The building that has lost the most units is <0>{0} {1}, {2}</0>, which has lost <1>{absRsLossAddrDiff}</1> {absRsLossAddrDiff, plural, one {unit} other {units}} in the past 10 years."
 
-#: src/components/EvictionsSummary.tsx:11
+#: src/components/EvictionsSummary.tsx:14
 msgid "The building with the most evictions was <0>{0} {1}, {2}</0> with {buildingTotalEvictions, plural, one {one eviction} other {# evictions}} that year."
 msgstr "The building with the most evictions was <0>{0} {1}, {2}</0> with {buildingTotalEvictions, plural, one {one eviction} other {# evictions}} that year."
 
-#: src/containers/NychaPage.js:119
+#: src/containers/NychaPage.js:132
 msgid "The city borough where your search address is located"
 msgstr "The city borough where your search address is located"
 
-#: src/containers/HomePage.tsx:137
+#: src/containers/HomePage.tsx:179
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
-#: src/components/PropertiesSummary.js:78
+#: src/components/PropertiesSummary.js:120
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
-#: src/components/PropertiesSummary.js:73
+#: src/components/PropertiesSummary.js:106
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
-#: src/containers/NychaPage.js:123
+#: src/components/DetailView.js:136
+msgid "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
+msgstr "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
+
+#: src/containers/NychaPage.js:138
 msgid "The number of residential units across all buildings in this development, according to the Dept. of City Planning."
 msgstr "The number of residential units across all buildings in this development, according to the Dept. of City Planning."
 
-#: src/components/PropertiesSummary.js:57
+#: src/components/DetailView.js:126
+msgid "The number of residential units in this building, according to the Dept. of City Planning."
+msgstr "The number of residential units in this building, according to the Dept. of City Planning."
+
+#: src/components/DetailView.js:118
+msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
+msgstr "The year that this building was originally constructed, according to the Dept. of City Planning."
+
+#: src/components/PropertiesSummary.js:75
 msgid "The {bldgs, plural, one {} other {average}} age of {bldgs, plural, one {this building} other {these buildings}} is <0>{age}</0> years old."
 msgstr "The {bldgs, plural, one {} other {average}} age of {bldgs, plural, one {this building} other {these buildings}} is <0>{age}</0> years old."
 
-#: src/components/SocialShare.tsx:46
+#: src/components/SocialShare.tsx:45
 msgid "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
 msgstr "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
 
-#: src/components/SocialShare.tsx:46
+#: src/components/SocialShare.tsx:45
 msgid "The {buildingCount} buildings that my landlord \"owns\" 👀... #WhoOwnsWhat @JustFixNYC"
 msgstr "The {buildingCount} buildings that my landlord \"owns\" 👀... #WhoOwnsWhat @JustFixNYC"
 
-#: src/components/PropertiesSummary.js:55
+#: src/components/PropertiesSummary.js:56
 msgid "There {bldgs, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{bldgs}</3> buildings</2>}} in this portfolio with a total of {units, plural, one {1 unit} other {# units}}."
 msgstr "There {bldgs, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{bldgs}</3> buildings</2>}} in this portfolio with a total of {units, plural, one {1 unit} other {# units}}."
 
-#: src/containers/NychaPage.js:113
+#: src/containers/NychaPage.js:126
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "This building is owned by the NYC Housing Authority (NYCHA)"
 
-#: src/containers/NotRegisteredPage.js:90
+#: src/containers/NotRegisteredPage.js:117
 msgid "This building seems like it should be registered with HPD!"
 msgstr "This building seems like it should be registered with HPD!"
 
-#: src/components/AddressToolbar.tsx:32
+#: src/components/AddressToolbar.tsx:37
 msgid "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 msgstr "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 
-#: src/components/PropertiesSummary.js:85
+#: src/components/PropertiesSummary.js:135
 msgid "This is <0>about the same</0> as the citywide average."
 msgstr "This is <0>about the same</0> as the citywide average."
 
-#: src/components/PropertiesSummary.js:88
+#: src/components/PropertiesSummary.js:144
 msgid "This is <0>better</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "This is <0>better</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 
-#: src/components/PropertiesSummary.js:87
+#: src/components/PropertiesSummary.js:139
 msgid "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
+
+#: src/components/DetailView.js:104
+msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
+msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
 #: src/components/RentstabSummary.tsx:15
 msgid "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
 msgstr "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
 
-#: src/components/PropertiesSummary.js:83
+#: src/components/PropertiesSummary.js:129
 msgid "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 msgstr "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 
-#: src/containers/HomePage.tsx:121
+#: src/containers/HomePage.tsx:146
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 
-#: src/components/RentstabSummary.tsx:19
+#: src/components/RentstabSummary.tsx:24
 msgid "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 msgstr "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 
-#: src/containers/NotRegisteredPage.js:77
+#: src/components/DetailView.js:144
+msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
+msgstr "This represents the total number of HPD Violations (both open & closed) recorded by the city."
+
+#: src/containers/NotRegisteredPage.js:86
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 
-#: src/components/AddressToolbar.tsx:31
+#: src/components/DetailView.js:160
+msgid "This tracks how rent stabilized units in the building have changed (i.e. \"&Delta;\") from 2007 to 2017. If the number for 2017 is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
+msgstr "This tracks how rent stabilized units in the building have changed (i.e. \"&Delta;\") from 2007 to 2017. If the number for 2017 is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
+
+#: src/components/AddressToolbar.tsx:33
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.js:209
+#: src/containers/AddressPage.js:184
 msgid "Timeline"
 msgstr "Timeline"
 
 #: src/components/IndicatorsViz.js:336
-#: src/components/PropertiesList.tsx:149
+#: src/components/PropertiesList.tsx:147
 msgid "Total"
 msgstr "Total"
 
-#: src/components/DetailView.js:105
+#: src/components/DetailView.js:147
 msgid "Total Violations"
 msgstr "Total Violations"
 
-#: src/containers/NotRegisteredPage.js:198
+#: src/containers/NotRegisteredPage.js:330
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "Unable to initiate a court action for nonpayment of rent."
 
-#: src/containers/NotRegisteredPage.js:197
+#: src/containers/NotRegisteredPage.js:329
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
-#: src/components/DetailView.js:95
+#: src/components/DetailView.js:129
 #: src/components/PropertiesList.tsx:83
-#: src/containers/NychaPage.js:124
+#: src/containers/NychaPage.js:141
 msgid "Units"
 msgstr "Units"
 
-#: src/containers/NotRegisteredPage.js:153
-#: src/containers/NychaPage.js:178
+#: src/containers/NotRegisteredPage.js:244
+#: src/containers/NychaPage.js:251
 msgid "Useful links:"
 msgstr "Useful links:"
 
-#: src/components/DetailView.js:127
+#: src/components/DetailView.js:197
 msgid "View data over time"
 msgstr "View data over time"
 
-#: src/components/PropertiesList.tsx:183
+#: src/components/PropertiesList.tsx:180
 msgid "View detail"
 msgstr "View detail"
 
-#: src/components/DetailView.js:185
-#: src/components/Indicators.js:529
-#: src/containers/NotRegisteredPage.js:156
+#: src/components/DetailView.js:315
+#: src/components/Indicators.js:467
+#: src/containers/NotRegisteredPage.js:253
 msgid "View documents on ACRIS"
 msgstr "View documents on ACRIS"
 
-#: src/components/PropertiesMap.js:220
+#: src/components/PropertiesMap.js:262
 msgid "View legend"
 msgstr "View legend"
 
-#: src/containers/HomePage.tsx:124
-#: src/containers/HomePage.tsx:141
-#: src/containers/HomePage.tsx:157
+#: src/containers/HomePage.tsx:161
+#: src/containers/HomePage.tsx:202
+#: src/containers/HomePage.tsx:231
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.js:66
+#: src/components/DetailView.js:76
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
-#: src/components/IndicatorsViz.js:247
+#: src/components/IndicatorsViz.js:255
 msgid "Violations Issued"
 msgstr "Violations Issued"
 
-#: src/components/EngagementPanel.tsx:19
+#: src/components/EngagementPanel.tsx:24
 msgid "Visit our website"
 msgstr "Visit our website"
 
-#: src/containers/App.js:43
+#: src/containers/App.js:38
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
-#: src/components/DetailView.js:225
+#: src/components/DetailView.js:416
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
-#: src/containers/NotRegisteredPage.js:55
+#: src/containers/NotRegisteredPage.js:59
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 
-#: src/containers/App.js:47
+#: src/containers/App.js:50
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 
-#: src/components/Indicators.js:450
+#: src/components/Indicators.js:393
 msgid "Year"
 msgstr "Year"
 
-#: src/components/DetailView.js:91
+#: src/components/DetailView.js:121
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/containers/HomePage.tsx:154
+#: src/containers/HomePage.tsx:220
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
@@ -736,19 +772,19 @@ msgstr "Zipcode"
 msgid "and"
 msgstr "and"
 
-#: src/components/PropertiesMap.js:224
+#: src/components/PropertiesMap.js:273
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/PropertiesMap.js:223
+#: src/components/PropertiesMap.js:272
 msgid "search address"
 msgstr "search address"
 
-#: src/components/PropertiesSummary.js:65
+#: src/components/PropertiesSummary.js:90
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 
-#: src/components/IndicatorsDatasets.tsx:45
+#: src/components/IndicatorsDatasets.tsx:62
 msgid "{value, plural, one {One Building Permit Application since 2010} other {# Building Permit Applications since 2010}}"
 msgstr "{value, plural, one {One Building Permit Application since 2010} other {# Building Permit Applications since 2010}}"
 
@@ -756,6 +792,6 @@ msgstr "{value, plural, one {One Building Permit Application since 2010} other {
 msgid "{value, plural, one {One HPD Complaint Issued since 2014} other {# HPD Complaints Issued since 2014}}"
 msgstr "{value, plural, one {One HPD Complaint Issued since 2014} other {# HPD Complaints Issued since 2014}}"
 
-#: src/components/IndicatorsDatasets.tsx:26
+#: src/components/IndicatorsDatasets.tsx:34
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,15 +13,15 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/DetailView.js:248
+#: src/components/DetailView.js:249
 msgid "(expired {0})"
 msgstr "(expired {0})"
 
-#: src/components/DetailView.js:255
+#: src/components/DetailView.js:256
 msgid "(expires {0})"
 msgstr "(expires {0})"
 
-#: src/components/DetailView.js:187
+#: src/components/DetailView.js:188
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
@@ -33,7 +33,7 @@ msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
-#: src/components/DetailView.js:155
+#: src/components/DetailView.js:156
 #: src/containers/NychaPage.js:149
 msgid "2019 Evictions"
 msgstr "2019 Evictions"
@@ -42,8 +42,8 @@ msgstr "2019 Evictions"
 msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 msgstr "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 
-#: src/components/DetailView.js:371
-#: src/components/Indicators.js:525
+#: src/components/DetailView.js:372
+#: src/components/Indicators.js:527
 #: src/containers/NotRegisteredPage.js:279
 #: src/containers/NychaPage.js:286
 msgid "ANHD DAP Portal"
@@ -57,7 +57,7 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 
-#: src/components/DetailView.js:297
+#: src/components/DetailView.js:298
 #: src/components/PropertiesSummary.js:161
 msgid "Additional links"
 msgstr "Additional links"
@@ -70,8 +70,8 @@ msgstr "Address"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: src/components/DetailView.js:265
-#: src/components/DetailView.js:379
+#: src/components/DetailView.js:266
+#: src/components/DetailView.js:380
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -79,7 +79,7 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/components/DetailView.js:84
+#: src/components/DetailView.js:85
 #: src/components/Indicators.js:303
 msgid "BUILDING:"
 msgstr "BUILDING:"
@@ -120,16 +120,16 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.js:215
-#: src/components/DetailView.js:460
-#: src/components/DetailView.js:471
+#: src/components/DetailView.js:216
+#: src/components/DetailView.js:461
+#: src/components/DetailView.js:472
 #: src/components/OwnersTable.tsx:19
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.js:204
-#: src/components/DetailView.js:438
-#: src/components/DetailView.js:449
+#: src/components/DetailView.js:205
+#: src/components/DetailView.js:439
+#: src/components/DetailView.js:450
 #: src/components/OwnersTable.tsx:25
 msgid "Business Entities"
 msgstr "Business Entities"
@@ -162,14 +162,14 @@ msgstr "Close legend"
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
-#: src/components/DetailView.js:345
-#: src/components/Indicators.js:499
+#: src/components/DetailView.js:346
+#: src/components/Indicators.js:501
 #: src/containers/NotRegisteredPage.js:271
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
-#: src/components/DetailView.js:358
-#: src/components/Indicators.js:512
+#: src/components/DetailView.js:359
+#: src/components/Indicators.js:514
 #: src/containers/NotRegisteredPage.js:261
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
@@ -212,7 +212,7 @@ msgstr "Enter email"
 msgid "Evictions"
 msgstr "Evictions"
 
-#: src/components/DetailView.js:152
+#: src/components/DetailView.js:153
 msgid "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
@@ -220,7 +220,7 @@ msgstr "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Co
 msgid "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
-#: src/components/AddressToolbar.tsx:24
+#: src/components/AddressToolbar.tsx:29
 msgid "Export Data"
 msgstr "Export Data"
 
@@ -232,18 +232,14 @@ msgstr "Failure to register a building with HPD"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/DetailView.js:332
-#: src/components/Indicators.js:486
+#: src/components/DetailView.js:333
+#: src/components/Indicators.js:488
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:6
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
-
-#: src/components/IndicatorsDatasets.tsx:12
-#~ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
-#~ msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:12
 msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
@@ -270,8 +266,8 @@ msgstr "Have thoughts about this page?"
 msgid "Home"
 msgstr "Home"
 
-#: src/components/DetailView.js:92
-#: src/components/DetailView.js:414
+#: src/components/DetailView.js:93
+#: src/components/DetailView.js:415
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
@@ -312,7 +308,7 @@ msgstr "Landlord"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.js:242
+#: src/components/DetailView.js:243
 msgid "Last registered:"
 msgstr "Last registered:"
 
@@ -359,14 +355,14 @@ msgid "MyNYCHA App"
 msgstr "MyNYCHA App"
 
 #: src/containers/NychaPage.js:268
-msgid "NYCHA Facility Directory"
-msgstr "NYCHA Facility Directory"
+msgid "NYCHA Directory"
+msgstr "NYCHA Directory"
 
 #: src/components/SocialShare.tsx:26
 msgid "New JustFix.nyc tool helps research on NYC landlords"
 msgstr "New JustFix.nyc tool helps research on NYC landlords"
 
-#: src/components/AddressToolbar.tsx:29
+#: src/components/AddressToolbar.tsx:26
 msgid "New Search"
 msgstr "New Search"
 
@@ -399,8 +395,8 @@ msgstr "Non-Emergency"
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
-#: src/components/DetailView.js:302
-#: src/components/Indicators.js:455
+#: src/components/DetailView.js:303
+#: src/components/Indicators.js:457
 msgid "Official building pages"
 msgstr "Official building pages"
 
@@ -412,17 +408,13 @@ msgstr "Oops! That email is invalid."
 msgid "Open"
 msgstr "Open"
 
-#: src/components/DetailView.js:139
+#: src/components/DetailView.js:140
 msgid "Open Violations"
 msgstr "Open Violations"
 
 #: src/containers/AddressPage.js:173
 msgid "Overview"
 msgstr "Overview"
-
-#: src/components/IndicatorsDatasets.tsx:50
-#~ msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/> Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
-#~ msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/> Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 
 #: src/components/IndicatorsDatasets.tsx:67
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
@@ -432,13 +424,9 @@ msgstr "Owners submit Building Permit Applications to the Department of Building
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/containers/AddressPage.js:145
-#~ msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
-#~ msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
-
-#: src/components/DetailView.js:227
-#: src/components/DetailView.js:484
-#: src/components/DetailView.js:496
+#: src/components/DetailView.js:228
+#: src/components/DetailView.js:485
+#: src/components/DetailView.js:497
 #: src/components/OwnersTable.tsx:31
 msgid "People"
 msgstr "People"
@@ -463,7 +451,7 @@ msgstr "Public Housing Development"
 msgid "Quarter"
 msgstr "Quarter"
 
-#: src/components/DetailView.js:164
+#: src/components/DetailView.js:165
 #: src/components/PropertiesList.tsx:116
 msgid "RS Units"
 msgstr "RS Units"
@@ -501,8 +489,8 @@ msgstr "Send us feedback!"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.js:282
-#: src/components/DetailView.js:393
+#: src/components/DetailView.js:283
+#: src/components/DetailView.js:394
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.js:185
 #: src/containers/App.js:81
@@ -510,12 +498,6 @@ msgstr "Share"
 #: src/containers/NychaPage.js:309
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
-
-#: src/components/DetailView.js:438
-#: src/components/DetailView.js:449
-#: src/components/OwnersTable.tsx:25
-#~ msgid "Shell Companies"
-#~ msgstr "Shell Companies"
 
 #: src/components/Subscribe.tsx:52
 msgid "Sign up"
@@ -541,8 +523,8 @@ msgstr "Source code"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/components/DetailView.js:276
-#: src/components/DetailView.js:387
+#: src/components/DetailView.js:277
+#: src/components/DetailView.js:388
 #: src/containers/NychaPage.js:303
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
@@ -579,7 +561,7 @@ msgstr "The most common corporate entity is <0>{0}</0> and the most common busin
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
-#: src/components/DetailView.js:136
+#: src/components/DetailView.js:137
 msgid "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
 msgstr "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
 
@@ -587,11 +569,11 @@ msgstr "The number of open HPD violations for this building, updated monthly. Cl
 msgid "The number of residential units across all buildings in this development, according to the Dept. of City Planning."
 msgstr "The number of residential units across all buildings in this development, according to the Dept. of City Planning."
 
-#: src/components/DetailView.js:126
+#: src/components/DetailView.js:127
 msgid "The number of residential units in this building, according to the Dept. of City Planning."
 msgstr "The number of residential units in this building, according to the Dept. of City Planning."
 
-#: src/components/DetailView.js:118
+#: src/components/DetailView.js:119
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "The year that this building was originally constructed, according to the Dept. of City Planning."
 
@@ -635,7 +617,7 @@ msgstr "This is <0>better</0> than the citywide average of {VIOLATIONS_AVG} per 
 msgid "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 
-#: src/components/DetailView.js:104
+#: src/components/DetailView.js:105
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
@@ -655,7 +637,7 @@ msgstr "This property management company owned by the Kushner family is notoriou
 msgid "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 msgstr "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 
-#: src/components/DetailView.js:144
+#: src/components/DetailView.js:145
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 
@@ -663,7 +645,7 @@ msgstr "This represents the total number of HPD Violations (both open & closed) 
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 
-#: src/components/DetailView.js:160
+#: src/components/DetailView.js:161
 msgid "This tracks how rent stabilized units in the building have changed (i.e. \"&Delta;\") from 2007 to 2017. If the number for 2017 is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
 msgstr "This tracks how rent stabilized units in the building have changed (i.e. \"&Delta;\") from 2007 to 2017. If the number for 2017 is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
 
@@ -680,7 +662,7 @@ msgstr "Timeline"
 msgid "Total"
 msgstr "Total"
 
-#: src/components/DetailView.js:147
+#: src/components/DetailView.js:148
 msgid "Total Violations"
 msgstr "Total Violations"
 
@@ -692,7 +674,7 @@ msgstr "Unable to initiate a court action for nonpayment of rent."
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
-#: src/components/DetailView.js:129
+#: src/components/DetailView.js:130
 #: src/components/PropertiesList.tsx:83
 #: src/containers/NychaPage.js:141
 msgid "Units"
@@ -703,7 +685,7 @@ msgstr "Units"
 msgid "Useful links:"
 msgstr "Useful links:"
 
-#: src/components/DetailView.js:197
+#: src/components/DetailView.js:198
 msgid "View data over time"
 msgstr "View data over time"
 
@@ -711,8 +693,8 @@ msgstr "View data over time"
 msgid "View detail"
 msgstr "View detail"
 
-#: src/components/DetailView.js:315
-#: src/components/Indicators.js:467
+#: src/components/DetailView.js:316
+#: src/components/Indicators.js:469
 #: src/containers/NotRegisteredPage.js:253
 msgid "View documents on ACRIS"
 msgstr "View documents on ACRIS"
@@ -727,7 +709,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.js:76
+#: src/components/DetailView.js:77
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -743,9 +725,13 @@ msgstr "Visit our website"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
-#: src/components/DetailView.js:416
+#: src/components/DetailView.js:417
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
+
+#: src/components/Indicators.js:448
+msgid "What are {0}?"
+msgstr "What are {0}?"
 
 #: src/containers/NotRegisteredPage.js:59
 msgid "What happens if the landlord has failed to register?"
@@ -759,7 +745,7 @@ msgstr "Who owns what in nyc?"
 msgid "Year"
 msgstr "Year"
 
-#: src/components/DetailView.js:121
+#: src/components/DetailView.js:122
 msgid "Year Built"
 msgstr "Year Built"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -303,7 +303,7 @@ msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgid "Landlord"
 msgstr "Landlord"
 
-#: src/components/IndicatorsViz.js:377
+#: src/components/IndicatorsViz.js:368
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
@@ -374,7 +374,7 @@ msgstr "New York Regional Office:"
 msgid "No address found"
 msgstr "No address found"
 
-#: src/components/IndicatorsViz.js:436
+#: src/components/IndicatorsViz.js:427
 msgid "No data available"
 msgstr "No data available"
 
@@ -501,7 +501,7 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/IndicatorsViz.js:376
+#: src/components/IndicatorsViz.js:367
 msgid "Sold to Current Owner"
 msgstr "Sold to Current Owner"
 
@@ -651,7 +651,7 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/IndicatorsViz.js:337
+#: src/components/IndicatorsViz.js:328
 #: src/components/PropertiesList.tsx:147
 msgid "Total"
 msgstr "Total"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -106,8 +106,8 @@ msgstr "Building Classification"
 msgid "Building Permit Applications"
 msgstr "Building Permit Applications"
 
-#: src/components/IndicatorsViz.js:181
-#: src/components/IndicatorsViz.js:256
+#: src/components/IndicatorsViz.js:182
+#: src/components/IndicatorsViz.js:257
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
@@ -137,15 +137,15 @@ msgstr "Business Entities"
 msgid "Civil penalties of $250-$500"
 msgstr "Civil penalties of $250-$500"
 
-#: src/components/IndicatorsViz.js:152
+#: src/components/IndicatorsViz.js:153
 msgid "Class A"
 msgstr "Class A"
 
-#: src/components/IndicatorsViz.js:145
+#: src/components/IndicatorsViz.js:146
 msgid "Class B"
 msgstr "Class B"
 
-#: src/components/IndicatorsViz.js:138
+#: src/components/IndicatorsViz.js:139
 msgid "Class C"
 msgstr "Class C"
 
@@ -157,7 +157,7 @@ msgstr "Click here to learn more."
 msgid "Close legend"
 msgstr "Close legend"
 
-#: src/components/IndicatorsViz.js:253
+#: src/components/IndicatorsViz.js:254
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
@@ -194,7 +194,7 @@ msgstr "Download"
 msgid "Email"
 msgstr "Email"
 
-#: src/components/IndicatorsViz.js:163
+#: src/components/IndicatorsViz.js:164
 msgid "Emergency"
 msgstr "Emergency"
 
@@ -303,7 +303,7 @@ msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgid "Landlord"
 msgstr "Landlord"
 
-#: src/components/IndicatorsViz.js:376
+#: src/components/IndicatorsViz.js:377
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
@@ -374,7 +374,7 @@ msgstr "New York Regional Office:"
 msgid "No address found"
 msgstr "No address found"
 
-#: src/components/IndicatorsViz.js:435
+#: src/components/IndicatorsViz.js:436
 msgid "No data available"
 msgstr "No data available"
 
@@ -386,7 +386,7 @@ msgstr "No registration found for {usersInputAddressFragment}!"
 msgid "No registration found!"
 msgstr "No registration found!"
 
-#: src/components/IndicatorsViz.js:170
+#: src/components/IndicatorsViz.js:171
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
@@ -501,7 +501,7 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/IndicatorsViz.js:375
+#: src/components/IndicatorsViz.js:376
 msgid "Sold to Current Owner"
 msgstr "Sold to Current Owner"
 
@@ -651,7 +651,7 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/IndicatorsViz.js:336
+#: src/components/IndicatorsViz.js:337
 #: src/components/PropertiesList.tsx:147
 msgid "Total"
 msgstr "Total"
@@ -710,7 +710,7 @@ msgstr "View portfolio"
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
-#: src/components/IndicatorsViz.js:255
+#: src/components/IndicatorsViz.js:256
 msgid "Violations Issued"
 msgstr "Violations Issued"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -60,7 +60,6 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 msgstr "Según los datos de HPD disponibles, esta cartera de edificios ha recibido un total de <0>{0}</0> infracciones."
 
-#: src/components/DetailView.js:298
 #: src/components/PropertiesSummary.js:161
 msgid "Additional links"
 msgstr "Enlaces adicionales"
@@ -398,11 +397,6 @@ msgstr "No Emergencia"
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
-#: src/components/DetailView.js:303
-#: src/components/Indicators.js:457
-msgid "Official building pages"
-msgstr "Páginas oficiales"
-
 #: src/components/Subscribe.tsx:34
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
@@ -683,10 +677,13 @@ msgstr "Imposible solicitar el despido de una Infracción del Código de Viviend
 msgid "Units"
 msgstr "Unidad Residencial"
 
+#: src/components/DetailView.js:298
+#: src/components/DetailView.js:303
+#: src/components/Indicators.js:457
 #: src/containers/NotRegisteredPage.js:244
 #: src/containers/NychaPage.js:251
-msgid "Useful links:"
-msgstr "Enlaces útiles:"
+msgid "Useful links"
+msgstr "Enlaces útiles"
 
 #: src/components/DetailView.js:198
 msgid "View data over time"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -28,11 +28,11 @@ msgstr "(caduca {0})"
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
-#: src/components/PropertiesMap.js:228
+#: src/components/PropertiesMap.js:278
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {pulsa} other {haz clic}} para ver los detalles)"
 
-#: src/containers/HomePage.tsx:108
+#: src/containers/HomePage.tsx:128
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de carteras de edificios:"
 
@@ -41,7 +41,7 @@ msgstr "... o descubre ejemplos de carteras de edificios:"
 msgid "2019 Evictions"
 msgstr "Desalojos 2019"
 
-#: src/containers/HomePage.tsx:25
+#: src/containers/HomePage.tsx:27
 msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 msgstr "<0>Actualización COVID-19: </0>JustFix.nyc sigue en funcionamiento, y hemos adaptado nuestros productos para que funcionen con las nuevas reglas establecidas durante la crisis de salud pública COVID-19. Gracias a la organización de los líderes inquilinos, los inquilinos de Nueva York ahora tienen protecciones más fuertes, incluyendo una suspensión total de los casos de desalojo. <1><2>Más información</2></1>"
 
@@ -52,11 +52,11 @@ msgstr "<0>Actualización COVID-19: </0>JustFix.nyc sigue en funcionamiento, y h
 msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
 
-#: src/containers/App.js:56
+#: src/containers/App.js:62
 msgid "About"
 msgstr "Acerca de"
 
-#: src/components/PropertiesSummary.js:89
+#: src/components/PropertiesSummary.js:149
 msgid "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 msgstr "Según los datos del HPD disponibles, esta cartera de edificios ha recibido un total de <0>{0}</0> infracciones."
 
@@ -77,7 +77,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
-#: src/containers/NychaPage.js:192
+#: src/containers/NychaPage.js:293
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
@@ -86,35 +86,35 @@ msgstr "¿Tienes problemas en tu edificio?"
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/Indicators.js:354
+#: src/components/Indicators.js:314
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
 #: src/components/PropertiesList.tsx:62
-#: src/containers/NychaPage.js:120
+#: src/containers/NychaPage.js:133
 msgid "Borough"
 msgstr "Municipio"
 
-#: src/containers/NychaPage.js:137
+#: src/containers/NychaPage.js:162
 msgid "Borough Management Office:"
 msgstr "Oficina de Gestión Municipal:"
 
-#: src/containers/NotRegisteredPage.js:78
-#: src/containers/NotRegisteredPage.js:91
-#: src/containers/NotRegisteredPage.js:102
+#: src/containers/NotRegisteredPage.js:100
+#: src/containers/NotRegisteredPage.js:130
+#: src/containers/NotRegisteredPage.js:159
 msgid "Building Classification"
 msgstr "Clasificación del Edificio"
 
-#: src/components/IndicatorsDatasets.tsx:44
+#: src/components/IndicatorsDatasets.tsx:61
 msgid "Building Permit Applications"
 msgstr "Solicitudes de Permisos de Construcción"
 
-#: src/components/IndicatorsViz.js:185
-#: src/components/IndicatorsViz.js:247
+#: src/components/IndicatorsViz.js:182
+#: src/components/IndicatorsViz.js:257
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
 
-#: src/containers/NotRegisteredPage.js:190
+#: src/containers/NotRegisteredPage.js:322
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
@@ -136,31 +136,31 @@ msgstr "Dirección Comercial"
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
-#: src/containers/NotRegisteredPage.js:194
+#: src/containers/NotRegisteredPage.js:326
 msgid "Civil penalties of $250-$500"
 msgstr "Sanciones civiles de $250-$500"
 
-#: src/components/IndicatorsViz.js:158
+#: src/components/IndicatorsViz.js:153
 msgid "Class A"
 msgstr "Clase A"
 
-#: src/components/IndicatorsViz.js:151
+#: src/components/IndicatorsViz.js:146
 msgid "Class B"
 msgstr "Clase B"
 
-#: src/components/IndicatorsViz.js:144
+#: src/components/IndicatorsViz.js:139
 msgid "Class C"
 msgstr "Clase C"
 
-#: src/containers/NotRegisteredPage.js:200
+#: src/containers/NotRegisteredPage.js:338
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
-#: src/components/PropertiesMap.js:220
+#: src/components/PropertiesMap.js:260
 msgid "Close legend"
 msgstr "Cerrar leyenda"
 
-#: src/components/IndicatorsViz.js:246
+#: src/components/IndicatorsViz.js:254
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
@@ -176,7 +176,7 @@ msgstr "Perfil de edificio en DOB"
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
-#: src/containers/App.js:51
+#: src/containers/App.js:54
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -184,24 +184,24 @@ msgstr "Sitio Demo"
 msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
 
-#: src/components/LegalFooter.tsx:19
-#: src/containers/App.js:58
+#: src/components/LegalFooter.tsx:31
+#: src/containers/App.js:68
 msgid "Donate"
 msgstr "Donar"
 
-#: src/components/AddressToolbar.tsx:34
+#: src/components/AddressToolbar.tsx:46
 msgid "Download"
 msgstr "Descargar"
 
-#: src/components/SocialShare.tsx:29
+#: src/components/SocialShare.tsx:28
 msgid "Email"
 msgstr "Email"
 
-#: src/components/IndicatorsViz.js:168
+#: src/components/IndicatorsViz.js:164
 msgid "Emergency"
 msgstr "Emergencia"
 
-#: src/containers/HomePage.tsx:97
+#: src/containers/HomePage.tsx:108
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
 
@@ -209,8 +209,8 @@ msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu pr
 msgid "Enter email"
 msgstr "Introducir email"
 
-#: src/components/PropertiesList.tsx:157
-#: src/components/PropertiesSummary.js:91
+#: src/components/PropertiesList.tsx:155
+#: src/components/PropertiesSummary.js:154
 msgid "Evictions"
 msgstr "Desalojos"
 
@@ -226,11 +226,11 @@ msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC en 2019. AN
 msgid "Export Data"
 msgstr "Exportar datos"
 
-#: src/containers/NotRegisteredPage.js:189
+#: src/containers/NotRegisteredPage.js:321
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PropertiesSummary.js:53
+#: src/components/PropertiesSummary.js:54
 msgid "General info"
 msgstr "Información general"
 
@@ -252,19 +252,19 @@ msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>p
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
-#: src/components/IndicatorsDatasets.tsx:31
+#: src/components/IndicatorsDatasets.tsx:39
 msgid "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner— however, HPD violations are notoriously unenforced by the City. These Violations fall into three categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8/>Read more about HPD Violations at the <9>official HPD page</9>."
 msgstr "Infracciones del HPD se dan cuando un Inspector oficial de la Ciudad determina que las condiciones de un hogar están en violación de la ley. Si no se corrigen, estas infraccines incurren multas para el propietario, sin embargo, las infracciones del HPD son notoriamente incumplidas por la Ciudad. Existen tres categorías de Infracciones:<0/><1/><2>Clase A</2> — no-peligrosa<3/><4>Clase B</4> — peligrosa<5/><6>Clase C</6> — de peligro inmediato<7/><8/>Encontraras más información sobre las Infracciones del HPD en la <9>página oficial del HPD</9>."
 
-#: src/containers/NychaPage.js:181
+#: src/containers/NychaPage.js:260
 msgid "HUD Complaint Form 958"
 msgstr "Formulario de queja HUD 958"
 
-#: src/components/Indicators.js:490
+#: src/components/Indicators.js:432
 msgid "Have thoughts about this page?"
 msgstr "¿Tienes ideas sobre esta página?"
 
-#: src/containers/App.js:55
+#: src/containers/App.js:59
 msgid "Home"
 msgstr "Inicio"
 
@@ -273,7 +273,7 @@ msgstr "Inicio"
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a esta cartera de edificios?"
 
-#: src/containers/App.js:57
+#: src/containers/App.js:65
 msgid "How to use"
 msgstr "Cómo se usa"
 
@@ -281,7 +281,7 @@ msgstr "Cómo se usa"
 msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "En el 2019, los Mariscales de NYC programaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en esta cartera de edificios."
 
-#: src/containers/NotRegisteredPage.js:196
+#: src/containers/NotRegisteredPage.js:328
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
@@ -289,7 +289,7 @@ msgstr "Inelegible para certificar infracciones"
 msgid "Information"
 msgstr "Información"
 
-#: src/containers/NotRegisteredPage.js:101
+#: src/containers/NotRegisteredPage.js:146
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "Parece que esta propiedad no necesita estar registrada con el HPD."
 
@@ -297,16 +297,16 @@ msgstr "Parece que esta propiedad no necesita estar registrada con el HPD."
 msgid "Join the fight for tenant rights!"
 msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 
-#: src/components/LegalFooter.tsx:13
+#: src/components/LegalFooter.tsx:19
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: src/components/PropertiesList.tsx:168
-#: src/components/PropertiesSummary.js:71
+#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesSummary.js:104
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
-#: src/components/IndicatorsViz.js:376
+#: src/components/IndicatorsViz.js:377
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
@@ -314,13 +314,13 @@ msgstr "Última venta desconocida"
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/PropertiesMap.js:220
+#: src/components/PropertiesMap.js:265
 msgid "Legend"
 msgstr "Leyenda"
 
-#: src/components/Indicators.js:332
-#: src/components/PropertiesMap.js:177
-#: src/containers/AddressPage.js:307
+#: src/components/Indicators.js:294
+#: src/components/PropertiesMap.js:191
+#: src/containers/AddressPage.js:274
 msgid "Loading"
 msgstr "Cargando"
 
@@ -328,31 +328,31 @@ msgstr "Cargando"
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/PropertiesSummary.js:99
+#: src/components/PropertiesSummary.js:165
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
-#: src/components/LegalFooter.tsx:17
+#: src/components/LegalFooter.tsx:25
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.nyc</0>"
 
-#: src/components/PropertiesSummary.js:81
+#: src/components/PropertiesSummary.js:127
 msgid "Maintenance code violations"
 msgstr "Infracciones del código de mantenimiento"
 
-#: src/containers/NotRegisteredPage.js:195
+#: src/containers/NotRegisteredPage.js:327
 msgid "May be issued official Orders"
 msgstr "Pueden emitirse órdenes oficiales"
 
-#: src/components/LegalFooter.tsx:23
+#: src/components/LegalFooter.tsx:41
 msgid "Methodology"
 msgstr "Metodología"
 
-#: src/components/Indicators.js:402
+#: src/components/Indicators.js:357
 msgid "Month"
 msgstr "Mes"
 
-#: src/containers/NychaPage.js:185
+#: src/containers/NychaPage.js:278
 msgid "MyNYCHA App"
 msgstr "App MyNYCHA"
 
@@ -360,7 +360,7 @@ msgstr "App MyNYCHA"
 msgid "NYCHA Directory"
 msgstr ""
 
-#: src/components/SocialShare.tsx:27
+#: src/components/SocialShare.tsx:26
 msgid "New JustFix.nyc tool helps research on NYC landlords"
 msgstr "La nueva herramienta JustFix.nyc te ayuda a investigar a propietarios de NYC"
 
@@ -368,32 +368,32 @@ msgstr "La nueva herramienta JustFix.nyc te ayuda a investigar a propietarios de
 msgid "New Search"
 msgstr "Nueva búsqueda"
 
-#: src/containers/NychaPage.js:151
+#: src/containers/NychaPage.js:188
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/containers/NotRegisteredPage.js:117
-#: src/containers/NychaPage.js:97
+#: src/containers/NotRegisteredPage.js:179
+#: src/containers/NychaPage.js:110
 msgid "No address found"
 msgstr "No se encontraron direcciones"
 
-#: src/components/IndicatorsViz.js:430
+#: src/components/IndicatorsViz.js:436
 msgid "No data available"
 msgstr "No hay datos disponibles"
 
-#: src/containers/NotRegisteredPage.js:136
+#: src/containers/NotRegisteredPage.js:201
 msgid "No registration found for {usersInputAddressFragment}!"
 msgstr "¡No se ha encontrado ningún registro para {usersInputAddressFragment}!"
 
-#: src/containers/NotRegisteredPage.js:138
+#: src/containers/NotRegisteredPage.js:203
 msgid "No registration found!"
 msgstr "¡No se ha encontrado nigún registro!"
 
-#: src/components/IndicatorsViz.js:175
+#: src/components/IndicatorsViz.js:171
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/PropertiesList.tsx:171
+#: src/components/PropertiesList.tsx:169
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -401,7 +401,7 @@ msgstr "Oficial/Propietario"
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:143
+#: src/components/PropertiesList.tsx:141
 msgid "Open"
 msgstr "Abrir"
 
@@ -409,7 +409,7 @@ msgstr "Abrir"
 msgid "Open Violations"
 msgstr "Infracciones Actuales"
 
-#: src/containers/AddressPage.js:194
+#: src/containers/AddressPage.js:173
 msgid "Overview"
 msgstr "Vista General"
 
@@ -432,19 +432,19 @@ msgstr "Personas"
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/containers/AddressPage.js:224
+#: src/containers/AddressPage.js:195
 msgid "Portfolio"
 msgstr "Cartera de Edificios"
 
-#: src/components/LegalFooter.tsx:21
+#: src/components/LegalFooter.tsx:37
 msgid "Privacy policy"
 msgstr "Política de privacidad"
 
-#: src/containers/NychaPage.js:110
+#: src/containers/NychaPage.js:123
 msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
-#: src/components/Indicators.js:427
+#: src/components/Indicators.js:375
 msgid "Quarter"
 msgstr "Trimestre"
 
@@ -453,36 +453,36 @@ msgstr "Trimestre"
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
-#: src/components/PropertiesSummary.js:93
+#: src/components/PropertiesSummary.js:156
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
-#: src/containers/NotRegisteredPage.js:182
-#: src/containers/NychaPage.js:212
+#: src/containers/NotRegisteredPage.js:313
+#: src/containers/NychaPage.js:334
 msgid "Search for a different address"
 msgstr "Buscar otra dirección"
 
-#: src/containers/BBLPage.tsx:131
+#: src/containers/BBLPage.tsx:141
 msgid "Searching"
 msgstr "Buscando"
 
-#: src/containers/HomePage.tsx:102
+#: src/containers/HomePage.tsx:114
 msgid "Searching for <0>{0} {1}, {2}</0>"
 msgstr "Buscando <0>{0} {1}, {2}</0>"
 
-#: src/components/Indicators.js:361
+#: src/components/Indicators.js:321
 msgid "Select a Dataset:"
 msgstr "Seleccione un conjunto de datos:"
 
-#: src/components/PropertiesSummary.js:102
+#: src/components/PropertiesSummary.js:179
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/components/Indicators.js:497
+#: src/components/Indicators.js:439
 msgid "Send us feedback!"
 msgstr "¡Comparte tu opinión con nosotros!"
 
-#: src/containers/App.js:61
+#: src/containers/App.js:72
 msgid "Share"
 msgstr "Compartir"
 
@@ -500,7 +500,7 @@ msgstr "Comparte esta página con tus vecinos"
 msgid "Sign up"
 msgstr "Regístrate"
 
-#: src/components/EngagementPanel.tsx:11
+#: src/components/EngagementPanel.tsx:12
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
@@ -508,15 +508,15 @@ msgstr "Regístrate para recibir noticias por email"
 msgid "Sold to Current Owner"
 msgstr "Vendido al Propietario Actual"
 
-#: src/components/PropertiesMap.js:187
+#: src/components/PropertiesMap.js:202
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Lo sentimos, parece que hay un error en el mapa. Inténtalo de nuevo con un navegador diferente o <0>habilita WebGL</0>."
 
-#: src/components/LegalFooter.tsx:24
+#: src/components/LegalFooter.tsx:44
 msgid "Source code"
 msgstr "Código fuente"
 
-#: src/containers/AddressPage.js:239
+#: src/containers/AddressPage.js:206
 msgid "Summary"
 msgstr "Resúmen"
 
@@ -526,35 +526,35 @@ msgstr "Resúmen"
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
 
-#: src/components/LegalFooter.tsx:20
+#: src/components/LegalFooter.tsx:34
 msgid "Terms of use"
 msgstr "Condiciones de uso"
 
-#: src/containers/NychaPage.js:136
+#: src/containers/NychaPage.js:159
 msgid "The NYCHA office overseeing your borough. Some experts suggest reaching out to Borough Management Offices to advocate for repairs, as they tend to have more administrative power than local management offices."
 msgstr "La oficina de la NYCHA que se encarga de tu municipio. Algunos expertos sugieren ponerse en contacto con las Oficinas de Administración Municipales para conseguir arreglos, ya que tienden a tener más poder administrativo que las oficinas locales."
 
-#: src/components/RentstabSummary.tsx:22
+#: src/components/RentstabSummary.tsx:27
 msgid "The building that has lost the most units is <0>{0} {1}, {2}</0>, which has lost <1>{absRsLossAddrDiff}</1> {absRsLossAddrDiff, plural, one {unit} other {units}} in the past 10 years."
 msgstr "El edificio con la major pérdida de unidades residencial de renta estabilizada es <0>{0} {1}, {2}</0>, con una pérdida de <1>{absRsLossAddrDiff}</1> {absRsLossAddrDiff, plural, one {unidad} other {unidades}} en los últimos 10 años."
 
-#: src/components/EvictionsSummary.tsx:11
+#: src/components/EvictionsSummary.tsx:14
 msgid "The building with the most evictions was <0>{0} {1}, {2}</0> with {buildingTotalEvictions, plural, one {one eviction} other {# evictions}} that year."
 msgstr "El edificio con la major cantidad de desalojos fue <0>{0} {1}, {2}</0> con {buildingTotalEvictions, plural, one {un desalojo} other {# desalojos}} ese año."
 
-#: src/containers/NychaPage.js:119
+#: src/containers/NychaPage.js:132
 msgid "The city borough where your search address is located"
 msgstr "El municipio donde se encuentra la dirección que has buscado"
 
-#: src/containers/HomePage.tsx:137
+#: src/containers/HomePage.tsx:179
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
-#: src/components/PropertiesSummary.js:78
+#: src/components/PropertiesSummary.js:120
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
-#: src/components/PropertiesSummary.js:73
+#: src/components/PropertiesSummary.js:106
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "{0, plural, one {El nombre más común que aparece en esta cartera de edificios es} other {Los nombres más comunes que aparecen en esta cartera de edificios son}} <0/>."
 
@@ -578,39 +578,39 @@ msgstr ""
 msgid "The {bldgs, plural, one {} other {average}} age of {bldgs, plural, one {this building} other {these buildings}} is <0>{age}</0> years old."
 msgstr "La {bldgs, plural, one {edad} other {edad media}} de {bldgs, plural, one {este edificio} other {estos edificios}} es de <0>{age}</0> años."
 
-#: src/components/SocialShare.tsx:46
+#: src/components/SocialShare.tsx:45
 msgid "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
 msgstr "Los {buildingCount} edificios que son propiedad del dueño de mi apartamento (a través de la herramienta Quién Posee Qué de JustFix.nyc)"
 
-#: src/components/SocialShare.tsx:46
+#: src/components/SocialShare.tsx:45
 msgid "The {buildingCount} buildings that my landlord \"owns\" 👀... #WhoOwnsWhat @JustFixNYC"
 msgstr "Los {buildingCount} edificios que son \"propiedad\" del dueño de mi apartamento 👀... #WhoOwnsWhat @JustFixNYC"
 
-#: src/components/PropertiesSummary.js:55
+#: src/components/PropertiesSummary.js:56
 msgid "There {bldgs, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{bldgs}</3> buildings</2>}} in this portfolio with a total of {units, plural, one {1 unit} other {# units}}."
 msgstr "Hay {bldgs, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{bldgs}</3> edificios</2>}} en esta cartera de edificios, con un total de {units, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
-#: src/containers/NychaPage.js:113
+#: src/containers/NychaPage.js:126
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "Este edificio es propiedad de la NYC Housing Authority (NYCHA)"
 
-#: src/containers/NotRegisteredPage.js:90
+#: src/containers/NotRegisteredPage.js:117
 msgid "This building seems like it should be registered with HPD!"
 msgstr "¡Parece que este edificio debería estar registrado con el HPD!"
 
-#: src/components/AddressToolbar.tsx:32
+#: src/components/AddressToolbar.tsx:37
 msgid "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 msgstr "Estos datos están en <0>formato de archivo CSV</0>, que puede utilizarse fácilmente en Excel, Google Sheets o cualquier otro programa de hoja de cálculo."
 
-#: src/components/PropertiesSummary.js:85
+#: src/components/PropertiesSummary.js:135
 msgid "This is <0>about the same</0> as the citywide average."
 msgstr "Esto es <0>parecido</0> al promedio de toda la ciudad."
 
-#: src/components/PropertiesSummary.js:88
+#: src/components/PropertiesSummary.js:144
 msgid "This is <0>better</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "Esto es <0>mejor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por unidad residencial."
 
-#: src/components/PropertiesSummary.js:87
+#: src/components/PropertiesSummary.js:139
 msgid "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por unidad residencial."
 
@@ -622,15 +622,15 @@ msgstr ""
 msgid "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
 msgstr "Esta cartera de edificios tuvo una <0>{changeType, select, gain {ganancia} other {perdida}} neta</0> de <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {apartamento de renta estabilizada} other {apartamentos de renta estabilizada}} desde el año 2007 (ganó {absTotalRsGain}, perdió {absTotalRsLoss})."
 
-#: src/components/PropertiesSummary.js:83
+#: src/components/PropertiesSummary.js:129
 msgid "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 msgstr "Esta cartera de edificios tiene un promedio de <0>{0}</0> infracciones del HPD Actuales por cada unidad residencial."
 
-#: src/containers/HomePage.tsx:121
+#: src/containers/HomePage.tsx:146
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "Esta empresa de gestión inmobiliaria es propiedad de la familia Kushner y es notoria por <0>violar las normas de vivienda</0> y por <1>comportamientos abusivos</1>. La participación financiera actualmente sostenida por Jared Kushner e Ivanka Trump asciende a 761 millones de dólares."
 
-#: src/components/RentstabSummary.tsx:19
+#: src/components/RentstabSummary.tsx:24
 msgid "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 msgstr "Esto representa el <0>{rsProportion}%</0> del tamaño total de esta cartera de edificios."
 
@@ -650,12 +650,12 @@ msgstr ""
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.js:209
+#: src/containers/AddressPage.js:184
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/IndicatorsViz.js:336
-#: src/components/PropertiesList.tsx:149
+#: src/components/IndicatorsViz.js:337
+#: src/components/PropertiesList.tsx:147
 msgid "Total"
 msgstr "Total"
 
@@ -663,17 +663,17 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Infracciones Totales"
 
-#: src/containers/NotRegisteredPage.js:198
+#: src/containers/NotRegisteredPage.js:330
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "No es possible iniciar una acción judicial por falta de pago del alquiler."
 
-#: src/containers/NotRegisteredPage.js:197
+#: src/containers/NotRegisteredPage.js:329
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/DetailView.js:130
 #: src/components/PropertiesList.tsx:83
-#: src/containers/NychaPage.js:124
+#: src/containers/NychaPage.js:141
 msgid "Units"
 msgstr "Unidades Residenciales"
 
@@ -689,7 +689,7 @@ msgstr "Enlaces útiles"
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
-#: src/components/PropertiesList.tsx:183
+#: src/components/PropertiesList.tsx:180
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -699,13 +699,13 @@ msgstr "Ver detalles"
 msgid "View documents on ACRIS"
 msgstr "Ver documentos en ACRIS"
 
-#: src/components/PropertiesMap.js:220
+#: src/components/PropertiesMap.js:262
 msgid "View legend"
 msgstr "Ver leyenda"
 
-#: src/containers/HomePage.tsx:124
-#: src/containers/HomePage.tsx:141
-#: src/containers/HomePage.tsx:157
+#: src/containers/HomePage.tsx:161
+#: src/containers/HomePage.tsx:202
+#: src/containers/HomePage.tsx:231
 msgid "View portfolio"
 msgstr "Ver cartera de edificios"
 
@@ -713,15 +713,15 @@ msgstr "Ver cartera de edificios"
 msgid "View portfolio map"
 msgstr "Ver mapa de la cartera de edificios"
 
-#: src/components/IndicatorsViz.js:247
+#: src/components/IndicatorsViz.js:256
 msgid "Violations Issued"
 msgstr "Infracciones emitidas"
 
-#: src/components/EngagementPanel.tsx:19
+#: src/components/EngagementPanel.tsx:24
 msgid "Visit our website"
 msgstr "Visite nuestro sitio web"
 
-#: src/containers/App.js:43
+#: src/containers/App.js:38
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
@@ -737,11 +737,11 @@ msgstr ""
 msgid "What happens if the landlord has failed to register?"
 msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 
-#: src/containers/App.js:47
+#: src/containers/App.js:50
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Posee Qué en Nueva York?"
 
-#: src/components/Indicators.js:450
+#: src/components/Indicators.js:393
 msgid "Year"
 msgstr "Año"
 
@@ -749,7 +749,7 @@ msgstr "Año"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/containers/HomePage.tsx:154
+#: src/containers/HomePage.tsx:220
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
@@ -761,19 +761,19 @@ msgstr "Código postal"
 msgid "and"
 msgstr "y"
 
-#: src/components/PropertiesMap.js:224
+#: src/components/PropertiesMap.js:273
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/PropertiesMap.js:223
+#: src/components/PropertiesMap.js:272
 msgid "search address"
 msgstr "dirección de búsqueda"
 
-#: src/components/PropertiesSummary.js:65
+#: src/components/PropertiesSummary.js:90
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una infracción del HPD actual} other {# infracciones del HPD actuales}} - la major cantidad en esta cartera de edificios."
 
-#: src/components/IndicatorsDatasets.tsx:45
+#: src/components/IndicatorsDatasets.tsx:62
 msgid "{value, plural, one {One Building Permit Application since 2010} other {# Building Permit Applications since 2010}}"
 msgstr "{value, plural, one {Una Solicitud de Permiso de Construcción desde el 2010} other {# Solicitudes de Permiso de Construcción desde el 2010}}"
 
@@ -781,7 +781,6 @@ msgstr "{value, plural, one {Una Solicitud de Permiso de Construcción desde el 
 msgid "{value, plural, one {One HPD Complaint Issued since 2014} other {# HPD Complaints Issued since 2014}}"
 msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Quejas del HPD emitidas desde el 2014}}"
 
-#: src/components/IndicatorsDatasets.tsx:26
+#: src/components/IndicatorsDatasets.tsx:34
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Infracción del HPD emitida desde el 2010} other {# Infracciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -131,6 +131,9 @@ msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
 #: src/components/DetailView.js:204
+#: src/components/DetailView.js:438
+#: src/components/DetailView.js:449
+#: src/components/OwnersTable.tsx:25
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
@@ -514,8 +517,8 @@ msgstr "Comparte esta página con tus vecinos"
 #: src/components/DetailView.js:438
 #: src/components/DetailView.js:449
 #: src/components/OwnersTable.tsx:25
-msgid "Shell Companies"
-msgstr "Compañía Ficticia"
+#~ msgid "Shell Companies"
+#~ msgstr "Compañía Ficticia"
 
 #: src/components/Subscribe.tsx:52
 msgid "Sign up"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -16,15 +16,15 @@ msgstr ""
 "X-Crowdin-Language: es-ES\n"
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 
-#: src/components/DetailView.js:248
+#: src/components/DetailView.js:249
 msgid "(expired {0})"
 msgstr "(caducado {0})"
 
-#: src/components/DetailView.js:255
+#: src/components/DetailView.js:256
 msgid "(expires {0})"
 msgstr "(caduca {0})"
 
-#: src/components/DetailView.js:187
+#: src/components/DetailView.js:188
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
@@ -36,7 +36,7 @@ msgstr "({browserType, select, mobile {pulsa} other {haz clic}} para ver los det
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de carteras de edificios:"
 
-#: src/components/DetailView.js:155
+#: src/components/DetailView.js:156
 #: src/containers/NychaPage.js:149
 msgid "2019 Evictions"
 msgstr "Desalojos 2019"
@@ -45,8 +45,8 @@ msgstr "Desalojos 2019"
 msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 msgstr "<0>Actualización COVID-19: </0>JustFix.nyc sigue en funcionamiento, y hemos adaptado nuestros productos para que funcionen con las nuevas reglas establecidas durante la crisis de salud pública COVID-19. Gracias a la organización de los líderes inquilinos, los inquilinos de Nueva York ahora tienen protecciones más fuertes, incluyendo una suspensión total de los casos de desalojo. <1><2>Más información</2></1>"
 
-#: src/components/DetailView.js:371
-#: src/components/Indicators.js:525
+#: src/components/DetailView.js:372
+#: src/components/Indicators.js:527
 #: src/containers/NotRegisteredPage.js:279
 #: src/containers/NychaPage.js:286
 msgid "ANHD DAP Portal"
@@ -60,7 +60,7 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 msgstr "Según los datos de HPD disponibles, esta cartera de edificios ha recibido un total de <0>{0}</0> infracciones."
 
-#: src/components/DetailView.js:297
+#: src/components/DetailView.js:298
 #: src/components/PropertiesSummary.js:161
 msgid "Additional links"
 msgstr "Enlaces adicionales"
@@ -73,8 +73,8 @@ msgstr "Dirección"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: src/components/DetailView.js:265
-#: src/components/DetailView.js:379
+#: src/components/DetailView.js:266
+#: src/components/DetailView.js:380
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -82,7 +82,7 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
-#: src/components/DetailView.js:84
+#: src/components/DetailView.js:85
 #: src/components/Indicators.js:303
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
@@ -123,16 +123,16 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.js:215
-#: src/components/DetailView.js:460
-#: src/components/DetailView.js:471
+#: src/components/DetailView.js:216
+#: src/components/DetailView.js:461
+#: src/components/DetailView.js:472
 #: src/components/OwnersTable.tsx:19
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.js:204
-#: src/components/DetailView.js:438
-#: src/components/DetailView.js:449
+#: src/components/DetailView.js:205
+#: src/components/DetailView.js:439
+#: src/components/DetailView.js:450
 #: src/components/OwnersTable.tsx:25
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
@@ -165,14 +165,14 @@ msgstr "Cerrar leyenda"
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
-#: src/components/DetailView.js:345
-#: src/components/Indicators.js:499
+#: src/components/DetailView.js:346
+#: src/components/Indicators.js:501
 #: src/containers/NotRegisteredPage.js:271
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
-#: src/components/DetailView.js:358
-#: src/components/Indicators.js:512
+#: src/components/DetailView.js:359
+#: src/components/Indicators.js:514
 #: src/containers/NotRegisteredPage.js:261
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
@@ -215,7 +215,7 @@ msgstr "Introducir email"
 msgid "Evictions"
 msgstr "Desalojos"
 
-#: src/components/DetailView.js:152
+#: src/components/DetailView.js:153
 msgid "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr ""
 
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este desarrollo por el Mariscal de NYC en 2019. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes de DOI."
 
-#: src/components/AddressToolbar.tsx:24
+#: src/components/AddressToolbar.tsx:29
 msgid "Export Data"
 msgstr "Exportar datos"
 
@@ -235,8 +235,8 @@ msgstr "Si no se registra un edificio con el HPD"
 msgid "General info"
 msgstr "Info general"
 
-#: src/components/DetailView.js:332
-#: src/components/Indicators.js:486
+#: src/components/DetailView.js:333
+#: src/components/Indicators.js:488
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
@@ -245,12 +245,8 @@ msgid "HPD Complaints"
 msgstr "Quejas de HPD"
 
 #: src/components/IndicatorsDatasets.tsx:12
-#~ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/> Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
-#~ msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
-
-#: src/components/IndicatorsDatasets.tsx:12
 msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
-msgstr ""
+msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/>Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
 #: src/components/PropertiesList.tsx:138
@@ -273,8 +269,8 @@ msgstr "¿Tienes ideas sobre esta página?"
 msgid "Home"
 msgstr "Inicio"
 
-#: src/components/DetailView.js:92
-#: src/components/DetailView.js:414
+#: src/components/DetailView.js:93
+#: src/components/DetailView.js:415
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a esta cartera de edificios?"
 
@@ -315,7 +311,7 @@ msgstr "Dueńo del edificio"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.js:242
+#: src/components/DetailView.js:243
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
@@ -362,14 +358,14 @@ msgid "MyNYCHA App"
 msgstr "App MyNYCHA"
 
 #: src/containers/NychaPage.js:268
-msgid "NYCHA Facility Directory"
-msgstr "Directorio de instalaciones de NYCHA"
+msgid "NYCHA Directory"
+msgstr ""
 
 #: src/components/SocialShare.tsx:26
 msgid "New JustFix.nyc tool helps research on NYC landlords"
 msgstr "La nueva herramienta JustFix.nyc te ayuda a investigar a propietarios de NYC"
 
-#: src/components/AddressToolbar.tsx:29
+#: src/components/AddressToolbar.tsx:26
 msgid "New Search"
 msgstr "Nueva búsqueda"
 
@@ -402,8 +398,8 @@ msgstr "No Emergencia"
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
-#: src/components/DetailView.js:302
-#: src/components/Indicators.js:455
+#: src/components/DetailView.js:303
+#: src/components/Indicators.js:457
 msgid "Official building pages"
 msgstr "Páginas oficiales"
 
@@ -415,7 +411,7 @@ msgstr "¡Vaya! Ese correo electrónico no es válido."
 msgid "Open"
 msgstr "Abrir"
 
-#: src/components/DetailView.js:139
+#: src/components/DetailView.js:140
 msgid "Open Violations"
 msgstr "Infracciones Actuales"
 
@@ -423,25 +419,17 @@ msgstr "Infracciones Actuales"
 msgid "Overview"
 msgstr "Vista General"
 
-#: src/components/IndicatorsDatasets.tsx:50
-#~ msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/> Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
-#~ msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/> Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
-
 #: src/components/IndicatorsDatasets.tsx:67
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
-msgstr ""
+msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/>Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
 
 #: src/containers/AddressPage.js:155
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "CARTERA DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/containers/AddressPage.js:145
-#~ msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
-#~ msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
-
-#: src/components/DetailView.js:227
-#: src/components/DetailView.js:484
-#: src/components/DetailView.js:496
+#: src/components/DetailView.js:228
+#: src/components/DetailView.js:485
+#: src/components/DetailView.js:497
 #: src/components/OwnersTable.tsx:31
 msgid "People"
 msgstr "Personas"
@@ -466,7 +454,7 @@ msgstr "Desarrollo de Vivienda Pública"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: src/components/DetailView.js:164
+#: src/components/DetailView.js:165
 #: src/components/PropertiesList.tsx:116
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
@@ -504,8 +492,8 @@ msgstr "¡Comparte tu opinión con nosotros!"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.js:282
-#: src/components/DetailView.js:393
+#: src/components/DetailView.js:283
+#: src/components/DetailView.js:394
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.js:185
 #: src/containers/App.js:81
@@ -513,12 +501,6 @@ msgstr "Compartir"
 #: src/containers/NychaPage.js:309
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
-
-#: src/components/DetailView.js:438
-#: src/components/DetailView.js:449
-#: src/components/OwnersTable.tsx:25
-#~ msgid "Shell Companies"
-#~ msgstr "Compañía Ficticia"
 
 #: src/components/Subscribe.tsx:52
 msgid "Sign up"
@@ -544,8 +526,8 @@ msgstr "Código fuente"
 msgid "Summary"
 msgstr "Resúmen"
 
-#: src/components/DetailView.js:276
-#: src/components/DetailView.js:387
+#: src/components/DetailView.js:277
+#: src/components/DetailView.js:388
 #: src/containers/NychaPage.js:303
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
@@ -582,7 +564,7 @@ msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección adminis
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "{0, plural, one {El nombre más común que aparece en esta cartera de edificios es} other {Los nombres más comunes que aparecen en esta cartera de edificios son}} <0/>."
 
-#: src/components/DetailView.js:136
+#: src/components/DetailView.js:137
 msgid "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
 msgstr ""
 
@@ -590,11 +572,11 @@ msgstr ""
 msgid "The number of residential units across all buildings in this development, according to the Dept. of City Planning."
 msgstr "El número de unidades residenciales en todos los edificios de este desarrollo, según el Departamento Planificación de la Ciudad."
 
-#: src/components/DetailView.js:126
+#: src/components/DetailView.js:127
 msgid "The number of residential units in this building, according to the Dept. of City Planning."
 msgstr ""
 
-#: src/components/DetailView.js:118
+#: src/components/DetailView.js:119
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr ""
 
@@ -638,7 +620,7 @@ msgstr "Esto es <0>mejor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} po
 msgid "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por unidad residencial."
 
-#: src/components/DetailView.js:104
+#: src/components/DetailView.js:105
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr ""
 
@@ -658,7 +640,7 @@ msgstr "Esta empresa de gestión inmobiliaria es propiedad de la familia Kushner
 msgid "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 msgstr "Esto representa el <0>{rsProportion}%</0> del tamaño total de esta cartera de edificios."
 
-#: src/components/DetailView.js:144
+#: src/components/DetailView.js:145
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr ""
 
@@ -666,7 +648,7 @@ msgstr ""
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "Este parece ser un edificio residencial pequeño. Si el dueńo no reside allí, el edificio debería estar registrado con el HPD."
 
-#: src/components/DetailView.js:160
+#: src/components/DetailView.js:161
 msgid "This tracks how rent stabilized units in the building have changed (i.e. \"&Delta;\") from 2007 to 2017. If the number for 2017 is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
 msgstr ""
 
@@ -683,7 +665,7 @@ msgstr "Cronología"
 msgid "Total"
 msgstr "Total"
 
-#: src/components/DetailView.js:147
+#: src/components/DetailView.js:148
 msgid "Total Violations"
 msgstr "Infracciones Totales"
 
@@ -695,7 +677,7 @@ msgstr "No es possible iniciar una acción judicial por falta de pago del alquil
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
-#: src/components/DetailView.js:129
+#: src/components/DetailView.js:130
 #: src/components/PropertiesList.tsx:83
 #: src/containers/NychaPage.js:141
 msgid "Units"
@@ -706,7 +688,7 @@ msgstr "Unidad Residencial"
 msgid "Useful links:"
 msgstr "Enlaces útiles:"
 
-#: src/components/DetailView.js:197
+#: src/components/DetailView.js:198
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
@@ -714,8 +696,8 @@ msgstr "Ver datos a lo largo del tiempo"
 msgid "View detail"
 msgstr "Ver detalles"
 
-#: src/components/DetailView.js:315
-#: src/components/Indicators.js:467
+#: src/components/DetailView.js:316
+#: src/components/Indicators.js:469
 #: src/containers/NotRegisteredPage.js:253
 msgid "View documents on ACRIS"
 msgstr "Ver documentos en ACRIS"
@@ -730,7 +712,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver cartera de edificios"
 
-#: src/components/DetailView.js:76
+#: src/components/DetailView.js:77
 msgid "View portfolio map"
 msgstr "Ver mapa de la cartera de edificios"
 
@@ -746,9 +728,13 @@ msgstr "Visite nuestro sitio web"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
-#: src/components/DetailView.js:416
+#: src/components/DetailView.js:417
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
+
+#: src/components/Indicators.js:448
+msgid "What are {0}?"
+msgstr ""
 
 #: src/containers/NotRegisteredPage.js:59
 msgid "What happens if the landlord has failed to register?"
@@ -762,7 +748,7 @@ msgstr "¿Quién posee qué en Nueva York?"
 msgid "Year"
 msgstr "Año"
 
-#: src/components/DetailView.js:121
+#: src/components/DetailView.js:122
 msgid "Year Built"
 msgstr "Año de construcción"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -306,7 +306,7 @@ msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
-#: src/components/IndicatorsViz.js:377
+#: src/components/IndicatorsViz.js:368
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
@@ -377,7 +377,7 @@ msgstr "Oficina Regional de Nueva York:"
 msgid "No address found"
 msgstr "No se encontraron direcciones"
 
-#: src/components/IndicatorsViz.js:436
+#: src/components/IndicatorsViz.js:427
 msgid "No data available"
 msgstr "No hay datos disponibles"
 
@@ -504,7 +504,7 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/IndicatorsViz.js:376
+#: src/components/IndicatorsViz.js:367
 msgid "Sold to Current Owner"
 msgstr "Vendido al Propietario Actual"
 
@@ -654,7 +654,7 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/IndicatorsViz.js:337
+#: src/components/IndicatorsViz.js:328
 #: src/components/PropertiesList.tsx:147
 msgid "Total"
 msgstr "Total"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -16,15 +16,15 @@ msgstr ""
 "X-Crowdin-Language: es-ES\n"
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 
-#: src/components/DetailView.js:219
+#: src/components/DetailView.js:248
 msgid "(expired {0})"
 msgstr "(caducado {0})"
 
-#: src/components/DetailView.js:226
+#: src/components/DetailView.js:255
 msgid "(expires {0})"
 msgstr "(caduca {0})"
 
-#: src/components/DetailView.js:158
+#: src/components/DetailView.js:187
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
@@ -36,7 +36,7 @@ msgstr "({browserType, select, mobile {pulsa} other {haz clic}} para ver los det
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de carteras de edificios:"
 
-#: src/components/DetailView.js:130
+#: src/components/DetailView.js:155
 #: src/containers/NychaPage.js:149
 msgid "2019 Evictions"
 msgstr "Desalojos 2019"
@@ -45,7 +45,7 @@ msgstr "Desalojos 2019"
 msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 msgstr "<0>Actualización COVID-19: </0>JustFix.nyc sigue en funcionamiento, y hemos adaptado nuestros productos para que funcionen con las nuevas reglas establecidas durante la crisis de salud pública COVID-19. Gracias a la organización de los líderes inquilinos, los inquilinos de Nueva York ahora tienen protecciones más fuertes, incluyendo una suspensión total de los casos de desalojo. <1><2>Más información</2></1>"
 
-#: src/components/DetailView.js:342
+#: src/components/DetailView.js:371
 #: src/components/Indicators.js:525
 #: src/containers/NotRegisteredPage.js:279
 #: src/containers/NychaPage.js:286
@@ -60,7 +60,7 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{0}</0> total violations."
 msgstr "Según los datos de HPD disponibles, esta cartera de edificios ha recibido un total de <0>{0}</0> infracciones."
 
-#: src/components/DetailView.js:268
+#: src/components/DetailView.js:297
 #: src/components/PropertiesSummary.js:161
 msgid "Additional links"
 msgstr "Enlaces adicionales"
@@ -73,8 +73,8 @@ msgstr "Dirección"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: src/components/DetailView.js:236
-#: src/components/DetailView.js:350
+#: src/components/DetailView.js:265
+#: src/components/DetailView.js:379
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -82,7 +82,7 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
-#: src/components/DetailView.js:81
+#: src/components/DetailView.js:84
 #: src/components/Indicators.js:303
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
@@ -123,14 +123,14 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.js:186
-#: src/components/DetailView.js:431
-#: src/components/DetailView.js:442
+#: src/components/DetailView.js:215
+#: src/components/DetailView.js:460
+#: src/components/DetailView.js:471
 #: src/components/OwnersTable.tsx:19
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.js:175
+#: src/components/DetailView.js:204
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
@@ -162,13 +162,13 @@ msgstr "Cerrar leyenda"
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
-#: src/components/DetailView.js:316
+#: src/components/DetailView.js:345
 #: src/components/Indicators.js:499
 #: src/containers/NotRegisteredPage.js:271
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
-#: src/components/DetailView.js:329
+#: src/components/DetailView.js:358
 #: src/components/Indicators.js:512
 #: src/containers/NotRegisteredPage.js:261
 msgid "DOF Property Tax Bills"
@@ -212,6 +212,10 @@ msgstr "Introducir email"
 msgid "Evictions"
 msgstr "Desalojos"
 
+#: src/components/DetailView.js:152
+msgid "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
+msgstr ""
+
 #: src/containers/NychaPage.js:146
 msgid "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este desarrollo por el Mariscal de NYC en 2019. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes de DOI."
@@ -228,7 +232,7 @@ msgstr "Si no se registra un edificio con el HPD"
 msgid "General info"
 msgstr "Info general"
 
-#: src/components/DetailView.js:303
+#: src/components/DetailView.js:332
 #: src/components/Indicators.js:486
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
@@ -266,8 +270,8 @@ msgstr "¿Tienes ideas sobre esta página?"
 msgid "Home"
 msgstr "Inicio"
 
-#: src/components/DetailView.js:89
-#: src/components/DetailView.js:385
+#: src/components/DetailView.js:92
+#: src/components/DetailView.js:414
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a esta cartera de edificios?"
 
@@ -308,7 +312,7 @@ msgstr "Dueńo del edificio"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.js:213
+#: src/components/DetailView.js:242
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
@@ -395,7 +399,7 @@ msgstr "No Emergencia"
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
-#: src/components/DetailView.js:273
+#: src/components/DetailView.js:302
 #: src/components/Indicators.js:455
 msgid "Official building pages"
 msgstr "Páginas oficiales"
@@ -408,7 +412,7 @@ msgstr "¡Vaya! Ese correo electrónico no es válido."
 msgid "Open"
 msgstr "Abrir"
 
-#: src/components/DetailView.js:122
+#: src/components/DetailView.js:139
 msgid "Open Violations"
 msgstr "Infracciones Actuales"
 
@@ -432,9 +436,9 @@ msgstr "CARTERA DE EDIFICIOS: La dirección que has buscado está asociada con <
 #~ msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
 #~ msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}:"
 
-#: src/components/DetailView.js:198
-#: src/components/DetailView.js:455
-#: src/components/DetailView.js:467
+#: src/components/DetailView.js:227
+#: src/components/DetailView.js:484
+#: src/components/DetailView.js:496
 #: src/components/OwnersTable.tsx:31
 msgid "People"
 msgstr "Personas"
@@ -459,7 +463,7 @@ msgstr "Desarrollo de Vivienda Pública"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: src/components/DetailView.js:135
+#: src/components/DetailView.js:164
 #: src/components/PropertiesList.tsx:116
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
@@ -497,8 +501,8 @@ msgstr "¡Comparte tu opinión con nosotros!"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.js:253
-#: src/components/DetailView.js:364
+#: src/components/DetailView.js:282
+#: src/components/DetailView.js:393
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.js:185
 #: src/containers/App.js:81
@@ -507,8 +511,8 @@ msgstr "Compartir"
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
 
-#: src/components/DetailView.js:409
-#: src/components/DetailView.js:420
+#: src/components/DetailView.js:438
+#: src/components/DetailView.js:449
 #: src/components/OwnersTable.tsx:25
 msgid "Shell Companies"
 msgstr "Compañía Ficticia"
@@ -537,8 +541,8 @@ msgstr "Código fuente"
 msgid "Summary"
 msgstr "Resúmen"
 
-#: src/components/DetailView.js:247
-#: src/components/DetailView.js:358
+#: src/components/DetailView.js:276
+#: src/components/DetailView.js:387
 #: src/containers/NychaPage.js:303
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
@@ -575,9 +579,21 @@ msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección adminis
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "{0, plural, one {El nombre más común que aparece en esta cartera de edificios es} other {Los nombres más comunes que aparecen en esta cartera de edificios son}} <0/>."
 
+#: src/components/DetailView.js:136
+msgid "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
+msgstr ""
+
 #: src/containers/NychaPage.js:138
 msgid "The number of residential units across all buildings in this development, according to the Dept. of City Planning."
 msgstr "El número de unidades residenciales en todos los edificios de este desarrollo, según el Departamento Planificación de la Ciudad."
+
+#: src/components/DetailView.js:126
+msgid "The number of residential units in this building, according to the Dept. of City Planning."
+msgstr ""
+
+#: src/components/DetailView.js:118
+msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
+msgstr ""
 
 #: src/components/PropertiesSummary.js:75
 msgid "The {bldgs, plural, one {} other {average}} age of {bldgs, plural, one {this building} other {these buildings}} is <0>{age}</0> years old."
@@ -619,6 +635,10 @@ msgstr "Esto es <0>mejor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} po
 msgid "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por unidad residencial."
 
+#: src/components/DetailView.js:104
+msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
+msgstr ""
+
 #: src/components/RentstabSummary.tsx:15
 msgid "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
 msgstr "Esta cartera de edificios tuvo una <0>{changeType, select, gain {ganancia} other {perdida}} neta</0> de <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {apartamento de renta estabilizada} other {apartamentos de renta estabilizada}} desde el año 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
@@ -635,9 +655,17 @@ msgstr "Esta empresa de gestión inmobiliaria es propiedad de la familia Kushner
 msgid "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 msgstr "Esto representa el <0>{rsProportion}%</0> del tamaño total de esta cartera de edificios."
 
+#: src/components/DetailView.js:144
+msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
+msgstr ""
+
 #: src/containers/NotRegisteredPage.js:86
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "Este parece ser un edificio residencial pequeño. Si el dueńo no reside allí, el edificio debería estar registrado con el HPD."
+
+#: src/components/DetailView.js:160
+msgid "This tracks how rent stabilized units in the building have changed (i.e. \"&Delta;\") from 2007 to 2017. If the number for 2017 is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
+msgstr ""
 
 #: src/components/AddressToolbar.tsx:33
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
@@ -652,7 +680,7 @@ msgstr "Cronología"
 msgid "Total"
 msgstr "Total"
 
-#: src/components/DetailView.js:126
+#: src/components/DetailView.js:147
 msgid "Total Violations"
 msgstr "Infracciones Totales"
 
@@ -664,7 +692,7 @@ msgstr "No es possible iniciar una acción judicial por falta de pago del alquil
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
-#: src/components/DetailView.js:116
+#: src/components/DetailView.js:129
 #: src/components/PropertiesList.tsx:83
 #: src/containers/NychaPage.js:141
 msgid "Units"
@@ -675,7 +703,7 @@ msgstr "Unidad Residencial"
 msgid "Useful links:"
 msgstr "Enlaces útiles:"
 
-#: src/components/DetailView.js:168
+#: src/components/DetailView.js:197
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
@@ -683,7 +711,7 @@ msgstr "Ver datos a lo largo del tiempo"
 msgid "View detail"
 msgstr "Ver detalles"
 
-#: src/components/DetailView.js:286
+#: src/components/DetailView.js:315
 #: src/components/Indicators.js:467
 #: src/containers/NotRegisteredPage.js:253
 msgid "View documents on ACRIS"
@@ -699,7 +727,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver cartera de edificios"
 
-#: src/components/DetailView.js:73
+#: src/components/DetailView.js:76
 msgid "View portfolio map"
 msgstr "Ver mapa de la cartera de edificios"
 
@@ -715,7 +743,7 @@ msgstr "Visite nuestro sitio web"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
-#: src/components/DetailView.js:387
+#: src/components/DetailView.js:416
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -731,7 +759,7 @@ msgstr "¿Quién posee qué en Nueva York?"
 msgid "Year"
 msgstr "Año"
 
-#: src/components/DetailView.js:112
+#: src/components/DetailView.js:121
 msgid "Year Built"
 msgstr "Año de construcción"
 

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -100,8 +100,12 @@ test("titleCase() works", () => {
   expect(helpers.titleCase("boop jones")).toBe("Boop Jones");
 });
 
-test("formatDate() works", () => {
-  expect(helpers.formatDate("2008-01-05")).toBe("January 2008");
+test("formatDateForTimeline() works", () => {
+  expect(helpers.formatDateForTimeline("2008-01-05")).toBe("January 2008");
+});
+
+test("formatDateForTimeline() works for non-English locales", () => {
+  expect(helpers.formatDateForTimeline("2010-03-05","es")).toBe("2010 de marzo");
 });
 
 test("formatStreetNameForHpdLink() works for directional prefixes", () => {

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -114,11 +114,11 @@ test("formatMonthSnippetForTimeline() works", () => {
 // See more here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
 
 test("formatDateForTimeline() works for non-English locales", () => {
-  expect(helpers.formatDateForTimeline("2008-01-05","es")).toMatch(/Enero de 2008|January 2008/i);
+  expect(helpers.formatDateForTimeline("2008-01-05", "es")).toMatch(/Enero de 2008|January 2008/i);
 });
 
 test("formatMonthSnippetForTimeline() works for non-English locales", () => {
-  expect(helpers.formatMonthSnippetForTimeline("2008-01-05","es")).toMatch(/Ene|Jan/i);
+  expect(helpers.formatMonthSnippetForTimeline("2008-01-05", "es")).toMatch(/Ene|Jan/i);
 });
 
 test("formatStreetNameForHpdLink() works for directional prefixes", () => {

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -104,8 +104,21 @@ test("formatDateForTimeline() works", () => {
   expect(helpers.formatDateForTimeline("2008-01-05")).toBe("January 2008");
 });
 
+test("formatMonthSnippetForTimeline() works", () => {
+  expect(helpers.formatMonthSnippetForTimeline("2008-01-05")).toBe("Jan");
+});
+
+// Note: Although there is generally good support across modern versions of the usual web browsers,
+// the "locale" prop in the toLocaleDateString function is not supported until Node 13.
+// Therefore, I implemented these two tests to match either the localized result or the default.
+// See more here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
+
 test("formatDateForTimeline() works for non-English locales", () => {
-  expect(helpers.formatDateForTimeline("2010-03-05","es")).toBe("2010 de marzo");
+  expect(helpers.formatDateForTimeline("2008-01-05","es")).toMatch(/Enero de 2008|January 2008/i);
+});
+
+test("formatMonthSnippetForTimeline() works for non-English locales", () => {
+  expect(helpers.formatMonthSnippetForTimeline("2008-01-05","es")).toMatch(/Ene|Jan/i);
 });
 
 test("formatStreetNameForHpdLink() works for directional prefixes", () => {

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -104,8 +104,8 @@ test("formatDateForTimeline() works", () => {
   expect(helpers.formatDateForTimeline("2008-01-05")).toBe("January 2008");
 });
 
-test("formatMonthSnippetForTimeline() works", () => {
-  expect(helpers.formatMonthSnippetForTimeline("2008-01-05")).toBe("Jan");
+test("formatMonthAbbreviationForTimeline() works", () => {
+  expect(helpers.formatMonthAbbreviationForTimeline("2008-01-05")).toBe("Jan");
 });
 
 // Note: Although there is generally good support across modern versions of the usual web browsers,
@@ -117,8 +117,8 @@ test("formatDateForTimeline() works for non-English locales", () => {
   expect(helpers.formatDateForTimeline("2008-01-05", "es")).toMatch(/Enero de 2008|January 2008/i);
 });
 
-test("formatMonthSnippetForTimeline() works for non-English locales", () => {
-  expect(helpers.formatMonthSnippetForTimeline("2008-01-05", "es")).toMatch(/Ene|Jan/i);
+test("formatMonthAbbreviationForTimeline() works for non-English locales", () => {
+  expect(helpers.formatMonthAbbreviationForTimeline("2008-01-05", "es")).toMatch(/Ene|Jan/i);
 });
 
 test("formatStreetNameForHpdLink() works for directional prefixes", () => {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -160,7 +160,7 @@ export default {
     return this.capitalize(date.toLocaleDateString(locale || "en", options));
   },
 
-  formatMonthSnippetForTimeline(dateString: string, locale?: SupportedLocale): string {
+  formatMonthAbbreviationForTimeline(dateString: string, locale?: SupportedLocale): string {
     var date = new Date(dateString);
     var options = { month: "short" };
     return this.capitalize(date.toLocaleDateString(locale || "en", options)).slice(0, 3);

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -160,6 +160,12 @@ export default {
     return this.capitalize(date.toLocaleDateString(locale || "en", options));
   },
 
+  formatMonthSnippetForTimeline(dateString: string, locale?: SupportedLocale): string {
+    var date = new Date(dateString);
+    var options = { month: "short" };
+    return this.capitalize(date.toLocaleDateString(locale || "en", options)).slice(0, 3);
+  },
+
   formatStreetNameForHpdLink(streetName: string): string {
     var arr = streetName.split(" ");
     if (arr === []) {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -4,6 +4,7 @@
 import _pickBy from "lodash/pickBy";
 import { deepEqual as assertDeepEqual } from "assert";
 import nycha_bbls from "../data/nycha_bbls.json";
+import { SupportedLocale } from "../i18n-base";
 
 /**
  * An array consisting of Who Owns What's standard enumerations for street names,
@@ -153,10 +154,10 @@ export default {
       .join(" ");
   },
 
-  formatDate(dateString: string): string {
+  formatDateForTimeline(dateString: string, locale?: SupportedLocale): string {
     var date = new Date(dateString);
     var options = { year: "numeric", month: "long" };
-    return date.toLocaleDateString("en-US", options);
+    return this.capitalize(date.toLocaleDateString(locale || "en", options));
   },
 
   formatStreetNameForHpdLink(streetName: string): string {


### PR DESCRIPTION
This PR implements various i18n tweaks that address some mission translations and other bugs detected during a QA session, such as:
1. Adding in missing i18n infrastructure (such as with the tooltips on the detail view)
2. Consolidating our choices of language to make wording more consistent, and thus reduce work for a translator
3. Internationalized dates and month abbreviations on the overview and timeline tabs