### PR TITLE
Add new spanish elements

### DIFF
--- a/client/src/components/DetailView.js
+++ b/client/src/components/DetailView.js
@@ -10,6 +10,7 @@ import "styles/DetailView.css";
 import { withI18n } from "@lingui/react";
 import { Trans } from "@lingui/macro";
 import { SocialSharePortfolio } from "./SocialShare";
+import { isPartOfGroupSale } from "./PropertiesList";
 import { Link } from "react-router-dom";
 import { LocaleLink } from "../i18n";
 import BuildingStatsTable from "./BuildingStatsTable";
@@ -49,6 +50,8 @@ class DetailViewWithoutI18n extends Component {
     }
 
     const isMobile = Browser.isMobile();
+
+    const formatPrice = new Intl.NumberFormat(this.props.i18n._language || "en");
 
     const streetView = (
       <LazyLoadWhenVisible>
@@ -163,6 +166,31 @@ class DetailViewWithoutI18n extends Component {
                             </span>
                           )}
                         </p>
+                        {this.props.addr.lastsaledate &&
+                          this.props.addr.lastsaleamount &&
+                          this.props.addrs && (
+                            <p>
+                              <b>
+                                <Trans>Last sold:</Trans>
+                              </b>{" "}
+                              <>
+                                {this.formatDate(this.props.addr.lastsaledate)}{" "}
+                                <Trans>
+                                  for ${formatPrice.format(this.props.addr.lastsaleamount)}
+                                </Trans>
+                                {this.props.addr.lastsaleacrisid &&
+                                  isPartOfGroupSale(
+                                    this.props.addr.lastsaleacrisid,
+                                    this.props.addrs
+                                  ) && (
+                                    <>
+                                      {" "}
+                                      <Trans>(as part of a group sale)</Trans>
+                                    </>
+                                  )}
+                              </>
+                            </p>
+                          )}
                       </div>
 
                       <div className="card-body-prompt hide-lg">

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -35,7 +35,7 @@ const formatDate = (dateString: string, locale?: SupportedLocale) => {
   return date.toLocaleDateString(locale || "en", options);
 };
 
