### PR TITLE
Fixed bug where React Table cell doesn't return anything

### DIFF
--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -255,22 +255,23 @@ const PropertiesListWithoutI18n: React.FC<{
                   Header: i18n._(t`Date`),
                   accessor: (d) => d.lastsaledate,
                   Cell: (row) =>
-                    row.original.lastsaledate && formatDate(row.original.lastsaledate, locale),
+                    row.original.lastsaledate ? formatDate(row.original.lastsaledate, locale) : "",
                   id: "lastsaledate",
                 },
                 {
                   Header: i18n._(t`Amount`),
                   accessor: (d) => (d.lastsaleamount ? parseInt(d.lastsaleamount) : null),
                   Cell: (row) =>
-                    row.original.lastsaleamount &&
-                    "$" + formatPrice.format(row.original.lastsaleamount),
+                    row.original.lastsaleamount
+                      ? "$" + formatPrice.format(row.original.lastsaleamount)
+                      : "",
                   id: "lastsaleamount",
                 },
                 {
                   Header: i18n._(t`Link to Deed`),
                   accessor: (d) => d.lastsaleacrisid,
                   Cell: (row) =>
-                    row.original.lastsaleacrisid && (
+                    row.original.lastsaleacrisid ? (
                       <a
                         href={`https://a836-acris.nyc.gov/DS/DocumentSearch/DocumentImageView?doc_id=${row.original.lastsaleacrisid}`}
                         className="btn"
@@ -279,6 +280,8 @@ const PropertiesListWithoutI18n: React.FC<{
                       >
                         <span style={{ padding: "0 3px" }}>&#8599;&#xFE0E;</span>
                       </a>
+                    ) : (
+                      <></>
                     ),
                   id: "lastsaleacrisid",
                 },
@@ -293,10 +296,11 @@ const PropertiesListWithoutI18n: React.FC<{
                     return `${idPrefix}${d.lastsaleacrisid}`;
                   },
                   Cell: (row) =>
-                    row.original.lastsaleacrisid &&
-                    (isPartOfGroupSale(row.original.lastsaleacrisid, props.addrs)
-                      ? i18n._(t`Yes`)
-                      : i18n._(t`No`)),
+                    row.original.lastsaleacrisid
+                      ? isPartOfGroupSale(row.original.lastsaleacrisid, props.addrs)
+                        ? i18n._(t`Yes`)
+                        : i18n._(t`No`)
+                      : "",
                   id: "lastsaleisgroupsale",
                 },
               ],

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -255,7 +255,9 @@ const PropertiesListWithoutI18n: React.FC<{
                   Header: i18n._(t`Date`),
                   accessor: (d) => d.lastsaledate,
                   Cell: (row) =>
-                    row.original.lastsaledate ? formatDate(row.original.lastsaledate, locale) : "",
+                    row.original.lastsaledate
+                      ? formatDate(row.original.lastsaledate, locale)
+                      : null,
                   id: "lastsaledate",
                 },
                 {
@@ -264,7 +266,7 @@ const PropertiesListWithoutI18n: React.FC<{
                   Cell: (row) =>
                     row.original.lastsaleamount
                       ? "$" + formatPrice.format(row.original.lastsaleamount)
-                      : "",
+                      : null,
                   id: "lastsaleamount",
                 },
                 {
@@ -280,9 +282,7 @@ const PropertiesListWithoutI18n: React.FC<{
                       >
                         <span style={{ padding: "0 3px" }}>&#8599;&#xFE0E;</span>
                       </a>
-                    ) : (
-                      <></>
-                    ),
+                    ) : null,
                   id: "lastsaleacrisid",
                 },
                 {
@@ -300,7 +300,7 @@ const PropertiesListWithoutI18n: React.FC<{
                       ? isPartOfGroupSale(row.original.lastsaleacrisid, props.addrs)
                         ? i18n._(t`Yes`)
                         : i18n._(t`No`)
-                      : "",
+                      : null,
                   id: "lastsaleisgroupsale",
                 },
               ],


### PR DESCRIPTION
This PR makes sure that any Cell render function in our PropertiesList table component always returns something. 