### PR TITLE
Add a .devcontainer setup for VSCode.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,52 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/docker-existing-dockerfile
+{
+	"name": "Who Owns What VSCode development container",
+	"context": "..",
+	"dockerFile": "../Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": null,
+		// This is where the virtual environment set up by our Docker Compose config is located.
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.linting.pylintEnabled": false,
+		"python.linting.flake8Enabled": false,
+		"python.linting.enabled": true,
+		"python.linting.mypyEnabled": true,
+		"[typescriptreact]": {
+			"editor.tabSize": 2,
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[typescript]": {
+			"editor.tabSize": 2,
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[json]": {
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[python]": {
+			"editor.detectIndentation": false,
+			"editor.tabSize": 4
+		},
+		"[javascript]": {
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"esbenp.prettier-vscode",
+		"dbaeumer.vscode-eslint",
+	],
+
+	"mounts": [
+		// These mounts will ensure that the volumes our Docker Compose setup uses
+		// (see `docker-compose.yml`) will be reused by VSCode.  Note that these
+		// rely on the project to be cloned in a folder called `who-owns-what`, since
+		// Docker Compose prefixes the volumes it creates with this directory name.
+		"source=who-owns-what_node-modules,target=/workspaces/who-owns-what/node_modules/,type=volume",
+		"source=who-owns-what_client-node-modules,target=/workspaces/who-owns-what/client/node_modules/,type=volume",
+	],
+}


### PR DESCRIPTION
This adds a `.devcontainer` folder for VSCode Remote Container Development.  It's largely based off https://github.com/JustFixNYC/tenants2/pull/1583.

Currently eslint integration doesn't actually seem to work, probably because of this whole doggone two `package.json`s thing.  Sigh.  CRA actually disincentivizes writing a backend in JS, since implementing a backend in a different language would only result in a single `package.json`.