### PR TITLE
Fix bug on indicator vis tooltip for "quarter" view

### DIFF
--- a/client/src/components/IndicatorsViz.js
+++ b/client/src/components/IndicatorsViz.js
@@ -297,15 +297,7 @@ class IndicatorsVizImplementation extends Component {
           title: function (tooltipItem) {
             if (timeSpan === "quarter") {
               const quarter = this._data.labels[tooltipItem[0].index].slice(-1);
-              const numOfLastMonthInQuarter = parseInt(quarter) * 3;
-              /** The quarter year written out as it's range of months (ex: "Jan - Mar")  */
-              const monthRange = `${Helpers.formatMonthAbbreviationForTimeline(
-                "2020/0" + (numOfLastMonthInQuarter - 2),
-                locale
-              )} - ${Helpers.formatMonthAbbreviationForTimeline(
-                "2020/0" + numOfLastMonthInQuarter,
-                locale
-              )}`;
+              const monthRange = Helpers.getMonthRangeFromQuarter(quarter, locale);
 
               return monthRange + " " + this._data.labels[tooltipItem[0].index].slice(0, 4);
             } else if (timeSpan === "year") {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -166,6 +166,23 @@ export default {
     return this.capitalize(date.toLocaleDateString(locale || "en", options)).slice(0, 3);
   },
 
+  /** The quarter number written out as it's range of months (ex: "1" becomes "Jan - Mar")  */
+  getMonthRangeFromQuarter(quarter: "1" | "2" | "3" | "4", locale?: SupportedLocale): string {
+    const monthRange = {
+      start: (parseInt(quarter) * 3 - 2).toString().padStart(2, "0"), // i.e "01"
+      end: (parseInt(quarter) * 3).toString().padStart(2, "0"), // i.e. "03"
+    };
+
+    // Note: the year and day of each of these dates is meaningless, as we only need to extract the month
+    const startDate = `2000-${monthRange.start}-15`;
+    const endDate = `2000-${monthRange.end}-15`;
+
+    return `${this.formatMonthAbbreviationForTimeline(
+      startDate,
+      locale
+    )} - ${this.formatMonthAbbreviationForTimeline(endDate, locale)}`;
+  },
+
   formatStreetNameForHpdLink(streetName: string): string {
     var arr = streetName.split(" ");
     if (arr === []) {


### PR DESCRIPTION
This PR fixes a bug where the abbreviation of months on the timeline tab would show up as invalid values— specifically when viewing the data by quarters on Safari or Firefox. 

![image](https://user-images.githubusercontent.com/12834575/87941545-4f5b9400-ca69-11ea-8948-3ff7e60e208a.png)
