### PR TITLE
Made prettier formatting required for build

### DIFF
--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -238,7 +238,7 @@
     }
 
     .card-body-links,
-    .card-body-prompt,
+      .card-body-prompt,
     .card-body-social {
       margin-top: 24px;
       margin-bottom: 24px;
@@ -263,9 +263,6 @@
 
       a.btn:not(:first-child) {
         margin-top: 10px;
-      }
-
-      .btn {
       }
     }
 

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -238,7 +238,7 @@
     }
 
     .card-body-links,
-      .card-body-prompt,
+    .card-body-prompt,
     .card-body-social {
       margin-top: 24px;
       margin-bottom: 24px;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "concurrently \"yarn server\" \"yarn client\"",
     "server": "nodemon server.js --exec babel-node",
     "client": "cd client && yarn start",
-    "build": "concurrently \"yarn build-server\" \"yarn build-client\"",
+    "build": "yarn prettier:check && concurrently \"yarn build-server\" \"yarn build-client\"",
     "build-server": "babel server -d dist",
     "build-client": "cd client && yarn --production=false && yarn run build",
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This PR adds `yarn prettier:check` to our build command to throw an error if our code isn't formatted via prettier. 