### PR TITLE
Hot fix: include wrapping div for netlify banner

### DIFF
--- a/client/src/components/LegalFooter.tsx
+++ b/client/src/components/LegalFooter.tsx
@@ -57,18 +57,15 @@ class LegalFooter extends Component {
                   <Trans>Source code</Trans>
                 </a>
               </nav>
-              <a
-                href="https://www.netlify.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hide-md"
-              >
-                <img
-                  src="https://www.netlify.com/img/global/badges/netlify-dark.svg"
-                  alt="Netlify"
-                  width="75"
-                />
-              </a>
+              <div className="hide-md">
+                <a href="https://www.netlify.com" target="_blank" rel="noopener noreferrer">
+                  <img
+                    src="https://www.netlify.com/img/global/badges/netlify-dark.svg"
+                    alt="Netlify"
+                    width="75"
+                  />
+                </a>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This quick fix fixes the bounding box for the netlify banner in the footer.