-const isPartOfGroupSale = (saleId: string, addrs: Addr[]) => {
+export const isPartOfGroupSale = (saleId: string, addrs: Addr[]) => {
   const addrsWithMatchingSale = addrs.filter((addr) => addr.lastsaleacrisid === saleId);
   return addrsWithMatchingSale.length > 1;
 };

--- a/client/src/containers/AddressPage.js
+++ b/client/src/containers/AddressPage.js
@@ -233,6 +233,7 @@ export default class AddressPage extends Component {
                 isVisible={this.props.currentTab === 0}
               />
               <DetailView
+                addrs={this.state.assocAddrs}
                 addr={this.state.detailAddr}
                 portfolioSize={this.state.assocAddrs.length}
                 mobileShow={this.state.detailMobileSlide}

--- a/client/src/data/how-to-use.es.json
+++ b/client/src/data/how-to-use.es.json
@@ -2,31 +2,32 @@
   "title": "Cómo utilizar",
   "slug": "how-to-use",
   "content": {
+    "nodeType": "document",
     "data": {},
     "content": [
       {
-        "data": {},
+        "nodeType": "heading-4",
         "content": [
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": "Las Cosas Más Importantes Que Puedes Hacer con Quién Es El Dueño",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           }
         ],
-        "nodeType": "heading-4"
+        "data": {}
       },
       {
-        "data": {},
+        "nodeType": "paragraph",
         "content": [
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": "",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           }
         ],
-        "nodeType": "paragraph"
+        "data": {}
       },
       {
         "nodeType": "paragraph",
@@ -102,7 +103,6 @@
         "content": [
           {
             "nodeType": "list-item",
-            "data": {},
             "content": [
               {
                 "nodeType": "paragraph",
@@ -145,7 +145,6 @@
                 "content": [
                   {
                     "nodeType": "list-item",
-                    "data": {},
                     "content": [
                       {
                         "nodeType": "paragraph",
@@ -159,7 +158,8 @@
                         ],
                         "data": {}
                       }
-                    ]
+                    ],
+                    "data": {}
                   },
                   {
                     "nodeType": "list-item",
@@ -194,7 +194,8 @@
                 ],
                 "data": {}
               }
-            ]
+            ],
+            "data": {}
           },
           {
             "nodeType": "list-item",
@@ -266,9 +267,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -278,9 +279,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "Comprueba a quién más puede estar perjudicando el dueño o manager de tu edificio, y determina si es posible crear una asociación de inquilinos.\n",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -335,16 +336,15 @@
         "content": [
           {
             "nodeType": "list-item",
-            "data": {},
             "content": [
               {
                 "nodeType": "paragraph",
                 "content": [
                   {
                     "nodeType": "text",
-                    "data": {},
                     "value": "Para obtener detalles sobre los problemas que hay en tu edificio y para ver si alguno de tus vecinos llama repetidamente al 311 para reportar Quejas, consulte la lista de \"Historial de Quejas\" en el \"Perfil de Edificio del HPD\". Si tienes la información de contacto de tus vecinos, envíales el perfil de edificio de Quién Es El Dueño a través de Facebook, Twitter, correo electrónico o mensaje de texto usando los botones para compartir. También le puedes proporcionar una lista inmediata de acciones a tomar compartiendo la página \"",
-                    "marks": []
+                    "marks": [],
+                    "data": {}
                   },
                   {
                     "nodeType": "hyperlink",
@@ -369,7 +369,8 @@
                 ],
                 "data": {}
               }
-            ]
+            ],
+            "data": {}
           },
           {
             "nodeType": "list-item",
@@ -435,9 +436,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -447,9 +448,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "Investiga los detalles de un edificio antes de mudarte.",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -546,9 +547,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -558,9 +559,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -570,9 +571,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -582,9 +583,9 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
@@ -680,13 +681,13 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "\"¿Cómo se asocia este edificio?\"",
             "marks": [
               {
                 "type": "bold"
               }
-            ]
+            ],
+            "data": {}
           },
           {
             "nodeType": "text",
@@ -712,7 +713,7 @@
           },
           {
             "nodeType": "text",
-            "value": " Los Apartamentos de Renta Estabilizada son apartamentos que están sujetos a reglas específicas, una de las cuales es que el dueño tiene que proporcionar un contrato de renta de 1 o 2 años, con un aumento máximo de renta que fija la Junta de Pautas de Alquiler (RGB por sus siglas en inglés). En el indicador de la pestaña \"Vista General\", si el número de apartamentos de renta estabilizada a la derecha es menor que el número de la izquierda y aparece en rojo, significa que algunos apartamentos han perdido su estatus de renta estabilizada (es decir, han sido desregulados), y puede significar que el dueño esté intentando echar a los inquilinos que vivan en los apartamentos de renta estabilizada.\n",
+            "value": " Los Apartamentos de Renta Estabilizada son apartamentos que están sujetos a reglas específicas, una de las cuales es que el dueño tiene que proporcionar un contrato de renta de 1 o 2 años, con un aumento máximo de renta que fija la Junta de Pautas de Alquiler (RGB por sus siglas en inglés). En el indicador de la pestaña \"Vista General\", si el número de apartamentos de renta estabilizada a la derecha es menor que el número de la izquierda y aparece en rojo, significa que algunos apartamentos han perdido su estatus de renta estabilizada (es decir, han sido desregulados), y puede significar que el dueño esté intentando echar a los inquilinos que vivan en los apartamentos de renta estabilizada.",
             "marks": [],
             "data": {}
           }
@@ -724,13 +725,13 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
             "value": "Infracciones Actuales, Infracciones Totales, HPD y 311:",
             "marks": [
               {
                 "type": "bold"
               }
-            ]
+            ],
+            "data": {}
           }
         ],
         "data": {}
@@ -740,7 +741,6 @@
         "content": [
           {
             "nodeType": "list-item",
-            "data": {},
             "content": [
               {
                 "nodeType": "paragraph",
@@ -754,7 +754,8 @@
                 ],
                 "data": {}
               }
-            ]
+            ],
+            "data": {}
           },
           {
             "nodeType": "list-item",
@@ -818,14 +819,209 @@
         "content": [
           {
             "nodeType": "text",
-            "data": {},
+            "value": "Tipos de personas asociadas al edificio:",
+            "marks": [
+              {
+                "type": "bold"
+              }
+            ],
+            "data": {}
+          }
+        ],
+        "data": {}
+      },
+      {
+        "nodeType": "unordered-list",
+        "content": [
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "\"Head Officer\" — Oficial Principal",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "\"Corporate Owner\" — Dueño Corporativo",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "\"Individual Owner\" — Dueño Individual",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "\"Joint Owner\" — Dueño Conjunto",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "\"Site Manager\" — Manager del Propiedad",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "\"Agent\" — Agente",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "\"Lessee\" — Arrendatario",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "\"Officer\" — Oficial",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "list-item",
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "\"Shareholder\" — Accionista",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              },
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ],
+            "data": {}
+          }
+        ],
+        "data": {}
+      },
+      {
+        "nodeType": "paragraph",
+        "content": [
+          {
+            "nodeType": "text",
             "value": "",
-            "marks": []
+            "marks": [],
+            "data": {}
           }
         ],
         "data": {}
       }
