### PR TITLE
Coalesce our pre-existing data-related type definitions with the new ones

### DIFF
--- a/client/src/components/EvictionsSummary.tsx
+++ b/client/src/components/EvictionsSummary.tsx
@@ -1,22 +1,13 @@
 import React from "react";
-import helpers, { MaybeStringyNumber } from "../util/helpers";
 import { Trans, Plural } from "@lingui/macro";
+import { SummaryStatsRecord } from "./APIDataTypes";
 
-export const EvictionsSummary: React.FC<{
-  totalevictions: MaybeStringyNumber;
-  evictionsaddr:
-    | {
-        housenumber: string;
-        streetname: string;
-        boro: string;
-        evictions: MaybeStringyNumber;
-      }
-    | null
-    | undefined;
-}> = (props) => {
-  const totalEvictions = helpers.coerceToInt(props.totalevictions, 0);
+type EvictionsSummaryData = Pick<SummaryStatsRecord, "evictionsaddr" | "totalevictions">;
+
+export const EvictionsSummary: React.FC<EvictionsSummaryData> = (props) => {
+  const totalEvictions = props.totalevictions || 0;
   const building = props.evictionsaddr;
-  const buildingTotalEvictions = helpers.coerceToInt(building && building.evictions, 0);
+  const buildingTotalEvictions = (building && building.evictions) || 0;
 
   return (
     <p>

--- a/client/src/components/EvictionsSummary.tsx
+++ b/client/src/components/EvictionsSummary.tsx
@@ -16,7 +16,7 @@ export const EvictionsSummary: React.FC<EvictionsSummaryData> = (props) => {
         <Plural value={totalEvictions} one="one eviction" other="# evictions" /> across this
         portfolio.
       </Trans>{" "}
-      {building && (
+      {building && totalEvictions > 0 && (
         <Trans>
           The building with the most evictions was{" "}
           <b>

--- a/client/src/components/OwnersTable.tsx
+++ b/client/src/components/OwnersTable.tsx
@@ -3,20 +3,13 @@ import "styles/OwnersTable.css";
 
 import _isEmpty from "lodash/isEmpty";
 import { Trans } from "@lingui/macro";
+import { AddressRecord } from "./APIDataTypes";
+
+type OwnersTableData = Pick<AddressRecord, "businessaddrs" | "corpnames" | "ownernames">;
 
 const OwnersTable: React.FC<{
-  addr: {
-    businessaddrs?: string[];
-    corpnames?: string[];
-    ownernames?: { title: string; value: string }[];
-  };
+  addr: OwnersTableData;
 }> = (props) => {
-  // let hasJustFixUsersWarning = null;
-  // // let hasJustFixUsersWarning = <br />;
-  // if(props.hasJustFixUsers) {
-  //   hasJustFixUsersWarning = <p className="mt-10 text-center text-bold text-danger text-large">This landlord has at least one active JustFix.nyc case!</p>
-  // }
-
   if (_isEmpty(props.addr)) {
     return null;
   } else {

--- a/client/src/components/RentstabSummary.tsx
+++ b/client/src/components/RentstabSummary.tsx
@@ -1,27 +1,21 @@
 import React from "react";
-import helpers, { MaybeStringyNumber } from "../util/helpers";
 import { Trans, Select, Plural } from "@lingui/macro";
+import { SummaryStatsRecord } from "./APIDataTypes";
 
-export const RentstabSummary: React.FC<{
-  totalrsdiff: MaybeStringyNumber;
-  totalrsgain: MaybeStringyNumber;
-  totalrsloss: MaybeStringyNumber;
-  rsproportion: MaybeStringyNumber;
-  rslossaddr: {
-    rsdiff: MaybeStringyNumber;
-    housenumber: string;
-    streetname: string;
-    boro: string;
-  };
-}> = (props) => {
-  const totalRsDiff = helpers.coerceToInt(props.totalrsdiff, 0);
+type RentstabSummaryData = Pick<
+  SummaryStatsRecord,
+  "totalrsdiff" | "totalrsgain" | "totalrsloss" | "rsproportion" | "rslossaddr"
+>;
+
+export const RentstabSummary: React.FC<RentstabSummaryData> = (props) => {
+  const totalRsDiff = props.totalrsdiff || 0;
   const absTotalRsDiff = Math.abs(totalRsDiff);
-  const absTotalRsGain = Math.abs(helpers.coerceToInt(props.totalrsgain, 0));
-  const absTotalRsLoss = Math.abs(helpers.coerceToInt(props.totalrsloss, 0));
-  const rsProportion = helpers.coerceToInt(props.rsproportion, 0);
+  const absTotalRsGain = Math.abs(props.totalrsgain || 0);
+  const absTotalRsLoss = Math.abs(props.totalrsloss || 0);
+  const rsProportion = props.rsproportion || 0;
   const changeType: "gain" | "loss" = totalRsDiff > 0 ? "gain" : "loss";
   const rsLossAddr = props.rslossaddr;
-  const rsLossAddrDiff = helpers.coerceToInt(rsLossAddr && rsLossAddr.rsdiff, 0);
+  const rsLossAddrDiff = (rsLossAddr && rsLossAddr.rsdiff) || 0;
   const absRsLossAddrDiff = Math.abs(rsLossAddrDiff);
 
   return (

--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -7,7 +7,7 @@ import twitterIcon from "../assets/img/twitter.svg";
 import { I18n } from "@lingui/core";
 import { t, Trans } from "@lingui/macro";
 import { withI18n } from "@lingui/react";
-import helpers, { MaybeStringyNumber } from "../util/helpers";
+import helpers from "../util/helpers";
 import { FB_APP_ID } from "./Page";
 import { Borough } from "./APIDataTypes";
 import { createRouteForAddressPage, getSiteOrigin } from "../routes";
@@ -94,7 +94,7 @@ const SocialSharePortfolioWithoutI18n: React.FC<{
   addr: { boro: Borough; housenumber?: string; streetname: string };
   buildings: number;
 }> = ({ i18n, location, addr, buildings }) => {
-  const buildingCount = helpers.coerceToInt(buildings, 0);
+  const buildingCount = buildings || 0;
   return (
     <SocialShareWithoutI18n
       i18n={i18n}

--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -92,7 +92,7 @@ const SocialSharePortfolioWithoutI18n: React.FC<{
   i18n: I18n;
   location?: string;
   addr: { boro: Borough; housenumber?: string; streetname: string };
-  buildings: MaybeStringyNumber;
+  buildings: number;
 }> = ({ i18n, location, addr, buildings }) => {
   const buildingCount = helpers.coerceToInt(buildings, 0);
   return (

--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -7,7 +7,6 @@ import twitterIcon from "../assets/img/twitter.svg";
 import { I18n } from "@lingui/core";
 import { t, Trans } from "@lingui/macro";
 import { withI18n } from "@lingui/react";
-import helpers from "../util/helpers";
 import { FB_APP_ID } from "./Page";
 import { Borough } from "./APIDataTypes";
 import { createRouteForAddressPage, getSiteOrigin } from "../routes";

--- a/client/src/components/ViolationsSummary.tsx
+++ b/client/src/components/ViolationsSummary.tsx
@@ -1,17 +1,19 @@
 import React from "react";
 import * as _ from "lodash";
-import { MaybeStringyNumber } from "../util/helpers";
 import { Trans } from "@lingui/macro";
+import { SummaryStatsRecord } from "./APIDataTypes";
 
 const VIOLATIONS_AVG = 0.7; // By Unit
 // 1668635 open violations according to wow_bldgs
 // 2366392 total units in registered buildings, according to wow_bldgs
 // Last updated: 5/25/2020
 
-export const ViolationsSummary: React.FC<{
-  openviolationsperresunit: MaybeStringyNumber;
-  totalviolations: number;
-}> = (props) => {
+type ViolationsSummaryData = Pick<
+  SummaryStatsRecord,
+  "openviolationsperresunit" | "totalviolations"
+>;
+
+export const ViolationsSummary: React.FC<ViolationsSummaryData> = (props) => {
   const { openviolationsperresunit, totalviolations } = props;
 
   return (

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -15,28 +15,6 @@ test("uniq() works", () => {
   expect(helpers.uniq([1, 1, 2, 4, 4])).toEqual([1, 2, 4]);
 });
 
-describe("coerceToInt()", () => {
-  it("Returns default value when input is NaN", () => {
-    expect(helpers.coerceToInt(NaN, 15)).toBe(15);
-  });
-
-  it("Returns default value when input is null or undefined", () => {
-    expect(helpers.coerceToInt(null, 15)).toBe(15);
-    expect(helpers.coerceToInt(undefined, 15)).toBe(15);
-  });
-
-  it("Returns value when it is already a number", () => {
-    expect(helpers.coerceToInt(0, 15)).toBe(0);
-    expect(helpers.coerceToInt(5, 15)).toBe(5);
-  });
-
-  it("Returns parsed value when it is a string", () => {
-    expect(helpers.coerceToInt("0", 15)).toBe(0);
-    expect(helpers.coerceToInt("5", 15)).toBe(5);
-    expect(helpers.coerceToInt("blarg", 15)).toBe(15);
-  });
-});
-
 describe("maxArray()", () => {
   it("returns 0 for arrays with negative numbers", () => {
     expect(helpers.maxArray([-1, -2])).toBe(0);

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -29,13 +29,6 @@ export const longDateOptions = { year: "numeric", month: "short", day: "numeric"
 export const mediumDateOptions = { year: "numeric", month: "long" };
 export const shortDateOptions = { month: "short" };
 
-/**
- * Urg, our codebase wasn't originally written in TypeScript and
- * some of our legacy code appears to pass around numbers as strings,
- * so this type accounts for that.
- */
-export type MaybeStringyNumber = string | null | undefined | number;
-
 export default {
   // filter repeated values in rbas and owners
   // uses Set which enforces uniqueness
@@ -44,27 +37,6 @@ export default {
     return Array.from(new Set(_array.map((val) => JSON.stringify(val)))).map((val) =>
       JSON.parse(val)
     );
-  },
-
-  /**
-   * Attempts to coerce the given argument into an integer, returning
-   * the given default value on failure.
-   *
-   * Note that this function will *not* convert a float to an int in
-   * any way; if a number is passed in, it is assumed to be an int and
-   * returned immediately.
-   */
-  coerceToInt<T>(value: MaybeStringyNumber, defaultValue: T): number | T {
-    if (typeof value === "number" && !isNaN(value)) {
-      return value;
-    }
-    if (typeof value === "string") {
-      let intValue = parseInt(value);
-      if (!isNaN(intValue)) {
-        return intValue;
-      }
-    }
-    return defaultValue;
   },
 
   find<T, K extends keyof T>(array: T[], attrib: K, value: T[K]): T | null {


### PR DESCRIPTION
This PR updates various components that utilize API Data to now reference types from APIDataTypes.ts instead. It also removes the `MaybeStringyNumber` type and the `CoerceToInt` helper function as those are no longer needed in our new world of strongly typed data inputs!! 

Fixes #348.  