### PR TITLE
Add api_dependencies array to who-owns-what.yml.

### DIFF
--- a/dbtool.py
+++ b/dbtool.py
@@ -195,7 +195,7 @@ class NycDbBuilder:
 
 
 def get_dataset_dependencies() -> List[str]:
-    return WOW_YML['dependencies']
+    return WOW_YML['dependencies'] + WOW_YML['api_dependencies']
 
 
 def get_sqlfile_paths() -> List[Path]:

--- a/dbtool.py
+++ b/dbtool.py
@@ -186,7 +186,7 @@ class NycDbBuilder:
         else:
             print("Loading the database with real data (this could take a while).")
 
-        for dataset in get_dataset_dependencies():
+        for dataset in get_dataset_dependencies(for_api=True):
             self.ensure_dataset(dataset, force_refresh=force_refresh)
 
         for sqlpath in get_sqlfile_paths():
@@ -194,8 +194,11 @@ class NycDbBuilder:
             self.run_sql_file(sqlpath)
 
 
-def get_dataset_dependencies() -> List[str]:
-    return WOW_YML['dependencies'] + WOW_YML['api_dependencies']
+def get_dataset_dependencies(for_api: bool) -> List[str]:
+    result = WOW_YML['dependencies']
+    if for_api:
+        result += WOW_YML['api_dependencies']
+    return result
 
 
 def get_sqlfile_paths() -> List[Path]:

--- a/tests/nycdb_context.py
+++ b/tests/nycdb_context.py
@@ -82,7 +82,7 @@ class NycdbContext:
         and then run all our custom SQL.
         '''
 
-        for dataset in dbtool.get_dataset_dependencies():
+        for dataset in dbtool.get_dataset_dependencies(for_api=False):
             self.load_dataset(dataset)
 
         all_sql = '\n'.join([

--- a/who-owns-what.yml
+++ b/who-owns-what.yml
@@ -7,6 +7,12 @@ dependencies:
   - hpd_registrations
   - hpd_violations
   - acris
+api_dependencies:
+  # These are NYCDB datasets that aren't needed by the
+  # SQL scripts, but which the Django server uses
+  # for the WoW API.
+  - hpd_complaints
+  - dobjobs
 sql:
   # These SQL scripts must be executed in order, as
   # some of them depend on others.

--- a/wow/tests/conftest.py
+++ b/wow/tests/conftest.py
@@ -3,13 +3,6 @@ import psycopg2
 
 import dbtool
 
-# Extra datasets that WoW needs to work, but which aren't
-# prerequisites for WoW's materialized views/functions.
-EXTRA_NYCDB_DATASETS = [
-    'hpd_complaints',
-    'dobjobs',
-]
-
 
 @pytest.fixture(scope='session')
 def django_db_setup(django_db_setup, django_db_blocker):
@@ -39,7 +32,3 @@ def django_db_setup(django_db_setup, django_db_blocker):
 
         if not is_already_built:
             dbtool.loadtestdata(db)
-
-            builder = dbtool.NycDbBuilder(db, is_testing=True)
-            for dataset in EXTRA_NYCDB_DATASETS:
-                builder.ensure_dataset(dataset, force_refresh=False)


### PR DESCRIPTION
This fixes #291 by adding a new `api_dependencies` array to `who-owns-what.yml` that declares NYCDB datasets that aren't needed to run WoW's SQL scripts (the ones that define functions and materialized views, etc) but which _are_ needed by the API server.  It also modifies `dbtool.py` to load these dependencies too.
