### PR TITLE
Allow for age to be null in aggregate endpoint

### DIFF
--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -75,7 +75,7 @@ type HpdViolationsAddress = AddressLocation & {
 };
 
 type SummaryStatsRecord = {
-  age: number;
+  age: number | null;
   avgevictions: number | null;
   avgrspercent: number | null;
   bldgs: number;

--- a/wow/views.py
+++ b/wow/views.py
@@ -82,7 +82,7 @@ def get_request_bbl(request) -> str:
 def clean_agg_info_dict(agg_info):
     return {
         **agg_info,
-        "age": int(agg_info['age']), 
+        "age": int_or_none(agg_info['age']),
         "avgevictions": float_or_none(agg_info['avgevictions']),
         "avgrspercent": float_or_none(agg_info['avgrspercent']),
         "openviolationsperbldg": float_or_none(agg_info['openviolationsperbldg']),


### PR DESCRIPTION
While WoW never seems to ping the `/api/aggregate` endpoint for BBLs that have no HPD registration, DAP does (albeit at the synonymous `/api/dap-aggregate` endpoint), and it sometimes asks about buildings that apparently either have no PLUTO data, or for which PLUTO reports the building's age as being `NULL`.  Regardless, the value our NYCDB returns is `NULL`, which our typecasting code introduced in #326 barfs on, so this fixes it.

The offending BBLs are very small buildings so I'm not comfortable posting the examples here, but they can be seen on Rollbar at https://rollbar.com/justfix-nyc/who-owns-what/items/1957/.
