### PR TITLE
Actually support IE 11 and non-ES6 browsers

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -83,6 +83,9 @@
     "npm-run-all": "^4.0.2",
     "prettier": "2.0.5"
   },
+   "engines": {
+    "node": ">=12.0.0"
+  },
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/client/package.json
+++ b/client/package.json
@@ -83,13 +83,10 @@
     "npm-run-all": "^4.0.2",
     "prettier": "2.0.5"
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
   "browserslist": [
     ">0.2%",
     "not dead",
-    "not ie <= 11",
+    "ie 11",
     "not op_mini all"
   ]
 }

--- a/client/package.json
+++ b/client/package.json
@@ -83,7 +83,7 @@
     "npm-run-all": "^4.0.2",
     "prettier": "2.0.5"
   },
-   "engines": {
+  "engines": {
     "node": ">=12.0.0"
   },
   "browserslist": [

--- a/client/package.json
+++ b/client/package.json
@@ -86,6 +86,7 @@
   "engines": {
     "node": ">=12.0.0"
   },
+  "@comment browserslist": "Note that when changing browserslist, you need to delete `node_modules/.cache` for the changes to propagate! For more details, see https://github.com/JustFixNYC/who-owns-what/pull/335.",
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,4 +11,10 @@
   publish = "build/"
 
   # Default build command.
-  command = "echo 'Building site!' && yarn build"
+  #
+  # Note that we are removing `node_modules/.cache` because Netlify caches
+  # `node_modules` by default, and Create React App currently over-uses
+  # this cache because, without clearing it, changes to `browserslist`
+  # in our package.json won't propagate. For more details on this, see
+  # https://github.com/JustFixNYC/who-owns-what/pull/335.
+  command = "rm -rf node_modules/.cache && yarn build"


### PR DESCRIPTION
Looking at Rollbar errors for the latest front-end version made me realize that there were arrow functions in our JS bundles.  Upon further inspection, I realized our `browserslist` specifies `not ie <= 11`, yet our `index.js` imports both `react-app-polyfill/ie11` and `babel-polyfill`.  These contradictory lines were actually all introduced in the same PR, #99, which is very odd.

I think the reason we might not have seen this strange behavior when writing that PR is because apparently [changing `browserslist` requires deleting `node_modules/.cache`][1].  So it's possible that during development, we never truly saw the results of our actions!  (Needless to say, I spent a lot of time in confusion after making this PR's simple code change, until I discovered the root cause.)

This means that even Netlify won't reflect changes to `browserslist` by default (it caches all of `node_modules` between builds), so I've modified its configuration to clear `node_modules/.cache` before building the site too.

[1]: https://github.com/facebook/create-react-app/issues/8197#issuecomment-619520596
