### PR TITLE
Initialize GTM in React.

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -66,8 +66,14 @@
     // End Rollbar Snippet
     </script>
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-67069242-5"></script>
+    <!--
+      Global site tag (gtag.js) - Google Analytics
+
+      Note that we insert the GTM script tag from JS to ensure that
+      GTM only initializes itself once we've set the title tag.
+      For more details, see GoogleTagManager.tsx in this repository.
+    -->
+    <meta name="jf-gtm-id" content="UA-67069242-5">
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}

--- a/client/src/components/GoogleTagManager.tsx
+++ b/client/src/components/GoogleTagManager.tsx
@@ -1,0 +1,28 @@
+import React, { useState, useEffect } from "react";
+
+/**
+ * Google Tag Manager reports the title of the landing page when it
+ * initializes, but because we only render the <title> on the client-side
+ * via React, we need to wait until it's rendered before we initialize
+ * GTM.
+ *
+ * This inserts the GTM script tag on mount, which is assumed to also
+ * be when the <title> tag should be set. This should ensure that
+ * GTM reports the correct landing page title.
+ */
+export const GoogleTagManager: React.FC<{}> = () => {
+  const [gtmId, setGtmId] = useState("");
+
+  useEffect(() => {
+    // This <meta> tag is set in our index.html.
+    const metaEl = document.querySelector('meta[name="jf-gtm-id"]');
+    const metaGtmId = metaEl && metaEl.getAttribute("content");
+    if (metaGtmId) {
+      setGtmId(metaGtmId);
+    }
+  }, []);
+
+  return gtmId ? (
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${gtmId}`}></script>
+  ) : null;
+};

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -18,6 +18,7 @@ import Modal from "components/Modal";
 import SocialShare from "components/SocialShare";
 import MethodologyPage from "./Methodology";
 import { withI18n } from "@lingui/react";
+import { GoogleTagManager } from "../components/GoogleTagManager";
 
 const HomeLink = withI18n()((props) => {
   const { i18n } = props;
@@ -50,6 +51,7 @@ export default class App extends Component {
       <Router>
         <I18n>
           <ScrollToTop>
+            <GoogleTagManager />
             <div className="App">
               <div className="App__warning old_safari_only">
                 <Trans render="h3">


### PR DESCRIPTION
This adds a `<GoogleTagManager>` component, which does the following:

```js
/**
 * Google Tag Manager reports the title of the landing page when it
 * initializes, but because we only render the <title> on the client-side
 * via React, we need to wait until it's rendered before we initialize
 * GTM.
 *
 * This inserts the GTM script tag on mount, which is assumed to also
 * be when the <title> tag should be set. This should ensure that
 * GTM reports the correct landing page title.
 */
```
