### PR TITLE
Upgrade mypy to 0.782, pin pyproj to 2.1.3.

### DIFF
--- a/dbtool.py
+++ b/dbtool.py
@@ -21,7 +21,7 @@ except ModuleNotFoundError:
 
 ROOT_DIR = Path(__file__).parent.resolve()
 SQL_DIR = ROOT_DIR / 'sql'
-WOW_YML = yaml.load((ROOT_DIR / 'who-owns-what.yml').read_text())
+WOW_YML = yaml.full_load((ROOT_DIR / 'who-owns-what.yml').read_text())
 
 # Just an alias for our database connection.
 DbConnection = Any

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -7,7 +7,7 @@ os.environ['SECRET_KEY'] = "for testing only!"
 
 from .settings import *
 
-DATABASES = copy.deepcopy(DATABASES)  # type: ignore
+DATABASES = copy.deepcopy(DATABASES)
 
 if 'TEST_DATABASE_URL' in os.environ:
     DATABASES['wow'] = dj_database_url.parse(os.environ['TEST_DATABASE_URL'])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,8 @@ PyYAML>=5.1
 pytest==4.4.0
 pytest-django==3.4.5
 python-dotenv==0.9.1
+
+# Pyproj is evolving very fast and is already logging some deprecation
+# warnings when we use nycdb; let's use the minimum supported version
+# so we don't get those warnings, at least.
+pyproj==2.1.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 https://github.com/nycdb/nycdb/archive/2560271cb47fc35d7e5584c673fd57cbcdb5880a.zip#subdirectory=src
-mypy==0.660
+mypy==0.782
 PyYAML>=5.1
 pytest==4.4.0
 pytest-django==3.4.5

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -116,7 +116,7 @@ class TestAddressExport(ApiTest):
 
         f = StringIO(res.content.decode('utf-8'))
         csvreader = csv.DictReader(f)
-        assert 'bbl' in csvreader.fieldnames
+        assert 'bbl' in (csvreader.fieldnames or [])
         assert len(list(csvreader)) > 0
 
     def test_it_returns_404_when_no_bbls_exist(self, db, client):


### PR DESCRIPTION
This upgrades mypy and also fixes a [yaml deprecation warning](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).  It also pins pyproj to 2.1.3 (the minimum supported by nycdb) to squelch some deprecation warnings (see https://github.com/nycdb/nycdb/issues/134).