### PR TITLE
Upgrade version if needed when user navigates to a new page.

### DIFF
--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -11,6 +11,7 @@ import Modal from "components/Modal";
 import SocialShare from "components/SocialShare";
 import { withI18n } from "@lingui/react";
 import { WhoOwnsWhatRoutes, createWhoOwnsWhatRoutePaths } from "../routes";
+import { VersionUpgrader } from "./VersionUpgrader";
 
 const HomeLink = withI18n()((props) => {
   const { i18n } = props;
@@ -39,11 +40,13 @@ export default class App extends Component {
 
   render() {
     const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
+    const version = process.env.REACT_APP_VERSION;
     const paths = createWhoOwnsWhatRoutePaths();
     return (
       <Router>
         <I18n>
           <ScrollToTop>
+            {version && <VersionUpgrader currentVersion={version} />}
             <div className="App">
               <div className="App__warning old_safari_only">
                 <Trans render="h3">

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -46,7 +46,13 @@ export default class App extends Component {
       <Router>
         <I18n>
           <ScrollToTop>
-            {version && <VersionUpgrader currentVersion={version} />}
+            {version && (
+              <VersionUpgrader
+                currentVersion={version}
+                latestVersionUrl="/version.txt"
+                checkIntervalMs={5000}
+              />
+            )}
             <div className="App">
               <div className="App__warning old_safari_only">
                 <Trans render="h3">

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -50,7 +50,7 @@ export default class App extends Component {
               <VersionUpgrader
                 currentVersion={version}
                 latestVersionUrl="/version.txt"
-                checkIntervalMs={5000}
+                checkIntervalSecs={300}
               />
             )}
             <div className="App">

--- a/client/src/containers/VersionUpgrader.tsx
+++ b/client/src/containers/VersionUpgrader.tsx
@@ -64,9 +64,10 @@ type VersionUpgraderProps = {
   latestVersionUrl: string;
 
   /**
-   * How frequently to check to see if a new version is available.
+   * How frequently to check to see if a new version is available,
+   * in seconds.
    */
-  checkIntervalMs: number;
+  checkIntervalSecs: number;
 };
 
 /**
@@ -80,12 +81,12 @@ type VersionUpgraderProps = {
 export const VersionUpgrader: React.FC<VersionUpgraderProps> = ({
   currentVersion,
   latestVersionUrl,
-  checkIntervalMs,
+  checkIntervalSecs,
 }) => {
   const loc = useLocation();
   const url = loc.pathname + loc.search;
   const prevUrl = usePrevious(url);
-  const latestVersion = useLatestFileText(latestVersionUrl, checkIntervalMs);
+  const latestVersion = useLatestFileText(latestVersionUrl, checkIntervalSecs * 1000);
   const didUrlChange = prevUrl && prevUrl !== url;
   const canUpgradeVersion = latestVersion && currentVersion !== latestVersion;
 

--- a/client/src/containers/VersionUpgrader.tsx
+++ b/client/src/containers/VersionUpgrader.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
+
+const FETCH_INTERVAL = 5000;
+
+// https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>(undefined);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}
+
+function useIntervalCounter(intervalMs: number): number {
+  const [counter, setCounter] = useState(0);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setCounter(Date.now());
+    }, intervalMs);
+
+    return () => window.clearInterval(interval);
+  }, [intervalMs]);
+
+  return counter;
+}
+
+function useLatestFileText(url: string, intervalMs: number): string | undefined {
+  const [text, setText] = useState<string | undefined>();
+  const counter = useIntervalCounter(intervalMs);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const getText = async () => {
+      const res = await fetch(url);
+      if (res.status === 200) {
+        const content = await res.text();
+        if (isActive) {
+          setText(content);
+        }
+      }
+    };
+
+    getText().catch((e) => {
+      console.log(`Error when fetching ${url}`, e);
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [counter, url]);
+
+  return text;
+}
+
+export const VersionUpgrader: React.FC<{
+  currentVersion: string;
+}> = ({ currentVersion }) => {
+  const loc = useLocation();
+  const url = loc.pathname + loc.search;
+  const prevUrl = usePrevious(url);
+  const latestVersion = useLatestFileText("/version.txt", FETCH_INTERVAL);
+
+  useEffect(() => {
+    const didUrlChange = prevUrl && prevUrl !== url;
+    const isNewVersionAvailable = latestVersion && currentVersion !== latestVersion;
+    if (didUrlChange && isNewVersionAvailable) {
+      // The user just navigated to a new page and we have a new
+      // version available, so simulate a "hard" page navigation
+      // rather than a "soft" pushState-based one.
+      window.location.reload();
+    }
+  }, [url, prevUrl, currentVersion, latestVersion]);
+
+  return null;
+};

--- a/client/src/containers/VersionUpgrader.tsx
+++ b/client/src/containers/VersionUpgrader.tsx
@@ -1,7 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
 
-// https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+/**
+ * Returns whatever the passed-in value was on
+ * the previous render. This was taken from:
+ *
+ *   https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+ *
+ * The first time it's called, it will return undefined,
+ * since there was no previous render.
+ */
 function usePrevious<T>(value: T): T | undefined {
   const ref = useRef<T | undefined>(undefined);
   useEffect(() => {
@@ -10,6 +18,13 @@ function usePrevious<T>(value: T): T | undefined {
   return ref.current;
 }
 
+/**
+ * Returns a number that changes every time the given
+ * number of milliseconds have elapsed.
+ *
+ * Note that the *amount* of the change is not deterministic. The
+ * only thing that can be relied upon is that it changes.
+ */
 function useIntervalCounter(intervalMs: number): number {
   const [counter, setCounter] = useState(0);
 
@@ -24,6 +39,14 @@ function useIntervalCounter(intervalMs: number): number {
   return counter;
 }
 
+/**
+ * Returns the contents of the text file at the
+ * given URL, re-fetching the URL at the given
+ * interval in milliseconds.
+ *
+ * If the file hasn't been retrieved yet, it returns
+ * undefined.
+ */
 function useLatestFileText(url: string, intervalMs: number): string | undefined {
   const [text, setText] = useState<string | undefined>();
   const counter = useIntervalCounter(intervalMs);


### PR DESCRIPTION
This adds functionality that regularly checks to see if a new version is available, and if so, upgrades the user when they next click on a link, submit a form, or perform any other kind of page navigation.

The one annoying thing with this solution is that it actually reloads _after_ the page transition, which could be a bit jarring for the user, as they'll see the new page but then see it immediately reload.  Ideally we'd convince React Router to make all page transitions "hard" once we know an upgrade is available, but there doesn't seem to be a way to do this.

One nice thing about Netlify's deploy previews is that they can be used to test out this functionality: if you load the deploy preview, and then push a commit to this PR, you should eventually see the following message in the preview's console:

```
A new version of the front-end is available, will upgrade on next page navigation.
```

Then you can try navigating to a new page and see how it works.
