### PR TITLE
Add explicit typecasts to any API data we need to alter for the front end

### DIFF
--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -130,22 +130,14 @@ export type BuildingInfoResults = {
 
 type MonthlyTimelineData = {
   month: string;
-  /** Front-end interprets as number */
-  complaints_emergency: string;
-  /** Front-end interprets as number */
-  complaints_nonemergency: string;
-  /** Front-end interprets as number */
-  complaints_total: string;
-  /** Front-end interprets as number */
-  permits_total: string;
-  /** Front-end interprets as number */
-  viols_class_a: string;
-  /** Front-end interprets as number */
-  viols_class_b: string;
-  /** Front-end interprets as number */
-  viols_class_c: string;
-  /** Front-end interprets as number */
-  viols_total: string;
+  complaints_emergency: number;
+  complaints_nonemergency: number;
+  complaints_total: number;
+  permits_total: number;
+  viols_class_a: number;
+  viols_class_b: number;
+  viols_class_c: number;
+  viols_total: number;
 };
 
 export type IndicatorsHistoryResults = {

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -17,8 +17,7 @@ type HpdOwnerContact = {
 
 type AddressRecord = {
   bbl: string;
-  /** Front-end interprets as string */
-  bin: number;
+  bin: string;
   boro: Borough;
   businessaddrs: string[] | null;
   corpnames: string[] | null;
@@ -26,19 +25,16 @@ type AddressRecord = {
   housenumber: string;
   lastregistrationdate: Date;
   lastsaleacrisid: string | null;
-  /** Front-end interprets as number */
-  lastsaleamount: string | null;
+  lastsaleamount: number | null;
   lastsaledate: Date | null;
   lat: number | null;
   lng: number | null;
   openviolations: number;
   ownernames: HpdOwnerContact[] | null;
   registrationenddate: Date;
-  /** Front-end interprets as string */
-  registrationid: number;
+  registrationid: string;
   rsdiff: number | null;
-  /** Front-end interprets as number */
-  rspercentchange: string | null;
+  rspercentchange: number | null;
   rsunits2007: number | null;
   rsunits2017: number | null;
   streetname: string;

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -75,39 +75,25 @@ type HpdViolationsAddress = AddressLocation & {
 };
 
 type SummaryStatsRecord = {
-  /** Front-end interprets as number */
-  age: string;
-  /** Front-end interprets as number */
-  avgevictions: string | null;
-  /** Front-end interprets as number */
-  avgrspercent: string | null;
-  /** Front-end interprets as number */
-  bldgs: string;
+  age: number;
+  avgevictions: number | null;
+  avgrspercent: number | null;
+  bldgs: number;
   evictionsaddr: EvictionAddress;
-  /** Front-end interprets as number */
-  openviolationsperbldg: string;
-  /** Front-end interprets as number */
-  openviolationsperresunit: string;
+  openviolationsperbldg: number;
+  openviolationsperresunit: number;
   rslossaddr: RentStabilizedAddress;
-  /** Front-end interprets as number */
-  rsproportion: string | null;
+  rsproportion: number | null;
   topbusinessaddr: string | null;
   topcorp: string | null;
   topowners: string[];
-  /** Front-end interprets as number */
-  totalevictions: string | null;
-  /** Front-end interprets as number */
-  totalopenviolations: string;
-  /** Front-end interprets as number */
-  totalrsdiff: string | null;
-  /** Front-end interprets as number */
-  totalrsgain: string;
-  /** Front-end interprets as number */
-  totalrsloss: string;
-  /** Front-end interprets as number */
-  totalviolations: string;
-  /** Front-end interprets as number */
-  units: string;
+  totalevictions: number | null;
+  totalopenviolations: number;
+  totalrsdiff: number | null;
+  totalrsgain: number;
+  totalrsloss: number;
+  totalviolations: number;
+  units: number;
   violationsaddr: HpdViolationsAddress;
 };
 

--- a/wow/datautil.py
+++ b/wow/datautil.py
@@ -1,0 +1,23 @@
+from typing import Optional, Any
+
+
+def int_or_none(val: Any) -> Optional[int]:
+    if val is None:
+        return None
+    else:
+        return int(val)
+
+
+def float_or_none(val: Any) -> Optional[float]:
+    if val is None:
+        return None
+    else:
+        return float(val)
+
+
+def str_or_none(val: Any) -> Optional[str]:
+    if val is None:
+        return None
+    else:
+        return str(val)
+

--- a/wow/tests/test_datautils.py
+++ b/wow/tests/test_datautils.py
@@ -1,0 +1,22 @@
+from .datautil import int_or_none, str_or_none, float_or_none
+
+
+class TestDataUtilsWork:
+
+    def test_int_or_none_works(self):
+        assert int_or_none(None) is None
+        assert int_or_none(1) == 1
+        assert int_or_none('1') == 1
+    
+
+    def test_float_or_none_works(self):
+        assert float_or_none(None) is None
+        assert float_or_none(1.0) == 1.0
+        assert float_or_none('1.0') == 1.0
+
+
+    def test_str_or_none_works(self):
+        assert str_or_none(None) is None
+        assert str_or_none('1') == '1'
+        assert str_or_none(1) == '1'
+

--- a/wow/tests/test_datautils.py
+++ b/wow/tests/test_datautils.py
@@ -1,4 +1,4 @@
-from .datautil import int_or_none, str_or_none, float_or_none
+from ..datautil import int_or_none, str_or_none, float_or_none
 
 
 class TestDataUtilsWork:

--- a/wow/views.py
+++ b/wow/views.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from django.http import HttpResponse, JsonResponse, Http404
 
 from .dbutil import call_db_func, exec_db_query
-from .datautil import int_or_none, float_or_none
+from .datautil import int_or_none, str_or_none, float_or_none
 from . import csvutil, apiutil
 from .apiutil import api, get_validated_form_data
 from .forms import PaddedBBLForm, SeparatedBBLForm
@@ -79,11 +79,25 @@ def get_request_bbl(request) -> str:
     return get_validated_form_data(PaddedBBLForm, request.GET)['bbl']
 
 
+def clean_agg_info_dict(agg_info):
+    return {
+        **agg_info,
+        "age": int(agg_info['age']), 
+        "avgevictions": float_or_none(agg_info['avgevictions']),
+        "avgrspercent": float_or_none(agg_info['avgrspercent']),
+        "openviolationsperbldg": float_or_none(agg_info['openviolationsperbldg']),
+        "openviolationsperresunit": float_or_none(agg_info['openviolationsperresunit']),
+        "rsproportion": float_or_none(agg_info['rsproportion']),
+        "totalevictions": int_or_none(agg_info['totalevictions'])
+    }
+
+
 @api
 def address_aggregate(request):
     bbl = get_request_bbl(request)
     result = call_db_func('get_agg_info_from_bbl', [bbl])
-    return JsonResponse({ 'result': result })
+    cleaned_result = map(clean_agg_info_dict, result)
+    return JsonResponse({ 'result': list(cleaned_result) })
 
 
 @api


### PR DESCRIPTION
This PR fixes #297 by adding explicit type casts in python to any API response data that isn't in the right type that the front end would interpret it to be in. At some point, we should determine how we can log explicit errors for when these typecasting methods totally fail (for example, if we ever tried to cast "BOOP" into an integer)