-    ],
-    "nodeType": "document"
+    ]
   }
 }

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,11 +13,15 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/DetailView.js:153
+#: src/components/DetailView.js:188
+msgid "(as part of a group sale)"
+msgstr "(as part of a group sale)"
+
+#: src/components/DetailView.js:156
 msgid "(expired {0})"
 msgstr "(expired {0})"
 
-#: src/components/DetailView.js:160
+#: src/components/DetailView.js:163
 msgid "(expires {0})"
 msgstr "(expires {0})"
 
@@ -42,7 +46,7 @@ msgstr "2019 Evictions"
 msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 msgstr "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 
-#: src/components/DetailView.js:276
+#: src/components/DetailView.js:304
 #: src/components/Indicators.js:524
 #: src/containers/NotRegisteredPage.js:279
 #: src/containers/NychaPage.js:286
@@ -70,12 +74,12 @@ msgstr "Address"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: src/components/PropertiesList.tsx:200
+#: src/components/PropertiesList.tsx:202
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/DetailView.js:170
-#: src/components/DetailView.js:284
+#: src/components/DetailView.js:198
+#: src/components/DetailView.js:312
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -83,7 +87,7 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/components/DetailView.js:78
+#: src/components/DetailView.js:81
 #: src/components/Indicators.js:290
 msgid "BUILDING:"
 msgstr "BUILDING:"
@@ -124,16 +128,16 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.js:120
-#: src/components/DetailView.js:365
-#: src/components/DetailView.js:376
+#: src/components/DetailView.js:123
+#: src/components/DetailView.js:393
+#: src/components/DetailView.js:404
 #: src/components/OwnersTable.tsx:19
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.js:109
-#: src/components/DetailView.js:343
-#: src/components/DetailView.js:354
+#: src/components/DetailView.js:112
+#: src/components/DetailView.js:371
+#: src/components/DetailView.js:382
 #: src/components/OwnersTable.tsx:25
 msgid "Business Entities"
 msgstr "Business Entities"
@@ -166,13 +170,13 @@ msgstr "Close legend"
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
-#: src/components/DetailView.js:250
+#: src/components/DetailView.js:278
 #: src/components/Indicators.js:498
 #: src/containers/NotRegisteredPage.js:271
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
-#: src/components/DetailView.js:263
+#: src/components/DetailView.js:291
 #: src/components/Indicators.js:511
 #: src/containers/NotRegisteredPage.js:261
 msgid "DOF Property Tax Bills"
