### PR TITLE
Refactored Mailchimp sign-ups to use new external API

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -32,24 +32,6 @@ GEOCLIENT_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 DATABASE_URL=postgresql://user:secret@localhost/dbname
 
 # =============
-# OPTIONAL ENV VARIABLES
-# =============
-#
-# We use MailChimp to manage email subscriptions that users submit through the homepage.
-#
-# The app should still run without these variables configured, but here is 
-# how to gather them if you'd like to include the MailChimp feature.
-#
-# https://developer.mailchimp.com/documentation/mailchimp/
-#
-
-# This is listed through the "Extras" tab on your MailChimp account's settings page
-MAILCHIMP_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# This is listed through the "Settings" tab for the MailChimp list you want users to subscribe to
-MAILCHIMP_LISTID=xxxxxxxx
-
-# =============
 # CLIENT-SIDE VARIABLES
 # =============
 # 

--- a/client/.env.local.sample
+++ b/client/.env.local.sample
@@ -49,3 +49,15 @@ CONTENTFUL_ACCESS_TOKEN=
 # Setting DEMO SITE to 1 will add a "Demo Site" label to the header.
 
 REACT_APP_DEMO_SITE=
+
+# =========================
+# TENANT PLATFORM SITE ORIGIN (OPTIONAL)
+# =========================
+# 
+# Setting TENANT PLATFORM SITE ORIGIN to the origin url of a server 
+# will configure the external database that certain features communicate with.
+# 
+# For example, setting this to `app.justfix.nyc` will allow our email sign-ups to get 
+# processed by our MailChimp endpoint on the JustFix Tenant Platform. 
+
+REACT_APP_TENANT_PLATFORM_SITE_ORIGIN=

--- a/client/.env.local.sample
+++ b/client/.env.local.sample
@@ -57,7 +57,7 @@ REACT_APP_DEMO_SITE=
 # Setting TENANT PLATFORM SITE ORIGIN to the origin url of a server 
 # will configure the external database that certain features communicate with.
 # 
-# For example, setting this to `app.justfix.nyc` will allow our email sign-ups to get 
+# For example, setting this to `https://app.justfix.nyc` will allow our email sign-ups to get 
 # processed by our MailChimp endpoint on the JustFix Tenant Platform. 
 
 REACT_APP_TENANT_PLATFORM_SITE_ORIGIN=

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -105,12 +105,6 @@ function parseJSON(response: Response) {
   return response.json();
 }
 
-/* Mailchimp */
-
-function postNewSubscriber(email: string) {
-  return post("/api/subscribe", { email });
-}
-
 const Client = {
   searchAddress,
   searchBBL,
@@ -118,7 +112,6 @@ const Client = {
   getBuildingInfo,
   getIndicatorHistory,
   getAddressExport,
-  postNewSubscriber,
 };
 
 export default Client;

--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -49,9 +49,9 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
       return;
     }
 
-    const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
+    const tenantPlatformOrigin = process.env.REACT_APP_TENANT_PLATFORM_SITE_ORIGIN === "1";
 
-    fetch(`https://${isDemoSite ? "demo" : "app"}.justfix.nyc/mailchimp/subscribe`, {
+    fetch(`https://${tenantPlatformOrigin}/mailchimp/subscribe`, {
       method: "POST",
       mode: "cors",
       body: `email=${encodeURIComponent(email)}&language=${locale}&source=wow`,
@@ -71,7 +71,9 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
             response: i18n._(t`Oops! That email is invalid.`),
           });
         } else {
-          window.Rollbar.error(`Mailchimp email signup responded with error code ${result.errorCode}.`);
+          window.Rollbar.error(
+            `Mailchimp email signup responded with error code ${result.errorCode}.`
+          );
           this.setState({
             response: i18n._(t`Oops! A network error occurred. Try again later.`),
           });

--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -49,7 +49,7 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
       return;
     }
 
-    const tenantPlatformOrigin = process.env.REACT_APP_TENANT_PLATFORM_SITE_ORIGIN === "1";
+    const tenantPlatformOrigin = process.env.REACT_APP_TENANT_PLATFORM_SITE_ORIGIN;
 
     fetch(`https://${tenantPlatformOrigin}/mailchimp/subscribe`, {
       method: "POST",

--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -58,18 +58,28 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
         "Content-Type": "application/x-www-form-urlencoded",
       },
     })
