### PR TITLE
Upgrade to Django 3.0 and add more tests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # This only contains dependencies for running the API
 # server. For all other dependencies, see requirements-dev.txt.
 psycopg2-binary==2.7.7
-django==2.2.13
+django==3.0.8
 rollbar==0.14.5
 dj-database-url==0.5.0
 gunicorn==19.9.0

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -1,9 +1,49 @@
 import csv
+from typing import List
 from io import StringIO
+from django.urls import path
+from django.test import Client
 import pytest
 
+from wow.apiutil import api
+from project.urls import handler500
 
-class TestAddressQuery:
+
+@api
+def api_server_error(request):
+    kaboom()  # type: ignore
+
+
+def server_error(request):
+    kaboom()  # type: ignore
+
+
+urlpatterns = [
+    path('api/server-error', api_server_error),
+    path('server-error', server_error),
+]
+
+
+class ApiTest:
+    HTTP_400_URLS: List[str] = []
+
+    def test_400s_work(self, db, client):
+        assert self.HTTP_400_URLS, "No HTTP 400 examples to test!"
+        for url in self.HTTP_400_URLS:
+            res = client.get(url)
+            assert res.status_code == 400, f"{url} should return HTTP 400"
+            assert res.json()['error'] == 'Bad request'
+            assert 'Access-Control-Allow-Origin' in res
+
+
+class TestAddressQuery(ApiTest):
+    HTTP_400_URLS = [
+        '/api/address',
+        '/api/address?block=01678&lot=0054&borough=0',
+        '/api/address?block=01678&lot=lol&borough=1',
+        '/api/address?block=lol&lot=0054&borough=1',
+    ]
+
     def test_it_works(self, db, client):
         res = client.get('/api/address?block=01678&lot=0054&borough=3')
         assert res.status_code == 200
@@ -15,35 +55,60 @@ class TestAddressQuery:
         }
 
 
-class TestAddressAggregate:
+class TestAddressAggregate(ApiTest):
+    HTTP_400_URLS = [
+        '/api/address/aggregate',
+        '/api/address/aggregate?bbl=1',
+    ]
+
     def test_it_works(self, db, client):
         res = client.get('/api/address/aggregate?bbl=3016780054')
         assert res.status_code == 200
         assert len(res.json()['result']) > 0
 
 
-class TestAddressDapAggregate:
+class TestAddressDapAggregate(ApiTest):
+    HTTP_400_URLS = [
+        '/api/address/dap-aggregate',
+        '/api/address/dap-aggregate?bbl=1',
+    ]
+
     def test_it_works(self, db, client):
         res = client.get('/api/address/dap-aggregate?bbl=3016780054')
         assert res.status_code == 200
         assert len(res.json()['result']) > 0
 
 
-class TestAddressBuildingInfo:
+class TestAddressBuildingInfo(ApiTest):
+    HTTP_400_URLS = [
+        '/api/address/buildinginfo',
+        '/api/address/buildinginfo?bbl=bop',
+    ]
+
     def test_it_works(self, db, client):
         res = client.get('/api/address/buildinginfo?bbl=3016780054')
         assert res.status_code == 200
         assert res.json()['result'] is not None
 
 
-class TestAddressIndicatorHistory:
+class TestAddressIndicatorHistory(ApiTest):
+    HTTP_400_URLS = [
+        '/api/address/indicatorhistory',
+        '/api/address/indicatorhistory?bbl=bop',
+    ]
+
     def test_it_works(self, db, client):
         res = client.get('/api/address/indicatorhistory?bbl=3016780054')
         assert res.status_code == 200
         assert res.json()['result'] is not None
 
 
-class TestAddressExport:
+class TestAddressExport(ApiTest):
+    HTTP_400_URLS = [
+        '/api/address/export',
+        '/api/address/export?bbl=bop',
+    ]
+
     def test_it_works(self, db, client):
         res = client.get('/api/address/export?bbl=3016780054')
         assert res.status_code == 200
@@ -53,3 +118,29 @@ class TestAddressExport:
         csvreader = csv.DictReader(f)
         assert 'bbl' in csvreader.fieldnames
         assert len(list(csvreader)) > 0
+
+    def test_it_returns_404_when_no_bbls_exist(self, db, client):
+        res = client.get('/api/address/export?bbl=1234567890')
+        assert res.status_code == 404
+        assert 'Access-Control-Allow-Origin' in res
+
+
+class TestServerError:
+    @pytest.fixture(autouse=True)
+    def setup_fixture(self, settings):
+        settings.ROOT_URLCONF = __name__
+        self.client = Client(raise_request_exception=False)
+
+    def test_it_returns_html_on_non_api_requests(self):
+        res = self.client.get('/server-error')
+        assert res.status_code == 500
+        assert res['Content-Type'] == 'text/html'
+        assert b"Server Error" in res.content
+
+    def test_it_returns_json_on_api_requests(self, settings):
+        res = self.client.get('/api/server-error')
+        assert res.status_code == 500
+        assert res['Content-Type'] == 'application/json'
+        assert res.json() == {
+            'error': 'An internal server error occurred.',
+        }

--- a/wow/views.py
+++ b/wow/views.py
@@ -95,7 +95,7 @@ def address_export(request):
     addrs = call_db_func('get_assoc_addrs_from_bbl', [bbl])
 
     if not addrs:
-        raise Http404()
+        return HttpResponse(status=404)
 
     first_row = addrs[0]
 


### PR DESCRIPTION
This upgrades us to Django 3.0 and adds more tests.  This fixes #313.

(The main reason for upgrading to Django 3 is because of its support for the `raise_request_exception` argument to the Django test client, which makes it easier for us to test our HTTP 500 errors.)