@@ -240,11 +244,11 @@ msgstr "Failure to register a building with HPD"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:215
+#: src/components/PropertiesList.tsx:218
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
-#: src/components/DetailView.js:237
+#: src/components/DetailView.js:265
 #: src/components/Indicators.js:485
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
@@ -279,8 +283,8 @@ msgstr "Have thoughts about this page?"
 msgid "Home"
 msgstr "Home"
 
-#: src/components/DetailView.js:86
-#: src/components/DetailView.js:319
+#: src/components/DetailView.js:89
+#: src/components/DetailView.js:347
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
@@ -330,22 +334,26 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.js:147
+#: src/components/DetailView.js:150
 msgid "Last registered:"
 msgstr "Last registered:"
+
+#: src/components/DetailView.js:174
+msgid "Last sold:"
+msgstr "Last sold:"
 
 #: src/components/PropertiesMap.js:265
 msgid "Legend"
 msgstr "Legend"
 
-#: src/components/PropertiesList.tsx:207
-#: src/components/PropertiesList.tsx:209
+#: src/components/PropertiesList.tsx:210
+#: src/components/PropertiesList.tsx:212
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
 #: src/components/Indicators.js:281
 #: src/components/PropertiesMap.js:191
-#: src/containers/AddressPage.js:285
+#: src/containers/AddressPage.js:287
 msgid "Loading"
 msgstr "Loading"
 
@@ -398,7 +406,7 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:226
+#: src/components/PropertiesList.tsx:229
 msgid "No"
 msgstr "No"
 
@@ -451,9 +459,9 @@ msgstr "Owners submit Building Permit Applications to the Department of Building
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/DetailView.js:132
-#: src/components/DetailView.js:389
-#: src/components/DetailView.js:401
+#: src/components/DetailView.js:135
+#: src/components/DetailView.js:417
+#: src/components/DetailView.js:429
 #: src/components/OwnersTable.tsx:31
 msgid "People"
 msgstr "People"
@@ -518,8 +526,8 @@ msgstr "Send us feedback!"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.js:187
-#: src/components/DetailView.js:298
+#: src/components/DetailView.js:215
+#: src/components/DetailView.js:326
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.js:155
 #: src/containers/App.js:91
@@ -552,8 +560,8 @@ msgstr "Source code"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/components/DetailView.js:181
-#: src/components/DetailView.js:292
+#: src/components/DetailView.js:209
+#: src/components/DetailView.js:320
 #: src/containers/NychaPage.js:303
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
@@ -714,8 +722,8 @@ msgstr "Units"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 
-#: src/components/DetailView.js:202
-#: src/components/DetailView.js:207
+#: src/components/DetailView.js:230
+#: src/components/DetailView.js:235
 #: src/components/Indicators.js:454
 #: src/containers/NotRegisteredPage.js:244
 #: src/containers/NychaPage.js:251
@@ -726,16 +734,16 @@ msgstr "Useful links"
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.js:102
+#: src/components/DetailView.js:105
 msgid "View data over time"
 msgstr "View data over time"
 
-#: src/components/PropertiesList.tsx:232
-#: src/components/PropertiesList.tsx:237
+#: src/components/PropertiesList.tsx:236
+#: src/components/PropertiesList.tsx:241
 msgid "View detail"
 msgstr "View detail"
 
-#: src/components/DetailView.js:220
+#: src/components/DetailView.js:248
 #: src/components/Indicators.js:466
 #: src/containers/NotRegisteredPage.js:253
 msgid "View documents on ACRIS"
@@ -751,7 +759,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.js:70
+#: src/components/DetailView.js:73
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -767,7 +775,7 @@ msgstr "Visit our website"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
-#: src/components/DetailView.js:321
+#: src/components/DetailView.js:349
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -798,7 +806,7 @@ msgstr "Year"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:225
+#: src/components/PropertiesList.tsx:228
 msgid "Yes"
 msgstr "Yes"
 
@@ -817,6 +825,10 @@ msgstr "and"
 #: src/components/PropertiesMap.js:273
 msgid "associated building"
 msgstr "associated building"
