### PR TITLE
Fix #351.

### DIFF
--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -361,7 +361,9 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                 </div>
 
                 <span className="title viz-title">
-                  {dataset && indicatorDataTotal && dataset.quantity(i18n, indicatorDataTotal)}
+                  {dataset &&
+                    indicatorDataTotal !== null &&
+                    dataset.quantity(i18n, indicatorDataTotal)}
                 </span>
 
                 <div className="Indicators__viz">


### PR DESCRIPTION
In the case where an indicator's total was `0`, this was causing a short-circuited expression to incorrectly short-circuit.  Now we explicitly test for a value to be `null` rather than simply falsy.