+      .then((result) => result.json())
       .then((result) => {
-        // Success
-        this.setState({
-          success: true,
-          response: i18n._(t`All set! Thanks for subscribing!`),
-        });
+        if (result.status === 200) {
+          this.setState({
+            success: true,
+            response: i18n._(t`All set! Thanks for subscribing!`),
+          });
+        } else if (result.errorCode === "INVALID_EMAIL") {
+          this.setState({
+            response: i18n._(t`Oops! That email is invalid.`),
+          });
+        } else {
+          window.Rollbar.error(`Mailchimp email signup responded with error code ${result.errorCode}.`);
+          this.setState({
+            response: i18n._(t`Oops! A network error occurred. Try again later.`),
+          });
+        }
       })
       .catch((err) => {
         this.setState({
-          response: i18n._(t`Oops! That email is invalid.`),
+          response: i18n._(t`Oops! A network error occurred. Try again later.`),
         });
-        window.Rollbar.error(err);
       });
   };
 

--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -39,6 +39,7 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
 
     const email = this.state.email || null;
     const { i18n } = this.props;
+    const locale = i18n.language;
 
     // check if email is missing, return undefined
     if (!email) {
@@ -53,7 +54,7 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
     fetch(`https://${isDemoSite ? "demo" : "app"}.justfix.nyc/mailchimp/subscribe`, {
       method: "POST",
       mode: "cors",
-      body: "email=" + encodeURIComponent(email) + "&language=en&source=wow",
+      body: `email=${encodeURIComponent(email)}&language=${locale}&source=wow`,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
       },

--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -48,7 +48,16 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
       return;
     }
 
-    APIClient.postNewSubscriber(this.state.email)
+    const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
+
+    fetch(`https://${isDemoSite ? "demo" : "app"}.justfix.nyc/mailchimp/subscribe`, {
+      method: "POST",
+      mode: "cors",
+      body: "email=" + encodeURIComponent(email) + "&language=en&source=wow",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    })
       .then((result) => {
         // Success
         this.setState({

--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -49,7 +49,8 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
       return;
     }
 
-    const tenantPlatformOrigin = process.env.REACT_APP_TENANT_PLATFORM_SITE_ORIGIN;
+    const tenantPlatformOrigin =
+      process.env.REACT_APP_TENANT_PLATFORM_SITE_ORIGIN || "demo.justfix.nyc";
 
     fetch(`https://${tenantPlatformOrigin}/mailchimp/subscribe`, {
       method: "POST",

--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -50,9 +50,9 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
     }
 
     const tenantPlatformOrigin =
-      process.env.REACT_APP_TENANT_PLATFORM_SITE_ORIGIN || "demo.justfix.nyc";
+      process.env.REACT_APP_TENANT_PLATFORM_SITE_ORIGIN || "https://demo.justfix.nyc";
 
-    fetch(`https://${tenantPlatformOrigin}/mailchimp/subscribe`, {
+    fetch(`${tenantPlatformOrigin}/mailchimp/subscribe`, {
       method: "POST",
       mode: "cors",
       body: `email=${encodeURIComponent(email)}&language=${locale}&source=wow`,

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -54,7 +54,7 @@ msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.js:74
+#: src/containers/App.js:72
 msgid "About"
 msgstr "About"
 
@@ -70,7 +70,7 @@ msgstr "Additional links"
 msgid "Address"
 msgstr "Address"
 
-#: src/components/Subscribe.tsx:29
+#: src/components/Subscribe.tsx:37
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
@@ -186,7 +186,7 @@ msgstr "DOF Property Tax Bills"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.js:66
+#: src/containers/App.js:64
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -195,7 +195,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
 #: src/components/LegalFooter.tsx:31
-#: src/containers/App.js:80
+#: src/containers/App.js:78
 msgid "Donate"
 msgstr "Donate"
 
@@ -215,7 +215,7 @@ msgstr "Emergency"
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Enter an NYC address and find other buildings your landlord might own:"
 
-#: src/components/Subscribe.tsx:51
+#: src/components/Subscribe.tsx:70
 msgid "Enter email"
 msgstr "Enter email"
 
@@ -279,7 +279,7 @@ msgstr "HUD Complaint Form 958"
 msgid "Have thoughts about this page?"
 msgstr "Have thoughts about this page?"
 
-#: src/containers/App.js:71
+#: src/containers/App.js:69
 msgid "Home"
 msgstr "Home"
 
@@ -288,7 +288,7 @@ msgstr "Home"
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.js:77
+#: src/containers/App.js:75
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -435,7 +435,12 @@ msgstr "Non-Emergency"
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
-#: src/components/Subscribe.tsx:34
+#: src/components/Subscribe.tsx:48
+#: src/components/Subscribe.tsx:54
+msgid "Oops! A network error occurred. Try again later."
+msgstr "Oops! A network error occurred. Try again later."
+
+#: src/components/Subscribe.tsx:42
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
@@ -466,7 +471,7 @@ msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural,
 msgid "People"
 msgstr "People"
 
-#: src/components/Subscribe.tsx:20
+#: src/components/Subscribe.tsx:19
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
@@ -522,7 +527,7 @@ msgstr "Send us a data request"
 msgid "Send us feedback!"
 msgstr "Send us feedback!"
 
-#: src/containers/App.js:84
+#: src/containers/App.js:82
 msgid "Share"
 msgstr "Share"
 
@@ -530,13 +535,13 @@ msgstr "Share"
 #: src/components/DetailView.js:326
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.js:155
-#: src/containers/App.js:93
+#: src/containers/App.js:91
 #: src/containers/NotRegisteredPage.js:288
 #: src/containers/NychaPage.js:309
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
 
-#: src/components/Subscribe.tsx:52
+#: src/components/Subscribe.tsx:71
 msgid "Sign up"
 msgstr "Sign up"
 
@@ -771,7 +776,7 @@ msgstr "Violations Issued"
 msgid "Visit our website"
 msgstr "Visit our website"
 
-#: src/containers/App.js:57
+#: src/containers/App.js:55
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
@@ -787,14 +792,14 @@ msgstr "What are {0}?"
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 
-#: src/containers/App.js:28
+#: src/containers/App.js:27
 msgid "Who owns what in n y c?"
 msgstr "Who owns what in n y c?"
 
 #: src/components/Page.tsx:9
 #: src/components/Page.tsx:19
 #: src/components/Page.tsx:20
-#: src/containers/App.js:34
+#: src/containers/App.js:33
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -59,7 +59,7 @@ msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.js:74
+#: src/containers/App.js:72
 msgid "About"
 msgstr "Acerca de"
 
@@ -75,7 +75,7 @@ msgstr "Enlaces adicionales"
 msgid "Address"
 msgstr "Dirección"
 
-#: src/components/Subscribe.tsx:29
+#: src/components/Subscribe.tsx:37
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
@@ -191,7 +191,7 @@ msgstr "Facturas de Impuestos del DOF"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.js:66
+#: src/containers/App.js:64
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -200,7 +200,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
 
 #: src/components/LegalFooter.tsx:31
-#: src/containers/App.js:80
+#: src/containers/App.js:78
 msgid "Donate"
 msgstr "Donar"
 
@@ -220,7 +220,7 @@ msgstr "Emergencia"
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
 
-#: src/components/Subscribe.tsx:51
+#: src/components/Subscribe.tsx:70
 msgid "Enter email"
 msgstr "Introducir email"
 
@@ -284,7 +284,7 @@ msgstr "Formulario de queja HUD 958"
 msgid "Have thoughts about this page?"
 msgstr "¿Tienes ideas sobre esta página?"
 
-#: src/containers/App.js:71
+#: src/containers/App.js:69
 msgid "Home"
 msgstr "Inicio"
 
@@ -293,7 +293,7 @@ msgstr "Inicio"
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.js:77
+#: src/containers/App.js:75
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
@@ -440,7 +440,12 @@ msgstr "No Emergencia"
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
-#: src/components/Subscribe.tsx:34
+#: src/components/Subscribe.tsx:48
+#: src/components/Subscribe.tsx:54
+msgid "Oops! A network error occurred. Try again later."
+msgstr ""
+
+#: src/components/Subscribe.tsx:42
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
@@ -471,7 +476,7 @@ msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada co
 msgid "People"
 msgstr "Personas (Encontrarás definiciones en español de los tipos de personas asociadas al edificio en la página \"Como se usa\".)"
 
-#: src/components/Subscribe.tsx:20
+#: src/components/Subscribe.tsx:19
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
@@ -527,7 +532,7 @@ msgstr "Envíanos una solicitud de datos"
 msgid "Send us feedback!"
 msgstr "¡Comparte tu opinión con nosotros!"
 
-#: src/containers/App.js:84
+#: src/containers/App.js:82
 msgid "Share"
 msgstr "Compartir"
 
@@ -535,13 +540,13 @@ msgstr "Compartir"
 #: src/components/DetailView.js:326
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.js:155
-#: src/containers/App.js:93
+#: src/containers/App.js:91
 #: src/containers/NotRegisteredPage.js:288
 #: src/containers/NychaPage.js:309
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
 
-#: src/components/Subscribe.tsx:52
+#: src/components/Subscribe.tsx:71
 msgid "Sign up"
 msgstr "Regístrate"
 
@@ -776,7 +781,7 @@ msgstr "Infracciones emitidas"
 msgid "Visit our website"
 msgstr "Visite nuestro sitio web"
 
-#: src/containers/App.js:57
+#: src/containers/App.js:55
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
@@ -792,14 +797,14 @@ msgstr "¿Qué son {0}?"
 msgid "What happens if the landlord has failed to register?"
 msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 
-#: src/containers/App.js:28
+#: src/containers/App.js:27
 msgid "Who owns what in n y c?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
 #: src/components/Page.tsx:9
 #: src/components/Page.tsx:19
 #: src/components/Page.tsx:20
-#: src/containers/App.js:34
+#: src/containers/App.js:33
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -443,7 +443,7 @@ msgstr "Oficial/Propietario"
 #: src/components/Subscribe.tsx:48
 #: src/components/Subscribe.tsx:54
 msgid "Oops! A network error occurred. Try again later."
-msgstr ""
+msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 
 #: src/components/Subscribe.tsx:42
 msgid "Oops! That email is invalid."

--- a/server/controllers/subscribe.js
+++ b/server/controllers/subscribe.js
@@ -1,3 +1,6 @@
+// NOTE: This Server export is deprecated! 
+// We will be removing from the codebase soon.
+
 const mailchimp = require("../services/mailchimp");
 
 const LISTID = process.env.MAILCHIMP_LISTID;

--- a/server/services/mailchimp.js
+++ b/server/services/mailchimp.js
@@ -1,3 +1,6 @@
+// NOTE: This Server export is deprecated! 
+// We will be removing from the codebase soon.
+
 const rp = require("request-promise");
 const rollbar = require("rollbar");
 


### PR DESCRIPTION
This PR replaces our current API for Mailchimp email signups and instead uses the [new API endpoint implemented in the Tenant Platform](https://github.com/JustFixNYC/tenants2/pull/1549/files)! It makes a note that the current server functions to handle Mailchimp signups are deprecated (see #289). 