+
+#: src/components/DetailView.js:178
+msgid "for ${0}"
+msgstr "for ${0}"
 
 #: src/components/PropertiesMap.js:272
 msgid "search address"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -16,11 +16,15 @@ msgstr ""
 "X-Crowdin-Language: es-ES\n"
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 
-#: src/components/DetailView.js:153
+#: src/components/DetailView.js:188
+msgid "(as part of a group sale)"
+msgstr "(como parte de una venta en grupo)"
+
+#: src/components/DetailView.js:156
 msgid "(expired {0})"
 msgstr "(caducado {0})"
 
-#: src/components/DetailView.js:160
+#: src/components/DetailView.js:163
 msgid "(expires {0})"
 msgstr "(caduca {0})"
 
@@ -45,7 +49,7 @@ msgstr "Desalojos 2019"
 msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 msgstr "<0>Actualización COVID-19: </0>JustFix.nyc sigue en funcionamiento, y hemos adaptado nuestros productos para que funcionen con las nuevas reglas establecidas durante la crisis de salud pública COVID-19. Gracias a la organización de los líderes inquilinos, los inquilinos de Nueva York ahora tienen protecciones más fuertes, incluyendo una suspensión total de los casos de desalojo. <1><2>Más información</2></1>"
 
-#: src/components/DetailView.js:276
+#: src/components/DetailView.js:304
 #: src/components/Indicators.js:524
 #: src/containers/NotRegisteredPage.js:279
 #: src/containers/NychaPage.js:286
@@ -73,12 +77,12 @@ msgstr "Dirección"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: src/components/PropertiesList.tsx:200
+#: src/components/PropertiesList.tsx:202
 msgid "Amount"
 msgstr "Importe"
 
-#: src/components/DetailView.js:170
-#: src/components/DetailView.js:284
+#: src/components/DetailView.js:198
+#: src/components/DetailView.js:312
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -86,7 +90,7 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
-#: src/components/DetailView.js:78
+#: src/components/DetailView.js:81
 #: src/components/Indicators.js:290
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
@@ -127,16 +131,16 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.js:120
-#: src/components/DetailView.js:365
-#: src/components/DetailView.js:376
+#: src/components/DetailView.js:123
+#: src/components/DetailView.js:393
+#: src/components/DetailView.js:404
 #: src/components/OwnersTable.tsx:19
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.js:109
-#: src/components/DetailView.js:343
-#: src/components/DetailView.js:354
+#: src/components/DetailView.js:112
+#: src/components/DetailView.js:371
+#: src/components/DetailView.js:382
 #: src/components/OwnersTable.tsx:25
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
@@ -169,13 +173,13 @@ msgstr "Cerrar leyenda"
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
-#: src/components/DetailView.js:250
+#: src/components/DetailView.js:278
 #: src/components/Indicators.js:498
 #: src/containers/NotRegisteredPage.js:271
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
-#: src/components/DetailView.js:263
+#: src/components/DetailView.js:291
 #: src/components/Indicators.js:511
 #: src/containers/NotRegisteredPage.js:261
 msgid "DOF Property Tax Bills"
@@ -243,11 +247,11 @@ msgstr "Si no se registra un edificio con el HPD"
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:215
+#: src/components/PropertiesList.tsx:218
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
-#: src/components/DetailView.js:237
+#: src/components/DetailView.js:265
 #: src/components/Indicators.js:485
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
@@ -282,8 +286,8 @@ msgstr "¿Tienes ideas sobre esta página?"
 msgid "Home"
 msgstr "Inicio"
 
-#: src/components/DetailView.js:86
-#: src/components/DetailView.js:319
+#: src/components/DetailView.js:89
+#: src/components/DetailView.js:347
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
@@ -333,22 +337,26 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.js:147
+#: src/components/DetailView.js:150
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
+
+#: src/components/DetailView.js:174
+msgid "Last sold:"
+msgstr "Vendido por última vez:"
 
 #: src/components/PropertiesMap.js:265
 msgid "Legend"
 msgstr "Leyenda"
 
