### PR TITLE
moved GTM tag to inside React Helmet component

### DIFF
--- a/client/src/components/Page.tsx
+++ b/client/src/components/Page.tsx
@@ -3,6 +3,7 @@ import { Helmet } from "react-helmet";
 import { t } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 import helpers from "../util/helpers";
+import { GoogleTagManager } from "../components/GoogleTagManager";
 
 const metadata = {
   keywords: t`Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What`,
@@ -30,6 +31,7 @@ const Page = withI18n()((props: PageProps & withI18nProps) => {
   return (
     <>
       <Helmet>
+        <GoogleTagManager />
         <title>{fullTitle}</title>
         <meta property="og:title" content={title} />
         <meta name="twitter:title" content={title} />

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -18,7 +18,6 @@ import Modal from "components/Modal";
 import SocialShare from "components/SocialShare";
 import MethodologyPage from "./Methodology";
 import { withI18n } from "@lingui/react";
-import { GoogleTagManager } from "../components/GoogleTagManager";
 
 const HomeLink = withI18n()((props) => {
   const { i18n } = props;
@@ -51,7 +50,6 @@ export default class App extends Component {
       <Router>
         <I18n>
           <ScrollToTop>
-            <GoogleTagManager />
             <div className="App">
               <div className="App__warning old_safari_only">
                 <Trans render="h3">


### PR DESCRIPTION
This PR attempts to fix the issue that made our google analytics disabled on Who Owns What— it moves the GTM tag to be within the head and not the body of each page.