### PR TITLE
Add typescript definitions to all data-related API responses

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
-  "//*":"NOTE: THIS REPOSITORY CONTAINS TWO PACKAGE.JSON FILES",
-  "//**":"FIND THE SERVER-SIDE PACKAGE.JSON FILE IN THE PARENT DIRECTORY",
+  "//*": "NOTE: THIS REPOSITORY CONTAINS TWO PACKAGE.JSON FILES",
+  "//**": "FIND THE SERVER-SIDE PACKAGE.JSON FILE IN THE PARENT DIRECTORY",
   "name": "client",
   "version": "0.1.0",
   "private": true,
@@ -81,7 +81,8 @@
     "@babel/register": "^7.7.4",
     "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
-    "npm-run-all": "^4.0.2"
+    "npm-run-all": "^4.0.2",
+    "ts-type-checked": "^0.5.0"
   },
   "browserslist": [
     ">0.2%",

--- a/client/package.json
+++ b/client/package.json
@@ -81,8 +81,7 @@
     "@babel/register": "^7.7.4",
     "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
-    "npm-run-all": "^4.0.2",
-    "ts-type-checked": "^0.5.0"
+    "npm-run-all": "^4.0.2"
   },
   "browserslist": [
     ">0.2%",

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -1,50 +1,52 @@
 /* eslint-disable no-undef */
 
-type WithBoroBlockLot = {
-  boro: string;
-  block: string;
-  lot: string;
-};
+import { NumericDictionary } from "lodash";
 
-type Q = {
-  bbl?: string;
-  housenumber: string;
-  streetname: string;
-  boro: string;
-};
+import {
+  SearchResults,
+  SummaryResults,
+  BuildingInfoResults,
+  IndicatorsHistoryResults,
+  AddressInput,
+  WithBoroBlockLot
+} from "./APIDataTypes";
 
-function searchAddress(q: Q) {
+// API REQUESTS TO THE DATABASE:
+
+function searchAddress(q: AddressInput): Promise<SearchResults> {
   if (q.bbl) {
     return searchBBL({
       boro: q.bbl.slice(0, 1),
       block: q.bbl.slice(1, 6),
-      lot: q.bbl.slice(6, 10),
+      lot: q.bbl.slice(6, 10)
     });
   }
   return get(`/api/address?houseNumber=${q.housenumber}&street=${q.streetname}&borough=${q.boro}`);
 }
 
-function searchBBL(q: WithBoroBlockLot) {
+function searchBBL(q: WithBoroBlockLot): Promise<SearchResults> {
   return get(`/api/address?block=${q.block}&lot=${q.lot}&borough=${q.boro}`);
 }
 
-function getAggregate(bbl: string) {
+function getAggregate(bbl: string): Promise<SummaryResults> {
   return get(`/api/address/aggregate?bbl=${bbl}`);
 }
 
-function getBuildingInfo(bbl: string) {
+function getBuildingInfo(bbl: string): Promise<BuildingInfoResults> {
   return get(`/api/address/buildinginfo?bbl=${bbl}`);
 }
 
-function getIndicatorHistory(bbl: string) {
+function getIndicatorHistory(bbl: string): Promise<IndicatorsHistoryResults> {
   return get(`/api/address/indicatorhistory?bbl=${bbl}`);
 }
 
-function getAddressExport(q: Q & WithBoroBlockLot) {
+function getAddressExport(q: AddressInput & WithBoroBlockLot) {
   return fetch(
     `/api/address/export?houseNumber=${q.housenumber}&street=${q.streetname}&borough=${q.boro}`
   ).then(checkStatus);
 }
+
+// OTHER API FUNCTIONS AND HELPERS:
 
 function get(url: string) {
   return fetch(url, { headers: { accept: "application/json" } })
@@ -57,11 +59,11 @@ function post(url: string, body: any) {
   return fetch(url, {
     headers: {
       Accept: "application/json",
-      "Content-Type": "application/json",
+      "Content-Type": "application/json"
     },
     method: "POST",
     mode: "cors",
-    body: JSON.stringify(body),
+    body: JSON.stringify(body)
   })
     .then(checkStatus)
     .then(verifyIsJson)
@@ -78,7 +80,7 @@ async function verifyIsJson(response: Response) {
   window.Rollbar.error(msg, {
     text,
     contentType,
-    url: response.url,
+    url: response.url
   });
   throw new Error(msg);
 }
@@ -111,7 +113,7 @@ const Client = {
   getAggregate,
   getBuildingInfo,
   getIndicatorHistory,
-  getAddressExport,
+  getAddressExport
 };
 
 export default Client;

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -8,7 +8,7 @@ import {
   BuildingInfoResults,
   IndicatorsHistoryResults,
   AddressInput,
-  WithBoroBlockLot
+  WithBoroBlockLot,
 } from "./APIDataTypes";
 
 // API REQUESTS TO THE DATABASE:
@@ -18,7 +18,7 @@ function searchAddress(q: AddressInput): Promise<SearchResults> {
     return searchBBL({
       boro: q.bbl.slice(0, 1),
       block: q.bbl.slice(1, 6),
-      lot: q.bbl.slice(6, 10)
+      lot: q.bbl.slice(6, 10),
     });
   }
   return get(`/api/address?houseNumber=${q.housenumber}&street=${q.streetname}&borough=${q.boro}`);
@@ -59,11 +59,11 @@ function post(url: string, body: any) {
   return fetch(url, {
     headers: {
       Accept: "application/json",
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
     },
     method: "POST",
     mode: "cors",
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
   })
     .then(checkStatus)
     .then(verifyIsJson)
@@ -80,7 +80,7 @@ async function verifyIsJson(response: Response) {
   window.Rollbar.error(msg, {
     text,
     contentType,
-    url: response.url
+    url: response.url,
   });
   throw new Error(msg);
 }
@@ -113,7 +113,7 @@ const Client = {
   getAggregate,
   getBuildingInfo,
   getIndicatorHistory,
-  getAddressExport
+  getAddressExport,
 };
 
 export default Client;

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -42,7 +42,7 @@ function getIndicatorHistory(bbl: string): Promise<IndicatorsHistoryResults> {
 
 function getAddressExport(q: AddressInput & WithBoroBlockLot) {
   return fetch(
-    `/api/address/export?houseNumber=${q.housenumber}&street=${q.streetname}&borough=${q.boro}`
+    `/api/address/export?houseNumber=${q.housenumber}&street=${q.streetname}&borough=${q.boro}`,
   ).then(checkStatus);
 }
 

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -13,9 +13,9 @@ import { SearchAddress } from "./AddressSearch";
 
 // API REQUESTS TO THE DATABASE:
 
-function searchAddress(q: SearchAddress): Promise<SearchResults> {
+function searchForAddress(q: SearchAddress): Promise<SearchResults> {
   if (q.bbl) {
-    return searchBBL({
+    return searchForBBL({
       boro: q.bbl.slice(0, 1),
       block: q.bbl.slice(1, 6),
       lot: q.bbl.slice(6, 10),
@@ -24,7 +24,7 @@ function searchAddress(q: SearchAddress): Promise<SearchResults> {
   return get(`/api/address?houseNumber=${q.housenumber}&street=${q.streetname}&borough=${q.boro}`);
 }
 
-function searchBBL(q: WithBoroBlockLot): Promise<SearchResults> {
+function searchForBBL(q: WithBoroBlockLot): Promise<SearchResults> {
   return get(`/api/address?block=${q.block}&lot=${q.lot}&borough=${q.boro}`);
 }
 
@@ -108,8 +108,8 @@ function parseJSON(response: Response) {
 }
 
 const Client = {
-  searchAddress,
-  searchBBL,
+  searchForAddress,
+  searchForBBL,
   getAggregate,
   getBuildingInfo,
   getIndicatorHistory,

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -42,7 +42,7 @@ function getIndicatorHistory(bbl: string): Promise<IndicatorsHistoryResults> {
 
 function getAddressExport(q: AddressInput & WithBoroBlockLot) {
   return fetch(
-    `/api/address/export?houseNumber=${q.housenumber}&street=${q.streetname}&borough=${q.boro}`,
+    `/api/address/export?houseNumber=${q.housenumber}&street=${q.streetname}&borough=${q.boro}`
   ).then(checkStatus);
 }
 

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -7,13 +7,13 @@ import {
   SummaryResults,
   BuildingInfoResults,
   IndicatorsHistoryResults,
-  AddressInput,
   WithBoroBlockLot,
 } from "./APIDataTypes";
+import { SearchAddress } from "./AddressSearch";
 
 // API REQUESTS TO THE DATABASE:
 
-function searchAddress(q: AddressInput): Promise<SearchResults> {
+function searchAddress(q: SearchAddress): Promise<SearchResults> {
   if (q.bbl) {
     return searchBBL({
       boro: q.bbl.slice(0, 1),
@@ -40,7 +40,7 @@ function getIndicatorHistory(bbl: string): Promise<IndicatorsHistoryResults> {
   return get(`/api/address/indicatorhistory?bbl=${bbl}`);
 }
 
-function getAddressExport(q: AddressInput & WithBoroBlockLot) {
+function getAddressExport(q: SearchAddress & WithBoroBlockLot) {
   return fetch(
     `/api/address/export?houseNumber=${q.housenumber}&street=${q.streetname}&borough=${q.boro}`
   ).then(checkStatus);

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -17,7 +17,8 @@ type HpdOwnerContact = {
 
 type AddressRecord = {
   bbl: string;
-  bin: number; // Should be string
+  /** Front-end interprets as string */
+  bin: number;
   boro: Borough;
   businessaddrs: string[] | null;
   corpnames: string[] | null;
@@ -25,16 +26,19 @@ type AddressRecord = {
   housenumber: string;
   lastregistrationdate: Date;
   lastsaleacrisid: string | null;
-  lastsaleamount: string | null; // Should be number
+  /** Front-end interprets as number */
+  lastsaleamount: string | null;
   lastsaledate: Date | null;
   lat: number | null;
   lng: number | null;
   openviolations: number;
   ownernames: HpdOwnerContact[] | null;
   registrationenddate: Date;
-  registrationid: number; // Should be string
+  /** Front-end interprets as string */
+  registrationid: number;
   rsdiff: number | null;
-  rspercentchange: string | null; // Should be number
+  /** Front-end interprets as number */
+  rspercentchange: string | null;
   rsunits2007: number | null;
   rsunits2017: number | null;
   streetname: string;
@@ -75,25 +79,39 @@ type HpdViolationsAddress = AddressLocation & {
 };
 
 type SummaryStatsRecord = {
-  age: string; // Should be number
-  avgevictions: string | null; // Should be number
-  avgrspercent: string | null; // Should be number
-  bldgs: string; // Should be number
+  /** Front-end interprets as number */
+  age: string;
+  /** Front-end interprets as number */
+  avgevictions: string | null;
+  /** Front-end interprets as number */
+  avgrspercent: string | null;
+  /** Front-end interprets as number */
+  bldgs: string;
   evictionsaddr: EvictionAddress;
-  openviolationsperbldg: string; // Should be number
-  openviolationsperresunit: string; // Should be number
+  /** Front-end interprets as number */
+  openviolationsperbldg: string;
+  /** Front-end interprets as number */
+  openviolationsperresunit: string;
   rslossaddr: RentStabilizedAddress;
-  rsproportion: string | null; // Should be number
+  /** Front-end interprets as number */
+  rsproportion: string | null;
   topbusinessaddr: string | null;
   topcorp: string | null;
   topowners: string[];
-  totalevictions: string | null; // Should be number
-  totalopenviolations: string; // Should be number
-  totalrsdiff: string | null; // Should be number
-  totalrsgain: string; // Should be number
-  totalrsloss: string; // Should be number
-  totalviolations: string; // Should be number
-  units: string; // Should be number
+  /** Front-end interprets as number */
+  totalevictions: string | null;
+  /** Front-end interprets as number */
+  totalopenviolations: string;
+  /** Front-end interprets as number */
+  totalrsdiff: string | null;
+  /** Front-end interprets as number */
+  totalrsgain: string;
+  /** Front-end interprets as number */
+  totalrsloss: string;
+  /** Front-end interprets as number */
+  totalviolations: string;
+  /** Front-end interprets as number */
+  units: string;
   violationsaddr: HpdViolationsAddress;
 };
 
@@ -116,14 +134,22 @@ export type BuildingInfoResults = {
 
 type MonthlyTimelineData = {
   month: string;
-  complaints_emergency: string; // Should be number
-  complaints_nonemergency: string; // Should be number
-  complaints_total: string; // Should be number
-  permits_total: string; // Should be number
-  viols_class_a: string; // Should be number
-  viols_class_b: string; // Should be number
-  viols_class_c: string; // Should be number
-  viols_total: string; // Should be number
+  /** Front-end interprets as number */
+  complaints_emergency: string;
+  /** Front-end interprets as number */
+  complaints_nonemergency: string;
+  /** Front-end interprets as number */
+  complaints_total: string;
+  /** Front-end interprets as number */
+  permits_total: string;
+  /** Front-end interprets as number */
+  viols_class_a: string;
+  /** Front-end interprets as number */
+  viols_class_b: string;
+  /** Front-end interprets as number */
+  viols_class_c: string;
+  /** Front-end interprets as number */
+  viols_total: string;
 };
 
 export type IndicatorsHistoryResults = {

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -24,19 +24,18 @@ type AddressRecord = {
   bbl: string;
   bin: number; // Should be string
   boro: string;
-  businessaddrs: string[];
-  corpnames: string[];
-  evictions: number | null; // Should be just number
+  businessaddrs: string[] | null;
+  corpnames: string[] | null;
+  evictions: number | null;
   housenumber: string;
   lastregistrationdate: Date;
   lastsaleacrisid: string | null;
   lastsaleamount: string | null; // Should be number
   lastsaledate: Date | null;
-  lat: number;
-  lng: number;
-  mapType: string; // What is this??
+  lat: number | null;
+  lng: number | null;
   openviolations: number;
-  ownernames: HpdOwnerContact[];
+  ownernames: HpdOwnerContact[] | null;
   registrationenddate: Date;
   registrationid: number; // Should be string
   rsdiff: number | null;
@@ -45,9 +44,9 @@ type AddressRecord = {
   rsunits2017: number | null;
   streetname: string;
   totalviolations: number;
-  unitsres: number;
-  yearbuilt: number;
-  zip: string;
+  unitsres: number | null;
+  yearbuilt: number | null;
+  zip: string | null;
 };
 
 export type SearchResults = {
@@ -69,33 +68,33 @@ type AddressLocation = {
 };
 
 type EvictionAddress = AddressLocation & {
-  evictions: number;
+  evictions: number | null;
 };
 
 type RentStabilizedAddress = AddressLocation & {
-  rsdiff: number;
+  rsdiff: number | null;
 };
 
 type HpdViolationsAddress = AddressLocation & {
-  openviolations: number;
+  openviolations: number | null;
 };
 
 type SummaryStatsRecord = {
   age: string; // Should be number
-  avgevictions: string; // Should be number
-  avgrspercent: string; // Should be number
+  avgevictions: string | null; // Should be number
+  avgrspercent: string | null; // Should be number
   bldgs: string; // Should be number
   evictionsaddr: EvictionAddress;
   openviolationsperbldg: string; // Should be number
   openviolationsperresunit: string; // Should be number
   rslossaddr: RentStabilizedAddress;
-  rsproportion: string; // Should be number
-  topbusinessaddr: string;
-  topcorp: string;
+  rsproportion: string | null; // Should be number
+  topbusinessaddr: string | null;
+  topcorp: string | null;
   topowners: string[];
-  totalevictions: string; // Should be number
+  totalevictions: string | null; // Should be number
   totalopenviolations: string; // Should be number
-  totalrsdiff: string; // Should be number
+  totalrsdiff: string | null; // Should be number
   totalrsgain: string; // Should be number
   totalrsloss: string; // Should be number
   totalviolations: string; // Should be number

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -1,0 +1,137 @@
+// TYPES ASSOCIATED WITH INPUT DATA:
+
+export type WithBoroBlockLot = {
+  boro: string;
+  block: string;
+  lot: string;
+};
+
+export type AddressInput = {
+  bbl?: string;
+  housenumber: string;
+  streetname: string;
+  boro: string;
+};
+
+// TYPES ASSOCIATED WITH ADDRESS SEARCH QUERY:
+
+type HpdOwnerContact = {
+  title: string;
+  value: string;
+};
+
+type AddressRecord = {
+  bbl: string;
+  bin: number; // Should be string
+  boro: string;
+  businessaddrs: string[];
+  corpnames: string[];
+  evictions: number | null; // Should be just number
+  housenumber: string;
+  lastregistrationdate: Date;
+  lastsaleacrisid: string | null;
+  lastsaleamount: string | null; // Should be number
+  lastsaledate: Date | null;
+  lat: number;
+  lng: number;
+  mapType: string; // What is this??
+  openviolations: number;
+  ownernames: HpdOwnerContact[];
+  registrationenddate: Date;
+  registrationid: number; // Should be string
+  rsdiff: number | null;
+  rspercentchange: string | null; // Should be number
+  rsunits2007: number | null;
+  rsunits2017: number | null;
+  streetname: string;
+  totalviolations: number;
+  unitsres: number;
+  yearbuilt: number;
+  zip: string;
+};
+
+export type SearchResults = {
+  addrs: AddressRecord[];
+  geosearch: {
+    geosupportReturnCode: string;
+    bbl: string;
+  };
+};
+
+// TYPES ASSOCIATED WITH SUMMARY AGGREGATE QUERY:
+
+type AddressLocation = {
+  boro: string;
+  housenumber: string;
+  lat: number;
+  lng: number;
+  streetname: string;
+};
+
+type EvictionAddress = AddressLocation & {
+  evictions: number;
+};
+
+type RentStabilizedAddress = AddressLocation & {
+  rsdiff: number;
+};
+
+type HpdViolationsAddress = AddressLocation & {
+  openviolations: number;
+};
+
+type SummaryStatsRecord = {
+  age: string; // Should be number
+  avgevictions: string; // Should be number
+  avgrspercent: string; // Should be number
+  bldgs: string; // Should be number
+  evictionsaddr: EvictionAddress;
+  openviolationsperbldg: string; // Should be number
+  openviolationsperresunit: string; // Should be number
+  rslossaddr: RentStabilizedAddress;
+  rsproportion: string; // Should be number
+  topbusinessaddr: string;
+  topcorp: string;
+  topowners: string[];
+  totalevictions: string; // Should be number
+  totalopenviolations: string; // Should be number
+  totalrsdiff: string; // Should be number
+  totalrsgain: string; // Should be number
+  totalrsloss: string; // Should be number
+  totalviolations: string; // Should be number
+  units: string; // Should be number
+  violationsaddr: HpdViolationsAddress;
+};
+
+export type SummaryResults = {
+  result: SummaryStatsRecord[];
+};
+
+// TYPES ASSOCIATED BUILDING INFO QUERY:
+
+type BuildingInfoRecord = AddressLocation & {
+  bldgclass: string;
+  formatted_address: string;
+};
+
+export type BuildingInfoResults = {
+  result: BuildingInfoRecord[];
+};
+
+// TYPES ASSOCIATED WITH INDICATORS (TIMELINE TAB) QUERY:
+
+type MonthlyTimelineData = {
+  month: string;
+  complaints_emergency: string; // Should be number
+  complaints_nonemergency: string; // Should be number
+  complaints_total: string; // Should be number
+  permits_total: string; // Should be number
+  viols_class_a: string; // Should be number
+  viols_class_b: string; // Should be number
+  viols_class_c: string; // Should be number
+  viols_total: string; // Should be number
+};
+
+export type IndicatorsHistoryResults = {
+  result: MonthlyTimelineData[];
+};

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -1,18 +1,11 @@
 // TYPES ASSOCIATED WITH INPUT DATA:
 
-export type Borough = "MANHATTAN" | "BRONX" | "BROOKLYN" | "QUEENS" | "STATEN ISLAND" | null;
+export type Borough = "MANHATTAN" | "BRONX" | "BROOKLYN" | "QUEENS" | "STATEN ISLAND";
 
 export type WithBoroBlockLot = {
   boro: string;
   block: string;
   lot: string;
-};
-
-export type AddressInput = {
-  bbl?: string;
-  housenumber: string;
-  streetname: string;
-  boro: Borough;
 };
 
 // TYPES ASSOCIATED WITH ADDRESS SEARCH QUERY:

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -1,6 +1,6 @@
 // TYPES ASSOCIATED WITH INPUT DATA:
 
-type Borough = "MANHATTAN" | "BRONX" | "BROOKLYN" | "QUEENS" | "STATEN ISLAND";
+export type Borough = "MANHATTAN" | "BRONX" | "BROOKLYN" | "QUEENS" | "STATEN ISLAND" | null;
 
 export type WithBoroBlockLot = {
   boro: string;

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -1,5 +1,7 @@
 // TYPES ASSOCIATED WITH INPUT DATA:
 
+type Borough = "MANHATTAN" | "BRONX" | "BROOKLYN" | "QUEENS" | "STATEN ISLAND";
+
 export type WithBoroBlockLot = {
   boro: string;
   block: string;
@@ -10,7 +12,7 @@ export type AddressInput = {
   bbl?: string;
   housenumber: string;
   streetname: string;
-  boro: string;
+  boro: Borough;
 };
 
 // TYPES ASSOCIATED WITH ADDRESS SEARCH QUERY:
@@ -23,7 +25,7 @@ type HpdOwnerContact = {
 type AddressRecord = {
   bbl: string;
   bin: number; // Should be string
-  boro: string;
+  boro: Borough;
   businessaddrs: string[] | null;
   corpnames: string[] | null;
   evictions: number | null;
@@ -60,7 +62,7 @@ export type SearchResults = {
 // TYPES ASSOCIATED WITH SUMMARY AGGREGATE QUERY:
 
 type AddressLocation = {
-  boro: string;
+  boro: Borough;
   housenumber: string;
   lat: number;
   lng: number;

--- a/client/src/components/AddressSearch.tsx
+++ b/client/src/components/AddressSearch.tsx
@@ -25,8 +25,11 @@ export interface SearchAddress {
   /** The street name, e.g. 'PARK PLACE'. */
   streetname: string;
 
-  /** The all-uppercase borough name, e.g. 'BROOKLYN'. */
-  boro: Borough;
+  /** The all-uppercase borough name, e.g. 'BROOKLYN'.
+   * We allow for an empty string case in this type as our GeoSearch form submission includes the possibility
+   * of an 'empty' address search. See AddressSearch.tsx for more details.
+   */
+  boro: Borough | "";
 
   /** The padded BBL, e.g. '1234567890'. */
   bbl: string;
@@ -54,18 +57,18 @@ export function makeEmptySearchAddress(): SearchAddress {
   return {
     housenumber: "",
     streetname: "",
-    boro: null,
+    boro: "",
     bbl: "",
   };
 }
 
 function toSearchAddresses(results: GeoSearchResults): SearchAddress[] {
   return results.features.map((feature) => {
-    let boro = feature.properties.borough.toUpperCase() as Borough;
+    let formattedBoroName = feature.properties.borough.toUpperCase() as Borough;
     const sa: SearchAddress = {
       housenumber: feature.properties.housenumber,
       streetname: feature.properties.street,
-      boro: boro,
+      boro: formattedBoroName,
       bbl: feature.properties.pad_bbl,
     };
     return sa;

--- a/client/src/components/AddressSearch.tsx
+++ b/client/src/components/AddressSearch.tsx
@@ -27,7 +27,7 @@ export interface SearchAddress {
 
   /** The all-uppercase borough name, e.g. 'BROOKLYN'.
    * We allow for an empty string case in this type as our GeoSearch form submission includes the possibility
-   * of an 'empty' address search. See AddressSearch.tsx for more details.
+   * of an 'empty' address search. See the AddressSearch class below for more details.
    */
   boro: Borough | "";
 

--- a/client/src/components/AddressSearch.tsx
+++ b/client/src/components/AddressSearch.tsx
@@ -60,7 +60,7 @@ export function makeEmptySearchAddress(): SearchAddress {
 }
 
 function toSearchAddresses(results: GeoSearchResults): SearchAddress[] {
-  return results.features.map(feature => {
+  return results.features.map((feature) => {
     let boro = feature.properties.borough.toUpperCase() as Borough;
     const sa: SearchAddress = {
       housenumber: feature.properties.housenumber,
@@ -87,10 +87,10 @@ export default class AddressSearch extends React.Component<AddressSearchProps, S
       results: [],
     };
     this.requester = new GeoSearchRequester({
-      onError: e => {
+      onError: (e) => {
         this.props.onFormSubmit(makeEmptySearchAddress(), e);
       },
-      onResults: results => {
+      onResults: (results) => {
         this.setState({
           isLoading: false,
           results: toSearchAddresses(results),
@@ -157,7 +157,7 @@ export default class AddressSearch extends React.Component<AddressSearchProps, S
               return changes;
           }
         }}
-        onChange={sa => {
+        onChange={(sa) => {
           if (sa) {
             this.props.onFormSubmit(sa, null);
           }
@@ -166,14 +166,14 @@ export default class AddressSearch extends React.Component<AddressSearchProps, S
           // There's no meaningful value for us to pass to `onFormSubmit` in
           // this case, so we will just do nothing.
         }}
-        itemToString={sa => {
+        itemToString={(sa) => {
           return sa ? searchAddressToString(sa) : "";
         }}
       >
-        {downshift => {
+        {(downshift) => {
           const inputOptions: GetInputPropsOptions = {
-            onKeyDown: e => this.handleAutocompleteKeyDown(downshift, e),
-            onChange: e => this.handleInputValueChange(e.currentTarget.value),
+            onKeyDown: (e) => this.handleAutocompleteKeyDown(downshift, e),
+            onChange: (e) => this.handleInputValueChange(e.currentTarget.value),
           };
           const suggestsClasses = ["geosuggest__suggests"];
           if (!(downshift.isOpen && this.state.results.length > 0)) {

--- a/client/src/containers/AddressPage.js
+++ b/client/src/containers/AddressPage.js
@@ -56,7 +56,7 @@ export default class AddressPage extends Component {
         .then((results) => {
           const firstResult = results.features[0];
           if (!firstResult) throw new Error("Invalid address!");
-          return APIClient.searchAddress({
+          return APIClient.searchForAddress({
             bbl: firstResult.properties.pad_bbl,
           });
         })

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -110,7 +110,7 @@ export default class BBLPage extends Component<BBLPageProps, State> {
 
   componentDidUpdate(prevProps: BBLPageProps, prevState: State) {
     if (!prevState.bblExists && this.state.bblExists) {
-      APIClient.searchBBL(this.strictGetSearchBBL())
+      APIClient.searchForBBL(this.strictGetSearchBBL())
         .then((results) => {
           this.setState({
             results: results,

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -7,6 +7,7 @@ import NotRegisteredPage from "./NotRegisteredPage";
 import { RouteComponentProps } from "react-router";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
+import { BuildingInfoResults, SearchResults } from "../components/APIDataTypes";
 
 // import 'styles/HomePage.css';
 
@@ -87,7 +88,7 @@ export default class BBLPage extends Component<BBLPageProps, State> {
     }
 
     APIClient.getBuildingInfo(fullBBL)
-      .then((results) => {
+      .then((results: BuildingInfoResults) => {
         if (!(results.result && results.result.length > 0)) {
           this.setState({
             bblExists: false,
@@ -103,7 +104,7 @@ export default class BBLPage extends Component<BBLPageProps, State> {
           });
         }
       })
-      .catch((err) => {
+      .catch((err: any) => {
         window.Rollbar.error("API error from BBL page: Building Info", err, fullBBL);
       });
   }
@@ -111,12 +112,12 @@ export default class BBLPage extends Component<BBLPageProps, State> {
   componentDidUpdate(prevProps: BBLPageProps, prevState: State) {
     if (!prevState.bblExists && this.state.bblExists) {
       APIClient.searchBBL(this.strictGetSearchBBL())
-        .then((results) => {
+        .then((results: SearchResults) => {
           this.setState({
             results: results,
           });
         })
-        .catch((err) => {
+        .catch((err: any) => {
           window.Rollbar.error("API error from BBL page: Search BBL", err, this.state.searchBBL);
           this.setState({
             results: { addrs: [] },

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -183,7 +183,7 @@ export default class BBLPage extends Component<BBLPageProps, State> {
               addressForURL.streetname,
             state: { results },
           }}
-        ></Redirect>
+        />
       );
     }
 

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -7,7 +7,6 @@ import NotRegisteredPage from "./NotRegisteredPage";
 import { RouteComponentProps } from "react-router";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
-import { BuildingInfoResults, SearchResults } from "../components/APIDataTypes";
 
 // import 'styles/HomePage.css';
 
@@ -88,7 +87,7 @@ export default class BBLPage extends Component<BBLPageProps, State> {
     }
 
     APIClient.getBuildingInfo(fullBBL)
-      .then((results: BuildingInfoResults) => {
+      .then((results) => {
         if (!(results.result && results.result.length > 0)) {
           this.setState({
             bblExists: false,
@@ -104,7 +103,7 @@ export default class BBLPage extends Component<BBLPageProps, State> {
           });
         }
       })
-      .catch((err: any) => {
+      .catch((err) => {
         window.Rollbar.error("API error from BBL page: Building Info", err, fullBBL);
       });
   }
@@ -112,12 +111,12 @@ export default class BBLPage extends Component<BBLPageProps, State> {
   componentDidUpdate(prevProps: BBLPageProps, prevState: State) {
     if (!prevState.bblExists && this.state.bblExists) {
       APIClient.searchBBL(this.strictGetSearchBBL())
-        .then((results: SearchResults) => {
+        .then((results) => {
           this.setState({
             results: results,
           });
         })
-        .catch((err: any) => {
+        .catch((err) => {
           window.Rollbar.error("API error from BBL page: Search BBL", err, this.state.searchBBL);
           this.setState({
             results: { addrs: [] },

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -97,7 +97,7 @@ class HomePage extends Component<HomePageProps, State> {
     } else {
       // searching on HomePage allows for more clean redirects
       // as opposed to HomePage > AddressPage > NotRegisteredPage
-      APIClient.searchAddress({
+      APIClient.searchForAddress({
         ...searchAddress,
         housenumber: searchAddress.housenumber || "",
       })

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -101,12 +101,12 @@ class HomePage extends Component<HomePageProps, State> {
         ...searchAddress,
         housenumber: searchAddress.housenumber || "",
       })
-        .then((results: SearchResults) => {
+        .then((results) => {
           this.setState({
             results: results,
           });
         })
-        .catch((err: any) => {
+        .catch((err) => {
           window.Rollbar.error("API error from homepage: Search Address", err, searchAddress);
           this.setState({
             results: { addrs: [] },

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -14,6 +14,7 @@ import aeLogo from "../assets/img/aande.jpeg";
 import AddressSearch, { makeEmptySearchAddress, SearchAddress } from "../components/AddressSearch";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
+import { SearchResults } from "../components/APIDataTypes";
 
 type HomePageProps = {};
 
@@ -100,12 +101,12 @@ class HomePage extends Component<HomePageProps, State> {
         ...searchAddress,
         housenumber: searchAddress.housenumber || "",
       })
-        .then((results) => {
+        .then((results: SearchResults) => {
           this.setState({
             results: results,
           });
         })
-        .catch((err) => {
+        .catch((err: any) => {
           window.Rollbar.error("API error from homepage: Search Address", err, searchAddress);
           this.setState({
             results: { addrs: [] },

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -14,7 +14,6 @@ import aeLogo from "../assets/img/aande.jpeg";
 import AddressSearch, { makeEmptySearchAddress, SearchAddress } from "../components/AddressSearch";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
-import { SearchResults } from "../components/APIDataTypes";
 
 type HomePageProps = {};
 

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,3 @@
 module.exports = {
   printWidth: 100,
-  trailingComma: "es5",
 };

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   printWidth: 100,
-  trailingComma: "all",
+  trailingComma: "es5",
 };

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   printWidth: 100,
+  trailingComma: "all",
 };


### PR DESCRIPTION
This PR fixes #258 by adding type definitions to all the data objects we receive from API calls to the database. It adds a new file called `APIDataTypes.ts` which includes these new typings as well as some pre-existing type infrastructure corresponding to data we input into these API calls. 

The typings were made based on the expected responses from these APIs (in reference to the data in nycdb they retrieve). I made sure to leave a comment next to any type that doesn't match up with how the front-end will interpret it. I aim to deal with these cases when we address #297 .