-#: src/components/PropertiesList.tsx:207
-#: src/components/PropertiesList.tsx:209
+#: src/components/PropertiesList.tsx:210
+#: src/components/PropertiesList.tsx:212
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
 #: src/components/Indicators.js:281
 #: src/components/PropertiesMap.js:191
-#: src/containers/AddressPage.js:285
+#: src/containers/AddressPage.js:287
 msgid "Loading"
 msgstr "Cargando"
 
@@ -401,7 +409,7 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:226
+#: src/components/PropertiesList.tsx:229
 msgid "No"
 msgstr "No"
 
@@ -454,9 +462,9 @@ msgstr "Antes de empezar cualquier proyecto de construcción, el propietario som
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/DetailView.js:132
-#: src/components/DetailView.js:389
-#: src/components/DetailView.js:401
+#: src/components/DetailView.js:135
+#: src/components/DetailView.js:417
+#: src/components/DetailView.js:429
 #: src/components/OwnersTable.tsx:31
 msgid "People"
 msgstr "Personas (Encontrarás definiciones en español de los tipos de personas asociadas al edificio en la página \"Como se usa\".)"
@@ -521,8 +529,8 @@ msgstr "¡Comparte tu opinión con nosotros!"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.js:187
-#: src/components/DetailView.js:298
+#: src/components/DetailView.js:215
+#: src/components/DetailView.js:326
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.js:155
 #: src/containers/App.js:91
@@ -555,8 +563,8 @@ msgstr "Código fuente"
 msgid "Summary"
 msgstr "Resúmen"
 
-#: src/components/DetailView.js:181
-#: src/components/DetailView.js:292
+#: src/components/DetailView.js:209
+#: src/components/DetailView.js:320
 #: src/containers/NychaPage.js:303
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
@@ -717,8 +725,8 @@ msgstr "Unidades Residenciales"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edificio e investigar a los arrendadores de Nueva York! Utilizamos el mapeo de propiedad para identificar el portafolio de edificios de un arrendador y proporcionar datos para revelar posibles casos de hostigamiento y desplazamiento de inquilinos."
 
-#: src/components/DetailView.js:202
-#: src/components/DetailView.js:207
+#: src/components/DetailView.js:230
+#: src/components/DetailView.js:235
 #: src/components/Indicators.js:454
 #: src/containers/NotRegisteredPage.js:244
 #: src/containers/NychaPage.js:251
@@ -729,16 +737,16 @@ msgstr "Enlaces útiles"
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.js:102
+#: src/components/DetailView.js:105
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
-#: src/components/PropertiesList.tsx:232
-#: src/components/PropertiesList.tsx:237
+#: src/components/PropertiesList.tsx:236
+#: src/components/PropertiesList.tsx:241
 msgid "View detail"
 msgstr "Ver detalles"
 
-#: src/components/DetailView.js:220
+#: src/components/DetailView.js:248
 #: src/components/Indicators.js:466
 #: src/containers/NotRegisteredPage.js:253
 msgid "View documents on ACRIS"
@@ -754,7 +762,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.js:70
+#: src/components/DetailView.js:73
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
@@ -770,7 +778,7 @@ msgstr "Visite nuestro sitio web"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
-#: src/components/DetailView.js:321
+#: src/components/DetailView.js:349
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -801,7 +809,7 @@ msgstr "Año"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:225
+#: src/components/PropertiesList.tsx:228
 msgid "Yes"
 msgstr "Si"
 
@@ -820,6 +828,10 @@ msgstr "y"
 #: src/components/PropertiesMap.js:273
 msgid "associated building"
 msgstr "edificio asociado"
+
+#: src/components/DetailView.js:178
+msgid "for ${0}"
+msgstr "por ${0}"
 
 #: src/components/PropertiesMap.js:272
 msgid "search address"


### PR DESCRIPTION
This PR updated the Spanish version of our "How to use" page to include translations of HPD contact names, and also adds an internationalized "Last sold" note to the detail view.