### PR TITLE
Add "Last Sale" data to WOW Portfolio page

### DIFF
--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -36,10 +36,6 @@ function getBuildingInfo(bbl: string) {
   return get(`/api/address/buildinginfo?bbl=${bbl}`);
 }
 
-function getSaleHistory(bbl: string) {
-  return get(`/api/address/salehistory?bbl=${bbl}`);
-}
-
 function getIndicatorHistory(bbl: string) {
   return get(`/api/address/indicatorhistory?bbl=${bbl}`);
 }
@@ -120,7 +116,6 @@ const Client = {
   searchBBL,
   getAggregate,
   getBuildingInfo,
-  getSaleHistory,
   getIndicatorHistory,
   getAddressExport,
   postNewSubscriber,

--- a/client/src/components/Indicators.js
+++ b/client/src/components/Indicators.js
@@ -221,17 +221,13 @@ class IndicatorsWithoutI18n extends Component {
     // 2. when activeTimeSpan changes
 
     if (
-      this.state.saleHistory &&
-      (!Helpers.jsonEqual(prevState.saleHistory, this.state.saleHistory) ||
-        prevState.activeTimeSpan !== this.state.activeTimeSpan)
+      (this.state.currentAddr &&
+        !prevState[this.state.defaultVis + "Data"].labels &&
+        this.state[this.state.defaultVis + "Data"].labels) ||
+      prevState.activeTimeSpan !== this.state.activeTimeSpan
     ) {
-      if (
-        this.state.saleHistory.length > 0 &&
-        (this.state.saleHistory[0].docdate || this.state.saleHistory[0].recordedfiled) &&
-        this.state.saleHistory[0].documentid
-      ) {
-        var lastSaleDate =
-          this.state.saleHistory[0].docdate || this.state.saleHistory[0].recordedfiled;
+      if (this.props.detailAddr.lastsaledate && this.props.detailAddr.lastsaleacrisid) {
+        var lastSaleDate = this.props.detailAddr.lastsaledate;
         var lastSaleYear = lastSaleDate.slice(0, 4);
         var lastSaleQuarter =
           lastSaleYear + "-Q" + Math.ceil(parseInt(lastSaleDate.slice(5, 7)) / 3);
@@ -246,7 +242,7 @@ class IndicatorsWithoutI18n extends Component {
                 : this.state.activeTimeSpan === "quarter"
                 ? lastSaleQuarter
                 : lastSaleMonth,
-            documentid: this.state.saleHistory[0].documentid,
+            documentid: this.props.detailAddr.lastsaleacrisid,
           },
         });
       } else {

--- a/client/src/components/Indicators.js
+++ b/client/src/components/Indicators.js
@@ -14,8 +14,6 @@ import { IndicatorsDatasetRadio, INDICATORS_DATASETS } from "./IndicatorsDataset
 import { Link } from "react-router-dom";
 
 const initialState = {
-  saleHistory: null,
-
   lastSale: {
     date: null,
     label: null,
@@ -127,12 +125,6 @@ class IndicatorsWithoutI18n extends Component {
 
   /** Fetches data for Indicators component via 2 API calls and saves the raw data in state */
   fetchData(detailAddr) {
-    APIClient.getSaleHistory(detailAddr.bbl)
-      .then((results) => this.setState({ saleHistory: results.result }))
-      .catch((err) => {
-        window.Rollbar.error("API error on Indicators: Sale History", err, detailAddr.bbl);
-      });
-
     APIClient.getIndicatorHistory(detailAddr.bbl)
       .then((results) => this.setState({ indicatorHistory: results.result }))
       .catch((err) => {
@@ -282,7 +274,6 @@ class IndicatorsWithoutI18n extends Component {
         <div className="Indicators__content Page__content">
           {!(
             this.props.isVisible &&
-            this.state.saleHistory &&
             this.state.indicatorHistory &&
             this.state[this.state.defaultVis + "Data"].labels
           ) ? (

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -294,7 +294,9 @@ const PropertiesListWithoutI18n: React.FC<{
                   },
                   Cell: (row) =>
                     row.original.lastsaleacrisid &&
-                    isPartOfGroupSale(row.original.lastsaleacrisid, props.addrs) && <span>✓</span>,
+                    (isPartOfGroupSale(row.original.lastsaleacrisid, props.addrs)
+                      ? i18n._(t`Yes`)
+                      : i18n._(t`No`)),
                   id: "lastsaleisgroupsale",
                 },
               ],

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -259,7 +259,7 @@ const PropertiesListWithoutI18n: React.FC<{
                   id: "lastsaledate",
                 },
                 {
-                  Header: i18n._(t`Price`),
+                  Header: i18n._(t`Amount`),
                   accessor: (d) => (d.lastsaleamount ? parseInt(d.lastsaleamount) : null),
                   Cell: (row) =>
                     row.original.lastsaleamount &&

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -23,7 +23,18 @@ type Addr = {
   totalviolations: number;
   evictions: string | null;
   ownernames: { title: string; value: string }[];
+  lastsaledate: string;
+  lastsaleamount: string;
+  lastsaleacrisid: string;
 };
+
+const formatDate = (dateString: string) => {
+  var date = new Date(dateString);
+  var options = { year: "numeric", month: "short", day: "numeric" };
+  return date.toLocaleDateString("en", options);
+};
+
+const formatPrice = new Intl.NumberFormat("en-US");
 
 const PropertiesListWithoutI18n: React.FC<{
   i18n: I18n;
@@ -33,7 +44,6 @@ const PropertiesListWithoutI18n: React.FC<{
 }> = (props) => {
   const { i18n } = props;
   // console.log(props.addrs);
-
   if (!props.addrs.length) {
     return null;
   } else {
@@ -230,6 +240,25 @@ const PropertiesListWithoutI18n: React.FC<{
                 //   Header: "Change in RS",
                 //   accessor: "totalviolations"
                 // }
+              ],
+            },
+            {
+              Header: i18n._(t`Last Sale`),
+              columns: [
+                {
+                  Header: i18n._(t`Date`),
+                  accessor: (d) => d.lastsaledate,
+                  Cell: (row) => row.original.lastsaledate && formatDate(row.original.lastsaledate),
+                  id: "lastsaledate",
+                },
+                {
+                  Header: i18n._(t`Price`),
+                  accessor: (d) => d.lastsaleamount,
+                  Cell: (row) =>
+                    row.original.lastsaleamount &&
+                    "$" + formatPrice.format(row.original.lastsaleamount),
+                  id: "lastsaleamount",
+                },
               ],
             },
             {

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -8,6 +8,7 @@ import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
 import { t } from "@lingui/macro";
 import { Link } from "react-router-dom";
+import { SupportedLocale } from "../i18n-base";
 
 type Addr = {
   housenumber: string;
@@ -28,13 +29,11 @@ type Addr = {
   lastsaleacrisid: string;
 };
 
-const formatDate = (dateString: string) => {
+const formatDate = (dateString: string, locale?: SupportedLocale) => {
   var date = new Date(dateString);
   var options = { year: "numeric", month: "short", day: "numeric" };
-  return date.toLocaleDateString("en", options);
+  return date.toLocaleDateString(locale || "en", options);
 };
-
-const formatPrice = new Intl.NumberFormat("en-US");
 
 const PropertiesListWithoutI18n: React.FC<{
   i18n: I18n;
@@ -43,6 +42,8 @@ const PropertiesListWithoutI18n: React.FC<{
   generateBaseUrl: () => string;
 }> = (props) => {
   const { i18n } = props;
+  const locale = (i18n.language as SupportedLocale) || "en";
+  const formatPrice = new Intl.NumberFormat(locale);
   // console.log(props.addrs);
   if (!props.addrs.length) {
     return null;
@@ -248,7 +249,8 @@ const PropertiesListWithoutI18n: React.FC<{
                 {
                   Header: i18n._(t`Date`),
                   accessor: (d) => d.lastsaledate,
-                  Cell: (row) => row.original.lastsaledate && formatDate(row.original.lastsaledate),
+                  Cell: (row) =>
+                    row.original.lastsaledate && formatDate(row.original.lastsaledate, locale),
                   id: "lastsaledate",
                 },
                 {

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -253,11 +253,27 @@ const PropertiesListWithoutI18n: React.FC<{
                 },
                 {
                   Header: i18n._(t`Price`),
-                  accessor: (d) => d.lastsaleamount,
+                  accessor: (d) => (d.lastsaleamount ? parseInt(d.lastsaleamount) : null),
                   Cell: (row) =>
                     row.original.lastsaleamount &&
                     "$" + formatPrice.format(row.original.lastsaleamount),
                   id: "lastsaleamount",
+                },
+                {
+                  Header: i18n._(t`Link to Deed`),
+                  accessor: (d) => d.lastsaleacrisid,
+                  Cell: (row) =>
+                    row.original.lastsaleacrisid && (
+                      <a
+                        href={`https://a836-acris.nyc.gov/DS/DocumentSearch/DocumentImageView?doc_id=${row.original.lastsaleacrisid}`}
+                        className="btn"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <span style={{ padding: "0 3px" }}>&#8599;&#xFE0E;</span>
+                      </a>
+                    ),
+                  id: "lastsaleacrisid",
                 },
               ],
             },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -35,6 +35,11 @@ const formatDate = (dateString: string, locale?: SupportedLocale) => {
   return date.toLocaleDateString(locale || "en", options);
 };
 
+const isPartOfGroupSale = (saleId: string, addrs: Addr[]) => {
+  const addrsWithMatchingSale = addrs.filter((addr) => addr.lastsaleacrisid === saleId);
+  return addrsWithMatchingSale.length > 1;
+};
+
 const PropertiesListWithoutI18n: React.FC<{
   i18n: I18n;
   addrs: Addr[];
@@ -276,6 +281,21 @@ const PropertiesListWithoutI18n: React.FC<{
                       </a>
                     ),
                   id: "lastsaleacrisid",
+                },
+                {
+                  Header: i18n._(t`Group Sale?`),
+                  accessor: (d) => {
+                    // Make id's that are part of group sales show up first when sorted:
+                    const idPrefix =
+                      d.lastsaleacrisid && isPartOfGroupSale(d.lastsaleacrisid, props.addrs)
+                        ? " "
+                        : "";
+                    return `${idPrefix}${d.lastsaleacrisid}`;
+                  },
+                  Cell: (row) =>
+                    row.original.lastsaleacrisid &&
+                    isPartOfGroupSale(row.original.lastsaleacrisid, props.addrs) && <span>✓</span>,
+                  id: "lastsaleisgroupsale",
                 },
               ],
             },

--- a/client/src/data/about.es.json
+++ b/client/src/data/about.es.json
@@ -22,7 +22,7 @@
           {
             "data": {},
             "marks": [],
-            "value": "Quién Posee Qué existe para ayudar a ",
+            "value": "Quién Es El Dueño existe para ayudar a ",
             "nodeType": "text"
           },
           {
@@ -100,7 +100,7 @@
         "content": [
           {
             "nodeType": "text",
-            "value": "\nQuién Posee Qué crea nexos de información",
+            "value": "\nQuién Es El Dueño crea nexos de información",
             "marks": [],
             "data": {}
           }

--- a/client/src/data/how-it-works.en.json
+++ b/client/src/data/how-it-works.en.json
@@ -590,6 +590,64 @@
                         "type": "bold"
                       }
                     ],
+                    "value": "ACRIS deed records ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "from ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {
+                      "uri": "https://data.cityofnewyork.us/City-Government/ACRIS-Real-Property-Master/bnx9-e6tj"
+                    },
+                    "content": [
+                      {
+                        "data": {},
+                        "marks": [],
+                        "value": "NYC Open Data",
+                        "nodeType": "text"
+                      }
+                    ],
+                    "nodeType": "hyperlink"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": ". Note: we only include deeds with an associated amount greater than $1. — ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
+                    "value": "updated bimonthly",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
                     "value": "Rent Stabilization unit estimates (from taxbills.nyc, adapted from Dept. of Finance tax bills).",
                     "nodeType": "text"
                   },

--- a/client/src/data/how-it-works.es.json
+++ b/client/src/data/how-it-works.es.json
@@ -2,38 +2,39 @@
   "title": "Metodología",
   "slug": "how-it-works",
   "content": {
+    "nodeType": "document",
     "data": {},
     "content": [
       {
-        "data": {},
+        "nodeType": "heading-4",
         "content": [
           {
-            "data": {},
+            "nodeType": "text",
+            "value": "Metodologia de Datos de Quién Es El Dueño",
             "marks": [],
-            "value": "Metodologia de Datos de Quien Posee Que",
-            "nodeType": "text"
+            "data": {}
           }
         ],
-        "nodeType": "heading-4"
-      },
-      {
-        "data": {},
-        "content": [
-          {
-            "data": {},
-            "marks": [],
-            "value": "",
-            "nodeType": "text"
-          }
-        ],
-        "nodeType": "paragraph"
+        "data": {}
       },
       {
         "nodeType": "paragraph",
         "content": [
           {
             "nodeType": "text",
-            "value": "En Quién Posee Qué, usamos el ",
+            "value": "",
+            "marks": [],
+            "data": {}
+          }
+        ],
+        "data": {}
+      },
+      {
+        "nodeType": "paragraph",
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "En Quién Es El Dueño, usamos el ",
             "marks": [],
             "data": {}
           },
@@ -81,9 +82,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
-            "value": "Cuando haces una búsqueda Quién Posee Qué, nuestra base de datos:",
-            "marks": []
+            "value": "Cuando haces una búsqueda Quién Es El Dueño, nuestra base de datos:",
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -93,7 +94,6 @@
         "content": [
           {
             "nodeType": "list-item",
-            "data": {},
             "content": [
               {
                 "nodeType": "paragraph",
@@ -123,7 +123,8 @@
                 ],
                 "data": {}
               }
-            ]
+            ],
+            "data": {}
           },
           {
             "nodeType": "list-item",
@@ -167,9 +168,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "De acuerdo con la política del HPD, “la ley requiere que los propietarios de edificios residenciales se registren anualmente con el HPD si la propiedad es una vivienda múltiple (más de 3 unidades residenciales) o una vivienda privada (1–2 unidades residenciales) donde no vive ni el dueño ni su familia inmediata\". Estos datos deben estar disponibles públicamente de acuerdo con la ley de datos abiertos de Nueva York.\n",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -179,13 +180,13 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "El HPD actualiza estos datos de registro (que se actualizan en vivo en este sitio web) mensualmente",
             "marks": [
               {
                 "type": "bold"
               }
-            ]
+            ],
+            "data": {}
           },
           {
             "nodeType": "text",
@@ -201,7 +202,6 @@
         "content": [
           {
             "nodeType": "list-item",
-            "data": {},
             "content": [
               {
                 "nodeType": "paragraph",
@@ -238,18 +238,28 @@
                   },
                   {
                     "nodeType": "text",
-                    "value": " — actualizado a diario",
+                    "value": " —",
                     "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": " actualizado a diario",
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
                     "data": {}
                   }
                 ],
                 "data": {}
               }
-            ]
+            ],
+            "data": {}
           },
           {
             "nodeType": "list-item",
-            "data": {},
             "content": [
               {
                 "nodeType": "paragraph",
@@ -286,14 +296,25 @@
                   },
                   {
                     "nodeType": "text",
-                    "value": " — actualizado mensualmente",
+                    "value": " — ",
                     "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "actualizado mensualmente",
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
                     "data": {}
                   }
                 ],
                 "data": {}
               }
-            ]
+            ],
+            "data": {}
           },
           {
             "nodeType": "list-item",
@@ -333,8 +354,18 @@
                   },
                   {
                     "nodeType": "text",
-                    "value": " — actualizado a diario",
+                    "value": " — ",
                     "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "actualizado a diario",
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
                     "data": {}
                   }
                 ],
@@ -415,7 +446,7 @@
                   },
                   {
                     "nodeType": "text",
-                    "value": "updated yearly",
+                    "value": "actualizado anualmente",
                     "marks": [
                       {
                         "type": "italic"
@@ -535,6 +566,64 @@
                 "content": [
                   {
                     "nodeType": "text",
+                    "value": "Registros de escrituras de ACRIS de",
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": " ",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "hyperlink",
+                    "content": [
+                      {
+                        "nodeType": "text",
+                        "value": "NYC Open Data",
+                        "marks": [],
+                        "data": {}
+                      }
+                    ],
+                    "data": {
+                      "uri": "https://data.cityofnewyork.us/City-Government/ACRIS-Real-Property-Master/bnx9-e6tj"
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": ". Nota: solo incluimos escrituras que tienen una cantidad asociada mas de $1. — ",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "actualizado bimensualmente",
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
                     "value": "Aproximaciones de las cantidades de Apartamentos de Renta Estabilizada (de taxbills.nyc, adaptadas de las facturas de impuestos del Departamento de Finanzas).",
                     "marks": [
                       {
@@ -551,9 +640,6 @@
                   },
                   {
                     "nodeType": "hyperlink",
-                    "data": {
-                      "uri": "http://blog.johnkrauss.com/where-is-decontrol/"
-                    },
                     "content": [
                       {
                         "nodeType": "text",
@@ -561,7 +647,10 @@
                         "marks": [],
                         "data": {}
                       }
-                    ]
+                    ],
+                    "data": {
+                      "uri": "http://blog.johnkrauss.com/where-is-decontrol/"
+                    }
                   },
                   {
                     "nodeType": "text",
@@ -571,13 +660,13 @@
                   },
                   {
                     "nodeType": "text",
-                    "data": {},
                     "value": "— actualizado anualmente",
                     "marks": [
                       {
                         "type": "italic"
                       }
-                    ]
+                    ],
+                    "data": {}
                   }
                 ],
                 "data": {}
@@ -593,9 +682,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "Nuestro código es Open Source y es accesible ",
-            "marks": []
+            "marks": [],
+            "data": {}
           },
           {
             "nodeType": "hyperlink",
@@ -640,7 +729,6 @@
         ],
         "data": {}
       }
-    ],
-    "nodeType": "document"
+    ]
   }
 }

--- a/client/src/data/how-it-works.es.json
+++ b/client/src/data/how-it-works.es.json
@@ -596,7 +596,7 @@
                   },
                   {
                     "nodeType": "text",
-                    "value": ". Nota: solo incluimos escrituras que tienen una cantidad asociada mas de $1. — ",
+                    "value": ". Nota: solo incluimos escrituras que tienen una cantidad asociada mas de $1.— ",
                     "marks": [],
                     "data": {}
                   },

--- a/client/src/data/how-it-works.es.json
+++ b/client/src/data/how-it-works.es.json
@@ -420,7 +420,7 @@
                   },
                   {
                     "nodeType": "text",
-                    "value": " from ",
+                    "value": " de ",
                     "marks": [],
                     "data": {}
                   },
@@ -566,7 +566,7 @@
                 "content": [
                   {
                     "nodeType": "text",
-                    "value": "Registros de escrituras de ACRIS de",
+                    "value": "Registros de escrituras de ACRIS ",
                     "marks": [
                       {
                         "type": "bold"
@@ -576,7 +576,7 @@
                   },
                   {
                     "nodeType": "text",
-                    "value": " ",
+                    "value": "de ",
                     "marks": [],
                     "data": {}
                   },

--- a/client/src/data/how-to-use.es.json
+++ b/client/src/data/how-to-use.es.json
@@ -10,7 +10,7 @@
           {
             "data": {},
             "marks": [],
-            "value": "Las Cosas Más Importantes Que Puedes Hacer con Quién Posee Qué",
+            "value": "Las Cosas Más Importantes Que Puedes Hacer con Quién Es El Dueño",
             "nodeType": "text"
           }
         ],
@@ -343,7 +343,7 @@
                   {
                     "nodeType": "text",
                     "data": {},
-                    "value": "Para obtener detalles sobre los problemas que hay en tu edificio y para ver si alguno de tus vecinos llama repetidamente al 311 para reportar Quejas, consulte la lista de \"Historial de Quejas\" en el \"Perfil de Edificio del HPD\". Si tienes la información de contacto de tus vecinos, envíales el perfil de edificio de Quién Posee Qué a través de Facebook, Twitter, correo electrónico o mensaje de texto usando los botones para compartir. También le puedes proporcionar una lista inmediata de acciones a tomar compartiendo la página \"",
+                    "value": "Para obtener detalles sobre los problemas que hay en tu edificio y para ver si alguno de tus vecinos llama repetidamente al 311 para reportar Quejas, consulte la lista de \"Historial de Quejas\" en el \"Perfil de Edificio del HPD\". Si tienes la información de contacto de tus vecinos, envíales el perfil de edificio de Quién Es El Dueño a través de Facebook, Twitter, correo electrónico o mensaje de texto usando los botones para compartir. También le puedes proporcionar una lista inmediata de acciones a tomar compartiendo la página \"",
                     "marks": []
                   },
                   {
@@ -528,7 +528,7 @@
                 "content": [
                   {
                     "nodeType": "text",
-                    "value": "Presta atención a los tipos de problemas que hayan tenido otros inquilinos y cuánto tiempo les ha llevado resolverlos. Los datos de Quién Posee Qué se actualizan todos los días.",
+                    "value": "Presta atención a los tipos de problemas que hayan tenido otros inquilinos y cuánto tiempo les ha llevado resolverlos. Los datos de Quién Es El Dueño se actualizan todos los días.",
                     "marks": [],
                     "data": {}
                   }

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -43,7 +43,7 @@ msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adap
 msgstr "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 
 #: src/components/DetailView.js:276
-#: src/components/Indicators.js:530
+#: src/components/Indicators.js:517
 #: src/containers/NotRegisteredPage.js:279
 #: src/containers/NychaPage.js:286
 msgid "ANHD DAP Portal"
@@ -61,13 +61,17 @@ msgstr "According to available HPD data, this portfolio has received <0>{totalvi
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:47
+#: src/components/PropertiesList.tsx:58
 msgid "Address"
 msgstr "Address"
 
 #: src/components/Subscribe.tsx:29
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
+
+#: src/components/PropertiesList.tsx:200
+msgid "Amount"
+msgstr "Amount"
 
 #: src/components/DetailView.js:170
 #: src/components/DetailView.js:284
@@ -79,15 +83,15 @@ msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
 #: src/components/DetailView.js:78
-#: src/components/Indicators.js:303
+#: src/components/Indicators.js:290
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/Indicators.js:314
+#: src/components/Indicators.js:301
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
-#: src/components/PropertiesList.tsx:62
+#: src/components/PropertiesList.tsx:73
 #: src/containers/NychaPage.js:133
 msgid "Borough"
 msgstr "Borough"
@@ -115,7 +119,7 @@ msgstr "Building Permits Applied For"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:77
+#: src/components/PropertiesList.tsx:88
 msgid "Built"
 msgstr "Built"
 
@@ -162,16 +166,20 @@ msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
 #: src/components/DetailView.js:250
-#: src/components/Indicators.js:504
+#: src/components/Indicators.js:491
 #: src/containers/NotRegisteredPage.js:271
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
 #: src/components/DetailView.js:263
-#: src/components/Indicators.js:517
+#: src/components/Indicators.js:504
 #: src/containers/NotRegisteredPage.js:261
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
+
+#: src/components/PropertiesList.tsx:194
+msgid "Date"
+msgstr "Date"
 
 #: src/containers/App.js:54
 msgid "Demo Site"
@@ -206,7 +214,7 @@ msgstr "Enter an NYC address and find other buildings your landlord might own:"
 msgid "Enter email"
 msgstr "Enter email"
 
-#: src/components/PropertiesList.tsx:155
+#: src/components/PropertiesList.tsx:166
 #: src/components/PropertiesSummary.js:124
 msgid "Evictions"
 msgstr "Evictions"
@@ -231,8 +239,12 @@ msgstr "Failure to register a building with HPD"
 msgid "General info"
 msgstr "General info"
 
+#: src/components/PropertiesList.tsx:215
+msgid "Group Sale?"
+msgstr "Group Sale?"
+
 #: src/components/DetailView.js:237
-#: src/components/Indicators.js:491
+#: src/components/Indicators.js:478
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
@@ -245,7 +257,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:138
+#: src/components/PropertiesList.tsx:149
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -257,8 +269,8 @@ msgstr "HPD Violations occur when an official City Inspector finds the condition
 msgid "HUD Complaint Form 958"
 msgstr "HUD Complaint Form 958"
 
-#: src/components/Indicators.js:435
-#: src/components/Indicators.js:538
+#: src/components/Indicators.js:422
+#: src/components/Indicators.js:525
 msgid "Have thoughts about this page?"
 msgstr "Have thoughts about this page?"
 
@@ -283,7 +295,7 @@ msgstr "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one evicti
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:74
+#: src/components/PropertiesList.tsx:85
 msgid "Information"
 msgstr "Information"
 
@@ -299,10 +311,14 @@ msgstr "Join the fight for tenant rights!"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 
-#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesList.tsx:177
 #: src/components/PropertiesSummary.js:100
 msgid "Landlord"
 msgstr "Landlord"
+
+#: src/components/PropertiesList.tsx:191
+msgid "Last Sale"
+msgstr "Last Sale"
 
 #: src/components/IndicatorsViz.js:368
 msgid "Last Sale Unknown"
@@ -316,13 +332,17 @@ msgstr "Last registered:"
 msgid "Legend"
 msgstr "Legend"
 
-#: src/components/Indicators.js:294
+#: src/components/PropertiesList.tsx:207
+msgid "Link to Deed"
+msgstr "Link to Deed"
+
+#: src/components/Indicators.js:281
 #: src/components/PropertiesMap.js:191
 #: src/containers/AddressPage.js:268
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:35
+#: src/components/PropertiesList.tsx:46
 msgid "Location"
 msgstr "Location"
 
@@ -346,7 +366,7 @@ msgstr "May be issued official Orders"
 msgid "Methodology"
 msgstr "Methodology"
 
-#: src/components/Indicators.js:360
+#: src/components/Indicators.js:347
 msgid "Month"
 msgstr "Month"
 
@@ -391,7 +411,7 @@ msgstr "No registration found!"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/PropertiesList.tsx:169
+#: src/components/PropertiesList.tsx:180
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -399,7 +419,7 @@ msgstr "Officer/Owner"
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:141
+#: src/components/PropertiesList.tsx:152
 msgid "Open"
 msgstr "Open"
 
@@ -442,12 +462,12 @@ msgstr "Privacy policy"
 msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
-#: src/components/Indicators.js:378
+#: src/components/Indicators.js:365
 msgid "Quarter"
 msgstr "Quarter"
 
 #: src/components/BuildingStatsTable.js:126
-#: src/components/PropertiesList.tsx:116
+#: src/components/PropertiesList.tsx:127
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -468,7 +488,7 @@ msgstr "Searching"
 msgid "Searching for <0>{0} {1}, {2}</0>"
 msgstr "Searching for <0>{0} {1}, {2}</0>"
 
-#: src/components/Indicators.js:321
+#: src/components/Indicators.js:308
 msgid "Select a Dataset:"
 msgstr "Select a Dataset:"
 
@@ -476,8 +496,8 @@ msgstr "Select a Dataset:"
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/components/Indicators.js:442
-#: src/components/Indicators.js:545
+#: src/components/Indicators.js:429
+#: src/components/Indicators.js:532
 msgid "Send us feedback!"
 msgstr "Send us feedback!"
 
@@ -654,7 +674,7 @@ msgid "Timeline"
 msgstr "Timeline"
 
 #: src/components/IndicatorsViz.js:328
-#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:158
 msgid "Total"
 msgstr "Total"
 
@@ -671,20 +691,20 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.js:65
-#: src/components/PropertiesList.tsx:83
+#: src/components/PropertiesList.tsx:94
 #: src/containers/NychaPage.js:141
 msgid "Units"
 msgstr "Units"
 
 #: src/components/DetailView.js:202
 #: src/components/DetailView.js:207
-#: src/components/Indicators.js:460
+#: src/components/Indicators.js:447
 #: src/containers/NotRegisteredPage.js:244
 #: src/containers/NychaPage.js:251
 msgid "Useful links"
 msgstr "Useful links"
 
-#: src/components/Indicators.js:342
+#: src/components/Indicators.js:329
 msgid "View by:"
 msgstr "View by:"
 
@@ -692,12 +712,12 @@ msgstr "View by:"
 msgid "View data over time"
 msgstr "View data over time"
 
-#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:230
 msgid "View detail"
 msgstr "View detail"
 
 #: src/components/DetailView.js:220
-#: src/components/Indicators.js:472
+#: src/components/Indicators.js:459
 #: src/containers/NotRegisteredPage.js:253
 msgid "View documents on ACRIS"
 msgstr "View documents on ACRIS"
@@ -732,7 +752,7 @@ msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
-#: src/components/Indicators.js:451
+#: src/components/Indicators.js:438
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
@@ -744,7 +764,7 @@ msgstr "What happens if the landlord has failed to register?"
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 
-#: src/components/Indicators.js:396
+#: src/components/Indicators.js:383
 msgid "Year"
 msgstr "Year"
 
@@ -756,7 +776,7 @@ msgstr "Year Built"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:56
+#: src/components/PropertiesList.tsx:67
 msgid "Zipcode"
 msgstr "Zipcode"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -390,6 +390,10 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
+#: src/components/PropertiesList.tsx:226
+msgid "No"
+msgstr "No"
+
 #: src/containers/NotRegisteredPage.js:179
 #: src/containers/NychaPage.js:110
 msgid "No address found"
@@ -712,7 +716,7 @@ msgstr "View by:"
 msgid "View data over time"
 msgstr "View data over time"
 
-#: src/components/PropertiesList.tsx:230
+#: src/components/PropertiesList.tsx:232
 msgid "View detail"
 msgstr "View detail"
 
@@ -771,6 +775,10 @@ msgstr "Year"
 #: src/components/BuildingStatsTable.js:50
 msgid "Year Built"
 msgstr "Year Built"
+
+#: src/components/PropertiesList.tsx:225
+msgid "Yes"
+msgstr "Yes"
 
 #: src/containers/HomePage.tsx:220
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -46,7 +46,7 @@ msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adap
 msgstr "<0>Actualización COVID-19: </0>JustFix.nyc sigue en funcionamiento, y hemos adaptado nuestros productos para que funcionen con las nuevas reglas establecidas durante la crisis de salud pública COVID-19. Gracias a la organización de los líderes inquilinos, los inquilinos de Nueva York ahora tienen protecciones más fuertes, incluyendo una suspensión total de los casos de desalojo. <1><2>Más información</2></1>"
 
 #: src/components/DetailView.js:276
-#: src/components/Indicators.js:530
+#: src/components/Indicators.js:517
 #: src/containers/NotRegisteredPage.js:279
 #: src/containers/NychaPage.js:286
 msgid "ANHD DAP Portal"
@@ -64,13 +64,17 @@ msgstr "Según los datos del HPD disponibles, esta cartera de edificios ha recib
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:47
+#: src/components/PropertiesList.tsx:58
 msgid "Address"
 msgstr "Dirección"
 
 #: src/components/Subscribe.tsx:29
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
+
+#: src/components/PropertiesList.tsx:200
+msgid "Amount"
+msgstr ""
 
 #: src/components/DetailView.js:170
 #: src/components/DetailView.js:284
@@ -82,15 +86,15 @@ msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
 #: src/components/DetailView.js:78
-#: src/components/Indicators.js:303
+#: src/components/Indicators.js:290
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/Indicators.js:314
+#: src/components/Indicators.js:301
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
-#: src/components/PropertiesList.tsx:62
+#: src/components/PropertiesList.tsx:73
 #: src/containers/NychaPage.js:133
 msgid "Borough"
 msgstr "Municipio"
@@ -118,7 +122,7 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:77
+#: src/components/PropertiesList.tsx:88
 msgid "Built"
 msgstr "Construido"
 
@@ -165,16 +169,20 @@ msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
 #: src/components/DetailView.js:250
-#: src/components/Indicators.js:504
+#: src/components/Indicators.js:491
 #: src/containers/NotRegisteredPage.js:271
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
 #: src/components/DetailView.js:263
-#: src/components/Indicators.js:517
+#: src/components/Indicators.js:504
 #: src/containers/NotRegisteredPage.js:261
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
+
+#: src/components/PropertiesList.tsx:194
+msgid "Date"
+msgstr ""
 
 #: src/containers/App.js:54
 msgid "Demo Site"
@@ -209,7 +217,7 @@ msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu pr
 msgid "Enter email"
 msgstr "Introducir email"
 
-#: src/components/PropertiesList.tsx:155
+#: src/components/PropertiesList.tsx:166
 #: src/components/PropertiesSummary.js:124
 msgid "Evictions"
 msgstr "Desalojos"
@@ -234,8 +242,12 @@ msgstr "Si no se registra un edificio con el HPD"
 msgid "General info"
 msgstr "Información general"
 
+#: src/components/PropertiesList.tsx:215
+msgid "Group Sale?"
+msgstr ""
+
 #: src/components/DetailView.js:237
-#: src/components/Indicators.js:491
+#: src/components/Indicators.js:478
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
@@ -248,7 +260,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:138
+#: src/components/PropertiesList.tsx:149
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
@@ -260,8 +272,8 @@ msgstr "Infracciones del HPD se dan cuando un Inspector oficial de la Ciudad det
 msgid "HUD Complaint Form 958"
 msgstr "Formulario de queja HUD 958"
 
-#: src/components/Indicators.js:435
-#: src/components/Indicators.js:538
+#: src/components/Indicators.js:422
+#: src/components/Indicators.js:525
 msgid "Have thoughts about this page?"
 msgstr "¿Tienes ideas sobre esta página?"
 
@@ -286,7 +298,7 @@ msgstr "En el 2019, los Mariscales de NYC programaron {totalEvictions, plural, o
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
-#: src/components/PropertiesList.tsx:74
+#: src/components/PropertiesList.tsx:85
 msgid "Information"
 msgstr "Información"
 
@@ -302,10 +314,14 @@ msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesList.tsx:177
 #: src/components/PropertiesSummary.js:100
 msgid "Landlord"
 msgstr "Dueño del edificio"
+
+#: src/components/PropertiesList.tsx:191
+msgid "Last Sale"
+msgstr ""
 
 #: src/components/IndicatorsViz.js:368
 msgid "Last Sale Unknown"
@@ -319,13 +335,17 @@ msgstr "Registrado por última vez:"
 msgid "Legend"
 msgstr "Leyenda"
 
-#: src/components/Indicators.js:294
+#: src/components/PropertiesList.tsx:207
+msgid "Link to Deed"
+msgstr ""
+
+#: src/components/Indicators.js:281
 #: src/components/PropertiesMap.js:191
 #: src/containers/AddressPage.js:268
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:35
+#: src/components/PropertiesList.tsx:46
 msgid "Location"
 msgstr "Ubicación"
 
@@ -349,7 +369,7 @@ msgstr "Pueden emitirse órdenes oficiales"
 msgid "Methodology"
 msgstr "Metodología"
 
-#: src/components/Indicators.js:360
+#: src/components/Indicators.js:347
 msgid "Month"
 msgstr "Mes"
 
@@ -394,7 +414,7 @@ msgstr "¡No se ha encontrado nigún registro!"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/PropertiesList.tsx:169
+#: src/components/PropertiesList.tsx:180
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -402,7 +422,7 @@ msgstr "Oficial/Propietario"
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:141
+#: src/components/PropertiesList.tsx:152
 msgid "Open"
 msgstr "Abrir"
 
@@ -445,12 +465,12 @@ msgstr "Política de privacidad"
 msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
-#: src/components/Indicators.js:378
+#: src/components/Indicators.js:365
 msgid "Quarter"
 msgstr "Trimestre"
 
 #: src/components/BuildingStatsTable.js:126
-#: src/components/PropertiesList.tsx:116
+#: src/components/PropertiesList.tsx:127
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
@@ -471,7 +491,7 @@ msgstr "Buscando"
 msgid "Searching for <0>{0} {1}, {2}</0>"
 msgstr "Buscando <0>{0} {1}, {2}</0>"
 
-#: src/components/Indicators.js:321
+#: src/components/Indicators.js:308
 msgid "Select a Dataset:"
 msgstr "Seleccione un conjunto de datos:"
 
@@ -479,8 +499,8 @@ msgstr "Seleccione un conjunto de datos:"
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/components/Indicators.js:442
-#: src/components/Indicators.js:545
+#: src/components/Indicators.js:429
+#: src/components/Indicators.js:532
 msgid "Send us feedback!"
 msgstr "¡Comparte tu opinión con nosotros!"
 
@@ -657,7 +677,7 @@ msgid "Timeline"
 msgstr "Cronología"
 
 #: src/components/IndicatorsViz.js:328
-#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:158
 msgid "Total"
 msgstr "Total"
 
@@ -674,20 +694,20 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.js:65
-#: src/components/PropertiesList.tsx:83
+#: src/components/PropertiesList.tsx:94
 #: src/containers/NychaPage.js:141
 msgid "Units"
 msgstr "Unidades Residenciales"
 
 #: src/components/DetailView.js:202
 #: src/components/DetailView.js:207
-#: src/components/Indicators.js:460
+#: src/components/Indicators.js:447
 #: src/containers/NotRegisteredPage.js:244
 #: src/containers/NychaPage.js:251
 msgid "Useful links"
 msgstr "Enlaces útiles"
 
-#: src/components/Indicators.js:342
+#: src/components/Indicators.js:329
 msgid "View by:"
 msgstr "Visualizar por:"
 
@@ -695,12 +715,12 @@ msgstr "Visualizar por:"
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
-#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:230
 msgid "View detail"
 msgstr "Ver detalles"
 
 #: src/components/DetailView.js:220
-#: src/components/Indicators.js:472
+#: src/components/Indicators.js:459
 #: src/containers/NotRegisteredPage.js:253
 msgid "View documents on ACRIS"
 msgstr "Ver documentos en ACRIS"
@@ -735,7 +755,7 @@ msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas 
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
-#: src/components/Indicators.js:451
+#: src/components/Indicators.js:438
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
@@ -747,7 +767,7 @@ msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
-#: src/components/Indicators.js:396
+#: src/components/Indicators.js:383
 msgid "Year"
 msgstr "Año"
 
@@ -759,7 +779,7 @@ msgstr "Año de construcción"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:56
+#: src/components/PropertiesList.tsx:67
 msgid "Zipcode"
 msgstr "Código postal"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -393,6 +393,10 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
+#: src/components/PropertiesList.tsx:226
+msgid "No"
+msgstr ""
+
 #: src/containers/NotRegisteredPage.js:179
 #: src/containers/NychaPage.js:110
 msgid "No address found"
@@ -715,7 +719,7 @@ msgstr "Visualizar por:"
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
-#: src/components/PropertiesList.tsx:230
+#: src/components/PropertiesList.tsx:232
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -774,6 +778,10 @@ msgstr "Año"
 #: src/components/BuildingStatsTable.js:50
 msgid "Year Built"
 msgstr "Año de construcción"
+
+#: src/components/PropertiesList.tsx:225
+msgid "Yes"
+msgstr ""
 
 #: src/containers/HomePage.tsx:220
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."

--- a/server/controllers/address.js
+++ b/server/controllers/address.js
@@ -75,15 +75,6 @@ module.exports = {
       });
   },
 
-  salehistory: (req, res) => {
-    db.querySaleHistory(req.query.bbl)
-      .then((result) => res.status(200).send({ result: result }))
-      .catch((err) => {
-        rollbar.error(err, req);
-        res.status(200).send({ error: err.message });
-      });
-  },
-
   indicatorhistory: (req, res) => {
     db.queryIndicatorHistory(req.query.bbl)
       .then((result) => res.status(200).send({ result: result }))

--- a/server/routes.js
+++ b/server/routes.js
@@ -9,7 +9,6 @@ router.get("/address", address.query);
 router.get("/address/aggregate", address.aggregate);
 router.get("/address/dap-aggregate", address.dapAggregate);
 router.get("/address/buildinginfo", address.buildinginfo);
-router.get("/address/salehistory", address.salehistory);
 router.get("/address/indicatorhistory", address.indicatorhistory);
 router.get("/address/export", address.export);
 router.get("/landlord", landlord.query);

--- a/server/services/db.js
+++ b/server/services/db.js
@@ -21,13 +21,7 @@ const buildingInfoSQL = `SELECT
    FROM PLUTO_19V2
    WHERE BBL = $1`;
 
-// WOW Indicators Custom Queries
-const saleHistorySQL = `SELECT * 
-   FROM REAL_PROPERTY_LEGALS L 
-   LEFT JOIN REAL_PROPERTY_MASTER M ON L.DOCUMENTID = M.DOCUMENTID
-   WHERE BBL = $1 AND DOCTYPE = 'DEED'
-   ORDER BY COALESCE(DOCDATE,RECORDEDFILED) DESC`;
-
+// WOW Indicators Custom Query for Timeline Tab
 const indicatorHistorySQL = `WITH TIME_SERIES AS (
       SELECT TO_CHAR(I::DATE , 'YYYY-MM') AS MONTH 
       FROM GENERATE_SERIES('2010-01-01', CURRENT_DATE - INTERVAL '1 MONTH', '1 MONTH'::INTERVAL) I
@@ -91,6 +85,5 @@ module.exports = {
   queryDapAggregate: (bbl) => db.func("get_agg_info_from_bbl", bbl),
   queryLandlord: (bbl) => db.any("SELECT * FROM hpd_landlord_contact WHERE bbl = $1", bbl),
   queryBuildingInfo: (bbl) => db.any(buildingInfoSQL, bbl),
-  querySaleHistory: (bbl) => db.any(saleHistorySQL, bbl),
   queryIndicatorHistory: (bbl) => db.any(indicatorHistorySQL, bbl),
 };


### PR DESCRIPTION
This PR adds data on buildings' last sale in ACRIS, using the new `wow_bldgs` structure implemented in #246. Specifically, this PR:
- [x] adds new columns on "Last Sale" to the Portfolio tab
- [x] refactor the Timeline tab to pull data from new wow_bldgs source
- [x] add documentation to the methodology page (or somewhere else) about ACRIS data