### PR TITLE
Allow wrapping on covid banner link text

### DIFF
--- a/client/src/styles/HomePage.scss
+++ b/client/src/styles/HomePage.scss
@@ -21,7 +21,6 @@
       a {
         color: $dark;
         text-decoration: underline;
-        white-space: nowrap;
 
         &:hover {
           text-decoration: none;


### PR DESCRIPTION
This quick PR fixes a styling bug on our COVID-19 banner on the homepage— now, the hyperlink text is allowed to wrap to two lines, avoiding spacing awkwardness. 