### PR TITLE
Fix #352.

### DIFF
--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -105,38 +105,36 @@ export default class AddressPage extends Component<AddressPageProps, State> {
   // Processes the results and setState accordingly. Doesn't care where results comes from
   handleResults = (results: SearchResults) => {
     const { geosearch, addrs } = results;
+    let userAddr: AddressRecord | undefined = undefined;
 
     if (!geosearch) {
       throw new Error("Address results do not contain geosearch results!");
     }
 
-    this.setState({
-      hasSearched: true,
-      geosearch: geosearch,
-      searchAddress: { ...this.state.searchAddress, bbl: geosearch.bbl },
-    });
-
     /* Case for when our API call returns a portfolio of multiple associated addresses */
     if (addrs.length) {
-      const userAddr = _find(addrs, { bbl: geosearch.bbl });
+      userAddr = _find(addrs, { bbl: geosearch.bbl });
 
       if (!userAddr) {
         throw new Error("The user's address was not found in the API Address Search results!");
       }
-
-      this.setState(
-        {
-          userAddr: userAddr,
-          assocAddrs: addrs,
-        },
-        () => {
-          this.handleAddrChange(userAddr);
-        }
-      );
     }
+
+    this.setState(
+      {
+        hasSearched: true,
+        geosearch: geosearch,
+        userAddr,
+        assocAddrs: addrs,
+        searchAddress: { ...this.state.searchAddress, bbl: geosearch.bbl },
+      },
+      () => {
+        this.handleAddrChange(userAddr);
+      }
+    );
   };
 
-  handleAddrChange = (addr: AddressRecord) => {
+  handleAddrChange = (addr?: AddressRecord) => {
     this.setState({
       detailAddr: addr,
       detailMobileSlide: true,


### PR DESCRIPTION
This fixes #352.  The bug was indeed introduced by #346, which essentially split what was previously a single state update into two separate ones: this then caused `render()` to be called in a state where the `<NotRegisteredPage>` was mounted and immediately unmounted.

The thing is, I'm not sure if my fix brings in other weird edge cases or something; @sraby, is there a reason you split the single state update into two in #346?  My fix changes it back to a single state update, which fixes the issue, but might introduce some undesirable behavior that I'm unaware of...