### PR TITLE
Add Xstate as our handler of all API data and state management

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "@types/react-router-dom": "5.1.5",
     "@types/react-table": "^6.8.5",
     "@types/react-transition-group": "^4.4.0",
+    "@xstate/react": "^0.8.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-plugin-macros": "^2.7.1",
     "babel-polyfill": "^6.26.0",

--- a/client/package.json
+++ b/client/package.json
@@ -61,7 +61,7 @@
     "react-transition-group": "^2.2.1",
     "rollbar": "^2.14.4",
     "spectre.scss": "0.0.2",
-    "typescript": "^3.3.3",
+    "typescript": "^3.9.7",
     "xstate": "^4.11.0"
   },
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -84,6 +84,7 @@
     "@babel/preset-typescript": "^7.7.4",
     "@babel/register": "^7.7.4",
     "dotenv": "^8.2.0",
+    "jest-fetch-mock": "^3.0.3",
     "npm-run-all": "^4.0.2",
     "prettier": "2.0.5"
   },

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -11,41 +11,12 @@ import { IndicatorsDatasetId } from "./IndicatorsDatasets";
 import {
   IndicatorsData,
   indicatorsInitialState,
-  indicatorsInitialDataStrucutre,
+  indicatorsInitialDataStructure,
   IndicatorsDataFromAPI,
 } from "./IndicatorsTypes";
+import helpers from "util/helpers";
 
 // API REQUESTS TO THE DATABASE:
-
-/** Reorganizes raw data from API call and then returns an object that matches the data stucture in state  */
-function createVizData(rawJSON: any, vizType: IndicatorsDatasetId): IndicatorsData {
-  // Generate object to hold data for viz
-  // Note: keys in "values" object need to match exact key names in data from API call
-  var vizData: IndicatorsData = Object.assign({}, indicatorsInitialDataStrucutre[vizType]);
-
-  vizData.labels = [];
-  for (const column in vizData.values) {
-    vizData.values[column] = [];
-  }
-
-  // Generate arrays of data for chart.js visualizations:
-  // Default grouping is by MONTH
-
-  const rawJSONLength = rawJSON.length;
-
-  for (let i = 0; i < rawJSONLength; i++) {
-    vizData.labels.push(rawJSON[i].month);
-
-    for (const column in vizData.values) {
-      const vizTypePlusColumn = vizType + "_" + column;
-      const values = vizData.values[column];
-      if (!values)
-        throw new Error(`Column "${column}" of visualization "${vizType}" is not an array!`);
-      values.push(parseInt(rawJSON[i][vizTypePlusColumn]));
-    }
-  }
-  return vizData;
-}
 
 function searchForAddressWithGeosearch(q: {
   housenumber?: string;
@@ -106,14 +77,14 @@ async function getIndicatorHistory(bbl: string): Promise<IndicatorsDataFromAPI> 
   const apiData: Promise<IndicatorsHistoryResults> = get(
     `/api/address/indicatorhistory?bbl=${bbl}`
   );
-  const boop = (await apiData).result;
-  const obj = Object.assign({}, indicatorsInitialDataStrucutre);
+  const rawIndicatorData = (await apiData).result;
+  const structuredIndicatorData = Object.assign({}, indicatorsInitialDataStructure);
 
   for (const indicator of indicatorsInitialState.indicatorList) {
-    var inputData = createVizData(boop, indicator);
-    obj[indicator] = inputData as any;
+    var inputData = helpers.createVizData(rawIndicatorData, indicator);
+    structuredIndicatorData[indicator] = inputData as any;
   }
-  return obj;
+  return structuredIndicatorData;
 }
 
 function getAddressExport(bbl: string) {

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -7,9 +7,7 @@ import {
 } from "./APIDataTypes";
 import { SearchAddress } from "./AddressSearch";
 import { GeoSearchRequester } from "@justfixnyc/geosearch-requester";
-import { IndicatorsDatasetId } from "./IndicatorsDatasets";
 import {
-  IndicatorsData,
   indicatorsInitialState,
   indicatorsInitialDataStructure,
   IndicatorsDataFromAPI,

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -26,7 +26,10 @@ function searchForAddressWithGeosearch(q: {
       onError: reject,
       onResults(results) {
         const firstResult = results.features[0];
-        if (!firstResult) throw new Error("Invalid address!");
+        if (!firstResult) return resolve({
+          addrs: [],
+          geosearch: undefined,
+        });
         resolve(searchForBBL(splitBBL(firstResult.properties.pad_bbl)));
       },
       throttleMs: 0,

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -80,6 +80,7 @@ async function getIndicatorHistory(bbl: string): Promise<IndicatorsDataFromAPI> 
 
   for (const indicator of indicatorsInitialState.indicatorList) {
     var inputData = helpers.createVizData(rawIndicatorData, indicator);
+    // TO DO: Fix this "any" typecasting
     structuredIndicatorData[indicator] = inputData as any;
   }
   return structuredIndicatorData;

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -26,10 +26,11 @@ function searchForAddressWithGeosearch(q: {
       onError: reject,
       onResults(results) {
         const firstResult = results.features[0];
-        if (!firstResult) return resolve({
-          addrs: [],
-          geosearch: undefined,
-        });
+        if (!firstResult)
+          return resolve({
+            addrs: [],
+            geosearch: undefined,
+          });
         resolve(searchForBBL(splitBBL(firstResult.properties.pad_bbl)));
       },
       throttleMs: 0,

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -19,7 +19,6 @@ function searchForAddressWithGeosearch(q: {
   if (q.housenumber) {
     addr = `${q.housenumber} ${addr}`;
   }
-  console.log("searching for", addr);
 
   return new Promise<SearchResults>((resolve, reject) => {
     const req = new GeoSearchRequester({

--- a/client/src/components/AddressSearch.tsx
+++ b/client/src/components/AddressSearch.tsx
@@ -35,7 +35,7 @@ export interface SearchAddress {
   bbl: string;
 }
 
-export interface AddressSearchProps extends SearchAddress {
+export interface AddressSearchProps {
   onFormSubmit: (searchAddress: SearchAddress, error: any) => void;
   labelText: string | JSX.Element;
   labelClass: string;

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -269,7 +269,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     <br />
                     <Link
                       to={this.props.generateBaseUrl()}
-                      onClick={() => this.props.onBackToOverview(detailAddr)}
+                      onClick={() => this.props.onBackToOverview(detailAddr.bbl)}
                     >
                       <Trans>Back to Overview</Trans>
                     </Link>

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -21,7 +21,6 @@ import {
   IndicatorsState,
   IndicatorChartShift,
   IndicatorsTimeSpan,
-  IndicatorsData,
 } from "./IndicatorsTypes";
 import { Nobr } from "./Nobr";
 

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -23,6 +23,7 @@ import {
   IndicatorsTimeSpan,
 } from "./IndicatorsTypes";
 import { Nobr } from "./Nobr";
+import { ErrorPageScaffolding } from "containers/NotFoundPage";
 
 class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> {
   constructor(props: IndicatorsProps) {
@@ -158,7 +159,11 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
         this.props.state.matches({ portfolioFound: { timeline: "success" } })
       )
     ) {
-      return (
+      return this.props.state.matches({ portfolioFound: { timeline: "error" } }) ? (
+        <ErrorPageScaffolding>
+          <Trans>Oops! A network error occurred. Try again later.</Trans>
+        </ErrorPageScaffolding>
+      ) : (
         <Loader loading={true} classNames="Loader-map">
           <Trans>Loading</Trans>
         </Loader>

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -172,12 +172,13 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
       const lot = bbl.slice(6, 10);
 
       const { activeVis } = this.state;
-      const data = state.context.timelineData[activeVis];
-      const xAxisLength = data.labels
-        ? Math.floor(data.labels.length / this.state.monthsInGroup)
+      const activeData = state.context.timelineData[activeVis];
+
+      const xAxisLength = activeData.labels
+        ? Math.floor(activeData.labels.length / this.state.monthsInGroup)
         : 0;
-      const indicatorDataTotal = data.values.total
-        ? data.values.total.reduce((total: number, sum: number) => total + sum)
+      const indicatorDataTotal = activeData.values.total
+        ? activeData.values.total.reduce((total: number, sum: number) => total + sum)
         : null;
 
       const i18n = this.props.i18n;
@@ -186,7 +187,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
         detailAddr.streetname
       )}, ${Helpers.titleCase(detailAddr.boro)}`;
 
-      const dataset = INDICATORS_DATASETS[this.state.activeVis];
+      const datasetDescription = INDICATORS_DATASETS[this.state.activeVis];
 
       return (
         <div className="Page Indicators">
@@ -295,9 +296,9 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                 </div>
 
                 <span className="title viz-title">
-                  {dataset &&
+                  {datasetDescription &&
                     indicatorDataTotal !== null &&
-                    dataset.quantity(i18n, indicatorDataTotal)}
+                    datasetDescription.quantity(i18n, indicatorDataTotal)}
                 </span>
 
                 <div className="Indicators__viz">
@@ -352,11 +353,11 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                 <div className="card">
                   <div className="card-header">
                     <div className="card-title h5">
-                      <Trans>What are {dataset && dataset.name(i18n)}?</Trans>
+                      <Trans>What are {datasetDescription && datasetDescription.name(i18n)}?</Trans>
                     </div>
                     <div className="card-subtitle text-gray" />
                   </div>
-                  <div className="card-body">{dataset && dataset.explanation(i18n)}</div>
+                  <div className="card-body">{datasetDescription && datasetDescription.explanation(i18n)}</div>
                 </div>
 
                 <div className="card card-links">

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -97,6 +97,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
 
   componentDidMount() {
     this.updateData();
+    this.handleXAxisChange("reset");
   }
 
   componentDidUpdate(prevProps: IndicatorsProps, prevState: IndicatorsState) {

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -32,11 +32,6 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
     this.handleVisChange = this.handleVisChange.bind(this);
   }
 
-  /** Resets the component to initial blank state */
-  reset() {
-    this.setState(indicatorsInitialState);
-  }
-
   /** Shifts the X-axis 'left' or 'right', or 'reset' the X-axis to default */
   handleXAxisChange(shift: IndicatorChartShift) {
     const span = this.state.xAxisViewableColumns;
@@ -92,17 +87,24 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
     });
   }
 
-  componentDidMount() {
-    if (this.props.state.matches({ portfolioFound: { timeline: "noData" } })) {
-      this.reset();
+  updateData() {
+    if (
+      this.props.state.matches({ portfolioFound: { timeline: "noData" } }) &&
+      this.props.isVisible
+    ) {
       this.props.send({ type: "VIEW_TIMELINE" });
     }
+  }
+
+  componentDidMount() {
+    this.updateData();
   }
 
   componentDidUpdate(prevProps: IndicatorsProps, prevState: IndicatorsState) {
     const { state } = this.props;
 
-    // process viz data from incoming API calls:
+    this.updateData();
+
     const newlyLoadedRawData =
       !prevProps.state.matches({ portfolioFound: { timeline: "success" } }) &&
       state.matches({ portfolioFound: { timeline: "success" } }) &&
@@ -163,14 +165,12 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
       );
     } else {
       const { state, send } = this.props;
-      console.log(state.value, state.context);
-      const { detailAddr } = state.context.portfolioData;
 
-      const boro = detailAddr ? detailAddr.bbl.slice(0, 1) : null;
-      const block = detailAddr ? detailAddr.bbl.slice(1, 6) : null;
-      const lot = detailAddr ? detailAddr.bbl.slice(6, 10) : null;
-      const housenumber = detailAddr ? detailAddr.housenumber : null;
-      const streetname = detailAddr ? detailAddr.streetname : null;
+      const { detailAddr } = state.context.portfolioData;
+      const { housenumber, streetname, bbl } = detailAddr;
+      const boro = bbl.slice(0, 1);
+      const block = bbl.slice(1, 6);
+      const lot = bbl.slice(6, 10);
 
       const { activeVis } = this.state;
       const data = state.context.timelineData[activeVis];
@@ -204,7 +204,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     <br />
                     <Link
                       to={this.props.generateBaseUrl()}
-                      onClick={() => this.props.onBackToOverview(detailAddr.bbl)}
+                      onClick={() => this.props.onBackToOverview(bbl)}
                     >
                       <Trans>Back to Overview</Trans>
                     </Link>
@@ -219,17 +219,17 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     <br />
                     <IndicatorsDatasetRadio
                       id="complaints"
-                      activeId={this.state.activeVis}
+                      activeId={activeVis}
                       onChange={this.handleVisChange}
                     />
                     <IndicatorsDatasetRadio
                       id="viols"
-                      activeId={this.state.activeVis}
+                      activeId={activeVis}
                       onChange={this.handleVisChange}
                     />
                     <IndicatorsDatasetRadio
                       id="permits"
-                      activeId={this.state.activeVis}
+                      activeId={activeVis}
                       onChange={this.handleVisChange}
                     />
                   </div>

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -357,7 +357,9 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     </div>
                     <div className="card-subtitle text-gray" />
                   </div>
-                  <div className="card-body">{datasetDescription && datasetDescription.explanation(i18n)}</div>
+                  <div className="card-body">
+                    {datasetDescription && datasetDescription.explanation(i18n)}
+                  </div>
                 </div>
 
                 <div className="card card-links">

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -1,6 +1,7 @@
 import { MonthlyTimelineData, AddressRecord } from "./APIDataTypes";
 import { IndicatorsDatasetId } from "./IndicatorsDatasets";
 import { withI18nProps } from "@lingui/react";
+import { WithMachineInStateProps } from "state-machine";
 
 export type IndicatorsTimeSpan = "month" | "quarter" | "year";
 
@@ -69,7 +70,6 @@ export type IndicatorsState = IndicatorsDataFromAPI & {
   monthsInGroup: number;
   xAxisStart: number;
   xAxisViewableColumns: number;
-  currentAddr: AddressRecord | null;
 };
 
 export const indicatorsInitialState: IndicatorsState = {
@@ -115,17 +115,16 @@ export const indicatorsInitialState: IndicatorsState = {
   monthsInGroup: 3,
   xAxisStart: 0,
   xAxisViewableColumns: 20,
-  currentAddr: null,
 };
 
 // Types Relating to the Props of the Indicators Component:
 
-export type IndicatorsProps = withI18nProps & {
-  isVisible: boolean;
-  detailAddr: AddressRecord | null;
-  onBackToOverview: (bbl: string) => void;
-  generateBaseUrl: () => string;
-};
+export type IndicatorsProps = withI18nProps &
+  WithMachineInStateProps<"portfolioFound"> & {
+    isVisible: boolean;
+    onBackToOverview: (bbl: string) => void;
+    generateBaseUrl: () => string;
+  };
 
 // Other Useful Types and Type-related utilites:
 

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -1,4 +1,3 @@
-import { MonthlyTimelineData, AddressRecord } from "./APIDataTypes";
 import { IndicatorsDatasetId } from "./IndicatorsDatasets";
 import { withI18nProps } from "@lingui/react";
 import { WithMachineInStateProps } from "state-machine";
@@ -59,7 +58,6 @@ export type IndicatorsDataFromAPI = IndicatorsDataIndex & {
 
 export type IndicatorsState = {
   lastSale: LastSaleData;
-
   indicatorList: IndicatorsDatasetId[];
   defaultVis: IndicatorsDatasetId;
   activeVis: IndicatorsDatasetId;

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -70,7 +70,7 @@ export type IndicatorsState = {
   xAxisViewableColumns: number;
 };
 
-export const indicatorsInitialDataStrucutre: IndicatorsDataFromAPI = {
+export const indicatorsInitialDataStructure: IndicatorsDataFromAPI = {
   viols: {
     labels: null,
     values: {

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -47,19 +47,17 @@ interface PermitsData extends IndicatorsData {
   };
 }
 
-type IndicatorsDataIndex = {
+export type IndicatorsDataIndex = {
   [k in IndicatorsDatasetId]: IndicatorsData;
 };
 
-type IndicatorsDataFromAPI = IndicatorsDataIndex & {
+export type IndicatorsDataFromAPI = IndicatorsDataIndex & {
   viols: ViolsData;
   complaints: ComplaintsData;
   permits: PermitsData;
 };
 
-export type IndicatorsState = IndicatorsDataFromAPI & {
-  indicatorHistory: MonthlyTimelineData[] | null;
-
+export type IndicatorsState = {
   lastSale: LastSaleData;
 
   indicatorList: IndicatorsDatasetId[];
@@ -72,15 +70,7 @@ export type IndicatorsState = IndicatorsDataFromAPI & {
   xAxisViewableColumns: number;
 };
 
-export const indicatorsInitialState: IndicatorsState = {
-  lastSale: {
-    date: null,
-    label: null,
-    documentid: null,
-  },
-
-  indicatorHistory: null,
-
+export const indicatorsInitialDataStrucutre: IndicatorsDataFromAPI = {
   viols: {
     labels: null,
     values: {
@@ -105,6 +95,14 @@ export const indicatorsInitialState: IndicatorsState = {
     values: {
       total: null,
     },
+  },
+};
+
+export const indicatorsInitialState: IndicatorsState = {
+  lastSale: {
+    date: null,
+    label: null,
+    documentid: null,
   },
 
   indicatorList: ["complaints", "viols", "permits"],

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -4,13 +4,7 @@ import { WithMachineInStateProps } from "state-machine";
 
 export type IndicatorsTimeSpan = "month" | "quarter" | "year";
 
-// Types Relating to the State of the Indicators Component:
-
-type LastSaleData = {
-  date: string | null;
-  label: string | null;
-  documentid: string | null;
-};
+// Types Relating to the State Machine Data for the Indicators Component:
 
 type IndicatorsDataValues = {
   [k in string]?: number[] | null;
@@ -56,18 +50,6 @@ export type IndicatorsDataFromAPI = IndicatorsDataIndex & {
   permits: PermitsData;
 };
 
-export type IndicatorsState = {
-  lastSale: LastSaleData;
-  indicatorList: IndicatorsDatasetId[];
-  defaultVis: IndicatorsDatasetId;
-  activeVis: IndicatorsDatasetId;
-  timeSpanList: IndicatorsTimeSpan[];
-  activeTimeSpan: IndicatorsTimeSpan;
-  monthsInGroup: number;
-  xAxisStart: number;
-  xAxisViewableColumns: number;
-};
-
 export const indicatorsInitialDataStructure: IndicatorsDataFromAPI = {
   viols: {
     labels: null,
@@ -94,6 +76,26 @@ export const indicatorsInitialDataStructure: IndicatorsDataFromAPI = {
       total: null,
     },
   },
+};
+
+// Types Relating to the State of the Indicators Component:
+
+type LastSaleData = {
+  date: string | null;
+  label: string | null;
+  documentid: string | null;
+};
+
+export type IndicatorsState = {
+  lastSale: LastSaleData;
+  indicatorList: IndicatorsDatasetId[];
+  defaultVis: IndicatorsDatasetId;
+  activeVis: IndicatorsDatasetId;
+  timeSpanList: IndicatorsTimeSpan[];
+  activeTimeSpan: IndicatorsTimeSpan;
+  monthsInGroup: number;
+  xAxisStart: number;
+  xAxisViewableColumns: number;
 };
 
 export const indicatorsInitialState: IndicatorsState = {

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -123,7 +123,7 @@ export const indicatorsInitialState: IndicatorsState = {
 export type IndicatorsProps = withI18nProps & {
   isVisible: boolean;
   detailAddr: AddressRecord | null;
-  onBackToOverview: (addr: AddressRecord) => void;
+  onBackToOverview: (bbl: string) => void;
   generateBaseUrl: () => string;
 };
 

--- a/client/src/components/IndicatorsViz.tsx
+++ b/client/src/components/IndicatorsViz.tsx
@@ -10,17 +10,18 @@ import * as ChartAnnotation from "chartjs-plugin-annotation";
 // reference: https://github.com/chartjs/chartjs-plugin-annotation
 // why we're using this import format: https://stackoverflow.com/questions/51664741/chartjs-plugin-annotations-not-displayed-in-angular-5/53071497#53071497
 
-import Helpers, { mediumDateOptions, shortDateOptions } from "../util/helpers";
+import Helpers, { mediumDateOptions, shortDateOptions, assertNotUndefined } from "../util/helpers";
 
 import "styles/Indicators.css";
 import { IndicatorsState } from "./IndicatorsTypes";
 import { SupportedLocale } from "../i18n-base";
 import { ChartOptions } from "chart.js";
+import { WithMachineInStateProps } from "state-machine";
 
 const DEFAULT_ANIMATION_MS = 1000;
 const MONTH_ANIMATION_MS = 2500;
 
-type IndicatorVizProps = IndicatorsState;
+type IndicatorVizProps = WithMachineInStateProps<"portfolioFound"> & IndicatorsState;
 
 type IndicatorVizState = IndicatorsState & {
   shouldRedraw: boolean;
@@ -80,7 +81,16 @@ export default class IndicatorsViz extends Component<IndicatorVizProps, Indicato
   }
 
   render() {
-    return <I18n>{({ i18n }) => <IndicatorsVizImplementation {...this.state} i18n={i18n} />}</I18n>;
+    const { state, send } = this.props;
+    if (state.matches({ portfolioFound: { timeline: "success" } })) {
+      return (
+        <I18n>
+          {({ i18n }) => (
+            <IndicatorsVizImplementation {...this.state} i18n={i18n} state={state} send={send} />
+          )}
+        </I18n>
+      );
+    } else return <></>;
   }
 }
 
@@ -98,7 +108,9 @@ function makeAnnotations(
   return result;
 }
 
-type IndicatorVizImplementationProps = withI18nProps & IndicatorVizState;
+type IndicatorVizImplementationProps = withI18nProps &
+  WithMachineInStateProps<"portfolioFound"> &
+  IndicatorVizState;
 
 class IndicatorsVizImplementation extends Component<IndicatorVizImplementationProps> {
   /** Returns new data labels match selected time span */
@@ -156,8 +168,9 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
 
   /** Returns maximum y-value across all datasets, grouped by selected timespan */
   getDataMaximum() {
+    var indicatorsData = assertNotUndefined(this.props.state.context.timelineData);
     var dataMaximums = this.props.indicatorList.map((indicatorData) => {
-      const { total } = this.props[indicatorData].values;
+      const { total } = indicatorsData[indicatorData].values;
       return total ? Helpers.maxArray(this.groupData(total) || [0]) : 0;
     });
 
@@ -167,6 +180,7 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
   render() {
     // Create "data" object according to Chart.js documentation
     var datasets: chartjs.ChartDataSets[];
+    var indicatorsData = assertNotUndefined(this.props.state.context.timelineData);
 
     const { i18n } = this.props;
     const locale = (i18n.language || "en") as SupportedLocale;
@@ -176,21 +190,21 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
         datasets = [
           {
             label: i18n._(t`Class C`),
-            data: this.groupData(this.props.viols.values.class_c) || [],
+            data: this.groupData(indicatorsData.viols.values.class_c) || [],
             backgroundColor: "rgba(136,65,157, 0.6)",
             borderColor: "rgba(136,65,157,1)",
             borderWidth: 1,
           },
           {
             label: i18n._(t`Class B`),
-            data: this.groupData(this.props.viols.values.class_b) || [],
+            data: this.groupData(indicatorsData.viols.values.class_b) || [],
             backgroundColor: "rgba(140,150,198, 0.6)",
             borderColor: "rgba(140,150,198,1)",
             borderWidth: 1,
           },
           {
             label: i18n._(t`Class A`),
-            data: this.groupData(this.props.viols.values.class_a) || [],
+            data: this.groupData(indicatorsData.viols.values.class_a) || [],
             backgroundColor: "rgba(157, 194, 227, 0.6)",
             borderColor: "rgba(157, 194, 227,1)",
             borderWidth: 1,
@@ -201,14 +215,14 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
         datasets = [
           {
             label: i18n._(t`Emergency`),
-            data: this.groupData(this.props.complaints.values.emergency) || [],
+            data: this.groupData(indicatorsData.complaints.values.emergency) || [],
             backgroundColor: "rgba(227,74,51, 0.6)",
             borderColor: "rgba(227,74,51,1)",
             borderWidth: 1,
           },
           {
             label: i18n._(t`Non-Emergency`),
-            data: this.groupData(this.props.complaints.values.nonemergency) || [],
+            data: this.groupData(indicatorsData.complaints.values.nonemergency) || [],
             backgroundColor: "rgba(255, 219, 170, 0.6)",
             borderColor: "rgba(255, 219, 170,1)",
             borderWidth: 1,
@@ -219,7 +233,7 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
         datasets = [
           {
             label: i18n._(t`Building Permits Applied For`),
-            data: this.groupData(this.props.permits.values.total) || [],
+            data: this.groupData(indicatorsData.permits.values.total) || [],
             backgroundColor: "rgba(73, 192, 179, 0.6)",
             borderColor: "rgb(73, 192, 179)",
             borderWidth: 1,
@@ -233,7 +247,7 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
 
     var { activeVis } = this.props;
     var data: ChartData<chartjs.ChartData> = {
-      labels: this.groupLabels(this.props[activeVis].labels) || [],
+      labels: this.groupLabels(indicatorsData[activeVis].labels) || [],
       datasets,
     };
 
@@ -286,7 +300,7 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
                 this.props.activeVis === "permits"
                   ? Math.max(
                       12,
-                      Helpers.maxArray(this.groupData(this.props.permits.values.total) || [0]) *
+                      Helpers.maxArray(this.groupData(indicatorsData.permits.values.total) || [0]) *
                         1.25
                     )
                   : Math.max(12, dataMaximum * 1.25),

--- a/client/src/components/IndicatorsViz.tsx
+++ b/client/src/components/IndicatorsViz.tsx
@@ -82,15 +82,13 @@ export default class IndicatorsViz extends Component<IndicatorVizProps, Indicato
 
   render() {
     const { state, send } = this.props;
-    if (state.matches({ portfolioFound: { timeline: "success" } })) {
-      return (
-        <I18n>
-          {({ i18n }) => (
-            <IndicatorsVizImplementation {...this.state} i18n={i18n} state={state} send={send} />
-          )}
-        </I18n>
-      );
-    } else return <></>;
+    return (
+      <I18n>
+        {({ i18n }) => (
+          <IndicatorsVizImplementation {...this.state} i18n={i18n} state={state} send={send} />
+        )}
+      </I18n>
+    );
   }
 }
 

--- a/client/src/components/IndicatorsViz.tsx
+++ b/client/src/components/IndicatorsViz.tsx
@@ -10,7 +10,7 @@ import * as ChartAnnotation from "chartjs-plugin-annotation";
 // reference: https://github.com/chartjs/chartjs-plugin-annotation
 // why we're using this import format: https://stackoverflow.com/questions/51664741/chartjs-plugin-annotations-not-displayed-in-angular-5/53071497#53071497
 
-import Helpers, { mediumDateOptions, shortDateOptions, assertNotUndefined } from "../util/helpers";
+import Helpers, { mediumDateOptions, shortDateOptions } from "../util/helpers";
 
 import "styles/Indicators.css";
 import { IndicatorsState } from "./IndicatorsTypes";
@@ -21,7 +21,8 @@ import { WithMachineInStateProps } from "state-machine";
 const DEFAULT_ANIMATION_MS = 1000;
 const MONTH_ANIMATION_MS = 2500;
 
-type IndicatorVizProps = WithMachineInStateProps<"portfolioFound"> & IndicatorsState;
+type IndicatorVizProps = WithMachineInStateProps<{ portfolioFound: { timeline: "success" } }> &
+  IndicatorsState;
 
 type IndicatorVizState = IndicatorsState & {
   shouldRedraw: boolean;
@@ -107,7 +108,7 @@ function makeAnnotations(
 }
 
 type IndicatorVizImplementationProps = withI18nProps &
-  WithMachineInStateProps<"portfolioFound"> &
+  WithMachineInStateProps<{ portfolioFound: { timeline: "success" } }> &
   IndicatorVizState;
 
 class IndicatorsVizImplementation extends Component<IndicatorVizImplementationProps> {
@@ -166,9 +167,9 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
 
   /** Returns maximum y-value across all datasets, grouped by selected timespan */
   getDataMaximum() {
-    var indicatorsData = assertNotUndefined(this.props.state.context.timelineData);
-    var dataMaximums = this.props.indicatorList.map((indicatorData) => {
-      const { total } = indicatorsData[indicatorData].values;
+    var { timelineData } = this.props.state.context;
+    var dataMaximums = this.props.indicatorList.map((datasetName) => {
+      const { total } = timelineData[datasetName].values;
       return total ? Helpers.maxArray(this.groupData(total) || [0]) : 0;
     });
 
@@ -178,7 +179,7 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
   render() {
     // Create "data" object according to Chart.js documentation
     var datasets: chartjs.ChartDataSets[];
-    var indicatorsData = assertNotUndefined(this.props.state.context.timelineData);
+    var { timelineData } = this.props.state.context;
 
     const { i18n } = this.props;
     const locale = (i18n.language || "en") as SupportedLocale;
@@ -188,21 +189,21 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
         datasets = [
           {
             label: i18n._(t`Class C`),
-            data: this.groupData(indicatorsData.viols.values.class_c) || [],
+            data: this.groupData(timelineData.viols.values.class_c) || [],
             backgroundColor: "rgba(136,65,157, 0.6)",
             borderColor: "rgba(136,65,157,1)",
             borderWidth: 1,
           },
           {
             label: i18n._(t`Class B`),
-            data: this.groupData(indicatorsData.viols.values.class_b) || [],
+            data: this.groupData(timelineData.viols.values.class_b) || [],
             backgroundColor: "rgba(140,150,198, 0.6)",
             borderColor: "rgba(140,150,198,1)",
             borderWidth: 1,
           },
           {
             label: i18n._(t`Class A`),
-            data: this.groupData(indicatorsData.viols.values.class_a) || [],
+            data: this.groupData(timelineData.viols.values.class_a) || [],
             backgroundColor: "rgba(157, 194, 227, 0.6)",
             borderColor: "rgba(157, 194, 227,1)",
             borderWidth: 1,
@@ -213,14 +214,14 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
         datasets = [
           {
             label: i18n._(t`Emergency`),
-            data: this.groupData(indicatorsData.complaints.values.emergency) || [],
+            data: this.groupData(timelineData.complaints.values.emergency) || [],
             backgroundColor: "rgba(227,74,51, 0.6)",
             borderColor: "rgba(227,74,51,1)",
             borderWidth: 1,
           },
           {
             label: i18n._(t`Non-Emergency`),
-            data: this.groupData(indicatorsData.complaints.values.nonemergency) || [],
+            data: this.groupData(timelineData.complaints.values.nonemergency) || [],
             backgroundColor: "rgba(255, 219, 170, 0.6)",
             borderColor: "rgba(255, 219, 170,1)",
             borderWidth: 1,
@@ -231,7 +232,7 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
         datasets = [
           {
             label: i18n._(t`Building Permits Applied For`),
-            data: this.groupData(indicatorsData.permits.values.total) || [],
+            data: this.groupData(timelineData.permits.values.total) || [],
             backgroundColor: "rgba(73, 192, 179, 0.6)",
             borderColor: "rgb(73, 192, 179)",
             borderWidth: 1,
@@ -245,7 +246,7 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
 
     var { activeVis } = this.props;
     var data: ChartData<chartjs.ChartData> = {
-      labels: this.groupLabels(indicatorsData[activeVis].labels) || [],
+      labels: this.groupLabels(timelineData[activeVis].labels) || [],
       datasets,
     };
 
@@ -298,7 +299,7 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
                 this.props.activeVis === "permits"
                   ? Math.max(
                       12,
-                      Helpers.maxArray(this.groupData(indicatorsData.permits.values.total) || [0]) *
+                      Helpers.maxArray(this.groupData(timelineData.permits.values.total) || [0]) *
                         1.25
                     )
                   : Math.max(12, dataMaximum * 1.25),

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -11,239 +11,241 @@ import { Link } from "react-router-dom";
 import { SupportedLocale } from "../i18n-base";
 import Helpers, { longDateOptions } from "../util/helpers";
 import { AddressRecord } from "./APIDataTypes";
+import { WithMachineProps } from "state-machine";
 
 export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
   const addrsWithMatchingSale = addrs.filter((addr) => addr.lastsaleacrisid === saleId);
   return addrsWithMatchingSale.length > 1;
 };
 
-const PropertiesListWithoutI18n: React.FC<{
-  i18n: I18n;
-  addrs: AddressRecord[];
-  onOpenDetail: (addr: AddressRecord) => void;
-  generateBaseUrl: () => string;
-}> = (props) => {
+const PropertiesListWithoutI18n: React.FC<
+  WithMachineProps & {
+    i18n: I18n;
+    onOpenDetail: (bbl: string) => void;
+    generateBaseUrl: () => string;
+  }
+> = (props) => {
   const { i18n } = props;
   const locale = (i18n.language as SupportedLocale) || "en";
-  if (!props.addrs.length) {
-    return null;
-  } else {
-    return (
-      <div className="PropertiesList">
-        <ReactTable
-          data={props.addrs}
-          minRows={Browser.isMobile() ? 5 : 10}
-          defaultPageSize={props.addrs.length}
-          showPagination={false}
-          columns={[
-            {
-              Header: i18n._(t`Location`),
-              columns: [
-                {
-                  Header: i18n._(t`Address`),
-                  accessor: (d) => `${d.housenumber} ${d.streetname}`,
-                  id: "address",
-                  minWidth: 150,
-                  style: {
-                    textAlign: "left",
-                  },
-                },
-                {
-                  Header: i18n._(t`Zipcode`),
-                  accessor: (d) => d.zip,
-                  id: "zip",
-                  width: 75,
-                },
-                {
-                  Header: i18n._(t`Borough`),
-                  accessor: (d) => d.boro,
-                  id: "boro",
-                },
-                {
-                  Header: "BBL",
-                  accessor: (d) => d.bbl,
-                  id: "bbl",
-                },
-              ],
-            },
-            {
-              Header: i18n._(t`Information`),
-              columns: [
-                {
-                  Header: i18n._(t`Built`),
-                  accessor: (d) => d.yearbuilt,
-                  id: "yearbuilt",
-                  maxWidth: 75,
-                },
-                {
-                  Header: i18n._(t`Units`),
-                  accessor: (d) => d.unitsres,
-                  id: "unitsres",
-                  maxWidth: 75,
-                },
-              ],
-            },
-            {
-              Header: i18n._(t`RS Units`),
-              columns: [
-                {
-                  Header: "2007",
-                  accessor: (d) => d.rsunits2007,
-                  id: "rsunits2007",
-                  maxWidth: 75,
-                },
-                {
-                  Header: "2017",
-                  accessor: (d) => d.rsunits2017,
-                  id: "rsunits2017",
-                  Cell: (row) => {
-                    return (
-                      <span
-                        className={`${
-                          row.original.rsunits2017 < row.original.rsunits2007 ? "text-danger" : ""
-                        }`}
-                      >
-                        {row.original.rsunits2017}
-                      </span>
-                    );
-                  },
-                  maxWidth: 75,
-                },
-              ],
-            },
-            {
-              Header: i18n._(t`HPD Violations`),
-              columns: [
-                {
-                  Header: i18n._(t`Open`),
-                  accessor: (d) => d.openviolations,
-                  id: "openviolations",
-                  maxWidth: 75,
-                },
-                {
-                  Header: i18n._(t`Total`),
-                  accessor: (d) => d.totalviolations,
-                  id: "totalviolations",
-                  maxWidth: 75,
-                },
-              ],
-            },
-            {
-              Header: i18n._(t`Evictions`),
-              columns: [
-                {
-                  Header: "2019",
-                  accessor: (d) => d.evictions || null,
-                  id: "evictions",
-                  maxWidth: 75,
-                },
-              ],
-            },
-            {
-              Header: i18n._(t`Landlord`),
-              columns: [
-                {
-                  Header: i18n._(t`Officer/Owner`),
-                  accessor: (d) => {
-                    var owner =
-                      d.ownernames &&
-                      d.ownernames.find(
-                        (o) => o.title === "HeadOfficer" || o.title === "IndividualOwner"
-                      );
-                    return owner ? owner.value : "";
-                  },
-                  id: "ownernames",
-                  minWidth: 150,
-                },
-              ],
-            },
-            {
-              Header: i18n._(t`Last Sale`),
-              columns: [
-                {
-                  Header: i18n._(t`Date`),
-                  accessor: (d) => d.lastsaledate,
-                  Cell: (row) =>
-                    row.original.lastsaledate
-                      ? Helpers.formatDate(row.original.lastsaledate, longDateOptions, locale)
-                      : null,
-                  id: "lastsaledate",
-                },
-                {
-                  Header: i18n._(t`Amount`),
-                  accessor: (d) => d.lastsaleamount || null,
-                  Cell: (row) =>
-                    row.original.lastsaleamount
-                      ? "$" + Helpers.formatPrice(row.original.lastsaleamount, locale)
-                      : null,
-                  id: "lastsaleamount",
-                },
-                {
-                  Header: i18n._(t`Link to Deed`),
-                  accessor: (d) => d.lastsaleacrisid,
-                  Cell: (row) =>
-                    row.original.lastsaleacrisid ? (
-                      <a
-                        href={`https://a836-acris.nyc.gov/DS/DocumentSearch/DocumentImageView?doc_id=${row.original.lastsaleacrisid}`}
-                        className="btn"
-                        target="_blank"
-                        aria-label={i18n._(t`Link to Deed`)}
-                        rel="noopener noreferrer"
-                      >
-                        <span style={{ padding: "0 3px" }}>&#8599;&#xFE0E;</span>
-                      </a>
-                    ) : null,
-                  id: "lastsaleacrisid",
-                },
-                {
-                  Header: i18n._(t`Group Sale?`),
-                  accessor: (d) => {
-                    // Make id's that are part of group sales show up first when sorted:
-                    const idPrefix =
-                      d.lastsaleacrisid && isPartOfGroupSale(d.lastsaleacrisid, props.addrs)
-                        ? " "
-                        : "";
-                    return `${idPrefix}${d.lastsaleacrisid}`;
-                  },
-                  Cell: (row) =>
-                    row.original.lastsaleacrisid
-                      ? isPartOfGroupSale(row.original.lastsaleacrisid, props.addrs)
-                        ? i18n._(t`Yes`)
-                        : i18n._(t`No`)
-                      : null,
-                  id: "lastsaleisgroupsale",
-                },
-              ],
-            },
-            {
-              Header: i18n._(t`View detail`),
-              accessor: (d) => d.bbl,
-              columns: [
-                {
-                  Cell: (row) => {
-                    return (
-                      <Link
-                        to={props.generateBaseUrl()}
-                        className="btn"
-                        aria-label={i18n._(t`View detail`)}
-                        onClick={() => props.onOpenDetail(row.original)}
-                      >
-                        <span style={{ padding: "0 3px" }}>&#10142;</span>
-                      </Link>
-                    );
-                  },
-                },
-              ],
-            },
-          ]}
-          style={{
-            height: "100%",
-          }}
-          className="-striped -highlight"
-        />
-      </div>
-    );
+
+  if (!props.state.matches("portfolioFound")) {
+    throw new Error(`Invalid state: ${props.state.value}`);
   }
+
+  const addrs = props.state.context.portfolioData.assocAddrs;
+  return (
+    <div className="PropertiesList">
+      <ReactTable
+        data={addrs}
+        minRows={Browser.isMobile() ? 5 : 10}
+        defaultPageSize={addrs.length}
+        showPagination={false}
+        columns={[
+          {
+            Header: i18n._(t`Location`),
+            columns: [
+              {
+                Header: i18n._(t`Address`),
+                accessor: (d) => `${d.housenumber} ${d.streetname}`,
+                id: "address",
+                minWidth: 150,
+                style: {
+                  textAlign: "left",
+                },
+              },
+              {
+                Header: i18n._(t`Zipcode`),
+                accessor: (d) => d.zip,
+                id: "zip",
+                width: 75,
+              },
+              {
+                Header: i18n._(t`Borough`),
+                accessor: (d) => d.boro,
+                id: "boro",
+              },
+              {
+                Header: "BBL",
+                accessor: (d) => d.bbl,
+                id: "bbl",
+              },
+            ],
+          },
+          {
+            Header: i18n._(t`Information`),
+            columns: [
+              {
+                Header: i18n._(t`Built`),
+                accessor: (d) => d.yearbuilt,
+                id: "yearbuilt",
+                maxWidth: 75,
+              },
+              {
+                Header: i18n._(t`Units`),
+                accessor: (d) => d.unitsres,
+                id: "unitsres",
+                maxWidth: 75,
+              },
+            ],
+          },
+          {
+            Header: i18n._(t`RS Units`),
+            columns: [
+              {
+                Header: "2007",
+                accessor: (d) => d.rsunits2007,
+                id: "rsunits2007",
+                maxWidth: 75,
+              },
+              {
+                Header: "2017",
+                accessor: (d) => d.rsunits2017,
+                id: "rsunits2017",
+                Cell: (row) => {
+                  return (
+                    <span
+                      className={`${
+                        row.original.rsunits2017 < row.original.rsunits2007 ? "text-danger" : ""
+                      }`}
+                    >
+                      {row.original.rsunits2017}
+                    </span>
+                  );
+                },
+                maxWidth: 75,
+              },
+            ],
+          },
+          {
+            Header: i18n._(t`HPD Violations`),
+            columns: [
+              {
+                Header: i18n._(t`Open`),
+                accessor: (d) => d.openviolations,
+                id: "openviolations",
+                maxWidth: 75,
+              },
+              {
+                Header: i18n._(t`Total`),
+                accessor: (d) => d.totalviolations,
+                id: "totalviolations",
+                maxWidth: 75,
+              },
+            ],
+          },
+          {
+            Header: i18n._(t`Evictions`),
+            columns: [
+              {
+                Header: "2019",
+                accessor: (d) => d.evictions || null,
+                id: "evictions",
+                maxWidth: 75,
+              },
+            ],
+          },
+          {
+            Header: i18n._(t`Landlord`),
+            columns: [
+              {
+                Header: i18n._(t`Officer/Owner`),
+                accessor: (d) => {
+                  var owner =
+                    d.ownernames &&
+                    d.ownernames.find(
+                      (o) => o.title === "HeadOfficer" || o.title === "IndividualOwner"
+                    );
+                  return owner ? owner.value : "";
+                },
+                id: "ownernames",
+                minWidth: 150,
+              },
+            ],
+          },
+          {
+            Header: i18n._(t`Last Sale`),
+            columns: [
+              {
+                Header: i18n._(t`Date`),
+                accessor: (d) => d.lastsaledate,
+                Cell: (row) =>
+                  row.original.lastsaledate
+                    ? Helpers.formatDate(row.original.lastsaledate, longDateOptions, locale)
+                    : null,
+                id: "lastsaledate",
+              },
+              {
+                Header: i18n._(t`Amount`),
+                accessor: (d) => d.lastsaleamount || null,
+                Cell: (row) =>
+                  row.original.lastsaleamount
+                    ? "$" + Helpers.formatPrice(row.original.lastsaleamount, locale)
+                    : null,
+                id: "lastsaleamount",
+              },
+              {
+                Header: i18n._(t`Link to Deed`),
+                accessor: (d) => d.lastsaleacrisid,
+                Cell: (row) =>
+                  row.original.lastsaleacrisid ? (
+                    <a
+                      href={`https://a836-acris.nyc.gov/DS/DocumentSearch/DocumentImageView?doc_id=${row.original.lastsaleacrisid}`}
+                      className="btn"
+                      target="_blank"
+                      aria-label={i18n._(t`Link to Deed`)}
+                      rel="noopener noreferrer"
+                    >
+                      <span style={{ padding: "0 3px" }}>&#8599;&#xFE0E;</span>
+                    </a>
+                  ) : null,
+                id: "lastsaleacrisid",
+              },
+              {
+                Header: i18n._(t`Group Sale?`),
+                accessor: (d) => {
+                  // Make id's that are part of group sales show up first when sorted:
+                  const idPrefix =
+                    d.lastsaleacrisid && isPartOfGroupSale(d.lastsaleacrisid, addrs) ? " " : "";
+                  return `${idPrefix}${d.lastsaleacrisid}`;
+                },
+                Cell: (row) =>
+                  row.original.lastsaleacrisid
+                    ? isPartOfGroupSale(row.original.lastsaleacrisid, addrs)
+                      ? i18n._(t`Yes`)
+                      : i18n._(t`No`)
+                    : null,
+                id: "lastsaleisgroupsale",
+              },
+            ],
+          },
+          {
+            Header: i18n._(t`View detail`),
+            accessor: (d) => d.bbl,
+            columns: [
+              {
+                Cell: (row) => {
+                  return (
+                    <Link
+                      to={props.generateBaseUrl()}
+                      className="btn"
+                      aria-label={i18n._(t`View detail`)}
+                      onClick={() => props.onOpenDetail(row.original.bbl)}
+                    >
+                      <span style={{ padding: "0 3px" }}>&#10142;</span>
+                    </Link>
+                  );
+                },
+              },
+            ],
+          },
+        ]}
+        style={{
+          height: "100%",
+        }}
+        className="-striped -highlight"
+      />
+    </div>
+  );
 };
 
 const PropertiesList = withI18n()(PropertiesListWithoutI18n);

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -11,7 +11,7 @@ import { Link } from "react-router-dom";
 import { SupportedLocale } from "../i18n-base";
 import Helpers, { longDateOptions } from "../util/helpers";
 import { AddressRecord } from "./APIDataTypes";
-import { WithMachineProps } from "state-machine";
+import { WithMachineInStateProps } from "state-machine";
 
 export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
   const addrsWithMatchingSale = addrs.filter((addr) => addr.lastsaleacrisid === saleId);
@@ -19,7 +19,7 @@ export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
 };
 
 const PropertiesListWithoutI18n: React.FC<
-  WithMachineProps & {
+  WithMachineInStateProps<"portfolioFound"> & {
     i18n: I18n;
     onOpenDetail: (bbl: string) => void;
     generateBaseUrl: () => string;
@@ -27,10 +27,6 @@ const PropertiesListWithoutI18n: React.FC<
 > = (props) => {
   const { i18n } = props;
   const locale = (i18n.language as SupportedLocale) || "en";
-
-  if (!props.state.matches("portfolioFound")) {
-    throw new Error(`Invalid state: ${props.state.value}`);
-  }
 
   const addrs = props.state.context.portfolioData.assocAddrs;
   return (

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -11,9 +11,9 @@ import { Trans, Select } from "@lingui/macro";
 import { AddressRecord } from "./APIDataTypes";
 import { Props as MapboxMapProps } from "react-mapbox-gl/lib/map";
 import { Events as MapboxMapEvents } from "react-mapbox-gl/lib/map-events";
-import { WithMachineProps, accessPortfolioData } from "state-machine";
+import { WithMachineInStateProps } from "state-machine";
 
-type Props = WithMachineProps & {
+type Props = WithMachineInStateProps<"portfolioFound"> & {
   onAddrChange: (bbl: string) => void;
   isVisible: boolean;
 };
@@ -110,7 +110,7 @@ export default class PropertiesMap extends Component<Props, State> {
     let addrsPos = new Set();
     let newAssocAddrs: JSX.Element[] = [];
 
-    const { assocAddrs, searchAddr } = accessPortfolioData(this.props);
+    const { assocAddrs, searchAddr } = this.props.state.context.portfolioData;
 
     // cycle through addrs, adding them to the set and categorizing them
     assocAddrs.forEach((addr, i) => {
@@ -185,8 +185,12 @@ export default class PropertiesMap extends Component<Props, State> {
     this.props.onAddrChange(addr.bbl);
   };
 
+  getPortfolioData() {
+    return this.props.state.context.portfolioData;
+  }
+
   handleMapPan = () => {
-    const { detailAddr } = accessPortfolioData(this.props);
+    const { detailAddr } = this.getPortfolioData();
 
     if (!(this.state.mapFocusBbl && detailAddr.bbl === this.state.mapFocusBbl)) {
       const { lat, lng } = detailAddr;
@@ -209,7 +213,7 @@ export default class PropertiesMap extends Component<Props, State> {
   };
 
   getMapTypeForAddr = (addr: AddressRecord) => {
-    const { assocAddrs } = accessPortfolioData(this.props);
+    const { assocAddrs } = this.getPortfolioData();
     const matchingAddr = assocAddrs.find((a) => Helpers.addrsAreEqual(a, addr));
     return matchingAddr ? matchingAddr.mapType : "base";
   };
@@ -217,7 +221,7 @@ export default class PropertiesMap extends Component<Props, State> {
   render() {
     const browserType = Browser.isMobile() ? "mobile" : "other";
 
-    const { detailAddr } = accessPortfolioData(this.props);
+    const { detailAddr } = this.getPortfolioData();
 
     return (
       <div className="PropertiesMap">

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -11,7 +11,7 @@ import { Trans, Select } from "@lingui/macro";
 import { AddressRecord } from "./APIDataTypes";
 import { Props as MapboxMapProps } from "react-mapbox-gl/lib/map";
 import { Events as MapboxMapEvents } from "react-mapbox-gl/lib/map-events";
-import { WithMachineProps, getPortfolioData } from "state-machine";
+import { WithMachineProps, accessPortfolioData } from "state-machine";
 
 type Props = WithMachineProps & {
   onAddrChange: (bbl: string) => void;
@@ -110,7 +110,7 @@ export default class PropertiesMap extends Component<Props, State> {
     let addrsPos = new Set();
     let newAssocAddrs: JSX.Element[] = [];
 
-    const { assocAddrs, searchAddr } = getPortfolioData(this.props);
+    const { assocAddrs, searchAddr } = accessPortfolioData(this.props);
 
     // cycle through addrs, adding them to the set and categorizing them
     assocAddrs.forEach((addr, i) => {
@@ -186,7 +186,7 @@ export default class PropertiesMap extends Component<Props, State> {
   };
 
   handleMapPan = () => {
-    const { detailAddr } = getPortfolioData(this.props);
+    const { detailAddr } = accessPortfolioData(this.props);
 
     if (!(this.state.mapFocusBbl && detailAddr.bbl === this.state.mapFocusBbl)) {
       const { lat, lng } = detailAddr;
@@ -209,7 +209,7 @@ export default class PropertiesMap extends Component<Props, State> {
   };
 
   getMapTypeForAddr = (addr: AddressRecord) => {
-    const { assocAddrs } = getPortfolioData(this.props);
+    const { assocAddrs } = accessPortfolioData(this.props);
     const matchingAddr = assocAddrs.find((a) => Helpers.addrsAreEqual(a, addr));
     return matchingAddr ? matchingAddr.mapType : "base";
   };
@@ -217,7 +217,7 @@ export default class PropertiesMap extends Component<Props, State> {
   render() {
     const browserType = Browser.isMobile() ? "mobile" : "other";
 
-    const { detailAddr } = getPortfolioData(this.props);
+    const { detailAddr } = accessPortfolioData(this.props);
 
     return (
       <div className="PropertiesMap">

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -187,6 +187,7 @@ export default class PropertiesMap extends Component<Props, State> {
 
   handleMapPan = () => {
     const { detailAddr } = getPortfolioData(this.props);
+
     if (!(this.state.mapFocusBbl && detailAddr.bbl === this.state.mapFocusBbl)) {
       const { lat, lng } = detailAddr;
 
@@ -207,15 +208,16 @@ export default class PropertiesMap extends Component<Props, State> {
     }
   };
 
+  getMapTypeForAddr = (addr: AddressRecord) => {
+    const { assocAddrs } = getPortfolioData(this.props);
+    const matchingAddr = assocAddrs.find((a) => Helpers.addrsAreEqual(a, addr));
+    return matchingAddr ? matchingAddr.mapType : "base";
+  };
+
   render() {
     const browserType = Browser.isMobile() ? "mobile" : "other";
 
-    const { assocAddrs, detailAddr } = getPortfolioData(this.props);
-
-    const getMapTypeForAddr = (addr: AddressRecord) => {
-      const matchingAddr = assocAddrs.find((a) => Helpers.addrsAreEqual(a, addr));
-      return matchingAddr ? matchingAddr.mapType : "base";
-    };
+    const { detailAddr } = getPortfolioData(this.props);
 
     return (
       <div className="PropertiesMap">
@@ -266,10 +268,10 @@ export default class PropertiesMap extends Component<Props, State> {
                   we need to lookup the property pe of this feature from the main addrs array
                   this affects the color of the marker while still outlining it as "selected"
                   */}
-              {detailAddr && detailAddr.lng && detailAddr.lat && (
+              {detailAddr.lng && detailAddr.lat && (
                 <Feature
                   properties={{
-                    mapType: getMapTypeForAddr(detailAddr),
+                    mapType: this.getMapTypeForAddr(detailAddr),
                   }}
                   coordinates={[detailAddr.lng, detailAddr.lat]}
                 />

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -16,7 +16,7 @@ type Props = {
   addrs: AddressRecord[];
   userAddr: AddressRecord;
   detailAddr: AddressRecord | null;
-  onAddrChange: (addr: AddressRecord) => void;
+  onAddrChange: (bbl: string) => void;
   isVisible: boolean;
 };
 
@@ -206,7 +206,7 @@ export default class PropertiesMap extends Component<Props, State> {
 
   handleAddrSelect = (addr: AddressRecord, e: any) => {
     // updates state with new focus address
-    this.props.onAddrChange(addr);
+    this.props.onAddrChange(addr.bbl);
   };
 
   render() {

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -24,10 +24,7 @@ const generateLinkToDataRequestForm = (fullAddress: string) =>
   )}`;
 
 export default class PropertiesSummary extends Component<Props, {}> {
-  constructor(props: Props) {
-    super(props);
-  }
-
+  
   updateData() {
     if (
       this.props.state.matches({ portfolioFound: { summary: "noData" } }) &&

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -24,7 +24,6 @@ const generateLinkToDataRequestForm = (fullAddress: string) =>
   )}`;
 
 export default class PropertiesSummary extends Component<Props, {}> {
-  
   updateData() {
     if (
       this.props.state.matches({ portfolioFound: { summary: "noData" } }) &&

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -11,6 +11,7 @@ import { ViolationsSummary } from "./ViolationsSummary";
 import { StringifyListWithConjunction } from "./StringifyList";
 import { SocialSharePortfolio } from "./SocialShare";
 import { WithMachineInStateProps } from "state-machine";
+import { ErrorPageScaffolding } from "containers/NotFoundPage";
 
 type Props = WithMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
@@ -40,13 +41,26 @@ export default class PropertiesSummary extends Component<Props, {}> {
   }
 
   render() {
-    let agg = this.props.state.context.summaryData;
-    let searchAddr = this.props.state.context.portfolioData.searchAddr;
+    const { state } = this.props;
+    let agg = state.context.summaryData;
+    let searchAddr = state.context.portfolioData.searchAddr;
 
-    return (
-      <div className="Page PropertiesSummary">
-        <div className="PropertiesSummary__content Page__content">
-          {agg ? (
+    if (state.matches({ portfolioFound: { summary: "error" } }))
+      return (
+        <ErrorPageScaffolding>
+          <Trans>Oops! A network error occurred. Try again later.</Trans>
+        </ErrorPageScaffolding>
+      );
+    else if (!agg) {
+      return (
+        <Loader loading={true} classNames="Loader-map">
+          <Trans>Loading</Trans>
+        </Loader>
+      );
+    } else {
+      return (
+        <div className="Page PropertiesSummary">
+          <div className="PropertiesSummary__content Page__content">
             <div>
               <Trans render="h6">General info</Trans>
               <p>
@@ -164,14 +178,10 @@ export default class PropertiesSummary extends Component<Props, {}> {
                 </div>
               </aside>
             </div>
-          ) : (
-            <Loader loading={true} classNames="Loader-map">
-              Loading
-            </Loader>
-          )}
+          </div>
+          <LegalFooter />
         </div>
-        <LegalFooter />
-      </div>
-    );
+      );
+    }
   }
 }

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -3,7 +3,6 @@ import { Trans, Plural } from "@lingui/macro";
 
 import Loader from "../components/Loader";
 import LegalFooter from "../components/LegalFooter";
-import APIClient from "../components/APIClient";
 
 import "styles/PropertiesSummary.css";
 import { EvictionsSummary } from "./EvictionsSummary";
@@ -11,7 +10,7 @@ import { RentstabSummary } from "./RentstabSummary";
 import { ViolationsSummary } from "./ViolationsSummary";
 import { StringifyListWithConjunction } from "./StringifyList";
 import { SocialSharePortfolio } from "./SocialShare";
-import { AddressRecord, SummaryStatsRecord } from "./APIDataTypes";
+import { AddressRecord } from "./APIDataTypes";
 import { WithMachineProps } from "state-machine";
 
 type Props = WithMachineProps & {

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -12,14 +12,11 @@ import { ViolationsSummary } from "./ViolationsSummary";
 import { StringifyListWithConjunction } from "./StringifyList";
 import { SocialSharePortfolio } from "./SocialShare";
 import { AddressRecord, SummaryStatsRecord } from "./APIDataTypes";
+import { WithMachineProps } from "state-machine";
 
-type Props = {
+type Props = WithMachineProps & {
   isVisible: boolean;
   userAddr: AddressRecord;
-};
-
-type State = {
-  agg: SummaryStatsRecord | null;
 };
 
 const generateLinkToDataRequestForm = (fullAddress: string) =>
@@ -27,25 +24,30 @@ const generateLinkToDataRequestForm = (fullAddress: string) =>
     fullAddress
   )}`;
 
-export default class PropertiesSummary extends Component<Props, State> {
+export default class PropertiesSummary extends Component<Props, {}> {
   constructor(props: Props) {
     super(props);
-
-    this.state = { agg: null };
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    // make the api call when we come into view and have
-    // the user addrs bbl
-    if (this.props.isVisible && this.props.userAddr && !this.state.agg) {
-      APIClient.getAggregate(this.props.userAddr.bbl)
-        .then((results) => this.setState({ agg: results.result[0] }))
-        .catch((err) => console.error(err));
+  updateData() {
+    if (
+      this.props.state.matches({ portfolioFound: { summary: "noData" } }) &&
+      this.props.isVisible
+    ) {
+      this.props.send({ type: "VIEW_SUMMARY" });
     }
   }
 
+  componentDidMount() {
+    this.updateData();
+  }
+
+  componentDidUpdate() {
+    this.updateData();
+  }
+
   render() {
-    let agg = this.state.agg;
+    let agg = this.props.state.context.summaryData;
 
     return (
       <div className="Page PropertiesSummary">

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -10,12 +10,10 @@ import { RentstabSummary } from "./RentstabSummary";
 import { ViolationsSummary } from "./ViolationsSummary";
 import { StringifyListWithConjunction } from "./StringifyList";
 import { SocialSharePortfolio } from "./SocialShare";
-import { AddressRecord } from "./APIDataTypes";
-import { WithMachineProps } from "state-machine";
+import { WithMachineInStateProps } from "state-machine";
 
-type Props = WithMachineProps & {
+type Props = WithMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
-  userAddr: AddressRecord;
 };
 
 const generateLinkToDataRequestForm = (fullAddress: string) =>
@@ -43,6 +41,7 @@ export default class PropertiesSummary extends Component<Props, {}> {
 
   render() {
     let agg = this.props.state.context.summaryData;
+    let searchAddr = this.props.state.context.portfolioData.searchAddr;
 
     return (
       <div className="Page PropertiesSummary">
@@ -141,7 +140,7 @@ export default class PropertiesSummary extends Component<Props, {}> {
                         window.gtag("event", "data-request");
                       }}
                       href={generateLinkToDataRequestForm(
-                        `${this.props.userAddr.housenumber}${this.props.userAddr.streetname},${this.props.userAddr.boro}`
+                        `${searchAddr.housenumber}${searchAddr.streetname},${searchAddr.boro}`
                       )}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -158,7 +157,7 @@ export default class PropertiesSummary extends Component<Props, {}> {
                     </h6>
                     <SocialSharePortfolio
                       location="summary-tab"
-                      addr={this.props.userAddr}
+                      addr={searchAddr}
                       buildings={agg.bldgs}
                     />
                   </div>

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -21,6 +21,7 @@ import Page from "../components/Page";
 import { SearchResults, AddressRecord, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
 import { WithMachineProps } from "state-machine";
+import NotFoundPage from "./NotFoundPage";
 
 type RouteParams = {
   locale?: string;
@@ -103,7 +104,10 @@ export default class AddressPage extends Component<AddressPageProps, State> {
   render() {
     const { state, send } = this.props;
 
-    if (state.value === "nychaFound") {
+    if (state.value === "bblNotFound") {
+      return <NotFoundPage />
+    }
+    else if (state.value === "nychaFound") {
       return <NychaPage state={state} send={send} />;
     } else if (state.value === "unregisteredFound") {
       return <NotRegisteredPage state={state} send={send} />;

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -16,7 +16,7 @@ import Loader from "../components/Loader";
 import "styles/AddressPage.css";
 import NychaPage from "./NychaPage";
 import NotRegisteredPage from "./NotRegisteredPage";
-import helpers from "../util/helpers";
+import helpers, { assertNotUndefined } from "../util/helpers";
 import { Trans, Plural } from "@lingui/macro";
 import { Link, RouteComponentProps } from "react-router-dom";
 import Page from "../components/Page";
@@ -32,7 +32,6 @@ type RouteParams = {
 };
 
 type RouteState = {
-  // TODO: Fix this typing.
   results?: SearchResults;
 };
 
@@ -42,13 +41,7 @@ type AddressPageProps = RouteComponentProps<RouteParams, {}, RouteState> &
   };
 
 type State = {
-  hasSearched: boolean;
   detailMobileSlide: boolean;
-  assocAddrs: AddressRecord[];
-  geosearch?: GeoSearchData;
-  searchAddress: SearchAddress;
-  userAddr?: AddressRecord;
-  detailAddr?: AddressRecord;
 };
 
 const validateRouteParams = (params: RouteParams) => {
@@ -72,75 +65,18 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     super(props);
 
     this.state = {
-      searchAddress: validateRouteParams(props.match.params), // maybe this should be
-      hasSearched: false,
-      geosearch: undefined,
-      assocAddrs: [],
       detailMobileSlide: false,
     };
   }
 
   componentDidMount() {
-    this.props.send({ type: "SEARCH", address: this.state.searchAddress });
-
-    // We need to check where to get the results data for the page...
-
-    // Here, the user conducted a search on HomePage and we already got the results
-    if (this.props.location && this.props.location.state && this.props.location.state.results) {
-      this.handleResults(this.props.location.state.results);
-
-      // Otherwise they navigated directly to this url, so lets fetch it
-    } else {
-      window.gtag("event", "direct-link");
-      APIClient.searchForAddressWithGeosearch(this.state.searchAddress)
-        .then((results) => {
-          this.handleResults(results);
-        })
-        .catch((err) => {
-          console.error(err);
-          this.setState({
-            hasSearched: true,
-            assocAddrs: [],
-          });
-        });
+    if (this.props.state.value === "noData") {
+      this.props.send({ type: "SEARCH", address: validateRouteParams(this.props.match.params) });
     }
   }
 
-  // Processes the results and setState accordingly. Doesn't care where results comes from
-  handleResults = (results: SearchResults) => {
-    const { geosearch, addrs } = results;
-    let userAddr: AddressRecord | undefined = undefined;
-
-    if (!geosearch) {
-      throw new Error("Address results do not contain geosearch results!");
-    }
-
-    /* Case for when our API call returns a portfolio of multiple associated addresses */
-    if (addrs.length) {
-      userAddr = _find(addrs, { bbl: geosearch.bbl });
-
-      if (!userAddr) {
-        throw new Error("The user's address was not found in the API Address Search results!");
-      }
-    }
-
-    this.setState(
-      {
-        hasSearched: true,
-        geosearch: geosearch,
-        userAddr,
-        assocAddrs: addrs,
-        searchAddress: { ...this.state.searchAddress, bbl: geosearch.bbl },
-      },
-      () => {
-        this.handleAddrChange(userAddr);
-      }
-    );
-  };
-
   handleAddrChange = (addr?: AddressRecord) => {
     this.setState({
-      detailAddr: addr,
       detailMobileSlide: true,
     });
   };
@@ -160,114 +96,108 @@ export default class AddressPage extends Component<AddressPageProps, State> {
   };
 
   // should this properly live in AddressToolbar? you tell me
-  handleExportClick = () => {
-    APIClient.getAddressExport(this.state.searchAddress.bbl)
+  handleExportClick = (bbl: string) => {
+    APIClient.getAddressExport(bbl)
       .then((response) => response.blob())
       .then((blob) => FileSaver.saveAs(blob, "export.csv"));
   };
 
   render() {
-    const { hasSearched, assocAddrs, detailAddr, userAddr } = this.state;
+    const { state, send } = this.props;
 
-    if (this.state.hasSearched && this.state.assocAddrs.length === 0) {
-      const nychaData = helpers.getNychaData(this.state.searchAddress.bbl);
-      return this.state.searchAddress && this.state.searchAddress.bbl && nychaData ? (
-        <Page
-          title={`${this.state.searchAddress.housenumber} ${this.state.searchAddress.streetname}`}
-        >
-          <NychaPage
-            geosearch={this.state.geosearch}
-            searchAddress={this.state.searchAddress}
-            nychaData={nychaData}
-          />
-        </Page>
-      ) : (
-        <Page
-          title={`${this.state.searchAddress.housenumber} ${this.state.searchAddress.streetname}`}
-        >
-          <NotRegisteredPage
-            geosearch={this.state.geosearch}
-            searchAddress={this.state.searchAddress}
-          />
-        </Page>
+    // if (state.value === 'nychaFound')
+    //   return <Page
+    //       title={`${this.state.searchAddress.housenumber} ${this.state.searchAddress.streetname}`}
+    //     >
+    //       <NychaPage
+    //         geosearch={this.state.geosearch}
+    //         searchAddress={this.state.searchAddress}
+    //         nychaData={state.context.nychaData}
+    //       />
+    //     </Page>
+    //   ) : (
+    //     <Page
+    //       title={`${this.state.searchAddress.housenumber} ${this.state.searchAddress.streetname}`}
+    //     >
+    //       <NotRegisteredPage
+    //         geosearch={this.state.geosearch}
+    //         searchAddress={this.state.searchAddress}
+    //       />
+    //     </Page>
+    //   );
+    // } else if (hasSearched && assocAddrs && assocAddrs.length && userAddr) {
+    if (state.value === "portfolioFound") {
+      const { detailAddr, assocAddrs, searchAddr } = assertNotUndefined(
+        state.context.portfolioData
       );
-    } else if (hasSearched && assocAddrs && assocAddrs.length && userAddr) {
       return (
         <Page
-          title={`${this.state.searchAddress.housenumber} ${this.state.searchAddress.streetname}`}
+          title={`${this.props.match.params.housenumber} ${this.props.match.params.streetname}`}
         >
           <div className="AddressPage">
             <div className="AddressPage__info">
               <AddressToolbar
-                onExportClick={this.handleExportClick}
-                searchAddr={this.state.searchAddress}
-                numOfAssocAddrs={this.state.assocAddrs.length}
+                onExportClick={() => this.handleExportClick(searchAddr.bbl)}
+                searchAddr={searchAddr}
+                numOfAssocAddrs={assocAddrs.length}
               />
               <p>{this.props.state.value}</p>
-              {this.state.userAddr && (
-                <div className="float-left">
-                  <h1 className="primary">
-                    <Trans>
-                      PORTFOLIO: Your search address is associated with{" "}
-                      <u>{this.state.assocAddrs.length}</u>{" "}
-                      <Plural
-                        value={this.state.assocAddrs.length}
-                        one="building"
-                        other="buildings"
-                      />
-                    </Trans>
-                    :
-                  </h1>
-                  <ul className="tab tab-block">
-                    <li className={`tab-item ${this.props.currentTab === 0 ? "active" : ""}`}>
-                      <Link
-                        to={this.generateBaseUrl()}
-                        tabIndex={this.props.currentTab === 0 ? -1 : 0}
-                        onClick={() => {
-                          if (Browser.isMobile() && this.state.detailMobileSlide) {
-                            this.handleCloseDetail();
-                          }
-                        }}
-                      >
-                        <Trans>Overview</Trans>
-                      </Link>
-                    </li>
-                    <li className={`tab-item ${this.props.currentTab === 1 ? "active" : ""}`}>
-                      <Link
-                        to={this.generateBaseUrl() + "/timeline"}
-                        tabIndex={this.props.currentTab === 1 ? -1 : 0}
-                        onClick={() => {
-                          window.gtag("event", "timeline-tab");
-                        }}
-                      >
-                        <Trans>Timeline</Trans>
-                      </Link>
-                    </li>
-                    <li className={`tab-item ${this.props.currentTab === 2 ? "active" : ""}`}>
-                      <Link
-                        to={this.generateBaseUrl() + "/portfolio"}
-                        tabIndex={this.props.currentTab === 2 ? -1 : 0}
-                        onClick={() => {
-                          window.gtag("event", "portfolio-tab");
-                        }}
-                      >
-                        <Trans>Portfolio</Trans>
-                      </Link>
-                    </li>
-                    <li className={`tab-item ${this.props.currentTab === 3 ? "active" : ""}`}>
-                      <Link
-                        to={this.generateBaseUrl() + "/summary"}
-                        tabIndex={this.props.currentTab === 3 ? -1 : 0}
-                        onClick={() => {
-                          window.gtag("event", "summary-tab");
-                        }}
-                      >
-                        <Trans>Summary</Trans>
-                      </Link>
-                    </li>
-                  </ul>
-                </div>
-              )}
+              <div className="float-left">
+                <h1 className="primary">
+                  <Trans>
+                    PORTFOLIO: Your search address is associated with <u>{assocAddrs.length}</u>{" "}
+                    <Plural value={assocAddrs.length} one="building" other="buildings" />
+                  </Trans>
+                </h1>
+                <ul className="tab tab-block">
+                  <li className={`tab-item ${this.props.currentTab === 0 ? "active" : ""}`}>
+                    <Link
+                      to={this.generateBaseUrl()}
+                      tabIndex={this.props.currentTab === 0 ? -1 : 0}
+                      onClick={() => {
+                        if (Browser.isMobile() && this.state.detailMobileSlide) {
+                          this.handleCloseDetail();
+                        }
+                      }}
+                    >
+                      <Trans>Overview</Trans>
+                    </Link>
+                  </li>
+                  <li className={`tab-item ${this.props.currentTab === 1 ? "active" : ""}`}>
+                    <Link
+                      to={this.generateBaseUrl() + "/timeline"}
+                      tabIndex={this.props.currentTab === 1 ? -1 : 0}
+                      onClick={() => {
+                        window.gtag("event", "timeline-tab");
+                      }}
+                    >
+                      <Trans>Timeline</Trans>
+                    </Link>
+                  </li>
+                  <li className={`tab-item ${this.props.currentTab === 2 ? "active" : ""}`}>
+                    <Link
+                      to={this.generateBaseUrl() + "/portfolio"}
+                      tabIndex={this.props.currentTab === 2 ? -1 : 0}
+                      onClick={() => {
+                        window.gtag("event", "portfolio-tab");
+                      }}
+                    >
+                      <Trans>Portfolio</Trans>
+                    </Link>
+                  </li>
+                  <li className={`tab-item ${this.props.currentTab === 3 ? "active" : ""}`}>
+                    <Link
+                      to={this.generateBaseUrl() + "/summary"}
+                      tabIndex={this.props.currentTab === 3 ? -1 : 0}
+                      onClick={() => {
+                        window.gtag("event", "summary-tab");
+                      }}
+                    >
+                      <Trans>Summary</Trans>
+                    </Link>
+                  </li>
+                </ul>
+              </div>
             </div>
             <div
               className={`AddressPage__content AddressPage__viz ${
@@ -276,17 +206,17 @@ export default class AddressPage extends Component<AddressPageProps, State> {
             >
               <PropertiesMap
                 addrs={assocAddrs}
-                userAddr={userAddr}
-                detailAddr={detailAddr || null}
+                userAddr={searchAddr}
+                detailAddr={detailAddr}
                 onAddrChange={this.handleAddrChange}
                 isVisible={this.props.currentTab === 0}
               />
               <DetailView
                 addrs={assocAddrs}
-                addr={detailAddr || null}
+                addr={detailAddr}
                 portfolioSize={assocAddrs.length}
                 mobileShow={this.state.detailMobileSlide}
-                userAddr={userAddr}
+                userAddr={searchAddr}
                 onCloseDetail={this.handleCloseDetail}
                 generateBaseUrl={this.generateBaseUrl}
               />
@@ -298,7 +228,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
             >
               <Indicators
                 isVisible={this.props.currentTab === 1}
-                detailAddr={detailAddr || null}
+                detailAddr={detailAddr}
                 onBackToOverview={this.handleAddrChange}
                 generateBaseUrl={this.generateBaseUrl}
               />
@@ -319,7 +249,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 this.props.currentTab === 3 ? "AddressPage__content-active" : ""
               }`}
             >
-              <PropertiesSummary isVisible={this.props.currentTab === 3} userAddr={userAddr} />
+              <PropertiesSummary isVisible={this.props.currentTab === 3} userAddr={searchAddr} />
             </div>
           </div>
         </Page>

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -17,7 +17,7 @@ import NotRegisteredPage from "./NotRegisteredPage";
 import { Trans, Plural } from "@lingui/macro";
 import { Link, RouteComponentProps } from "react-router-dom";
 import Page from "../components/Page";
-import { SearchResults, AddressRecord, Borough } from "../components/APIDataTypes";
+import { SearchResults, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
 import { WithMachineProps } from "state-machine";
 import NotFoundPage from "./NotFoundPage";
@@ -71,7 +71,8 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     this.props.send({ type: "SEARCH", address: validateRouteParams(this.props.match.params) });
   }
 
-  handleAddrChange = (addr?: AddressRecord) => {
+  handleAddrChange = (newFocusBbl: string) => {
+    this.props.send({ type: "SELECT_DETAIL_ADDR", bbl: newFocusBbl });
     this.setState({
       detailMobileSlide: true,
     });
@@ -217,7 +218,8 @@ export default class AddressPage extends Component<AddressPageProps, State> {
               }`}
             >
               <PropertiesList
-                addrs={assocAddrs}
+                state={state}
+                send={send}
                 onOpenDetail={this.handleAddrChange}
                 generateBaseUrl={this.generateBaseUrl}
               />

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -72,7 +72,12 @@ export default class AddressPage extends Component<AddressPageProps, State> {
   }
 
   handleAddrChange = (newFocusBbl: string) => {
-    this.props.send({ type: "SELECT_DETAIL_ADDR", bbl: newFocusBbl });
+    if (!this.props.state.matches("portfolioFound")) {
+      throw new Error("A change of detail address was attempted without any portfolio data found.");
+    }
+    const detailBbl = this.props.state.context.portfolioData.detailAddr.bbl;
+    if (newFocusBbl !== detailBbl)
+      this.props.send({ type: "SELECT_DETAIL_ADDR", bbl: newFocusBbl });
     this.setState({
       detailMobileSlide: true,
     });

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -2,8 +2,6 @@ import React, { Component } from "react";
 import FileSaver from "file-saver";
 import Browser from "../util/browser";
 
-import _find from "lodash/find";
-
 import AddressToolbar from "../components/AddressToolbar";
 import PropertiesMap from "../components/PropertiesMap";
 import PropertiesList from "../components/PropertiesList";
@@ -16,11 +14,11 @@ import Loader from "../components/Loader";
 import "styles/AddressPage.css";
 import NychaPage from "./NychaPage";
 import NotRegisteredPage from "./NotRegisteredPage";
-import helpers, { assertNotUndefined } from "../util/helpers";
+import { assertNotUndefined } from "../util/helpers";
 import { Trans, Plural } from "@lingui/macro";
 import { Link, RouteComponentProps } from "react-router-dom";
 import Page from "../components/Page";
-import { SearchResults, AddressRecord, GeoSearchData, Borough } from "../components/APIDataTypes";
+import { SearchResults, AddressRecord, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
 import { WithMachineProps } from "state-machine";
 
@@ -104,29 +102,12 @@ export default class AddressPage extends Component<AddressPageProps, State> {
 
   render() {
     const { state, send } = this.props;
-
-    // if (state.value === 'nychaFound')
-    //   return <Page
-    //       title={`${this.state.searchAddress.housenumber} ${this.state.searchAddress.streetname}`}
-    //     >
-    //       <NychaPage
-    //         geosearch={this.state.geosearch}
-    //         searchAddress={this.state.searchAddress}
-    //         nychaData={state.context.nychaData}
-    //       />
-    //     </Page>
-    //   ) : (
-    //     <Page
-    //       title={`${this.state.searchAddress.housenumber} ${this.state.searchAddress.streetname}`}
-    //     >
-    //       <NotRegisteredPage
-    //         geosearch={this.state.geosearch}
-    //         searchAddress={this.state.searchAddress}
-    //       />
-    //     </Page>
-    //   );
-    // } else if (hasSearched && assocAddrs && assocAddrs.length && userAddr) {
-    if (state.value === "portfolioFound") {
+    
+    if (state.value === "nychaFound") {
+      return <NychaPage state={state} send={send} />;
+    } else if (state.value === "unregisteredFound") {
+      return <NotRegisteredPage state={state} send={send} />;
+    } else if (state.value === "portfolioFound") {
       const { detailAddr, assocAddrs, searchAddr } = assertNotUndefined(
         state.context.portfolioData
       );

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -229,7 +229,12 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 this.props.currentTab === 3 ? "AddressPage__content-active" : ""
               }`}
             >
-              <PropertiesSummary isVisible={this.props.currentTab === 3} userAddr={searchAddr} />
+              <PropertiesSummary
+                state={state}
+                send={send}
+                isVisible={this.props.currentTab === 3}
+                userAddr={searchAddr}
+              />
             </div>
           </div>
         </Page>

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -102,7 +102,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
 
   render() {
     const { state, send } = this.props;
-    
+
     if (state.value === "nychaFound") {
       return <NychaPage state={state} send={send} />;
     } else if (state.value === "unregisteredFound") {

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -21,6 +21,7 @@ import { SearchResults, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
 import { WithMachineProps } from "state-machine";
 import NotFoundPage from "./NotFoundPage";
+import { searchAddrsAreEqual } from "util/helpers";
 
 type RouteParams = {
   locale?: string;
@@ -68,7 +69,13 @@ export default class AddressPage extends Component<AddressPageProps, State> {
   }
 
   componentDidMount() {
-    this.props.send({ type: "SEARCH", address: validateRouteParams(this.props.match.params) });
+    const { state, send, match } = this.props;
+    if (
+      state.matches("portfolioFound") &&
+      searchAddrsAreEqual(state.context.portfolioData.searchAddr, validateRouteParams(match.params))
+    )
+      return;
+    send({ type: "SEARCH", address: validateRouteParams(match.params) });
   }
 
   handleAddrChange = (newFocusBbl: string) => {

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -14,7 +14,6 @@ import Loader from "../components/Loader";
 import "styles/AddressPage.css";
 import NychaPage from "./NychaPage";
 import NotRegisteredPage from "./NotRegisteredPage";
-import { assertNotUndefined } from "../util/helpers";
 import { Trans, Plural } from "@lingui/macro";
 import { Link, RouteComponentProps } from "react-router-dom";
 import Page from "../components/Page";
@@ -102,16 +101,14 @@ export default class AddressPage extends Component<AddressPageProps, State> {
   render() {
     const { state, send } = this.props;
 
-    if (state.value === "bblNotFound") {
+    if (state.matches("bblNotFound")) {
       return <NotFoundPage />;
-    } else if (state.value === "nychaFound") {
+    } else if (state.matches("nychaFound")) {
       return <NychaPage state={state} send={send} />;
-    } else if (state.value === "unregisteredFound") {
+    } else if (state.matches("unregisteredFound")) {
       return <NotRegisteredPage state={state} send={send} />;
-    } else if (state.value === "portfolioFound") {
-      const { detailAddr, assocAddrs, searchAddr } = assertNotUndefined(
-        state.context.portfolioData
-      );
+    } else if (state.matches("portfolioFound")) {
+      const { detailAddr, assocAddrs, searchAddr } = state.context.portfolioData;
       return (
         <Page
           title={`${this.props.match.params.housenumber} ${this.props.match.params.streetname}`}

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -1,4 +1,4 @@
-import React, { Component, useEffect } from "react";
+import React, { Component } from "react";
 import FileSaver from "file-saver";
 import Browser from "../util/browser";
 
@@ -20,16 +20,9 @@ import helpers from "../util/helpers";
 import { Trans, Plural } from "@lingui/macro";
 import { Link, RouteComponentProps } from "react-router-dom";
 import Page from "../components/Page";
-import {
-  SearchResults,
-  AddressRecord,
-  GeoSearchData,
-  Borough,
-  SearchAddressWithoutBbl,
-} from "../components/APIDataTypes";
+import { SearchResults, AddressRecord, GeoSearchData, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
-import { useMachine } from "@xstate/react";
-import { wowMachine, WithMachineProps } from "state-machine";
+import { WithMachineProps } from "state-machine";
 
 type RouteParams = {
   locale?: string;

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -69,9 +69,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
   }
 
   componentDidMount() {
-    if (this.props.state.value === "noData") {
-      this.props.send({ type: "SEARCH", address: validateRouteParams(this.props.match.params) });
-    }
+    this.props.send({ type: "SEARCH", address: validateRouteParams(this.props.match.params) });
   }
 
   handleAddrChange = (addr?: AddressRecord) => {
@@ -125,7 +123,6 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 searchAddr={searchAddr}
                 numOfAssocAddrs={assocAddrs.length}
               />
-              <p>{this.props.state.value}</p>
               <div className="float-left">
                 <h1 className="primary">
                   <Trans>

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -115,16 +115,16 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     const { state, send } = this.props;
 
     if (state.matches("bblNotFound")) {
-      window.gtag("event", "bblNotFoundPage");
+      window.gtag("event", "bbl-not-found-page");
       return <NotFoundPage />;
     } else if (state.matches("nychaFound")) {
-      window.gtag("event", "nychaPage");
+      window.gtag("event", "nycha-page");
       return <NychaPage state={state} send={send} />;
     } else if (state.matches("unregisteredFound")) {
-      window.gtag("event", "unregisteredPage");
+      window.gtag("event", "unregistered-page");
       return <NotRegisteredPage state={state} send={send} />;
     } else if (state.matches("portfolioFound")) {
-      window.gtag("event", "portfolioFoundPage");
+      window.gtag("event", "portfolio-found-page");
       const { detailAddr, assocAddrs, searchAddr } = state.context.portfolioData;
       return (
         <Page

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -206,7 +206,8 @@ export default class AddressPage extends Component<AddressPageProps, State> {
             >
               <Indicators
                 isVisible={this.props.currentTab === 1}
-                detailAddr={detailAddr}
+                state={state}
+                send={send}
                 onBackToOverview={this.handleAddrChange}
                 generateBaseUrl={this.generateBaseUrl}
               />

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -105,9 +105,8 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     const { state, send } = this.props;
 
     if (state.value === "bblNotFound") {
-      return <NotFoundPage />
-    }
-    else if (state.value === "nychaFound") {
+      return <NotFoundPage />;
+    } else if (state.value === "nychaFound") {
       return <NychaPage state={state} send={send} />;
     } else if (state.value === "unregisteredFound") {
       return <NotRegisteredPage state={state} send={send} />;

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, useEffect } from "react";
 import FileSaver from "file-saver";
 import Browser from "../util/browser";
 
@@ -20,8 +20,16 @@ import helpers from "../util/helpers";
 import { Trans, Plural } from "@lingui/macro";
 import { Link, RouteComponentProps } from "react-router-dom";
 import Page from "../components/Page";
-import { SearchResults, AddressRecord, GeoSearchData, Borough } from "../components/APIDataTypes";
+import {
+  SearchResults,
+  AddressRecord,
+  GeoSearchData,
+  Borough,
+  SearchAddressWithoutBbl,
+} from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
+import { useMachine } from "@xstate/react";
+import { wowMachine, WithMachineProps } from "state-machine";
 
 type RouteParams = {
   locale?: string;
@@ -35,9 +43,10 @@ type RouteState = {
   results?: SearchResults;
 };
 
-type AddressPageProps = RouteComponentProps<RouteParams, {}, RouteState> & {
-  currentTab: number;
-};
+type AddressPageProps = RouteComponentProps<RouteParams, {}, RouteState> &
+  WithMachineProps & {
+    currentTab: number;
+  };
 
 type State = {
   hasSearched: boolean;
@@ -79,6 +88,8 @@ export default class AddressPage extends Component<AddressPageProps, State> {
   }
 
   componentDidMount() {
+    this.props.send({ type: "SEARCH", address: this.state.searchAddress });
+
     // We need to check where to get the results data for the page...
 
     // Here, the user conducted a search on HomePage and we already got the results
@@ -199,6 +210,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 searchAddr={this.state.searchAddress}
                 numOfAssocAddrs={this.state.assocAddrs.length}
               />
+              <p>{this.props.state.value}</p>
               {this.state.userAddr && (
                 <div className="float-left">
                   <h1 className="primary">

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -115,12 +115,16 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     const { state, send } = this.props;
 
     if (state.matches("bblNotFound")) {
+      window.gtag("event", "bblNotFoundPage");
       return <NotFoundPage />;
     } else if (state.matches("nychaFound")) {
+      window.gtag("event", "nychaPage");
       return <NychaPage state={state} send={send} />;
     } else if (state.matches("unregisteredFound")) {
+      window.gtag("event", "unregisteredPage");
       return <NotRegisteredPage state={state} send={send} />;
     } else if (state.matches("portfolioFound")) {
+      window.gtag("event", "portfolioFoundPage");
       const { detailAddr, assocAddrs, searchAddr } = state.context.portfolioData;
       return (
         <Page

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -238,7 +238,6 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 state={state}
                 send={send}
                 isVisible={this.props.currentTab === 3}
-                userAddr={searchAddr}
               />
             </div>
           </div>

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -184,9 +184,8 @@ export default class AddressPage extends Component<AddressPageProps, State> {
               }`}
             >
               <PropertiesMap
-                addrs={assocAddrs}
-                userAddr={searchAddr}
-                detailAddr={detailAddr}
+                state={state}
+                send={send}
                 onAddrChange={this.handleAddrChange}
                 isVisible={this.props.currentTab === 0}
               />

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -127,44 +127,44 @@ export default class BBLPage extends Component<BBLPageProps, State> {
   }
 
   render() {
-    if (this.state.bblExists === false) {
-      window.gtag("event", "search-notfound");
-      return <NotRegisteredPage />;
-    }
+    // if (this.state.bblExists === false) {
+    //   window.gtag("event", "search-notfound");
+    //   return <NotRegisteredPage />;
+    // }
 
-    // If searched and got results,
-    else if (this.state.bblExists && this.state.results && this.state.results.addrs) {
-      // redirect doesn't like `this` so lets make a ref
-      const results = this.state.results;
+    // // If searched and got results,
+    // else if (this.state.bblExists && this.state.results && this.state.results.addrs) {
+    //   // redirect doesn't like `this` so lets make a ref
+    //   const results = this.state.results;
 
-      var addressForURL: SearchAddress;
+    //   var addressForURL: SearchAddress;
 
-      if (results.addrs.length > 0) {
-        window.gtag("event", "search-found", {
-          value: this.state.results.addrs.length,
-        });
-        const searchBBL = this.strictGetSearchBBL();
-        const foundAddr = this.state.results.addrs.find(
-          (element) => element.bbl === searchBBL.boro + searchBBL.block + searchBBL.lot
-        );
-        if (!foundAddr) {
-          throw new Error("BBL not found in results!");
-        }
-        addressForURL = foundAddr;
-      } else {
-        window.gtag("event", "search-notfound");
-        addressForURL = this.state.foundAddress;
-      }
+    //   if (results.addrs.length > 0) {
+    //     window.gtag("event", "search-found", {
+    //       value: this.state.results.addrs.length,
+    //     });
+    //     const searchBBL = this.strictGetSearchBBL();
+    //     const foundAddr = this.state.results.addrs.find(
+    //       (element) => element.bbl === searchBBL.boro + searchBBL.block + searchBBL.lot
+    //     );
+    //     if (!foundAddr) {
+    //       throw new Error("BBL not found in results!");
+    //     }
+    //     addressForURL = foundAddr;
+    //   } else {
+    //     window.gtag("event", "search-notfound");
+    //     addressForURL = this.state.foundAddress;
+    //   }
 
-      return (
-        <Redirect
-          to={{
-            pathname: createRouteForAddressPage(addressForURL),
-            state: { results },
-          }}
-        />
-      );
-    }
+    //   return (
+    //     <Redirect
+    //       to={{
+    //         pathname: createRouteForAddressPage(addressForURL),
+    //         state: { results },
+    //       }}
+    //     />
+    //   );
+    // }
 
     return (
       <Page>

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -6,8 +6,6 @@ import { RouteComponentProps, useHistory } from "react-router";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
 import { createRouteForAddressPage } from "../routes";
-import { makeEmptySearchAddress } from "../components/AddressSearch";
-import { SearchAddressWithoutBbl } from "../components/APIDataTypes";
 import NotFoundPage from "./NotFoundPage";
 
 // This will be *either* bbl *or* boro, block, and lot.
@@ -26,7 +24,6 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
   const [isNotFound, setIsNotFound] = useState(false);
 
   var fullBBL: string;
-  var searchAddress: SearchAddressWithoutBbl = makeEmptySearchAddress();
 
   // handling for when url parameter is separated bbl
   if (params.bbl) {
@@ -47,12 +44,11 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
           setIsNotFound(true);
           return;
         }
-        searchAddress = {
+        const addressPage = createRouteForAddressPage({
           boro: results.result[0].boro,
           housenumber: results.result[0].housenumber,
           streetname: results.result[0].streetname,
-        };
-        const addressPage = createRouteForAddressPage(searchAddress);
+        });
         history.push(addressPage);
       })
       .catch((err) => {
@@ -62,7 +58,7 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [fullBBL, history]);
 
   return isNotFound ? (
     <NotFoundPage />

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import Loader from "../components/Loader";
 import APIClient from "../components/APIClient";
@@ -8,6 +8,7 @@ import Page from "../components/Page";
 import { createRouteForAddressPage } from "../routes";
 import { makeEmptySearchAddress } from "../components/AddressSearch";
 import { SearchAddressWithoutBbl } from "../components/APIDataTypes";
+import NotFoundPage from "./NotFoundPage";
 
 // This will be *either* bbl *or* boro, block, and lot.
 type BBLPageParams = {
@@ -22,6 +23,7 @@ type BBLPageProps = RouteComponentProps<BBLPageParams>;
 const BBLPage: React.FC<BBLPageProps> = (props) => {
   const history = useHistory();
   const params = props.match.params;
+  const [isNotFound, setIsNotFound] = useState(false);
 
   var fullBBL: string;
   var searchAddress: SearchAddressWithoutBbl = makeEmptySearchAddress();
@@ -35,21 +37,36 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
     throw new Error("Invalid params, expected either a BBL or boro/block/lot!");
   }
 
-  APIClient.getBuildingInfo(fullBBL)
-    .then((results) => {
-      searchAddress = {
-        boro: results.result[0].boro,
-        housenumber: results.result[0].housenumber,
-        streetname: results.result[0].streetname,
-      };
-      const addressPage = createRouteForAddressPage(searchAddress);
-      history.push(addressPage);
-    })
-    .catch((err) => {
-      window.Rollbar.error("API error from BBL page: Building Info", err, fullBBL);
-    });
+  useEffect(() => {
+    let isMounted = true;
 
-  return (
+    APIClient.getBuildingInfo(fullBBL)
+      .then((results) => {
+        if (!isMounted) return;
+        if (results.result.length === 0) {
+          setIsNotFound(true);
+          return;
+        }
+        searchAddress = {
+          boro: results.result[0].boro,
+          housenumber: results.result[0].housenumber,
+          streetname: results.result[0].streetname,
+        };
+        const addressPage = createRouteForAddressPage(searchAddress);
+        history.push(addressPage);
+      })
+      .catch((err) => {
+        window.Rollbar.error("API error from BBL page: Building Info", err, fullBBL);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return isNotFound ? (
+    <NotFoundPage />
+  ) : (
     <Page>
       <Loader loading={true} classNames="Loader-map">
         <Trans>Loading</Trans>

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -1,17 +1,12 @@
-import React, { Component } from "react";
+import React from "react";
 
-import { LocaleRedirect as Redirect } from "../i18n";
 import Loader from "../components/Loader";
 import APIClient from "../components/APIClient";
-import NotRegisteredPage from "./NotRegisteredPage";
-import { RouteComponentProps } from "react-router";
+import { RouteComponentProps, useHistory } from "react-router";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
-import { SearchResults } from "../components/APIDataTypes";
 import { createRouteForAddressPage } from "../routes";
-import { SearchAddress, makeEmptySearchAddress } from "../components/AddressSearch";
-
-// import 'styles/HomePage.css';
+import { makeEmptySearchAddress } from "../components/AddressSearch";
 
 // This will be *either* bbl *or* boro, block, and lot.
 type BBLPageParams = {
@@ -23,161 +18,53 @@ type BBLPageParams = {
 
 type BBLPageProps = RouteComponentProps<BBLPageParams>;
 
-type State = {
-  searchBBL: BBLPageParams;
-  results: SearchResults | null;
-  bblExists: boolean | null;
-  foundAddress: SearchAddress;
-};
+const BBLPage: React.FC<BBLPageProps> = (props) => {
+  const history = useHistory();
 
-export default class BBLPage extends Component<BBLPageProps, State> {
-  constructor(props: BBLPageProps) {
-    super(props);
+  window.gtag("event", "direct-link");
 
-    this.state = {
-      searchBBL: { ...props.match.params },
-      results: null,
-      bblExists: null,
-      foundAddress: makeEmptySearchAddress(),
-    };
+  const params = props.match.params;
+
+  var fullBBL: string;
+  var searchAddress = makeEmptySearchAddress();
+
+  // handling for when url parameter is separated bbl
+  if (params.bbl) {
+    fullBBL = params.bbl;
+  } else if (params.boro && params.block && params.lot) {
+    fullBBL = params.boro + params.block.padStart(5, "0") + params.lot.padStart(4, "0");
+  } else {
+    throw new Error("Invalid params, expected either a BBL or boro/block/lot!");
   }
 
-  componentDidMount() {
-    window.gtag("event", "direct-link");
-
-    var fullBBL: string;
-
-    // handling for when url parameter is full bbl
-    if (this.state.searchBBL.bbl) {
-      fullBBL = this.state.searchBBL.bbl;
-
-      this.setState({
-        searchBBL: {
-          boro: fullBBL.slice(0, 1),
-          block: fullBBL.slice(1, 6),
-          lot: fullBBL.slice(6, 10),
-        },
-      });
-    } else if (
-      this.state.searchBBL.boro &&
-      this.state.searchBBL.block &&
-      this.state.searchBBL.lot
-    ) {
-      const searchBBL = {
-        boro: this.state.searchBBL.boro,
-        block: this.state.searchBBL.block.padStart(5, "0"),
-        lot: this.state.searchBBL.lot.padStart(4, "0"),
+  APIClient.getBuildingInfo(fullBBL)
+    .then((results) => {
+      searchAddress = {
+        boro: results.result[0].boro,
+        housenumber: results.result[0].housenumber,
+        streetname: results.result[0].streetname,
+        bbl: fullBBL,
       };
+      const addressPage = createRouteForAddressPage(searchAddress);
+      history.push(addressPage);
+    })
+    .catch((err) => {
+      window.Rollbar.error("API error from BBL page: Building Info", err, fullBBL);
+    });
 
-      fullBBL = searchBBL.boro + searchBBL.block + searchBBL.lot;
-
-      this.setState({
-        searchBBL: searchBBL,
-      });
-    } else {
-      throw new Error("Invalid params, expected either a BBL or boro/block/lot!");
-    }
-
-    APIClient.getBuildingInfo(fullBBL)
-      .then((results) => {
-        if (!(results.result && results.result.length > 0)) {
-          this.setState({
-            bblExists: false,
-          });
-        } else {
-          this.setState({
-            bblExists: true,
-            foundAddress: {
-              boro: results.result[0].boro,
-              housenumber: results.result[0].housenumber,
-              streetname: results.result[0].streetname,
-              bbl: fullBBL,
-            },
-          });
-        }
-      })
-      .catch((err) => {
-        window.Rollbar.error("API error from BBL page: Building Info", err, fullBBL);
-      });
-  }
-
-  componentDidUpdate(prevProps: BBLPageProps, prevState: State) {
-    if (!prevState.bblExists && this.state.bblExists) {
-      APIClient.searchForBBL(this.strictGetSearchBBL())
-        .then((results) => {
-          this.setState({
-            results: results,
-          });
-        })
-        .catch((err) => {
-          window.Rollbar.error("API error from BBL page: Search BBL", err, this.state.searchBBL);
-          this.setState({
-            results: { addrs: [] },
-          });
-        });
-    }
-  }
-
-  strictGetSearchBBL() {
-    const { boro, block, lot } = this.state.searchBBL;
-    if (!(boro && block && lot)) {
-      throw new Error(`boro, block, and lot must be non-empty!`);
-    }
-    return { boro, block, lot };
-  }
-
-  render() {
-    // if (this.state.bblExists === false) {
-    //   window.gtag("event", "search-notfound");
-    //   return <NotRegisteredPage />;
-    // }
-
-    // // If searched and got results,
-    // else if (this.state.bblExists && this.state.results && this.state.results.addrs) {
-    //   // redirect doesn't like `this` so lets make a ref
-    //   const results = this.state.results;
-
-    //   var addressForURL: SearchAddress;
-
-    //   if (results.addrs.length > 0) {
-    //     window.gtag("event", "search-found", {
-    //       value: this.state.results.addrs.length,
-    //     });
-    //     const searchBBL = this.strictGetSearchBBL();
-    //     const foundAddr = this.state.results.addrs.find(
-    //       (element) => element.bbl === searchBBL.boro + searchBBL.block + searchBBL.lot
-    //     );
-    //     if (!foundAddr) {
-    //       throw new Error("BBL not found in results!");
-    //     }
-    //     addressForURL = foundAddr;
-    //   } else {
-    //     window.gtag("event", "search-notfound");
-    //     addressForURL = this.state.foundAddress;
-    //   }
-
-    //   return (
-    //     <Redirect
-    //       to={{
-    //         pathname: createRouteForAddressPage(addressForURL),
-    //         state: { results },
-    //       }}
-    //     />
-    //   );
-    // }
-
-    return (
-      <Page>
-        <div className="Page HomePage">
-          <div className="HomePage__content">
-            <div className="HomePage__search">
-              <Loader classNames="Loader--centered" loading={true}>
-                <Trans>Searching</Trans>
-              </Loader>
-            </div>
+  return (
+    <Page>
+      <div className="Page HomePage">
+        <div className="HomePage__content">
+          <div className="HomePage__search">
+            <Loader classNames="Loader--centered" loading={true}>
+              <Trans>Searching</Trans>
+            </Loader>
           </div>
         </div>
-      </Page>
-    );
-  }
-}
+      </div>
+    </Page>
+  );
+};
+
+export default BBLPage;

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -51,15 +51,9 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
 
   return (
     <Page>
-      <div className="Page HomePage">
-        <div className="HomePage__content">
-          <div className="HomePage__search">
-            <Loader classNames="Loader--centered" loading={true}>
-              <Trans>Searching</Trans>
-            </Loader>
-          </div>
-        </div>
-      </div>
+      <Loader loading={true} classNames="Loader-map">
+        <Trans>Loading</Trans>
+      </Loader>
     </Page>
   );
 };

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -35,6 +35,7 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
   }
 
   useEffect(() => {
+    window.gtag("event", "bblLink");
     let isMounted = true;
 
     APIClient.getBuildingInfo(fullBBL)

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -7,6 +7,7 @@ import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
 import { createRouteForAddressPage } from "../routes";
 import { makeEmptySearchAddress } from "../components/AddressSearch";
+import { SearchAddressWithoutBbl } from "../components/APIDataTypes";
 
 // This will be *either* bbl *or* boro, block, and lot.
 type BBLPageParams = {
@@ -20,13 +21,10 @@ type BBLPageProps = RouteComponentProps<BBLPageParams>;
 
 const BBLPage: React.FC<BBLPageProps> = (props) => {
   const history = useHistory();
-
-  window.gtag("event", "direct-link");
-
   const params = props.match.params;
 
   var fullBBL: string;
-  var searchAddress = makeEmptySearchAddress();
+  var searchAddress: SearchAddressWithoutBbl = makeEmptySearchAddress();
 
   // handling for when url parameter is separated bbl
   if (params.bbl) {
@@ -43,7 +41,6 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
         boro: results.result[0].boro,
         housenumber: results.result[0].housenumber,
         streetname: results.result[0].streetname,
-        bbl: fullBBL,
       };
       const addressPage = createRouteForAddressPage(searchAddress);
       history.push(addressPage);

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -1,35 +1,27 @@
 import React, { Component } from "react";
 
-import Loader from "../components/Loader";
-import APIClient from "../components/APIClient";
 import EngagementPanel from "../components/EngagementPanel";
 import LegalFooter from "../components/LegalFooter";
 
 import "styles/HomePage.css";
 
-import { LocaleLink as Link, LocaleRedirect as Redirect } from "../i18n";
+import { LocaleLink as Link } from "../i18n";
 import westminsterLogo from "../assets/img/westminster.svg";
 import allyearLogo from "../assets/img/allyear.png";
 import aeLogo from "../assets/img/aande.jpeg";
-import AddressSearch, { makeEmptySearchAddress, SearchAddress } from "../components/AddressSearch";
+import AddressSearch, { SearchAddress } from "../components/AddressSearch";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
 import { createRouteForAddressPage } from "../routes";
-
-type HomePageProps = {};
-
-type State = {
-  searchAddress: SearchAddress;
-  results: { addrs: unknown[] } | null;
-  sampleURLs: string[];
-};
+import { WithMachineProps } from "state-machine";
+import { useHistory } from "react-router-dom";
 
 type BannerState = {
   isHidden: boolean;
 };
 
-class MoratoriumBanner extends Component<HomePageProps, BannerState> {
-  constructor(Props: HomePageProps) {
+class MoratoriumBanner extends Component<{}, BannerState> {
+  constructor(Props: {}) {
     super(Props);
 
     this.state = {
@@ -67,315 +59,243 @@ class MoratoriumBanner extends Component<HomePageProps, BannerState> {
   }
 }
 
-class HomePage extends Component<HomePageProps, State> {
-  constructor(props: HomePageProps) {
-    super(props);
+const getSampleUrls = () => [
+  createRouteForAddressPage({
+    boro: "BROOKLYN",
+    housenumber: "89",
+    streetname: "HICKS STREET",
+  }),
+  createRouteForAddressPage({
+    boro: "QUEENS",
+    housenumber: "4125",
+    streetname: "CASE STREET",
+  }),
+  createRouteForAddressPage({
+    boro: "BROOKLYN",
+    housenumber: "196",
+    streetname: "RALPH AVENUE",
+  }),
+];
 
-    this.state = {
-      searchAddress: makeEmptySearchAddress(),
-      results: null,
-      sampleURLs: [
-        createRouteForAddressPage({
-          boro: "BROOKLYN",
-          housenumber: "89",
-          streetname: "HICKS STREET",
-        }),
-        createRouteForAddressPage({
-          boro: "QUEENS",
-          housenumber: "4125",
-          streetname: "CASE STREET",
-        }),
-        createRouteForAddressPage({
-          boro: "BROOKLYN",
-          housenumber: "196",
-          streetname: "RALPH AVENUE",
-        }),
-      ],
-    };
-  }
-
-  handleFormSubmit = (searchAddress: SearchAddress, error: any) => {
-    // set state (mainly to show addr on load)
-    this.setState({
-      searchAddress: searchAddress,
-    });
-
+const HomePage: React.FC<WithMachineProps> = (props) => {
+  const handleFormSubmit = (searchAddress: SearchAddress, error: any) => {
     window.gtag("event", "search");
 
     if (error) {
       window.gtag("event", "search-error");
-      this.setState({
-        results: { addrs: [] },
-      });
     } else {
-      // searching on HomePage allows for more clean redirects
-      // as opposed to HomePage > AddressPage > NotRegisteredPage
-      APIClient.searchForAddress({
-        ...searchAddress,
-        housenumber: searchAddress.housenumber || "",
-      })
-        .then((results) => {
-          this.setState({
-            results: results,
-          });
-        })
-        .catch((err) => {
-          window.Rollbar.error("API error from homepage: Search Address", err, searchAddress);
-          this.setState({
-            results: { addrs: [] },
-          });
-        });
+      const addressPage = createRouteForAddressPage(searchAddress);
+      history.push(addressPage);
     }
   };
 
-  render() {
-    // If searched and got results,
-    if (this.state.results) {
-      // redirect doesn't like `this` so lets make a ref
-      const results = this.state.results;
+  const history = useHistory();
 
-      // no addrs = not found
-      if (!this.state.results.addrs || !this.state.results.addrs.length) {
-        window.gtag("event", "search-notfound");
+  const labelText = (
+    <Trans>Enter an NYC address and find other buildings your landlord might own:</Trans>
+  );
 
-        // lets redirect to AddressPage and pass the results along with us
-      } else {
-        window.gtag("event", "search-found", {
-          value: this.state.results.addrs.length,
-        });
-      }
-      return (
-        <Redirect
-          push
-          to={{
-            pathname: createRouteForAddressPage(this.state.searchAddress),
-            state: { results },
-          }}
-        />
-      );
-    }
-
-    const labelText = (
-      <Trans>Enter an NYC address and find other buildings your landlord might own:</Trans>
-    );
-
-    return (
-      <Page>
-        <div className="HomePage Page">
-          <MoratoriumBanner />
-          <div className="HomePage__content">
-            <div className="HomePage__search">
-              {this.state.searchAddress.housenumber ? (
-                <Loader loading={true}>
-                  <Trans>
-                    Searching for{" "}
-                    <b>
-                      {this.state.searchAddress.housenumber} {this.state.searchAddress.streetname},{" "}
-                      {this.state.searchAddress.boro}
-                    </b>
-                  </Trans>
-                </Loader>
-              ) : (
-                <div>
-                  <h1 className="text-center">{labelText}</h1>
-                  <AddressSearch
-                    {...this.state.searchAddress}
-                    labelText={labelText}
-                    labelClass="text-assistive"
-                    onFormSubmit={this.handleFormSubmit}
-                  />
+  return (
+    <Page>
+      <div className="HomePage Page">
+        <MoratoriumBanner />
+        <div className="HomePage__content">
+          <div className="HomePage__search">
+            <div>
+              <h1 className="text-center">{labelText}</h1>
+              <AddressSearch
+                labelText={labelText}
+                labelClass="text-assistive"
+                onFormSubmit={handleFormSubmit}
+              />
+            </div>{" "}
+          </div>
+          <div className="HomePage__samples">
+            <h5 className="text-center">
+              <Trans>... or view some sample portfolios:</Trans>
+            </h5>
+            <div className="container">
+              <div className="columns">
+                <div className="column col-4 col-sm-12">
+                  <div className="HomePage__sample">
+                    <h6>
+                      <Link
+                        to={getSampleUrls()[0]}
+                        onClick={() => {
+                          window.gtag("event", "example-portfolio-1-homepage");
+                        }}
+                      >
+                        Kushner Companies / Westminster Management
+                      </Link>
+                    </h6>
+                    <Link
+                      className="image"
+                      tabIndex={-1} // Since link is not necessary navigation, removing tab focus
+                      to={getSampleUrls()[0]}
+                      onClick={() => {
+                        window.gtag("event", "example-portfolio-1-homepage");
+                      }}
+                    >
+                      <img className="img-responsive" src={westminsterLogo} alt="Westminster" />
+                    </Link>
+                    <Trans render="p">
+                      This property management company owned by the Kushner family is notorious for{" "}
+                      <a
+                        href="https://www.nytimes.com/2017/08/15/business/tenants-sue-kushner-companies-claiming-rent-rule-violations.html"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        violating rent regulations
+                      </a>{" "}
+                      and{" "}
+                      <a
+                        href="https://www.villagevoice.com/2017/01/12/jared-kushners-east-village-tenants-horrified-their-landlord-will-be-working-in-the-white-house/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        harassing tenants
+                      </a>
+                      . The stake currently held by Jared Kushner and Ivanka Trump is worth as much
+                      as $761 million.
+                    </Trans>
+                    <Link
+                      className="btn block text-center"
+                      to={getSampleUrls()[0]}
+                      onClick={() => {
+                        window.gtag("event", "example-portfolio-1-homepage");
+                      }}
+                    >
+                      <Trans>View portfolio</Trans> &#10230;
+                    </Link>
+                  </div>
                 </div>
-              )}
-            </div>
-            <div className="HomePage__samples">
-              <h5 className="text-center">
-                <Trans>... or view some sample portfolios:</Trans>
-              </h5>
-              <div className="container">
-                <div className="columns">
-                  <div className="column col-4 col-sm-12">
-                    <div className="HomePage__sample">
-                      <h6>
-                        <Link
-                          to={this.state.sampleURLs[0]}
-                          onClick={() => {
-                            window.gtag("event", "example-portfolio-1-homepage");
-                          }}
-                        >
-                          Kushner Companies / Westminster Management
-                        </Link>
-                      </h6>
+                <div className="column col-4 col-sm-12">
+                  <div className="HomePage__sample">
+                    <h6>
                       <Link
-                        className="image"
-                        tabIndex={-1} // Since link is not necessary navigation, removing tab focus
-                        to={this.state.sampleURLs[0]}
-                        onClick={() => {
-                          window.gtag("event", "example-portfolio-1-homepage");
-                        }}
-                      >
-                        <img className="img-responsive" src={westminsterLogo} alt="Westminster" />
-                      </Link>
-                      <Trans render="p">
-                        This property management company owned by the Kushner family is notorious
-                        for{" "}
-                        <a
-                          href="https://www.nytimes.com/2017/08/15/business/tenants-sue-kushner-companies-claiming-rent-rule-violations.html"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          violating rent regulations
-                        </a>{" "}
-                        and{" "}
-                        <a
-                          href="https://www.villagevoice.com/2017/01/12/jared-kushners-east-village-tenants-horrified-their-landlord-will-be-working-in-the-white-house/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          harassing tenants
-                        </a>
-                        . The stake currently held by Jared Kushner and Ivanka Trump is worth as
-                        much as $761 million.
-                      </Trans>
-                      <Link
-                        className="btn block text-center"
-                        to={this.state.sampleURLs[0]}
-                        onClick={() => {
-                          window.gtag("event", "example-portfolio-1-homepage");
-                        }}
-                      >
-                        <Trans>View portfolio</Trans> &#10230;
-                      </Link>
-                    </div>
-                  </div>
-                  <div className="column col-4 col-sm-12">
-                    <div className="HomePage__sample">
-                      <h6>
-                        <Link
-                          to={this.state.sampleURLs[1]}
-                          onClick={() => {
-                            window.gtag("event", "example-portfolio-2-homepage");
-                          }}
-                        >
-                          A&amp;E Real Estate
-                        </Link>
-                      </h6>
-                      <Link
-                        className="image"
-                        tabIndex={-1} // Since link is not necessary navigation, removing tab focus
-                        to={this.state.sampleURLs[1]}
+                        to={getSampleUrls()[1]}
                         onClick={() => {
                           window.gtag("event", "example-portfolio-2-homepage");
                         }}
                       >
-                        <img
-                          className="emassoc img-responsive"
-                          src={aeLogo}
-                          alt="A&amp;E Real Estate"
-                        />
+                        A&amp;E Real Estate
                       </Link>
-                      <Trans render="p">
-                        The city’s fifth{" "}
-                        <a
-                          href="https://www.worstevictorsnyc.org/evictors-list/citywide"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          worst evictor
-                        </a>{" "}
-                        in 2018, A&E is a prime example of a landlord who engages in{" "}
-                        <a
-                          href="https://www.dnainfo.com/new-york/20170124/washington-heights/ae-real-estate-holdings-affordable-housing-nyc-tax-breaks/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          aggressive eviction strategies
-                        </a>{" "}
-                        to displace low-income tenants. Besides lack of repairs and frivolous
-                        evictions in housing court, A&E has also been known to use{" "}
-                        <a
-                          href="https://hcr.ny.gov/faqs-major-capital-and-individual-apartment-improvements"
-                          target="blank"
-                          rel="noopener noreferrer"
-                        >
-                          MCIs
-                        </a>{" "}
-                        to{" "}
-                        <a
-                          href="https://www.nytimes.com/interactive/2018/05/20/nyregion/nyc-affordable-housing.html"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          double rents
-                        </a>{" "}
-                        in rent-stabilized buildings.
-                      </Trans>
-                      <Link
-                        className="btn block text-center"
-                        to={this.state.sampleURLs[1]}
-                        onClick={() => {
-                          window.gtag("event", "example-portfolio-2-homepage");
-                        }}
+                    </h6>
+                    <Link
+                      className="image"
+                      tabIndex={-1} // Since link is not necessary navigation, removing tab focus
+                      to={getSampleUrls()[1]}
+                      onClick={() => {
+                        window.gtag("event", "example-portfolio-2-homepage");
+                      }}
+                    >
+                      <img
+                        className="emassoc img-responsive"
+                        src={aeLogo}
+                        alt="A&amp;E Real Estate"
+                      />
+                    </Link>
+                    <Trans render="p">
+                      The city’s fifth{" "}
+                      <a
+                        href="https://www.worstevictorsnyc.org/evictors-list/citywide"
+                        target="_blank"
+                        rel="noopener noreferrer"
                       >
-                        <Trans>View portfolio</Trans> &#10230;
-                      </Link>
-                    </div>
+                        worst evictor
+                      </a>{" "}
+                      in 2018, A&E is a prime example of a landlord who engages in{" "}
+                      <a
+                        href="https://www.dnainfo.com/new-york/20170124/washington-heights/ae-real-estate-holdings-affordable-housing-nyc-tax-breaks/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        aggressive eviction strategies
+                      </a>{" "}
+                      to displace low-income tenants. Besides lack of repairs and frivolous
+                      evictions in housing court, A&E has also been known to use{" "}
+                      <a
+                        href="https://hcr.ny.gov/faqs-major-capital-and-individual-apartment-improvements"
+                        target="blank"
+                        rel="noopener noreferrer"
+                      >
+                        MCIs
+                      </a>{" "}
+                      to{" "}
+                      <a
+                        href="https://www.nytimes.com/interactive/2018/05/20/nyregion/nyc-affordable-housing.html"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        double rents
+                      </a>{" "}
+                      in rent-stabilized buildings.
+                    </Trans>
+                    <Link
+                      className="btn block text-center"
+                      to={getSampleUrls()[1]}
+                      onClick={() => {
+                        window.gtag("event", "example-portfolio-2-homepage");
+                      }}
+                    >
+                      <Trans>View portfolio</Trans> &#10230;
+                    </Link>
                   </div>
-                  <div className="column col-4 col-sm-12">
-                    <div className="HomePage__sample">
-                      <h6>
-                        <Link
-                          to={this.state.sampleURLs[2]}
-                          onClick={() => {
-                            window.gtag("event", "example-portfolio-1-homepage");
-                          }}
-                        >
-                          All Year Management
-                        </Link>
-                      </h6>
+                </div>
+                <div className="column col-4 col-sm-12">
+                  <div className="HomePage__sample">
+                    <h6>
                       <Link
-                        className="image"
-                        tabIndex={-1} // Since link is not necessary navigation, removing tab focus
-                        to={this.state.sampleURLs[2]}
+                        to={getSampleUrls()[2]}
                         onClick={() => {
                           window.gtag("event", "example-portfolio-1-homepage");
                         }}
                       >
-                        <img className="img-responsive" src={allyearLogo} alt="All Year" />
+                        All Year Management
                       </Link>
-                      <Trans render="p">
-                        Yoel Goldman's All Year Management has been at the{" "}
-                        <a
-                          href="https://commercialobserver.com/2017/09/yoel-goldman-all-year-management-brooklyn-real-estate/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          forefront of gentrification
-                        </a>{" "}
-                        in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown
-                        Heights have been forced to live in horrendous and often dangerous
-                        conditions.
-                      </Trans>
-                      <Link
-                        className="btn block text-center"
-                        to={this.state.sampleURLs[2]}
-                        onClick={() => {
-                          window.gtag("event", "example-portfolio-3-homepage");
-                        }}
+                    </h6>
+                    <Link
+                      className="image"
+                      tabIndex={-1} // Since link is not necessary navigation, removing tab focus
+                      to={getSampleUrls()[2]}
+                      onClick={() => {
+                        window.gtag("event", "example-portfolio-1-homepage");
+                      }}
+                    >
+                      <img className="img-responsive" src={allyearLogo} alt="All Year" />
+                    </Link>
+                    <Trans render="p">
+                      Yoel Goldman's All Year Management has been at the{" "}
+                      <a
+                        href="https://commercialobserver.com/2017/09/yoel-goldman-all-year-management-brooklyn-real-estate/"
+                        target="_blank"
+                        rel="noopener noreferrer"
                       >
-                        <Trans>View portfolio</Trans> &#10230;
-                      </Link>
-                    </div>
+                        forefront of gentrification
+                      </a>{" "}
+                      in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown
+                      Heights have been forced to live in horrendous and often dangerous conditions.
+                    </Trans>
+                    <Link
+                      className="btn block text-center"
+                      to={getSampleUrls()[2]}
+                      onClick={() => {
+                        window.gtag("event", "example-portfolio-3-homepage");
+                      }}
+                    >
+                      <Trans>View portfolio</Trans> &#10230;
+                    </Link>
                   </div>
                 </div>
               </div>
             </div>
-            <EngagementPanel location="homepage" />
           </div>
-          <LegalFooter />
+          <EngagementPanel location="homepage" />
         </div>
-      </Page>
-    );
-  }
-}
+        <LegalFooter />
+      </div>
+    </Page>
+  );
+};
 
 export default HomePage;

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -248,7 +248,7 @@ const HomePage: React.FC<WithMachineProps> = (props) => {
                       <Link
                         to={getSampleUrls()[2]}
                         onClick={() => {
-                          window.gtag("event", "example-portfolio-1-homepage");
+                          window.gtag("event", "example-portfolio-3-homepage");
                         }}
                       >
                         All Year Management
@@ -259,7 +259,7 @@ const HomePage: React.FC<WithMachineProps> = (props) => {
                       tabIndex={-1} // Since link is not necessary navigation, removing tab focus
                       to={getSampleUrls()[2]}
                       onClick={() => {
-                        window.gtag("event", "example-portfolio-1-homepage");
+                        window.gtag("event", "example-portfolio-3-homepage");
                       }}
                     >
                       <img className="img-responsive" src={allyearLogo} alt="All Year" />

--- a/client/src/containers/NotFoundPage.tsx
+++ b/client/src/containers/NotFoundPage.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Trans, t } from "@lingui/macro";
+import { withI18n, withI18nProps } from "@lingui/react";
+import Page from "components/Page";
+
+const NotFoundPageWithoutI18n: React.FC<withI18nProps> = (props) => {
+  const i18n = props.i18n;
+  return (
+    <Page title={i18n._(t`No address found`)}>
+      <div className="NotRegisteredPage Page">
+        <div className="HomePage__content">
+          <div className="HomePage__search">
+            <h5 className="mt-10 text-danger text-center text-bold text-large">
+              <Trans>No address found</Trans>
+            </h5>
+          </div>
+        </div>
+      </div>
+    </Page>
+  );
+};
+
+const NotFoundPage = withI18n()(NotFoundPageWithoutI18n);
+
+export default NotFoundPage;

--- a/client/src/containers/NotFoundPage.tsx
+++ b/client/src/containers/NotFoundPage.tsx
@@ -3,7 +3,7 @@ import { Trans, t } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 import Page from "components/Page";
 
-export const ErrorPageScaffolding = (props: {children: React.ReactNode}) => (
+export const ErrorPageScaffolding = (props: { children: React.ReactNode }) => (
   <div className="NotRegisteredPage Page">
     <div className="HomePage__content">
       <div className="HomePage__search">

--- a/client/src/containers/NotFoundPage.tsx
+++ b/client/src/containers/NotFoundPage.tsx
@@ -3,19 +3,23 @@ import { Trans, t } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 import Page from "components/Page";
 
+export const ErrorPageScaffolding = (props: {children: React.ReactNode}) => (
+  <div className="NotRegisteredPage Page">
+    <div className="HomePage__content">
+      <div className="HomePage__search">
+        <h5 className="mt-10 text-danger text-center text-bold text-large">{props.children}</h5>
+      </div>
+    </div>
+  </div>
+);
+
 const NotFoundPageWithoutI18n: React.FC<withI18nProps> = (props) => {
   const i18n = props.i18n;
   return (
     <Page title={i18n._(t`No address found`)}>
-      <div className="NotRegisteredPage Page">
-        <div className="HomePage__content">
-          <div className="HomePage__search">
-            <h5 className="mt-10 text-danger text-center text-bold text-large">
-              <Trans>No address found</Trans>
-            </h5>
-          </div>
-        </div>
-      </div>
+      <ErrorPageScaffolding>
+        <Trans>No address found</Trans>
+      </ErrorPageScaffolding>
     </Page>
   );
 };

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -6,7 +6,7 @@ import { Trans } from "@lingui/macro";
 import { createRouteForAddressPage, getSiteOrigin, AddressPageUrlParams } from "../routes";
 import Modal from "../components/Modal";
 import LegalFooter from "../components/LegalFooter";
-import Helpers, { assertNotUndefined } from "../util/helpers";
+import Helpers from "../util/helpers";
 import SocialShare from "../components/SocialShare";
 import { Nobr } from "../components/Nobr";
 import { WithMachineProps } from "state-machine";
@@ -40,9 +40,13 @@ export default class NotRegisteredPage extends Component<Props, State> {
   }
 
   render() {
-    const { searchAddrParams, searchAddrBbl } = this.props.state.context;
-    const buildingInfo = assertNotUndefined(this.props.state.context.buildingInfo);
-    const { boro, block, lot } = Helpers.splitBBL(assertNotUndefined(searchAddrBbl));
+    const { state } = this.props;
+    if (!state.matches("unregisteredFound")) {
+      throw new Error(`Invalid state: ${state.value}`);
+    }
+    const { searchAddrParams, searchAddrBbl, buildingInfo } = state.context;
+
+    const { boro, block, lot } = Helpers.splitBBL(searchAddrBbl);
 
     const usersInputAddress = searchAddrParams
       ? {

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -10,6 +10,7 @@ import Helpers, { assertNotUndefined } from "../util/helpers";
 import SocialShare from "../components/SocialShare";
 import { Nobr } from "../components/Nobr";
 import { WithMachineProps } from "state-machine";
+import Page from "components/Page";
 
 type Props = WithMachineProps;
 
@@ -161,21 +162,6 @@ export default class NotRegisteredPage extends Component<Props, State> {
         break;
     }
 
-    // if (!geosearch && !buildingInfo) {
-    //   return (
-    //     <div className="NotRegisteredPage Page">
-    //       <div className="HomePage__content">
-    //         <div className="HomePage__search">
-    //           <h5 className="mt-10 text-danger text-center text-bold text-large">
-    //             <Trans>No address found</Trans>
-    //           </h5>
-    //         </div>
-    //         `
-    //       </div>
-    //     </div>
-    //   );
-    // }
-
     const usersInputAddressFragment = usersInputAddress ? (
       <>
         {usersInputAddress.housenumber === " " ? "" : usersInputAddress.housenumber + " "}
@@ -184,123 +170,129 @@ export default class NotRegisteredPage extends Component<Props, State> {
     ) : null;
 
     return (
-      <div className="NotRegisteredPage Page">
-        <div className="HomePage__content">
-          <div className="HomePage__search">
-            <h5 className="mt-10 text-danger text-center text-bold text-large">
-              {usersInputAddress ? (
-                <Trans>No registration found for {usersInputAddressFragment}!</Trans>
-              ) : (
-                <Trans>No registration found!</Trans>
-              )}
-            </h5>
-            {buildingTypeMessage}
-            <div className="wrapper">
-              {buildingInfo && buildingInfo.latitude && buildingInfo.longitude && (
-                <img
-                  src={`https://maps.googleapis.com/maps/api/streetview?size=800x200&location=${buildingInfo.latitude},${buildingInfo.longitude}&key=${process.env.REACT_APP_STREETVIEW_API_KEY}`}
-                  alt="Google Street View"
-                  className="streetview img-responsive"
-                />
-              )}
-              <div className="bbl-link">
-                <span>
-                  Boro-Block-Lot (BBL):{" "}
-                  <Nobr>
-                    <a
-                      href={"https://zola.planning.nyc.gov/lot/" + boro + "/" + block + "/" + lot}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {boro}
-                      {bblDash}
-                      {block}
-                      {bblDash}
-                      {lot}
-                    </a>
-                  </Nobr>
-                </span>
-              </div>
-              <br />
-              <div>
-                <Trans render="p">Useful links</Trans>
+      <Page
+        title={searchAddrParams && `${searchAddrParams.housenumber} ${searchAddrParams.streetname}`}
+      >
+        <div className="NotRegisteredPage Page">
+          <div className="HomePage__content">
+            <div className="HomePage__search">
+              <h5 className="mt-10 text-danger text-center text-bold text-large">
+                {usersInputAddress ? (
+                  <Trans>No registration found for {usersInputAddressFragment}!</Trans>
+                ) : (
+                  <Trans>No registration found!</Trans>
+                )}
+              </h5>
+              {buildingTypeMessage}
+              <div className="wrapper">
+                {buildingInfo && buildingInfo.latitude && buildingInfo.longitude && (
+                  <img
+                    src={`https://maps.googleapis.com/maps/api/streetview?size=800x200&location=${buildingInfo.latitude},${buildingInfo.longitude}&key=${process.env.REACT_APP_STREETVIEW_API_KEY}`}
+                    alt="Google Street View"
+                    className="streetview img-responsive"
+                  />
+                )}
+                <div className="bbl-link">
+                  <span>
+                    Boro-Block-Lot (BBL):{" "}
+                    <Nobr>
+                      <a
+                        href={"https://zola.planning.nyc.gov/lot/" + boro + "/" + block + "/" + lot}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {boro}
+                        {bblDash}
+                        {block}
+                        {bblDash}
+                        {lot}
+                      </a>
+                    </Nobr>
+                  </span>
+                </div>
+                <br />
                 <div>
-                  <div className="btn-group btn-group-block">
-                    <a
-                      href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="btn"
-                    >
-                      <Trans>View documents on ACRIS</Trans> &#8599;
-                    </a>
-                    <a
-                      href={`http://webapps.nyc.gov:8084/CICS/fin1/find001i?FFUNC=C&FBORO=${boro}&FBLOCK=${block}&FLOT=${lot}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="btn"
-                    >
-                      <Trans>DOF Property Tax Bills</Trans> &#8599;
-                    </a>
-                  </div>
-                  <div className="btn-group btn-group-block">
-                    <a
-                      href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="btn"
-                    >
-                      <Trans>DOB Building Profile</Trans> &#8599;
-                    </a>
-                    <a
-                      href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="btn"
-                    >
-                      <Trans>ANHD DAP Portal</Trans> &#8599;
-                    </a>
+                  <Trans render="p">Useful links</Trans>
+                  <div>
+                    <div className="btn-group btn-group-block">
+                      <a
+                        href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn"
+                      >
+                        <Trans>View documents on ACRIS</Trans> &#8599;
+                      </a>
+                      <a
+                        href={`http://webapps.nyc.gov:8084/CICS/fin1/find001i?FFUNC=C&FBORO=${boro}&FBLOCK=${block}&FLOT=${lot}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn"
+                      >
+                        <Trans>DOF Property Tax Bills</Trans> &#8599;
+                      </a>
+                    </div>
+                    <div className="btn-group btn-group-block">
+                      <a
+                        href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn"
+                      >
+                        <Trans>DOB Building Profile</Trans> &#8599;
+                      </a>
+                      <a
+                        href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn"
+                      >
+                        <Trans>ANHD DAP Portal</Trans> &#8599;
+                      </a>
+                    </div>
                   </div>
                 </div>
+
+                <SocialShareForNotRegisteredPage addr={usersInputAddress} />
+                <br />
+                <br />
+
+                <Link className="btn btn-primary btn-block" to="/">
+                  &lt;-- <Trans>Search for a different address</Trans>
+                </Link>
               </div>
-
-              <SocialShareForNotRegisteredPage addr={usersInputAddress} />
-              <br />
-              <br />
-
-              <Link className="btn btn-primary btn-block" to="/">
-                &lt;-- <Trans>Search for a different address</Trans>
-              </Link>
-            </div>
-            <Modal
-              width={60}
-              showModal={this.state.showModal}
-              onClose={() => this.setState({ showModal: false })}
-            >
-              <Trans render="h5">Failure to register a building with HPD</Trans>
-              <Trans render="p">
-                Buildings without valid property registration are subject to the following:
-              </Trans>
-              <ul>
-                <Trans render="li">Civil penalties of $250-$500</Trans>
-                <Trans render="li">May be issued official Orders</Trans>
-                <Trans render="li">Ineligible to certify violations</Trans>
-                <Trans render="li">Unable to request Code Violation Dismissals</Trans>
-                <Trans render="li">Unable to initiate a court action for nonpayment of rent.</Trans>
-              </ul>
-              <a
-                className="btn"
-                href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Modal
+                width={60}
+                showModal={this.state.showModal}
+                onClose={() => this.setState({ showModal: false })}
               >
-                <Trans>Click here to learn more.</Trans> &#8599;
-              </a>
-            </Modal>
+                <Trans render="h5">Failure to register a building with HPD</Trans>
+                <Trans render="p">
+                  Buildings without valid property registration are subject to the following:
+                </Trans>
+                <ul>
+                  <Trans render="li">Civil penalties of $250-$500</Trans>
+                  <Trans render="li">May be issued official Orders</Trans>
+                  <Trans render="li">Ineligible to certify violations</Trans>
+                  <Trans render="li">Unable to request Code Violation Dismissals</Trans>
+                  <Trans render="li">
+                    Unable to initiate a court action for nonpayment of rent.
+                  </Trans>
+                </ul>
+                <a
+                  className="btn"
+                  href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Trans>Click here to learn more.</Trans> &#8599;
+                </a>
+              </Modal>
+            </div>
           </div>
+          <LegalFooter />
         </div>
-        <LegalFooter />
-      </div>
+      </Page>
     );
   }
 }

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -9,10 +9,10 @@ import LegalFooter from "../components/LegalFooter";
 import Helpers from "../util/helpers";
 import SocialShare from "../components/SocialShare";
 import { Nobr } from "../components/Nobr";
-import { WithMachineProps } from "state-machine";
+import { WithMachineInStateProps } from "state-machine";
 import Page from "components/Page";
 
-type Props = WithMachineProps;
+type Props = WithMachineInStateProps<"unregisteredFound">;
 
 type State = {
   showModal: boolean;
@@ -41,9 +41,6 @@ export default class NotRegisteredPage extends Component<Props, State> {
 
   render() {
     const { state } = this.props;
-    if (!state.matches("unregisteredFound")) {
-      throw new Error(`Invalid state: ${state.value}`);
-    }
     const { searchAddrParams, searchAddrBbl, buildingInfo } = state.context;
 
     const { boro, block, lot } = Helpers.splitBBL(searchAddrBbl);

--- a/client/src/containers/NychaPage.tsx
+++ b/client/src/containers/NychaPage.tsx
@@ -22,8 +22,8 @@ export type NychaData = {
 type NychaPageProps = WithMachineProps & withI18nProps;
 
 const NychaPageWithoutI18n: React.FC<NychaPageProps> = (props) => {
-  const {i18n, state} = props;
-  if (!state.matches('nychaFound')) {
+  const { i18n, state } = props;
+  if (!state.matches("nychaFound")) {
     throw new Error(`Invalid state ${state.value}`);
   }
 

--- a/client/src/containers/NychaPage.tsx
+++ b/client/src/containers/NychaPage.tsx
@@ -84,7 +84,9 @@ const NychaPageWithoutI18n: React.FC<NychaPageProps> = (props) => {
   const takeActionURL = Helpers.createTakeActionURL(usersInputAddress, "nycha_page");
 
   return (
-    <Page title={searchAddrParams && `${searchAddrParams.housenumber} ${searchAddrParams.streetname}`}>
+    <Page
+      title={searchAddrParams && `${searchAddrParams.housenumber} ${searchAddrParams.streetname}`}
+    >
       <div className="NotRegisteredPage Page">
         <div className="HomePage__content">
           <div className="HomePage__search">

--- a/client/src/containers/NychaPage.tsx
+++ b/client/src/containers/NychaPage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { LocaleLink as Link } from "../i18n";
 import Browser from "../util/browser";
 import LegalFooter from "../components/LegalFooter";
-import Helpers, { assertNotUndefined } from "../util/helpers";
+import Helpers from "../util/helpers";
 
 import "styles/NotRegisteredPage.css";
 import { Trans, t } from "@lingui/macro";
@@ -22,9 +22,13 @@ export type NychaData = {
 type NychaPageProps = WithMachineProps & withI18nProps;
 
 const NychaPageWithoutI18n: React.FC<NychaPageProps> = (props) => {
-  const i18n = props.i18n;
-  const { searchAddrParams, searchAddrBbl, nychaData, buildingInfo } = props.state.context;
-  const { boro, block, lot } = Helpers.splitBBL(assertNotUndefined(searchAddrBbl));
+  const {i18n, state} = props;
+  if (!state.matches('nychaFound')) {
+    throw new Error(`Invalid state ${state.value}`);
+  }
+
+  const { searchAddrParams, searchAddrBbl, nychaData: nycha, buildingInfo } = state.context;
+  const { boro, block, lot } = Helpers.splitBBL(searchAddrBbl);
 
   const bblDash = (
     <span className="unselectable" unselectable="on">
@@ -32,7 +36,6 @@ const NychaPageWithoutI18n: React.FC<NychaPageProps> = (props) => {
     </span>
   );
 
-  const nycha = assertNotUndefined(nychaData);
   const boroData =
     boro === "1"
       ? {

--- a/client/src/containers/NychaPage.tsx
+++ b/client/src/containers/NychaPage.tsx
@@ -13,15 +13,17 @@ import { GeoSearchData, BuildingInfoRecord } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
 import { SocialShareForNotRegisteredPage } from "./NotRegisteredPage";
 
+export type NychaData = {
+  bbl: number;
+  development: string;
+  dev_evictions: string | number;
+  dev_unitsres: number;
+};
+
 type Props = withI18nProps & {
   geosearch?: GeoSearchData;
   searchAddress: SearchAddress;
-  nychaData: {
-    bbl: number;
-    development: string;
-    dev_evictions: string | number;
-    dev_unitsres: number;
-  };
+  nychaData: NychaData;
 };
 
 type State = {

--- a/client/src/containers/NychaPage.tsx
+++ b/client/src/containers/NychaPage.tsx
@@ -9,7 +9,7 @@ import { Trans, t } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { Nobr } from "../components/Nobr";
 import { SocialShareForNotRegisteredPage } from "./NotRegisteredPage";
-import { WithMachineProps } from "state-machine";
+import { WithMachineInStateProps } from "state-machine";
 import Page from "components/Page";
 
 export type NychaData = {
@@ -19,13 +19,10 @@ export type NychaData = {
   dev_unitsres: number;
 };
 
-type NychaPageProps = WithMachineProps & withI18nProps;
+type NychaPageProps = WithMachineInStateProps<"nychaFound"> & withI18nProps;
 
 const NychaPageWithoutI18n: React.FC<NychaPageProps> = (props) => {
   const { i18n, state } = props;
-  if (!state.matches("nychaFound")) {
-    throw new Error(`Invalid state ${state.value}`);
-  }
 
   const { searchAddrParams, searchAddrBbl, nychaData: nycha, buildingInfo } = state.context;
   const { boro, block, lot } = Helpers.splitBBL(searchAddrBbl);

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -29,27 +29,27 @@ msgstr "(expires {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
-#: src/components/PropertiesMap.tsx:197
+#: src/components/PropertiesMap.tsx:203
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 
-#: src/containers/HomePage.tsx:139
+#: src/containers/HomePage.tsx:85
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
 #: src/components/BuildingStatsTable.tsx:70
-#: src/containers/NychaPage.tsx:121
+#: src/containers/NychaPage.tsx:87
 msgid "2019 Evictions"
 msgstr "2019 Evictions"
 
-#: src/containers/HomePage.tsx:29
+#: src/containers/HomePage.tsx:28
 msgid "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. While NYC is in Phase 2, we still recommend full precautions. Thanks to tenant organizing during this time, renters cannot be evicted for any reason until August 6. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
 msgstr "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. While NYC is in Phase 2, we still recommend full precautions. Thanks to tenant organizing during this time, renters cannot be evicted for any reason until August 6. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
 
 #: src/components/DetailView.tsx:216
-#: src/components/Indicators.js:524
-#: src/containers/NotRegisteredPage.tsx:200
-#: src/containers/NychaPage.tsx:202
+#: src/components/Indicators.tsx:285
+#: src/containers/NotRegisteredPage.tsx:159
+#: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
 
@@ -58,15 +58,15 @@ msgstr "ANHD DAP Portal"
 msgid "About"
 msgstr "About"
 
-#: src/components/ViolationsSummary.tsx:30
+#: src/components/ViolationsSummary.tsx:27
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 
-#: src/components/PropertiesSummary.tsx:86
+#: src/components/PropertiesSummary.tsx:97
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:27
+#: src/components/PropertiesList.tsx:24
 msgid "Address"
 msgstr "Address"
 
@@ -74,7 +74,7 @@ msgstr "Address"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:144
 msgid "Amount"
 msgstr "Amount"
 
@@ -83,31 +83,31 @@ msgstr "Amount"
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
-#: src/containers/NychaPage.tsx:209
+#: src/containers/NychaPage.tsx:175
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
 #: src/components/DetailView.tsx:70
-#: src/components/Indicators.js:290
+#: src/components/Indicators.tsx:149
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/Indicators.js:301
+#: src/components/Indicators.tsx:154
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
-#: src/components/PropertiesList.tsx:42
-#: src/containers/NychaPage.tsx:113
+#: src/components/PropertiesList.tsx:39
+#: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
 
-#: src/containers/NychaPage.tsx:129
+#: src/containers/NychaPage.tsx:95
 msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
+#: src/containers/NotRegisteredPage.tsx:65
 #: src/containers/NotRegisteredPage.tsx:85
-#: src/containers/NotRegisteredPage.tsx:107
-#: src/containers/NotRegisteredPage.tsx:128
+#: src/containers/NotRegisteredPage.tsx:104
 msgid "Building Classification"
 msgstr "Building Classification"
 
@@ -115,74 +115,74 @@ msgstr "Building Classification"
 msgid "Building Permit Applications"
 msgstr "Building Permit Applications"
 
-#: src/components/IndicatorsViz.js:182
-#: src/components/IndicatorsViz.js:257
+#: src/components/IndicatorsViz.tsx:173
+#: src/components/IndicatorsViz.tsx:241
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
-#: src/containers/NotRegisteredPage.tsx:217
+#: src/containers/NotRegisteredPage.tsx:175
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:57
+#: src/components/PropertiesList.tsx:54
 msgid "Built"
 msgstr "Built"
 
 #: src/components/DetailView.tsx:102
 #: src/components/DetailView.tsx:290
 #: src/components/DetailView.tsx:299
-#: src/components/OwnersTable.tsx:19
+#: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
 #: src/components/DetailView.tsx:93
 #: src/components/DetailView.tsx:270
 #: src/components/DetailView.tsx:279
-#: src/components/OwnersTable.tsx:25
+#: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Business Entities"
 
-#: src/containers/NotRegisteredPage.tsx:221
+#: src/containers/NotRegisteredPage.tsx:179
 msgid "Civil penalties of $250-$500"
 msgstr "Civil penalties of $250-$500"
 
-#: src/components/IndicatorsViz.js:153
+#: src/components/IndicatorsViz.tsx:144
 msgid "Class A"
 msgstr "Class A"
 
-#: src/components/IndicatorsViz.js:146
+#: src/components/IndicatorsViz.tsx:137
 msgid "Class B"
 msgstr "Class B"
 
-#: src/components/IndicatorsViz.js:139
+#: src/components/IndicatorsViz.tsx:130
 msgid "Class C"
 msgstr "Class C"
 
-#: src/containers/NotRegisteredPage.tsx:228
+#: src/containers/NotRegisteredPage.tsx:188
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
-#: src/components/PropertiesMap.tsx:185
+#: src/components/PropertiesMap.tsx:191
 msgid "Close legend"
 msgstr "Close legend"
 
-#: src/components/IndicatorsViz.js:254
+#: src/components/IndicatorsViz.tsx:238
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
 #: src/components/DetailView.tsx:202
-#: src/components/Indicators.js:498
-#: src/containers/NotRegisteredPage.tsx:197
+#: src/components/Indicators.tsx:271
+#: src/containers/NotRegisteredPage.tsx:156
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
 #: src/components/DetailView.tsx:209
-#: src/components/Indicators.js:511
-#: src/containers/NotRegisteredPage.tsx:192
+#: src/components/Indicators.tsx:278
+#: src/containers/NotRegisteredPage.tsx:151
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
-#: src/components/PropertiesList.tsx:139
+#: src/components/PropertiesList.tsx:136
 msgid "Date"
 msgstr "Date"
 
@@ -203,15 +203,15 @@ msgstr "Donate"
 msgid "Download"
 msgstr "Download"
 
-#: src/components/SocialShare.tsx:30
+#: src/components/SocialShare.tsx:29
 msgid "Email"
 msgstr "Email"
 
-#: src/components/IndicatorsViz.js:164
+#: src/components/IndicatorsViz.tsx:155
 msgid "Emergency"
 msgstr "Emergency"
 
-#: src/containers/HomePage.tsx:118
+#: src/containers/HomePage.tsx:72
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Enter an NYC address and find other buildings your landlord might own:"
 
@@ -219,8 +219,8 @@ msgstr "Enter an NYC address and find other buildings your landlord might own:"
 msgid "Enter email"
 msgstr "Enter email"
 
-#: src/components/PropertiesList.tsx:110
-#: src/components/PropertiesSummary.tsx:79
+#: src/components/PropertiesList.tsx:107
+#: src/components/PropertiesSummary.tsx:90
 msgid "Evictions"
 msgstr "Evictions"
 
@@ -228,7 +228,7 @@ msgstr "Evictions"
 msgid "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
-#: src/containers/NychaPage.tsx:120
+#: src/containers/NychaPage.tsx:86
 msgid "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
@@ -236,20 +236,20 @@ msgstr "Evictions executed in this development by NYC Marshals in 2019. ANHD and
 msgid "Export Data"
 msgstr "Export Data"
 
-#: src/containers/NotRegisteredPage.tsx:216
+#: src/containers/NotRegisteredPage.tsx:174
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PropertiesSummary.tsx:32
+#: src/components/PropertiesSummary.tsx:43
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:163
+#: src/components/PropertiesList.tsx:160
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
 #: src/components/DetailView.tsx:195
-#: src/components/Indicators.js:485
+#: src/components/Indicators.tsx:264
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
@@ -262,7 +262,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:93
+#: src/components/PropertiesList.tsx:90
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -270,12 +270,12 @@ msgstr "HPD Violations"
 msgid "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner— however, HPD violations are notoriously unenforced by the City. These Violations fall into three categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8/>Read more about HPD Violations at the <9>official HPD page</9>."
 msgstr "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner— however, HPD violations are notoriously unenforced by the City. These Violations fall into three categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8/>Read more about HPD Violations at the <9>official HPD page</9>."
 
-#: src/containers/NychaPage.tsx:191
+#: src/containers/NychaPage.tsx:157
 msgid "HUD Complaint Form 958"
 msgstr "HUD Complaint Form 958"
 
-#: src/components/Indicators.js:429
-#: src/components/Indicators.js:532
+#: src/components/Indicators.tsx:226
+#: src/components/Indicators.tsx:293
 msgid "Have thoughts about this page?"
 msgstr "Have thoughts about this page?"
 
@@ -293,19 +293,19 @@ msgstr "How is this building associated to this portfolio?"
 msgid "How to use"
 msgstr "How to use"
 
-#: src/components/EvictionsSummary.tsx:9
+#: src/components/EvictionsSummary.tsx:8
 msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/containers/NotRegisteredPage.tsx:223
+#: src/containers/NotRegisteredPage.tsx:181
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:54
+#: src/components/PropertiesList.tsx:51
 msgid "Information"
 msgstr "Information"
 
-#: src/containers/NotRegisteredPage.tsx:121
+#: src/containers/NotRegisteredPage.tsx:99
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "It doesn't seem like this property is required to register with HPD."
 
@@ -317,8 +317,8 @@ msgstr "Join the fight for tenant rights!"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 
-#: src/components/PropertiesList.tsx:121
-#: src/components/PropertiesSummary.tsx:64
+#: src/components/PropertiesList.tsx:118
+#: src/components/PropertiesSummary.tsx:75
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -326,11 +326,11 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:136
+#: src/components/PropertiesList.tsx:133
 msgid "Last Sale"
 msgstr "Last Sale"
 
-#: src/components/IndicatorsViz.js:360
+#: src/components/IndicatorsViz.tsx:351
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
@@ -342,26 +342,28 @@ msgstr "Last registered:"
 msgid "Last sold:"
 msgstr "Last sold:"
 
-#: src/components/PropertiesMap.tsx:185
+#: src/components/PropertiesMap.tsx:191
 msgid "Legend"
 msgstr "Legend"
 
-#: src/components/PropertiesList.tsx:155
-#: src/components/PropertiesList.tsx:157
+#: src/components/PropertiesList.tsx:152
+#: src/components/PropertiesList.tsx:154
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
-#: src/components/Indicators.js:281
-#: src/components/PropertiesMap.tsx:148
-#: src/containers/AddressPage.js:274
+#: src/components/Indicators.tsx:121
+#: src/components/PropertiesMap.tsx:154
+#: src/components/PropertiesSummary.tsx:36
+#: src/containers/AddressPage.tsx:160
+#: src/containers/BBLPage.tsx:51
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:24
+#: src/components/PropertiesList.tsx:21
 msgid "Location"
 msgstr "Location"
 
-#: src/components/PropertiesSummary.tsx:90
+#: src/components/PropertiesSummary.tsx:101
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
@@ -369,11 +371,11 @@ msgstr "Looking for more information?"
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 
-#: src/components/ViolationsSummary.tsx:11
+#: src/components/ViolationsSummary.tsx:8
 msgid "Maintenance code violations"
 msgstr "Maintenance code violations"
 
-#: src/containers/NotRegisteredPage.tsx:222
+#: src/containers/NotRegisteredPage.tsx:180
 msgid "May be issued official Orders"
 msgstr "May be issued official Orders"
 
@@ -382,19 +384,19 @@ msgstr "May be issued official Orders"
 msgid "Methodology"
 msgstr "Methodology"
 
-#: src/components/Indicators.js:347
+#: src/components/Indicators.tsx:178
 msgid "Month"
 msgstr "Month"
 
-#: src/containers/NychaPage.tsx:199
+#: src/containers/NychaPage.tsx:165
 msgid "MyNYCHA App"
 msgstr "MyNYCHA App"
 
-#: src/containers/NychaPage.tsx:194
+#: src/containers/NychaPage.tsx:160
 msgid "NYCHA Directory"
 msgstr "NYCHA Directory"
 
-#: src/components/SocialShare.tsx:28
+#: src/components/SocialShare.tsx:27
 msgid "New JustFix.nyc tool helps research on NYC landlords"
 msgstr "New JustFix.nyc tool helps research on NYC landlords"
 
@@ -402,39 +404,41 @@ msgstr "New JustFix.nyc tool helps research on NYC landlords"
 msgid "New Search"
 msgstr "New Search"
 
-#: src/containers/NychaPage.tsx:146
+#: src/containers/NychaPage.tsx:112
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:174
+#: src/components/PropertiesList.tsx:169
 msgid "No"
 msgstr "No"
 
-#: src/containers/NotRegisteredPage.tsx:145
-#: src/containers/NychaPage.tsx:93
+#: src/containers/NotFoundPage.tsx:14
+#: src/containers/NotFoundPage.tsx:16
 msgid "No address found"
 msgstr "No address found"
 
-#: src/components/IndicatorsViz.js:419
+#: src/components/IndicatorsViz.tsx:405
 msgid "No data available"
 msgstr "No data available"
 
-#: src/containers/NotRegisteredPage.tsx:160
+#: src/containers/NotRegisteredPage.tsx:123
 msgid "No registration found for {usersInputAddressFragment}!"
 msgstr "No registration found for {usersInputAddressFragment}!"
 
-#: src/containers/NotRegisteredPage.tsx:160
+#: src/containers/NotRegisteredPage.tsx:123
 msgid "No registration found!"
 msgstr "No registration found!"
 
-#: src/components/IndicatorsViz.js:171
+#: src/components/IndicatorsViz.tsx:162
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/PropertiesList.tsx:124
+#: src/components/PropertiesList.tsx:121
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
+#: src/components/Indicators.tsx:119
+#: src/components/PropertiesSummary.tsx:32
 #: src/components/Subscribe.tsx:49
 #: src/components/Subscribe.tsx:55
 msgid "Oops! A network error occurred. Try again later."
@@ -444,7 +448,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:96
+#: src/components/PropertiesList.tsx:93
 msgid "Open"
 msgstr "Open"
 
@@ -452,7 +456,7 @@ msgstr "Open"
 msgid "Open Violations"
 msgstr "Open Violations"
 
-#: src/containers/AddressPage.js:170
+#: src/containers/AddressPage.tsx:114
 msgid "Overview"
 msgstr "Overview"
 
@@ -460,14 +464,14 @@ msgstr "Overview"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 
-#: src/containers/AddressPage.js:148
+#: src/containers/AddressPage.tsx:102
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
 #: src/components/DetailView.tsx:112
 #: src/components/DetailView.tsx:310
 #: src/components/DetailView.tsx:320
-#: src/components/OwnersTable.tsx:31
+#: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "People"
 
@@ -475,7 +479,7 @@ msgstr "People"
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/containers/AddressPage.js:192
+#: src/containers/AddressPage.tsx:128
 msgid "Portfolio"
 msgstr "Portfolio"
 
@@ -484,46 +488,38 @@ msgstr "Portfolio"
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
-#: src/containers/NychaPage.tsx:103
+#: src/containers/NychaPage.tsx:69
 msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
-#: src/components/Indicators.js:365
+#: src/components/Indicators.tsx:186
 msgid "Quarter"
 msgstr "Quarter"
 
 #: src/components/BuildingStatsTable.tsx:80
-#: src/components/PropertiesList.tsx:71
+#: src/components/PropertiesList.tsx:68
 msgid "RS Units"
 msgstr "RS Units"
 
-#: src/components/PropertiesSummary.tsx:81
+#: src/components/PropertiesSummary.tsx:92
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/containers/NotRegisteredPage.tsx:212
-#: src/containers/NychaPage.tsx:224
+#: src/containers/NotRegisteredPage.tsx:170
+#: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
 msgstr "Search for a different address"
 
-#: src/containers/BBLPage.tsx:131
-msgid "Searching"
-msgstr "Searching"
-
-#: src/containers/HomePage.tsx:125
-msgid "Searching for <0>{0} {1}, {2}</0>"
-msgstr "Searching for <0>{0} {1}, {2}</0>"
-
-#: src/components/Indicators.js:308
+#: src/components/Indicators.tsx:161
 msgid "Select a Dataset:"
 msgstr "Select a Dataset:"
 
-#: src/components/PropertiesSummary.tsx:96
+#: src/components/PropertiesSummary.tsx:107
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/components/Indicators.js:436
-#: src/components/Indicators.js:539
+#: src/components/Indicators.tsx:229
+#: src/components/Indicators.tsx:296
 msgid "Send us feedback!"
 msgstr "Send us feedback!"
 
@@ -534,7 +530,7 @@ msgstr "Share"
 #: src/components/DetailView.tsx:165
 #: src/components/DetailView.tsx:233
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:102
+#: src/components/PropertiesSummary.tsx:113
 #: src/containers/App.tsx:71
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
@@ -548,11 +544,11 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/IndicatorsViz.js:359
+#: src/components/IndicatorsViz.tsx:350
 msgid "Sold to Current Owner"
 msgstr "Sold to Current Owner"
 
-#: src/components/PropertiesMap.tsx:153
+#: src/components/PropertiesMap.tsx:159
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 
@@ -560,13 +556,13 @@ msgstr "Sorry, it looks like there's an error on the map. Try again on a differe
 msgid "Source code"
 msgstr "Source code"
 
-#: src/containers/AddressPage.js:203
+#: src/containers/AddressPage.tsx:135
 msgid "Summary"
 msgstr "Summary"
 
 #: src/components/DetailView.tsx:159
 #: src/components/DetailView.tsx:227
-#: src/containers/NychaPage.tsx:213
+#: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
 
@@ -575,31 +571,31 @@ msgstr "Take action on JustFix.nyc!"
 msgid "Terms of use"
 msgstr "Terms of use"
 
-#: src/containers/NychaPage.tsx:128
+#: src/containers/NychaPage.tsx:94
 msgid "The NYCHA office overseeing your borough. Some experts suggest reaching out to Borough Management Offices to advocate for repairs, as they tend to have more administrative power than local management offices."
 msgstr "The NYCHA office overseeing your borough. Some experts suggest reaching out to Borough Management Offices to advocate for repairs, as they tend to have more administrative power than local management offices."
 
-#: src/components/RentstabSummary.tsx:27
+#: src/components/RentstabSummary.tsx:26
 msgid "The building that has lost the most units is <0>{0} {1}, {2}</0>, which has lost <1>{absRsLossAddrDiff}</1> {absRsLossAddrDiff, plural, one {unit} other {units}} in the past 10 years."
 msgstr "The building that has lost the most units is <0>{0} {1}, {2}</0>, which has lost <1>{absRsLossAddrDiff}</1> {absRsLossAddrDiff, plural, one {unit} other {units}} in the past 10 years."
 
-#: src/components/EvictionsSummary.tsx:14
+#: src/components/EvictionsSummary.tsx:13
 msgid "The building with the most evictions was <0>{0} {1}, {2}</0> with {buildingTotalEvictions, plural, one {one eviction} other {# evictions}} that year."
 msgstr "The building with the most evictions was <0>{0} {1}, {2}</0> with {buildingTotalEvictions, plural, one {one eviction} other {# evictions}} that year."
 
-#: src/containers/NychaPage.tsx:112
+#: src/containers/NychaPage.tsx:78
 msgid "The city borough where your search address is located"
 msgstr "The city borough where your search address is located"
 
-#: src/containers/HomePage.tsx:193
+#: src/containers/HomePage.tsx:138
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
-#: src/components/PropertiesSummary.tsx:72
+#: src/components/PropertiesSummary.tsx:83
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:66
+#: src/components/PropertiesSummary.tsx:77
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
@@ -607,7 +603,7 @@ msgstr "The most common {0, plural, one {name that appears in this portfolio is}
 msgid "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
 msgstr "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
 
-#: src/containers/NychaPage.tsx:116
+#: src/containers/NychaPage.tsx:82
 msgid "The number of residential units across all buildings in this development, according to the Dept. of City Planning."
 msgstr "The number of residential units across all buildings in this development, according to the Dept. of City Planning."
 
@@ -619,27 +615,27 @@ msgstr "The number of residential units in this building, according to the Dept.
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "The year that this building was originally constructed, according to the Dept. of City Planning."
 
-#: src/components/PropertiesSummary.tsx:45
+#: src/components/PropertiesSummary.tsx:56
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 
-#: src/components/SocialShare.tsx:50
+#: src/components/SocialShare.tsx:49
 msgid "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
 msgstr "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
 
-#: src/components/SocialShare.tsx:50
+#: src/components/SocialShare.tsx:49
 msgid "The {buildingCount} buildings that my landlord \"owns\" 👀... #WhoOwnsWhat @JustFixNYC"
 msgstr "The {buildingCount} buildings that my landlord \"owns\" 👀... #WhoOwnsWhat @JustFixNYC"
 
-#: src/components/PropertiesSummary.tsx:34
+#: src/components/PropertiesSummary.tsx:45
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
-#: src/containers/NychaPage.tsx:106
+#: src/containers/NychaPage.tsx:72
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "This building is owned by the NYC Housing Authority (NYCHA)"
 
-#: src/containers/NotRegisteredPage.tsx:100
+#: src/containers/NotRegisteredPage.tsx:80
 msgid "This building seems like it should be registered with HPD!"
 msgstr "This building seems like it should be registered with HPD!"
 
@@ -647,15 +643,15 @@ msgstr "This building seems like it should be registered with HPD!"
 msgid "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 msgstr "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 
-#: src/components/ViolationsSummary.tsx:20
+#: src/components/ViolationsSummary.tsx:17
 msgid "This is <0>about the same</0> as the citywide average."
 msgstr "This is <0>about the same</0> as the citywide average."
 
-#: src/components/ViolationsSummary.tsx:25
+#: src/components/ViolationsSummary.tsx:22
 msgid "This is <0>better</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "This is <0>better</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 
-#: src/components/ViolationsSummary.tsx:22
+#: src/components/ViolationsSummary.tsx:19
 msgid "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 
@@ -663,19 +659,19 @@ msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per r
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
-#: src/components/RentstabSummary.tsx:15
+#: src/components/RentstabSummary.tsx:14
 msgid "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
 msgstr "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
 
-#: src/components/ViolationsSummary.tsx:15
+#: src/components/ViolationsSummary.tsx:12
 msgid "This portfolio has an average of <0>{openviolationsperresunit}</0> open HPD violations per residential unit."
 msgstr "This portfolio has an average of <0>{openviolationsperresunit}</0> open HPD violations per residential unit."
 
-#: src/containers/HomePage.tsx:158
+#: src/containers/HomePage.tsx:104
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 
-#: src/components/RentstabSummary.tsx:24
+#: src/components/RentstabSummary.tsx:23
 msgid "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 msgstr "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 
@@ -683,7 +679,7 @@ msgstr "This represents <0>{rsProportion}%</0> of the total size of this portfol
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 
-#: src/containers/NotRegisteredPage.tsx:77
+#: src/containers/NotRegisteredPage.tsx:57
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 
@@ -695,12 +691,12 @@ msgstr "This tracks how rent stabilized units in the building have changed (i.e.
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.js:181
+#: src/containers/AddressPage.tsx:121
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/IndicatorsViz.js:320
-#: src/components/PropertiesList.tsx:102
+#: src/components/IndicatorsViz.tsx:313
+#: src/components/PropertiesList.tsx:99
 msgid "Total"
 msgstr "Total"
 
@@ -708,17 +704,17 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Total Violations"
 
-#: src/containers/NotRegisteredPage.tsx:225
+#: src/containers/NotRegisteredPage.tsx:183
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "Unable to initiate a court action for nonpayment of rent."
 
-#: src/containers/NotRegisteredPage.tsx:224
+#: src/containers/NotRegisteredPage.tsx:182
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:43
-#: src/components/PropertiesList.tsx:63
-#: src/containers/NychaPage.tsx:117
+#: src/components/PropertiesList.tsx:60
+#: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
 
@@ -728,13 +724,13 @@ msgstr "Use this free tool from JustFix.nyc to research your building and invest
 
 #: src/components/DetailView.tsx:176
 #: src/components/DetailView.tsx:181
-#: src/components/Indicators.js:454
-#: src/containers/NotRegisteredPage.tsx:185
-#: src/containers/NychaPage.tsx:187
+#: src/components/Indicators.tsx:249
+#: src/containers/NotRegisteredPage.tsx:144
+#: src/containers/NychaPage.tsx:153
 msgid "Useful links"
 msgstr "Useful links"
 
-#: src/components/Indicators.js:329
+#: src/components/Indicators.tsx:170
 msgid "View by:"
 msgstr "View by:"
 
@@ -742,24 +738,24 @@ msgstr "View by:"
 msgid "View data over time"
 msgstr "View data over time"
 
+#: src/components/PropertiesList.tsx:176
 #: src/components/PropertiesList.tsx:181
-#: src/components/PropertiesList.tsx:186
 msgid "View detail"
 msgstr "View detail"
 
 #: src/components/DetailView.tsx:188
-#: src/components/Indicators.js:466
-#: src/containers/NotRegisteredPage.tsx:189
+#: src/components/Indicators.tsx:255
+#: src/containers/NotRegisteredPage.tsx:148
 msgid "View documents on ACRIS"
 msgstr "View documents on ACRIS"
 
-#: src/components/PropertiesMap.tsx:185
+#: src/components/PropertiesMap.tsx:191
 msgid "View legend"
 msgstr "View legend"
 
-#: src/containers/HomePage.tsx:174
-#: src/containers/HomePage.tsx:216
-#: src/containers/HomePage.tsx:247
+#: src/containers/HomePage.tsx:119
+#: src/containers/HomePage.tsx:161
+#: src/containers/HomePage.tsx:191
 msgid "View portfolio"
 msgstr "View portfolio"
 
@@ -767,7 +763,7 @@ msgstr "View portfolio"
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
-#: src/components/IndicatorsViz.js:256
+#: src/components/IndicatorsViz.tsx:240
 msgid "Violations Issued"
 msgstr "Violations Issued"
 
@@ -783,11 +779,11 @@ msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
-#: src/components/Indicators.js:445
+#: src/components/Indicators.tsx:238
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
-#: src/containers/NotRegisteredPage.tsx:60
+#: src/containers/NotRegisteredPage.tsx:44
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 
@@ -802,7 +798,7 @@ msgstr "Who owns what in n y c?"
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 
-#: src/components/Indicators.js:383
+#: src/components/Indicators.tsx:194
 msgid "Year"
 msgstr "Year"
 
@@ -810,15 +806,15 @@ msgstr "Year"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:173
+#: src/components/PropertiesList.tsx:168
 msgid "Yes"
 msgstr "Yes"
 
-#: src/containers/HomePage.tsx:235
+#: src/containers/HomePage.tsx:180
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:36
+#: src/components/PropertiesList.tsx:33
 msgid "Zipcode"
 msgstr "Zipcode"
 
@@ -826,7 +822,7 @@ msgstr "Zipcode"
 msgid "and"
 msgstr "and"
 
-#: src/components/PropertiesMap.tsx:192
+#: src/components/PropertiesMap.tsx:198
 msgid "associated building"
 msgstr "associated building"
 
@@ -834,11 +830,11 @@ msgstr "associated building"
 msgid "for ${0}"
 msgstr "for ${0}"
 
-#: src/components/PropertiesMap.tsx:191
+#: src/components/PropertiesMap.tsx:197
 msgid "search address"
 msgstr "search address"
 
-#: src/components/PropertiesSummary.tsx:55
+#: src/components/PropertiesSummary.tsx:66
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -34,27 +34,27 @@ msgstr "(caduca {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
-#: src/components/PropertiesMap.tsx:197
+#: src/components/PropertiesMap.tsx:203
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {pulsa} other {haz clic}} para ver detalles)"
 
-#: src/containers/HomePage.tsx:139
+#: src/containers/HomePage.tsx:85
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de portafolios de edificios:"
 
 #: src/components/BuildingStatsTable.tsx:70
-#: src/containers/NychaPage.tsx:121
+#: src/containers/NychaPage.tsx:87
 msgid "2019 Evictions"
 msgstr "Desalojos 2019"
 
-#: src/containers/HomePage.tsx:29
+#: src/containers/HomePage.tsx:28
 msgid "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. While NYC is in Phase 2, we still recommend full precautions. Thanks to tenant organizing during this time, renters cannot be evicted for any reason until August 6. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
 msgstr "<0>Actualización COVID-19: </0>JustFix.nyc está operativo, y hemos adaptado nuestros productos a las normas establecidas durante la crisis de COVID-19. Aunque NYC se encuentre en la fase 2, todavía recomendamos que se tomen todas las precauciones posibles. Gracias al poder de la organización de inquilinos, los inquilinos no pueden ser desalojados por ninguna razón hasta el 6 de agosto. Visita las <1><2>Preguntas Más Frecuentes sobre la Moratoria de Desalojo del Right to Council</2></1> para obtener más información."
 
 #: src/components/DetailView.tsx:216
-#: src/components/Indicators.js:524
-#: src/containers/NotRegisteredPage.tsx:200
-#: src/containers/NychaPage.tsx:202
+#: src/components/Indicators.tsx:285
+#: src/containers/NotRegisteredPage.tsx:159
+#: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
 
@@ -63,15 +63,15 @@ msgstr "Portal DAP de ANHD"
 msgid "About"
 msgstr "Acerca de"
 
-#: src/components/ViolationsSummary.tsx:30
+#: src/components/ViolationsSummary.tsx:27
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha recibido un total de <0>{totalviolations}</0> infracciones."
 
-#: src/components/PropertiesSummary.tsx:86
+#: src/components/PropertiesSummary.tsx:97
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:27
+#: src/components/PropertiesList.tsx:24
 msgid "Address"
 msgstr "Dirección"
 
@@ -79,7 +79,7 @@ msgstr "Dirección"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:144
 msgid "Amount"
 msgstr "Importe"
 
@@ -88,31 +88,31 @@ msgstr "Importe"
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
-#: src/containers/NychaPage.tsx:209
+#: src/containers/NychaPage.tsx:175
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
 #: src/components/DetailView.tsx:70
-#: src/components/Indicators.js:290
+#: src/components/Indicators.tsx:149
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/Indicators.js:301
+#: src/components/Indicators.tsx:154
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
-#: src/components/PropertiesList.tsx:42
-#: src/containers/NychaPage.tsx:113
+#: src/components/PropertiesList.tsx:39
+#: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
 
-#: src/containers/NychaPage.tsx:129
+#: src/containers/NychaPage.tsx:95
 msgid "Borough Management Office:"
 msgstr "Oficina de Gestión Municipal:"
 
+#: src/containers/NotRegisteredPage.tsx:65
 #: src/containers/NotRegisteredPage.tsx:85
-#: src/containers/NotRegisteredPage.tsx:107
-#: src/containers/NotRegisteredPage.tsx:128
+#: src/containers/NotRegisteredPage.tsx:104
 msgid "Building Classification"
 msgstr "Clasificación del Edificio"
 
@@ -120,74 +120,74 @@ msgstr "Clasificación del Edificio"
 msgid "Building Permit Applications"
 msgstr "Solicitudes de Permisos de Construcción"
 
-#: src/components/IndicatorsViz.js:182
-#: src/components/IndicatorsViz.js:257
+#: src/components/IndicatorsViz.tsx:173
+#: src/components/IndicatorsViz.tsx:241
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
 
-#: src/containers/NotRegisteredPage.tsx:217
+#: src/containers/NotRegisteredPage.tsx:175
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:57
+#: src/components/PropertiesList.tsx:54
 msgid "Built"
 msgstr "Construido"
 
 #: src/components/DetailView.tsx:102
 #: src/components/DetailView.tsx:290
 #: src/components/DetailView.tsx:299
-#: src/components/OwnersTable.tsx:19
+#: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
 #: src/components/DetailView.tsx:93
 #: src/components/DetailView.tsx:270
 #: src/components/DetailView.tsx:279
-#: src/components/OwnersTable.tsx:25
+#: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
-#: src/containers/NotRegisteredPage.tsx:221
+#: src/containers/NotRegisteredPage.tsx:179
 msgid "Civil penalties of $250-$500"
 msgstr "Sanciones civiles de $250-$500"
 
-#: src/components/IndicatorsViz.js:153
+#: src/components/IndicatorsViz.tsx:144
 msgid "Class A"
 msgstr "Clase A"
 
-#: src/components/IndicatorsViz.js:146
+#: src/components/IndicatorsViz.tsx:137
 msgid "Class B"
 msgstr "Clase B"
 
-#: src/components/IndicatorsViz.js:139
+#: src/components/IndicatorsViz.tsx:130
 msgid "Class C"
 msgstr "Clase C"
 
-#: src/containers/NotRegisteredPage.tsx:228
+#: src/containers/NotRegisteredPage.tsx:188
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
-#: src/components/PropertiesMap.tsx:185
+#: src/components/PropertiesMap.tsx:191
 msgid "Close legend"
 msgstr "Cerrar leyenda"
 
-#: src/components/IndicatorsViz.js:254
+#: src/components/IndicatorsViz.tsx:238
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
 #: src/components/DetailView.tsx:202
-#: src/components/Indicators.js:498
-#: src/containers/NotRegisteredPage.tsx:197
+#: src/components/Indicators.tsx:271
+#: src/containers/NotRegisteredPage.tsx:156
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
 #: src/components/DetailView.tsx:209
-#: src/components/Indicators.js:511
-#: src/containers/NotRegisteredPage.tsx:192
+#: src/components/Indicators.tsx:278
+#: src/containers/NotRegisteredPage.tsx:151
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
-#: src/components/PropertiesList.tsx:139
+#: src/components/PropertiesList.tsx:136
 msgid "Date"
 msgstr "Fecha"
 
@@ -208,15 +208,15 @@ msgstr "Donar"
 msgid "Download"
 msgstr "Descargar"
 
-#: src/components/SocialShare.tsx:30
+#: src/components/SocialShare.tsx:29
 msgid "Email"
 msgstr "Email"
 
-#: src/components/IndicatorsViz.js:164
+#: src/components/IndicatorsViz.tsx:155
 msgid "Emergency"
 msgstr "Emergencia"
 
-#: src/containers/HomePage.tsx:118
+#: src/containers/HomePage.tsx:72
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
 
@@ -224,8 +224,8 @@ msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu pr
 msgid "Enter email"
 msgstr "Introducir email"
 
-#: src/components/PropertiesList.tsx:110
-#: src/components/PropertiesSummary.tsx:79
+#: src/components/PropertiesList.tsx:107
+#: src/components/PropertiesSummary.tsx:90
 msgid "Evictions"
 msgstr "Desalojos"
 
@@ -233,7 +233,7 @@ msgstr "Desalojos"
 msgid "Evictions executed by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este edificio por el Mariscal de NYC en 2019. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, que provienen originalmente del DOI."
 
-#: src/containers/NychaPage.tsx:120
+#: src/containers/NychaPage.tsx:86
 msgid "Evictions executed in this development by NYC Marshals in 2019. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC en 2019. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes del DOI."
 
@@ -241,20 +241,20 @@ msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC en 2019. AN
 msgid "Export Data"
 msgstr "Exportar datos"
 
-#: src/containers/NotRegisteredPage.tsx:216
+#: src/containers/NotRegisteredPage.tsx:174
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PropertiesSummary.tsx:32
+#: src/components/PropertiesSummary.tsx:43
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:163
+#: src/components/PropertiesList.tsx:160
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
 #: src/components/DetailView.tsx:195
-#: src/components/Indicators.js:485
+#: src/components/Indicators.tsx:264
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
@@ -267,7 +267,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:93
+#: src/components/PropertiesList.tsx:90
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
@@ -275,12 +275,12 @@ msgstr "Infracciones del HPD"
 msgid "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner— however, HPD violations are notoriously unenforced by the City. These Violations fall into three categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8/>Read more about HPD Violations at the <9>official HPD page</9>."
 msgstr "Infracciones del HPD se dan cuando un Inspector oficial de la Ciudad determina que las condiciones de un hogar están en violación de la ley. Si no se corrigen, estas infraccines incurren multas para el propietario, sin embargo, las infracciones del HPD son notoriamente incumplidas por la Ciudad. Existen tres categorías de Infracciones:<0/><1/><2>Clase A</2> — no-peligrosa<3/><4>Clase B</4> — peligrosa<5/><6>Clase C</6> — de peligro inmediato<7/><8/>Encontraras más información sobre las Infracciones del HPD en la <9>página oficial del HPD</9>."
 
-#: src/containers/NychaPage.tsx:191
+#: src/containers/NychaPage.tsx:157
 msgid "HUD Complaint Form 958"
 msgstr "Formulario de queja HUD 958"
 
-#: src/components/Indicators.js:429
-#: src/components/Indicators.js:532
+#: src/components/Indicators.tsx:226
+#: src/components/Indicators.tsx:293
 msgid "Have thoughts about this page?"
 msgstr "¿Tienes ideas sobre esta página?"
 
@@ -298,19 +298,19 @@ msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 msgid "How to use"
 msgstr "Cómo se usa"
 
-#: src/components/EvictionsSummary.tsx:9
+#: src/components/EvictionsSummary.tsx:8
 msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "En el 2019, los Mariscales de NYC programaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en este portafolio de edificios."
 
-#: src/containers/NotRegisteredPage.tsx:223
+#: src/containers/NotRegisteredPage.tsx:181
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
-#: src/components/PropertiesList.tsx:54
+#: src/components/PropertiesList.tsx:51
 msgid "Information"
 msgstr "Información"
 
-#: src/containers/NotRegisteredPage.tsx:121
+#: src/containers/NotRegisteredPage.tsx:99
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "Parece que esta propiedad no necesita estar registrada con el HPD."
 
@@ -322,8 +322,8 @@ msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: src/components/PropertiesList.tsx:121
-#: src/components/PropertiesSummary.tsx:64
+#: src/components/PropertiesList.tsx:118
+#: src/components/PropertiesSummary.tsx:75
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -331,11 +331,11 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:136
+#: src/components/PropertiesList.tsx:133
 msgid "Last Sale"
 msgstr "Última venta"
 
-#: src/components/IndicatorsViz.js:360
+#: src/components/IndicatorsViz.tsx:351
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
@@ -347,26 +347,28 @@ msgstr "Registrado por última vez:"
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
-#: src/components/PropertiesMap.tsx:185
+#: src/components/PropertiesMap.tsx:191
 msgid "Legend"
 msgstr "Leyenda"
 
-#: src/components/PropertiesList.tsx:155
-#: src/components/PropertiesList.tsx:157
+#: src/components/PropertiesList.tsx:152
+#: src/components/PropertiesList.tsx:154
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
-#: src/components/Indicators.js:281
-#: src/components/PropertiesMap.tsx:148
-#: src/containers/AddressPage.js:274
+#: src/components/Indicators.tsx:121
+#: src/components/PropertiesMap.tsx:154
+#: src/components/PropertiesSummary.tsx:36
+#: src/containers/AddressPage.tsx:160
+#: src/containers/BBLPage.tsx:51
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:24
+#: src/components/PropertiesList.tsx:21
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/PropertiesSummary.tsx:90
+#: src/components/PropertiesSummary.tsx:101
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
@@ -374,11 +376,11 @@ msgstr "¿Buscas más información?"
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.nyc</0>"
 
-#: src/components/ViolationsSummary.tsx:11
+#: src/components/ViolationsSummary.tsx:8
 msgid "Maintenance code violations"
 msgstr "Infracciones del código de mantenimiento"
 
-#: src/containers/NotRegisteredPage.tsx:222
+#: src/containers/NotRegisteredPage.tsx:180
 msgid "May be issued official Orders"
 msgstr "Pueden emitirse órdenes oficiales"
 
@@ -387,19 +389,19 @@ msgstr "Pueden emitirse órdenes oficiales"
 msgid "Methodology"
 msgstr "Metodología"
 
-#: src/components/Indicators.js:347
+#: src/components/Indicators.tsx:178
 msgid "Month"
 msgstr "Mes"
 
-#: src/containers/NychaPage.tsx:199
+#: src/containers/NychaPage.tsx:165
 msgid "MyNYCHA App"
 msgstr "App MyNYCHA"
 
-#: src/containers/NychaPage.tsx:194
+#: src/containers/NychaPage.tsx:160
 msgid "NYCHA Directory"
 msgstr "Directorio de NYCHA"
 
-#: src/components/SocialShare.tsx:28
+#: src/components/SocialShare.tsx:27
 msgid "New JustFix.nyc tool helps research on NYC landlords"
 msgstr "La nueva herramienta JustFix.nyc te ayuda a investigar a propietarios de NYC"
 
@@ -407,39 +409,41 @@ msgstr "La nueva herramienta JustFix.nyc te ayuda a investigar a propietarios de
 msgid "New Search"
 msgstr "Nueva búsqueda"
 
-#: src/containers/NychaPage.tsx:146
+#: src/containers/NychaPage.tsx:112
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:174
+#: src/components/PropertiesList.tsx:169
 msgid "No"
 msgstr "No"
 
-#: src/containers/NotRegisteredPage.tsx:145
-#: src/containers/NychaPage.tsx:93
+#: src/containers/NotFoundPage.tsx:14
+#: src/containers/NotFoundPage.tsx:16
 msgid "No address found"
 msgstr "No se encontraron direcciones"
 
-#: src/components/IndicatorsViz.js:419
+#: src/components/IndicatorsViz.tsx:405
 msgid "No data available"
 msgstr "No hay datos disponibles"
 
-#: src/containers/NotRegisteredPage.tsx:160
+#: src/containers/NotRegisteredPage.tsx:123
 msgid "No registration found for {usersInputAddressFragment}!"
 msgstr "¡No se ha encontrado ningún registro para {usersInputAddressFragment}!"
 
-#: src/containers/NotRegisteredPage.tsx:160
+#: src/containers/NotRegisteredPage.tsx:123
 msgid "No registration found!"
 msgstr "¡No se ha encontrado nigún registro!"
 
-#: src/components/IndicatorsViz.js:171
+#: src/components/IndicatorsViz.tsx:162
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/PropertiesList.tsx:124
+#: src/components/PropertiesList.tsx:121
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
+#: src/components/Indicators.tsx:119
+#: src/components/PropertiesSummary.tsx:32
 #: src/components/Subscribe.tsx:49
 #: src/components/Subscribe.tsx:55
 msgid "Oops! A network error occurred. Try again later."
@@ -449,7 +453,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:96
+#: src/components/PropertiesList.tsx:93
 msgid "Open"
 msgstr "Abrir"
 
@@ -457,7 +461,7 @@ msgstr "Abrir"
 msgid "Open Violations"
 msgstr "Infracciones Actuales"
 
-#: src/containers/AddressPage.js:170
+#: src/containers/AddressPage.tsx:114
 msgid "Overview"
 msgstr "General"
 
@@ -465,14 +469,14 @@ msgstr "General"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/> Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
 
-#: src/containers/AddressPage.js:148
+#: src/containers/AddressPage.tsx:102
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
 #: src/components/DetailView.tsx:112
 #: src/components/DetailView.tsx:310
 #: src/components/DetailView.tsx:320
-#: src/components/OwnersTable.tsx:31
+#: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "Personas (Encontrarás definiciones en español de los tipos de personas asociadas al edificio en la página \"Como se usa\".)"
 
@@ -480,7 +484,7 @@ msgstr "Personas (Encontrarás definiciones en español de los tipos de personas
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/containers/AddressPage.js:192
+#: src/containers/AddressPage.tsx:128
 msgid "Portfolio"
 msgstr "Portafolio"
 
@@ -489,46 +493,38 @@ msgstr "Portafolio"
 msgid "Privacy policy"
 msgstr "Política de privacidad"
 
-#: src/containers/NychaPage.tsx:103
+#: src/containers/NychaPage.tsx:69
 msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
-#: src/components/Indicators.js:365
+#: src/components/Indicators.tsx:186
 msgid "Quarter"
 msgstr "Trimestre"
 
 #: src/components/BuildingStatsTable.tsx:80
-#: src/components/PropertiesList.tsx:71
+#: src/components/PropertiesList.tsx:68
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
-#: src/components/PropertiesSummary.tsx:81
+#: src/components/PropertiesSummary.tsx:92
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
-#: src/containers/NotRegisteredPage.tsx:212
-#: src/containers/NychaPage.tsx:224
+#: src/containers/NotRegisteredPage.tsx:170
+#: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
 msgstr "Buscar otra dirección"
 
-#: src/containers/BBLPage.tsx:131
-msgid "Searching"
-msgstr "Buscando"
-
-#: src/containers/HomePage.tsx:125
-msgid "Searching for <0>{0} {1}, {2}</0>"
-msgstr "Buscando <0>{0} {1}, {2}</0>"
-
-#: src/components/Indicators.js:308
+#: src/components/Indicators.tsx:161
 msgid "Select a Dataset:"
 msgstr "Seleccione un conjunto de datos:"
 
-#: src/components/PropertiesSummary.tsx:96
+#: src/components/PropertiesSummary.tsx:107
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/components/Indicators.js:436
-#: src/components/Indicators.js:539
+#: src/components/Indicators.tsx:229
+#: src/components/Indicators.tsx:296
 msgid "Send us feedback!"
 msgstr "¡Comparte tu opinión con nosotros!"
 
@@ -539,7 +535,7 @@ msgstr "Compartir"
 #: src/components/DetailView.tsx:165
 #: src/components/DetailView.tsx:233
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:102
+#: src/components/PropertiesSummary.tsx:113
 #: src/containers/App.tsx:71
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
@@ -553,11 +549,11 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/IndicatorsViz.js:359
+#: src/components/IndicatorsViz.tsx:350
 msgid "Sold to Current Owner"
 msgstr "Vendido al Propietario Actual"
 
-#: src/components/PropertiesMap.tsx:153
+#: src/components/PropertiesMap.tsx:159
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Lo sentimos, parece que hay un error en el mapa. Inténtalo de nuevo con un navegador diferente o <0>habilita WebGL</0>."
 
@@ -565,13 +561,13 @@ msgstr "Lo sentimos, parece que hay un error en el mapa. Inténtalo de nuevo con
 msgid "Source code"
 msgstr "Código fuente"
 
-#: src/containers/AddressPage.js:203
+#: src/containers/AddressPage.tsx:135
 msgid "Summary"
 msgstr "Resúmen"
 
 #: src/components/DetailView.tsx:159
 #: src/components/DetailView.tsx:227
-#: src/containers/NychaPage.tsx:213
+#: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
 
@@ -580,31 +576,31 @@ msgstr "¡Toma acción en JustFix.nyc!"
 msgid "Terms of use"
 msgstr "Condiciones de uso"
 
-#: src/containers/NychaPage.tsx:128
+#: src/containers/NychaPage.tsx:94
 msgid "The NYCHA office overseeing your borough. Some experts suggest reaching out to Borough Management Offices to advocate for repairs, as they tend to have more administrative power than local management offices."
 msgstr "La oficina de la NYCHA que se encarga de tu municipio. Algunos expertos sugieren ponerse en contacto con las Oficinas de Administración Municipales para conseguir arreglos, ya que tienden a tener más poder administrativo que las oficinas locales."
 
-#: src/components/RentstabSummary.tsx:27
+#: src/components/RentstabSummary.tsx:26
 msgid "The building that has lost the most units is <0>{0} {1}, {2}</0>, which has lost <1>{absRsLossAddrDiff}</1> {absRsLossAddrDiff, plural, one {unit} other {units}} in the past 10 years."
 msgstr "El edificio con la major pérdida de unidades residencial de renta estabilizada es <0>{0} {1}, {2}</0>, con una pérdida de <1>{absRsLossAddrDiff}</1> {absRsLossAddrDiff, plural, one {unidad} other {unidades}} en los últimos 10 años."
 
-#: src/components/EvictionsSummary.tsx:14
+#: src/components/EvictionsSummary.tsx:13
 msgid "The building with the most evictions was <0>{0} {1}, {2}</0> with {buildingTotalEvictions, plural, one {one eviction} other {# evictions}} that year."
 msgstr "El edificio con la major cantidad de desalojos fue <0>{0} {1}, {2}</0> con {buildingTotalEvictions, plural, one {un desalojo} other {# desalojos}} ese año."
 
-#: src/containers/NychaPage.tsx:112
+#: src/containers/NychaPage.tsx:78
 msgid "The city borough where your search address is located"
 msgstr "El municipio donde se encuentra la dirección que has buscado"
 
-#: src/containers/HomePage.tsx:193
+#: src/containers/HomePage.tsx:138
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
-#: src/components/PropertiesSummary.tsx:72
+#: src/components/PropertiesSummary.tsx:83
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:66
+#: src/components/PropertiesSummary.tsx:77
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "{0, plural, one {El nombre más común que aparece en este portafolio de edificios es} other {Los nombres más comunes que aparecen en este portafolio de edificios son}} <0/>."
 
@@ -612,7 +608,7 @@ msgstr "{0, plural, one {El nombre más común que aparece en este portafolio de
 msgid "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
 msgstr "El número de infracciones del HPD abiertas en este edificio, actualizado mensualmente. Haz clic en el botón del Perfil de Edificio del HPD para obtener la información más reciente."
 
-#: src/containers/NychaPage.tsx:116
+#: src/containers/NychaPage.tsx:82
 msgid "The number of residential units across all buildings in this development, according to the Dept. of City Planning."
 msgstr "El número de unidades residenciales en todos los edificios de este complejo, según el Departamento de Planificación de la Ciudad."
 
@@ -624,27 +620,27 @@ msgstr "El número de unidades residenciales en este edificio, según el Departa
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "El año en que este edificio fue construido, según el Departamento de Planificación de la Ciudad."
 
-#: src/components/PropertiesSummary.tsx:45
+#: src/components/PropertiesSummary.tsx:56
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
-#: src/components/SocialShare.tsx:50
+#: src/components/SocialShare.tsx:49
 msgid "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
 msgstr "Los {buildingCount} edificios que son propiedad del dueño de mi apartamento (a través de la herramienta Quién Es El Dueño de JustFix.nyc)"
 
-#: src/components/SocialShare.tsx:50
+#: src/components/SocialShare.tsx:49
 msgid "The {buildingCount} buildings that my landlord \"owns\" 👀... #WhoOwnsWhat @JustFixNYC"
 msgstr "Los {buildingCount} edificios que son \"propiedad\" del dueño de mi apartamento 👀... #WhoOwnsWhat @JustFixNYC"
 
-#: src/components/PropertiesSummary.tsx:34
+#: src/components/PropertiesSummary.tsx:45
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
-#: src/containers/NychaPage.tsx:106
+#: src/containers/NychaPage.tsx:72
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "Este edificio es propiedad de la NYC Housing Authority (NYCHA)"
 
-#: src/containers/NotRegisteredPage.tsx:100
+#: src/containers/NotRegisteredPage.tsx:80
 msgid "This building seems like it should be registered with HPD!"
 msgstr "¡Parece que este edificio debería estar registrado con el HPD!"
 
@@ -652,15 +648,15 @@ msgstr "¡Parece que este edificio debería estar registrado con el HPD!"
 msgid "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 msgstr "Estos datos están en <0>formato de archivo CSV</0>, que puede utilizarse fácilmente en Excel, Google Sheets o cualquier otro programa de hoja de cálculo."
 
-#: src/components/ViolationsSummary.tsx:20
+#: src/components/ViolationsSummary.tsx:17
 msgid "This is <0>about the same</0> as the citywide average."
 msgstr "Esto es <0>parecido</0> al promedio de toda la ciudad."
 
-#: src/components/ViolationsSummary.tsx:25
+#: src/components/ViolationsSummary.tsx:22
 msgid "This is <0>better</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "Esto es <0>mejor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por unidad residencial."
 
-#: src/components/ViolationsSummary.tsx:22
+#: src/components/ViolationsSummary.tsx:19
 msgid "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per residential unit."
 msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por unidad residencial."
 
@@ -668,19 +664,19 @@ msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "El identificador oficial del edificio según los registros del Departamento de Finanzas."
 
-#: src/components/RentstabSummary.tsx:15
+#: src/components/RentstabSummary.tsx:14
 msgid "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
 msgstr "Este portafolio de edificios tuvo una <0>{changeType, select, gain {ganancia} other {perdida}} neta</0> de <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {apartamento de renta estabilizada} other {apartamentos de renta estabilizada}} desde el año 2007 (ganó {absTotalRsGain}, perdió {absTotalRsLoss})."
 
-#: src/components/ViolationsSummary.tsx:15
+#: src/components/ViolationsSummary.tsx:12
 msgid "This portfolio has an average of <0>{openviolationsperresunit}</0> open HPD violations per residential unit."
 msgstr "Este portafolio de edificios tiene un promedio de <0>{openviolationsperresunit}</0> infracciones del HPD Actuales por cada unidad residencial."
 
-#: src/containers/HomePage.tsx:158
+#: src/containers/HomePage.tsx:104
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "Esta empresa de gestión inmobiliaria es propiedad de la familia Kushner y es notoria por <0>violar las normas de vivienda</0> y por <1>comportamientos abusivos</1>. La participación financiera actualmente sostenida por Jared Kushner e Ivanka Trump asciende a 761 millones de dólares."
 
-#: src/components/RentstabSummary.tsx:24
+#: src/components/RentstabSummary.tsx:23
 msgid "This represents <0>{rsProportion}%</0> of the total size of this portfolio."
 msgstr "Esto representa el <0>{rsProportion}%</0> del tamaño total de este portafolio de edificios."
 
@@ -688,7 +684,7 @@ msgstr "Esto representa el <0>{rsProportion}%</0> del tamaño total de este port
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr "Esto representa el número total de Infracciones del HPD (tanto actuales como cerradas) registradas por la ciudad."
 
-#: src/containers/NotRegisteredPage.tsx:77
+#: src/containers/NotRegisteredPage.tsx:57
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "Este parece ser un edificio residencial pequeño. Si el dueño no reside allí, el edificio debería estar registrado con el HPD."
 
@@ -700,12 +696,12 @@ msgstr "El cambio en apartamentos de renta estabilizada que hay en el edificio (
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.js:181
+#: src/containers/AddressPage.tsx:121
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/IndicatorsViz.js:320
-#: src/components/PropertiesList.tsx:102
+#: src/components/IndicatorsViz.tsx:313
+#: src/components/PropertiesList.tsx:99
 msgid "Total"
 msgstr "Total"
 
@@ -713,17 +709,17 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Infracciones Totales"
 
-#: src/containers/NotRegisteredPage.tsx:225
+#: src/containers/NotRegisteredPage.tsx:183
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "No es possible iniciar una acción judicial por falta de pago del alquiler."
 
-#: src/containers/NotRegisteredPage.tsx:224
+#: src/containers/NotRegisteredPage.tsx:182
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:43
-#: src/components/PropertiesList.tsx:63
-#: src/containers/NychaPage.tsx:117
+#: src/components/PropertiesList.tsx:60
+#: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades Residenciales"
 
@@ -733,13 +729,13 @@ msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edif
 
 #: src/components/DetailView.tsx:176
 #: src/components/DetailView.tsx:181
-#: src/components/Indicators.js:454
-#: src/containers/NotRegisteredPage.tsx:185
-#: src/containers/NychaPage.tsx:187
+#: src/components/Indicators.tsx:249
+#: src/containers/NotRegisteredPage.tsx:144
+#: src/containers/NychaPage.tsx:153
 msgid "Useful links"
 msgstr "Enlaces útiles"
 
-#: src/components/Indicators.js:329
+#: src/components/Indicators.tsx:170
 msgid "View by:"
 msgstr "Visualizar por:"
 
@@ -747,24 +743,24 @@ msgstr "Visualizar por:"
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
+#: src/components/PropertiesList.tsx:176
 #: src/components/PropertiesList.tsx:181
-#: src/components/PropertiesList.tsx:186
 msgid "View detail"
 msgstr "Ver detalles"
 
 #: src/components/DetailView.tsx:188
-#: src/components/Indicators.js:466
-#: src/containers/NotRegisteredPage.tsx:189
+#: src/components/Indicators.tsx:255
+#: src/containers/NotRegisteredPage.tsx:148
 msgid "View documents on ACRIS"
 msgstr "Ver documentos en ACRIS"
 
-#: src/components/PropertiesMap.tsx:185
+#: src/components/PropertiesMap.tsx:191
 msgid "View legend"
 msgstr "Ver leyenda"
 
-#: src/containers/HomePage.tsx:174
-#: src/containers/HomePage.tsx:216
-#: src/containers/HomePage.tsx:247
+#: src/containers/HomePage.tsx:119
+#: src/containers/HomePage.tsx:161
+#: src/containers/HomePage.tsx:191
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
@@ -772,7 +768,7 @@ msgstr "Ver portafolio de edificios"
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
-#: src/components/IndicatorsViz.js:256
+#: src/components/IndicatorsViz.tsx:240
 msgid "Violations Issued"
 msgstr "Infracciones emitidas"
 
@@ -788,11 +784,11 @@ msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas 
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
-#: src/components/Indicators.js:445
+#: src/components/Indicators.tsx:238
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
-#: src/containers/NotRegisteredPage.tsx:60
+#: src/containers/NotRegisteredPage.tsx:44
 msgid "What happens if the landlord has failed to register?"
 msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 
@@ -807,7 +803,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
-#: src/components/Indicators.js:383
+#: src/components/Indicators.tsx:194
 msgid "Year"
 msgstr "Año"
 
@@ -815,15 +811,15 @@ msgstr "Año"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:173
+#: src/components/PropertiesList.tsx:168
 msgid "Yes"
 msgstr "Si"
 
-#: src/containers/HomePage.tsx:235
+#: src/containers/HomePage.tsx:180
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:36
+#: src/components/PropertiesList.tsx:33
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -831,7 +827,7 @@ msgstr "Código postal"
 msgid "and"
 msgstr "y"
 
-#: src/components/PropertiesMap.tsx:192
+#: src/components/PropertiesMap.tsx:198
 msgid "associated building"
 msgstr "edificio asociado"
 
@@ -839,11 +835,11 @@ msgstr "edificio asociado"
 msgid "for ${0}"
 msgstr "por ${0}"
 
-#: src/components/PropertiesMap.tsx:191
+#: src/components/PropertiesMap.tsx:197
 msgid "search address"
 msgstr "dirección de búsqueda"
 
-#: src/components/PropertiesSummary.tsx:55
+#: src/components/PropertiesSummary.tsx:66
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una infracción del HPD actual} other {# infracciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -9,6 +9,8 @@ import MethodologyPage from "./containers/Methodology";
 import TermsOfUsePage from "./containers/TermsOfUsePage";
 import PrivacyPolicyPage from "./containers/PrivacyPolicyPage";
 import { SearchAddressWithoutBbl } from "components/APIDataTypes";
+import { useMachine } from "@xstate/react";
+import { wowMachine } from "state-machine";
 
 export type AddressPageUrlParams = SearchAddressWithoutBbl;
 
@@ -64,25 +66,27 @@ export const getSiteOrigin = () => `${window.location.protocol}//${window.locati
 
 export const WhoOwnsWhatRoutes = () => {
   const paths = createWhoOwnsWhatRoutePaths("/:locale");
+  const [state, send] = useMachine(wowMachine);
+  const machineProps = { state, send };
   return (
     <Switch>
       <Route exact path={paths.home} component={HomePage} />
       <Route
         path={paths.addressPageOverview}
-        render={(props) => <AddressPage currentTab={0} {...props} />}
+        render={(props) => <AddressPage currentTab={0} {...machineProps} {...props} />}
         exact
       />
       <Route
         path={paths.addressPageTimeline}
-        render={(props) => <AddressPage currentTab={1} {...props} />}
+        render={(props) => <AddressPage currentTab={1} {...machineProps} {...props} />}
       />
       <Route
         path={paths.addressPagePortfolio}
-        render={(props) => <AddressPage currentTab={2} {...props} />}
+        render={(props) => <AddressPage currentTab={2} {...machineProps} {...props} />}
       />
       <Route
         path={paths.addressPageSummary}
-        render={(props) => <AddressPage currentTab={3} {...props} />}
+        render={(props) => <AddressPage currentTab={3} {...machineProps} {...props} />}
       />
       <Route path={paths.bbl} component={BBLPage} />
       <Route path={paths.bblWithFullBblInUrl} component={BBLPage} />

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,0 +1,1 @@
+require("jest-fetch-mock").enableMocks();

--- a/client/src/state-machine.test.ts
+++ b/client/src/state-machine.test.ts
@@ -12,6 +12,8 @@ const SEARCH_EVENT: WowEvent = {
   },
 };
 
+const SEARCH_URL = `${GEO_AUTOCOMPLETE_URL}?text=150%20court%20st%2C%20BROOKLYN`;
+
 describe("wowMachine", () => {
   it("should start w/ no data", () => {
     const wm = interpret(wowMachine).start();
@@ -19,11 +21,21 @@ describe("wowMachine", () => {
   });
 
   it("should deal w/ geosearch network errors", async () => {
-    fetchMock.mockIf(GEO_AUTOCOMPLETE_URL, async (req) => ({
+    fetchMock.mockIf(SEARCH_URL, async (req) => ({
       status: 500,
     }));
     const wm = interpret(wowMachine).start();
     wm.send(SEARCH_EVENT);
     await waitUntilStateMatches(wm, "networkErrorOccurred");
+  });
+
+  it("should deal w/ invalid addresses", async () => {
+    fetchMock.mockIf(SEARCH_URL, async (req) => ({
+      body: JSON.stringify({ features: [] }),
+      status: 200,
+    }));
+    const wm = interpret(wowMachine).start();
+    wm.send(SEARCH_EVENT);
+    await waitUntilStateMatches(wm, "bblNotFound");
   });
 });

--- a/client/src/state-machine.test.ts
+++ b/client/src/state-machine.test.ts
@@ -1,0 +1,10 @@
+import { wowMachine } from "./state-machine";
+import { interpret } from "xstate";
+
+describe("wowMachine", () => {
+  it("should start with no data", () => {
+    const wm = interpret(wowMachine);
+    wm.start();
+    expect(wm.state.value).toBe("noData");
+  });
+});

--- a/client/src/state-machine.test.ts
+++ b/client/src/state-machine.test.ts
@@ -1,10 +1,29 @@
-import { wowMachine } from "./state-machine";
+import { wowMachine, WowEvent } from "./state-machine";
 import { interpret } from "xstate";
+import { GEO_AUTOCOMPLETE_URL } from "@justfixnyc/geosearch-requester";
+
+const SEARCH_EVENT: WowEvent = {
+  type: "SEARCH",
+  address: {
+    housenumber: "150",
+    streetname: "court st",
+    boro: "BROOKLYN",
+  },
+};
 
 describe("wowMachine", () => {
-  it("should start with no data", () => {
-    const wm = interpret(wowMachine);
-    wm.start();
+  it("should deal w/ geosearch network errors", (done) => {
+    fetchMock.mockIf(GEO_AUTOCOMPLETE_URL, async (req) => ({
+      status: 500,
+    }));
+    const wm = interpret(wowMachine)
+      .onTransition((state) => {
+        if (state.matches("networkErrorOccurred")) {
+          done();
+        }
+      })
+      .start();
     expect(wm.state.value).toBe("noData");
+    wm.send(SEARCH_EVENT);
   });
 });

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -13,24 +13,28 @@ type WowEvent =
   | { type: "VIEW_SUMMARY" }
   | { type: "VIEW_TIMELINE" };
 
+type PortfolioData = {
+  /** The full set of data for the original search address */
+  searchAddr: AddressRecord;
+  /**
+   * All associated addresses connected to the search address
+   * found in our database of HPD registered buildings
+   */
+  assocAddrs: AddressRecord[];
+  /** The address in focus on the Overview Tab and Timeline Tab */
+  detailAddr: AddressRecord;
+};
+
 interface WowContext {
   /** The original parameters that a user inputs to locate their building on WOW */
   searchAddrParams?: SearchAddressWithoutBbl;
   /** The BBL code found by GeoSearch corresponding with the search address parameters */
   searchAddrBbl?: string;
   /**
-   * The full set of data for the search address,
-   * retrieved ONLY if the address's bbl has a matching record
-   * in our database of HPD registered buildings
+   * All data regarding the portfolio of buildings associated with the search address
+   * retrieved ONLY if the address's bbl has a matching record in our database of HPD registered buildings
    */
-  searchAddr?: AddressRecord;
-  /**
-   * All associated addresses connected to the search address
-   * found in our database of HPD registered buildings
-   */
-  assocAddrs?: AddressRecord[];
-  /** The address in focus on the Overview Tab and Timeline Tab */
-  detailAddr?: AddressRecord;
+  portfolioData?: PortfolioData;
 }
 
 const wowMachine = Machine<WowContext, WowStateSchema, WowEvent>({

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -86,6 +86,7 @@ interface WowContext {
    * database of HPD registered buildings
    */
   buildingInfo?: BuildingInfoRecord;
+  nychaData?: NychaData;
 }
 
 type WowMachineEverything = State<WowContext, WowEvent, any, WowState>;

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -3,9 +3,7 @@ import {
   SearchAddressWithoutBbl,
   AddressRecord,
   BuildingInfoRecord,
-  MonthlyTimelineData,
   SummaryStatsRecord,
-  IndicatorsHistoryResults,
   SummaryResults,
 } from "components/APIDataTypes";
 import { NychaData } from "containers/NychaPage";
@@ -13,7 +11,7 @@ import APIClient from "components/APIClient";
 import helpers, { assertNotUndefined } from "util/helpers";
 
 import _find from "lodash/find";
-import { IndicatorsDataFromAPI, IndicatorsData } from "components/IndicatorsTypes";
+import { IndicatorsDataFromAPI } from "components/IndicatorsTypes";
 
 type WowState =
   | { value: "noData"; context: {} }

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -1,4 +1,4 @@
-import { createMachine, assign, DoneInvokeEvent } from "xstate";
+import { createMachine, assign, DoneInvokeEvent, State } from "xstate";
 import {
   SearchAddressWithoutBbl,
   AddressRecord,
@@ -87,6 +87,13 @@ interface WowContext {
   buildingInfo?: BuildingInfoRecord;
 }
 
+type WowMachineEverything = State<WowContext, WowEvent, any, WowState>;
+
+export type WithMachineProps = {
+  state: WowMachineEverything;
+  send: (event: WowEvent) => WowMachineEverything;
+};
+
 async function getSearchResult(addr: SearchAddressWithoutBbl): Promise<WowState> {
   const apiResults = await APIClient.searchForAddressWithGeosearch(addr);
   if (!apiResults.geosearch) {
@@ -138,6 +145,10 @@ async function getSearchResult(addr: SearchAddressWithoutBbl): Promise<WowState>
   }
 }
 
+const assignWowStateContext = assign((ctx: WowContext, event: DoneInvokeEvent<WowState>) => {
+  return { ...event.data.context };
+});
+
 export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
   id: "wow",
   initial: "noData",
@@ -162,31 +173,23 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
           {
             target: "bblNotFound",
             cond: (ctx, event: DoneInvokeEvent<WowState>) => event.data.value === "bblNotFound",
-            actions: assign((ctx, event: DoneInvokeEvent<WowState>) => {
-              return { ...event.data.context };
-            }),
+            actions: assignWowStateContext,
           },
           {
             target: "nychaFound",
             cond: (ctx, event: DoneInvokeEvent<WowState>) => event.data.value === "nychaFound",
-            actions: assign((ctx, event: DoneInvokeEvent<WowState>) => {
-              return { ...event.data.context };
-            }),
+            actions: assignWowStateContext,
           },
           {
             target: "unregisteredFound",
             cond: (ctx, event: DoneInvokeEvent<WowState>) =>
               event.data.value === "unregisteredFound",
-            actions: assign((ctx, event: DoneInvokeEvent<WowState>) => {
-              return { ...event.data.context };
-            }),
+            actions: assignWowStateContext,
           },
           {
             target: "portfolioFound",
             cond: (ctx, event: DoneInvokeEvent<WowState>) => event.data.value === "portfolioFound",
-            actions: assign((ctx, event: DoneInvokeEvent<WowState>) => {
-              return { ...event.data.context };
-            }),
+            actions: assignWowStateContext,
           },
         ],
       },

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -13,6 +13,7 @@ import APIClient from "components/APIClient";
 import helpers, { assertNotUndefined } from "util/helpers";
 
 import _find from "lodash/find";
+import { IndicatorsDataFromAPI, IndicatorsData } from "components/IndicatorsTypes";
 
 type WowState =
   | { value: "noData"; context: {} }
@@ -62,7 +63,7 @@ type WowState =
   | {
       value: { portfolioFound: { timeline: "success" } };
       context: WowPortfolioFoundContext & {
-        timelineData: TimelineData;
+        timelineData: IndicatorsDataFromAPI;
       };
     }
   | {
@@ -113,10 +114,6 @@ type PortfolioData = {
   detailAddr: AddressRecord;
 };
 
-type TimelineData = {
-  monthlyTimelineData: MonthlyTimelineData;
-};
-
 type SummaryData = {
   summaryStats: SummaryStatsRecord;
 };
@@ -139,7 +136,7 @@ interface WowContext {
   /** NYCHA Public Housing development details (grabbed if the search address is public housing) */
   nychaData?: NychaData;
   /** All data used to render the "Timeline tab" of the Address Page. Updates on any change to `detailAddr` */
-  timelineData?: TimelineData;
+  timelineData?: IndicatorsDataFromAPI;
   /** All data used to render the "Summary tab" of the Address Page. Updates on any change to `searchAddr` */
   summaryData?: SummaryData;
 }
@@ -312,10 +309,8 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
                 onDone: {
                   target: "success",
                   actions: assign({
-                    timelineData: (ctx, event: DoneInvokeEvent<IndicatorsHistoryResults>) => {
-                      return {
-                        monthlyTimelineData: event.data.result[0],
-                      };
+                    timelineData: (ctx, event: DoneInvokeEvent<IndicatorsDataFromAPI>) => {
+                      return event.data;
                     },
                   }),
                 },

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -178,6 +178,14 @@ const handleSearchEvent: TransitionsConfig<WowContext, WowEvent> = {
   },
 };
 
+export const getPortfolioData = (props: WithMachineProps) => {
+  const { state } = props;
+  if (!state.matches("portfolioFound")) {
+    throw new Error(`Invalid state ${state.value}`);
+  }
+  return state.context.portfolioData;
+};
+
 export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
   id: "wow",
   initial: "noData",

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -366,7 +366,7 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
           target: [".summary.pending"],
         },
         SELECT_DETAIL_ADDR: {
-          target: [".summary.noData", ".timeline.noData"],
+          target: [".timeline.noData"],
           actions: assign((ctx, event) => {
             const portfolioData = assertNotUndefined(ctx.portfolioData);
             const newDetailAddr = assertNotUndefined(

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -79,7 +79,7 @@ type WowState =
   | {
       value: { portfolioFound: { summary: "success" } };
       context: WowPortfolioFoundContext & {
-        summaryData: SummaryData;
+        summaryData: SummaryStatsRecord;
       };
     }
   | {
@@ -112,10 +112,6 @@ type PortfolioData = {
   detailAddr: AddressRecord;
 };
 
-type SummaryData = {
-  summaryStats: SummaryStatsRecord;
-};
-
 interface WowContext {
   /** The original parameters that a user inputs to locate their building on WOW */
   searchAddrParams?: SearchAddressWithoutBbl;
@@ -136,7 +132,7 @@ interface WowContext {
   /** All data used to render the "Timeline tab" of the Address Page. Updates on any change to `detailAddr` */
   timelineData?: IndicatorsDataFromAPI;
   /** All data used to render the "Summary tab" of the Address Page. Updates on any change to `searchAddr` */
-  summaryData?: SummaryData;
+  summaryData?: SummaryStatsRecord;
 }
 
 type WowMachineEverything = State<WowContext, WowEvent, any, WowState>;
@@ -334,9 +330,7 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
                   target: "success",
                   actions: assign({
                     summaryData: (ctx, event: DoneInvokeEvent<SummaryResults>) => {
-                      return {
-                        summaryStats: event.data.result[0],
-                      };
+                      return event.data.result[0];
                     },
                   }),
                 },

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -1,4 +1,4 @@
-import { Machine, createMachine } from "xstate";
+import { createMachine } from "xstate";
 import {
   SearchAddressWithoutBbl,
   AddressRecord,
@@ -11,6 +11,10 @@ type WowState =
   | {
       value: "searchInProgress";
       context: WowContext & { searchAddrParams: SearchAddressWithoutBbl };
+    }
+  | {
+      value: "bblNotFound";
+      context: WowContext & { searchAddrParams: SearchAddressWithoutBbl; searchAddrBbl: undefined };
     }
   | {
       value: "portfolioNotFound";
@@ -38,6 +42,10 @@ type WowState =
         searchAddrBbl: string;
         portfolioData: PortfolioData;
       };
+    }
+  | {
+      value: "networkErrorOccurred";
+      context: WowContext & { searchAddrParams: SearchAddressWithoutBbl };
     };
 
 type WowEvent =
@@ -79,7 +87,15 @@ const wowMachine = createMachine<WowContext, WowEvent, WowState>({
   id: "wow",
   initial: "noData",
   states: {
-    noData: {},
+    noData: {
+      on: {
+        SEARCH: {
+          target: "searchInProgress",
+          cond: (ctx, event) => !!event.address.boro && !!event.address.streetname,
+        },
+      },
+      entry: (ctx, event) => console.log("To Do: Make network request to GeoSearch for "),
+    },
     searchInProgress: {},
     searchFound: {},
   },

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -94,7 +94,7 @@ type WowPortfolioFoundContext = WowContext & {
   portfolioData: PortfolioData;
 };
 
-type WowEvent =
+export type WowEvent =
   | { type: "SEARCH"; address: SearchAddressWithoutBbl }
   | { type: "RESET_DATA" }
   | { type: "SELECT_DETAIL_ADDR"; bbl: string }

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -108,8 +108,28 @@ interface WowContext {
 
 type WowMachineEverything = State<WowContext, WowEvent, any, WowState>;
 
+type WowMachineInState<TSV extends Stupid["value"], Stupid extends WowState = WowState> = State<
+  (Stupid extends { value: TSV } ? Stupid : never)["context"],
+  WowEvent,
+  any,
+  Stupid
+>;
+
 export type WithMachineProps = {
   state: WowMachineEverything;
+  send: (event: WowEvent) => WowMachineEverything;
+};
+
+export type WithMachineInStateProps<
+  TSV extends Stupid["value"],
+  /**
+   * I have no idea why this type has to be parametrized
+   * since we never change this default, hence the name
+   * "Stupid". -AV
+   */
+  Stupid extends WowState = WowState
+> = {
+  state: WowMachineInState<TSV, Stupid>;
   send: (event: WowEvent) => WowMachineEverything;
 };
 
@@ -176,14 +196,6 @@ const handleSearchEvent: TransitionsConfig<WowContext, WowEvent> = {
       return { searchAddrParams: event.address };
     }),
   },
-};
-
-export const accessPortfolioData = (props: WithMachineProps) => {
-  const { state } = props;
-  if (!state.matches("portfolioFound")) {
-    throw new Error(`Invalid state ${state.value}`);
-  }
-  return state.context.portfolioData;
 };
 
 export const wowMachine = createMachine<WowContext, WowEvent, WowState>({

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -2,7 +2,7 @@ import { createMachine, assign, DoneInvokeEvent } from "xstate";
 import {
   SearchAddressWithoutBbl,
   AddressRecord,
-  BuildingInfoRecord
+  BuildingInfoRecord,
 } from "components/APIDataTypes";
 import { NychaData } from "containers/NychaPage";
 import APIClient from "components/APIClient";
@@ -183,8 +183,7 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
           },
           {
             target: "portfolioFound",
-            cond: (ctx, event: DoneInvokeEvent<WowState>) =>
-              event.data.value === "portfolioFound",
+            cond: (ctx, event: DoneInvokeEvent<WowState>) => event.data.value === "portfolioFound",
             actions: assign((ctx, event: DoneInvokeEvent<WowState>) => {
               return { ...event.data.context };
             }),

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -221,6 +221,21 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
     portfolioFound: {
       on: {
         ...handleSearchEvent,
+        SELECT_DETAIL_ADDR: {
+          target: "portfolioFound",
+          actions: assign((ctx, event) => {
+            const portfolioData = assertNotUndefined(ctx.portfolioData);
+            const newDetailAddr = assertNotUndefined(
+              _find(portfolioData.assocAddrs, { bbl: event.bbl })
+            );
+            return {
+              portfolioData: {
+                ...portfolioData,
+                detailAddr: newDetailAddr,
+              },
+            };
+          }),
+        },
       },
     },
   },

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -1,4 +1,4 @@
-import { createMachine } from "xstate";
+import { createMachine, assign } from "xstate";
 import {
   SearchAddressWithoutBbl,
   AddressRecord,
@@ -83,18 +83,21 @@ interface WowContext {
   buildingInfo?: BuildingInfoRecord;
 }
 
-const wowMachine = createMachine<WowContext, WowEvent, WowState>({
+export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
   id: "wow",
   initial: "noData",
+  context: {},
   states: {
     noData: {
       on: {
         SEARCH: {
           target: "searchInProgress",
           cond: (ctx, event) => !!event.address.boro && !!event.address.streetname,
+          actions: assign((ctx, event) => {
+            return { searchAddrParams: event.address };
+          }),
         },
       },
-      entry: (ctx, event) => console.log("To Do: Make network request to GeoSearch for "),
     },
     searchInProgress: {},
     searchFound: {},

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -1,11 +1,44 @@
-import { Machine } from "xstate";
-import { SearchAddressWithoutBbl, AddressRecord } from "components/APIDataTypes";
+import { Machine, createMachine } from "xstate";
+import {
+  SearchAddressWithoutBbl,
+  AddressRecord,
+  BuildingInfoRecord,
+} from "components/APIDataTypes";
+import { NychaData } from "containers/NychaPage";
 
-interface WowStateSchema {
-  states: {
-    noData: {};
-  };
-}
+type WowState =
+  | { value: "noData"; context: {} }
+  | {
+      value: "searchInProgress";
+      context: WowContext & { searchAddrParams: SearchAddressWithoutBbl };
+    }
+  | {
+      value: "portfolioNotFound";
+      context: WowContext & {
+        searchAddrParams: SearchAddressWithoutBbl;
+        searchAddrBbl: string;
+        portfolioData: undefined;
+        buildingInfo: BuildingInfoRecord;
+      };
+    }
+  | {
+      value: "nychaFound";
+      context: WowContext & {
+        searchAddrParams: SearchAddressWithoutBbl;
+        searchAddrBbl: string;
+        portfolioData: undefined;
+        nychaData: NychaData;
+        buildingInfo: BuildingInfoRecord;
+      };
+    }
+  | {
+      value: "portfolioFound";
+      context: WowContext & {
+        searchAddrParams: SearchAddressWithoutBbl;
+        searchAddrBbl: string;
+        portfolioData: PortfolioData;
+      };
+    };
 
 type WowEvent =
   | { type: "SEARCH"; address: SearchAddressWithoutBbl }
@@ -35,12 +68,19 @@ interface WowContext {
    * retrieved ONLY if the address's bbl has a matching record in our database of HPD registered buildings
    */
   portfolioData?: PortfolioData;
+  /**
+   * Secondary building-specific data gathered if we can't find the building address in our
+   * database of HPD registered buildings
+   */
+  buildingInfo?: BuildingInfoRecord;
 }
 
-const wowMachine = Machine<WowContext, WowStateSchema, WowEvent>({
+const wowMachine = createMachine<WowContext, WowEvent, WowState>({
   id: "wow",
   initial: "noData",
   states: {
     noData: {},
+    searchInProgress: {},
+    searchFound: {},
   },
 });

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -206,22 +206,22 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
     bblNotFound: {
       on: {
         ...handleSearchEvent,
-      }
+      },
     },
     nychaFound: {
       on: {
         ...handleSearchEvent,
-      }
+      },
     },
     unregisteredFound: {
       on: {
         ...handleSearchEvent,
-      }
+      },
     },
     portfolioFound: {
       on: {
         ...handleSearchEvent,
-      }
+      },
     },
   },
 });

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -3,6 +3,8 @@ import {
   SearchAddressWithoutBbl,
   AddressRecord,
   BuildingInfoRecord,
+  MonthlyTimelineData,
+  SummaryStatsRecord,
 } from "components/APIDataTypes";
 import { NychaData } from "containers/NychaPage";
 import APIClient from "components/APIClient";
@@ -71,6 +73,16 @@ type PortfolioData = {
   detailAddr: AddressRecord;
 };
 
+type TimelineData = {
+  timelineBbl: string;
+  monthlyTimelineData: MonthlyTimelineData;
+};
+
+type SummaryData = {
+  summaryBbl: string;
+  summaryStats: SummaryStatsRecord;
+};
+
 interface WowContext {
   /** The original parameters that a user inputs to locate their building on WOW */
   searchAddrParams?: SearchAddressWithoutBbl;
@@ -86,7 +98,12 @@ interface WowContext {
    * database of HPD registered buildings
    */
   buildingInfo?: BuildingInfoRecord;
+  /** NYCHA Public Housing development details (grabbed if the search address is public housing) */
   nychaData?: NychaData;
+  /** All data used to render the "Timeline tab" of the Address Page. Updates on any change to `detailAddr` */
+  timelineData?: TimelineData;
+  /** All data used to render the "Summary tab" of the Address Page. Updates on any change to `searchAddr` */
+  summaryData?: SummaryData;
 }
 
 type WowMachineEverything = State<WowContext, WowEvent, any, WowState>;

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -221,7 +221,7 @@ const handleSearchEvent: TransitionsConfig<WowContext, WowEvent> = {
     target: "searchInProgress",
     cond: (ctx, event) => !!event.address.boro && !!event.address.streetname,
     actions: assign((ctx, event) => {
-      return { searchAddrParams: event.address };
+      return { searchAddrParams: event.address, summaryData: undefined, timelineData: undefined };
     }),
   },
 };

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -13,7 +13,7 @@ import helpers, { assertNotUndefined } from "util/helpers";
 import _find from "lodash/find";
 import { IndicatorsDataFromAPI } from "components/IndicatorsTypes";
 
-type WowState =
+export type WowState =
   | { value: "noData"; context: {} }
   | {
       value: "searchInProgress";
@@ -111,7 +111,7 @@ type PortfolioData = {
   detailAddr: AddressRecord;
 };
 
-interface WowContext {
+export interface WowContext {
   /** The original parameters that a user inputs to locate their building on WOW */
   searchAddrParams?: SearchAddressWithoutBbl;
   /** The BBL code found by GeoSearch corresponding with the search address parameters */

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -95,7 +95,6 @@ type WowPortfolioFoundContext = WowContext & {
 
 export type WowEvent =
   | { type: "SEARCH"; address: SearchAddressWithoutBbl }
-  | { type: "RESET_DATA" }
   | { type: "SELECT_DETAIL_ADDR"; bbl: string }
   | { type: "VIEW_SUMMARY" }
   | { type: "VIEW_TIMELINE" };

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -54,6 +54,7 @@ type WowState =
 
 type WowEvent =
   | { type: "SEARCH"; address: SearchAddressWithoutBbl }
+  | { type: "RESET_DATA" }
   | { type: "SELECT_DETAIL_ADDR"; bbl: string }
   | { type: "VIEW_SUMMARY" }
   | { type: "VIEW_TIMELINE" };

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -329,7 +329,7 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
             noData: {},
             pending: {
               invoke: {
-                id: "timeline",
+                id: "summary",
                 src: (ctx, event) =>
                   APIClient.getAggregate(assertNotUndefined(ctx.portfolioData).detailAddr.bbl),
                 onDone: {

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -178,7 +178,7 @@ const handleSearchEvent: TransitionsConfig<WowContext, WowEvent> = {
   },
 };
 
-export const getPortfolioData = (props: WithMachineProps) => {
+export const accessPortfolioData = (props: WithMachineProps) => {
   const { state } = props;
   if (!state.matches("portfolioFound")) {
     throw new Error(`Invalid state ${state.value}`);

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -108,11 +108,18 @@ interface WowContext {
 
 type WowMachineEverything = State<WowContext, WowEvent, any, WowState>;
 
-type WowMachineInState<TSV extends Stupid["value"], Stupid extends WowState = WowState> = State<
-  (Stupid extends { value: TSV } ? Stupid : never)["context"],
+type WowMachineInState<
+  TSV extends WowStateByAnotherName["value"],
+  /**
+   * I have no idea why this type has to be parametrized
+   * since we never change this default, hence the name. -AV
+   */
+  WowStateByAnotherName extends WowState = WowState
+> = State<
+  (WowStateByAnotherName extends { value: TSV } ? WowStateByAnotherName : never)["context"],
   WowEvent,
   any,
-  Stupid
+  WowStateByAnotherName
 >;
 
 export type WithMachineProps = {
@@ -120,16 +127,8 @@ export type WithMachineProps = {
   send: (event: WowEvent) => WowMachineEverything;
 };
 
-export type WithMachineInStateProps<
-  TSV extends Stupid["value"],
-  /**
-   * I have no idea why this type has to be parametrized
-   * since we never change this default, hence the name
-   * "Stupid". -AV
-   */
-  Stupid extends WowState = WowState
-> = {
-  state: WowMachineInState<TSV, Stupid>;
+export type WithMachineInStateProps<TSV extends WowState["value"]> = {
+  state: WowMachineInState<TSV>;
   send: (event: WowEvent) => WowMachineEverything;
 };
 

--- a/client/src/tests/test-util.tsx
+++ b/client/src/tests/test-util.tsx
@@ -1,26 +1,34 @@
-import { WowState, WowContext, WowEvent } from "state-machine";
-import { Interpreter, State } from "xstate";
+import { Interpreter, State, EventObject, StateSchema, Typestate } from "xstate";
 
+/**
+ * Wait until a XState interpreter's state matches the given one,
+ * and return it.
+ *
+ * If the interpreter's current state matches the given one, return
+ * it immediately.
+ */
 export async function waitUntilStateMatches<
-  TSV extends WowStateByAnotherName["value"],
-  /**
-   * I have no idea why this type has to be parametrized
-   * since we never change this default, hence the name. -AV
-   */
-  WowStateByAnotherName extends WowState = WowState
+  TContext,
+  TSV extends TTypestate["value"],
+  TEvent extends EventObject = EventObject,
+  TStateSchema extends StateSchema<TContext> = any,
+  TTypestate extends Typestate<TContext> = {
+    value: any;
+    context: TContext;
+  }
 >(
-  wm: Interpreter<WowContext, any, WowEvent, WowState>,
+  wm: Interpreter<TContext, any, TEvent, TTypestate>,
   match: TSV
 ): Promise<
   State<
-    (WowStateByAnotherName extends { value: TSV } ? WowStateByAnotherName : never)["context"],
-    WowEvent,
+    (TTypestate extends { value: TSV } ? TTypestate : never)["context"],
+    TEvent,
     any,
-    WowStateByAnotherName
+    TTypestate
   >
 > {
   return new Promise((resolve, reject) => {
-    function handleTransition(state: State<WowContext, WowEvent, any, WowState>) {
+    function handleTransition(state: State<TContext, TEvent, any, TTypestate>) {
       if (state.matches(match)) {
         wm.off(handleTransition);
         resolve(state);

--- a/client/src/tests/test-util.tsx
+++ b/client/src/tests/test-util.tsx
@@ -1,0 +1,33 @@
+import { WowState, WowContext, WowEvent } from "state-machine";
+import { Interpreter, State } from "xstate";
+
+export async function waitUntilStateMatches<
+  TSV extends WowStateByAnotherName["value"],
+  /**
+   * I have no idea why this type has to be parametrized
+   * since we never change this default, hence the name. -AV
+   */
+  WowStateByAnotherName extends WowState = WowState
+>(
+  wm: Interpreter<WowContext, any, WowEvent, WowState>,
+  match: TSV
+): Promise<
+  State<
+    (WowStateByAnotherName extends { value: TSV } ? WowStateByAnotherName : never)["context"],
+    WowEvent,
+    any,
+    WowStateByAnotherName
+  >
+> {
+  return new Promise((resolve, reject) => {
+    function handleTransition(state: State<WowContext, WowEvent, any, WowState>) {
+      if (state.matches(match)) {
+        wm.off(handleTransition);
+        resolve(state);
+      }
+    }
+
+    wm.onTransition(handleTransition);
+    handleTransition(wm.state);
+  });
+}

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -7,6 +7,7 @@ import nycha_bbls from "../data/nycha_bbls.json";
 import { SupportedLocale } from "../i18n-base";
 import { IndicatorsDatasetId } from "components/IndicatorsDatasets";
 import { IndicatorsData, indicatorsInitialDataStructure } from "components/IndicatorsTypes";
+import { SearchAddressWithoutBbl } from "components/APIDataTypes";
 
 /**
  * An array consisting of Who Owns What's standard enumerations for street names,
@@ -44,6 +45,17 @@ export function assertNotUndefined<T>(thing: T | undefined): T | never {
     throw new Error("Assertion failure, expected argument to not be undefined!");
   }
   return thing;
+}
+
+export function searchAddrsAreEqual(
+  addr1: SearchAddressWithoutBbl,
+  addr2: SearchAddressWithoutBbl
+) {
+  return (
+    addr1.boro === addr2.boro &&
+    addr1.streetname === addr2.streetname &&
+    addr1.housenumber === addr2.housenumber
+  );
 }
 
 export default {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -29,6 +29,23 @@ export const longDateOptions = { year: "numeric", month: "short", day: "numeric"
 export const mediumDateOptions = { year: "numeric", month: "long" };
 export const shortDateOptions = { month: "short" };
 
+/**
+ * Assert that the given argument isn't undefined and return it. Throw
+ * an exception otherwise.
+ *
+ * This is primarily useful for situations where we're unable to
+ * statically verify that something isn't undefined (e.g. due to the limitations
+ * of typings we didn't write) but are sure it won't be in practice.
+ */
+export function assertNotUndefined<T>(thing: T | undefined): T | never {
+  if (thing === undefined) {
+    throw new Error(
+      "Assertion failure, expected argument to not be undefined!"
+    );
+  }
+  return thing;
+}
+
 export default {
   // filter repeated values in rbas and owners
   // uses Set which enforces uniqueness

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -39,9 +39,7 @@ export const shortDateOptions = { month: "short" };
  */
 export function assertNotUndefined<T>(thing: T | undefined): T | never {
   if (thing === undefined) {
-    throw new Error(
-      "Assertion failure, expected argument to not be undefined!"
-    );
+    throw new Error("Assertion failure, expected argument to not be undefined!");
   }
   return thing;
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2977,6 +2977,11 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@xstate/react@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-0.8.1.tgz#df200547cca24c909572b7aef1ddab8bca3a0603"
+  integrity sha512-8voZm4GX3x70lNQVvoGedoObPYapkQIbgMhE+xOQEsm8Ait4Zto6R01SZ6WJD4qvLl8JPV6uq96OcFRdEsVESg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4892,6 +4892,13 @@ create-react-class@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cross-fetch@^3.0.4:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
+  integrity sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==
+  dependencies:
+    node-fetch "2.6.0"
+
 cross-spawn@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
@@ -8081,6 +8088,14 @@ jest-environment-node@^24.9.0:
     jest-mock "^24.9.0"
     jest-util "^24.9.0"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -9414,6 +9429,11 @@ node-fetch@1.6.3:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -11134,6 +11154,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
 promise@8.0.2:
   version "8.0.2"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -13646,10 +13646,10 @@ typescript@^2.9.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-typescript@^3.3.3:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
-  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
This PR moves our entire front-end codebase towards managing major API requests and state management with [XState](https://xstate.js.org/docs/). Now, we handle all major transitions between different "states" of the tool through a global `state-machine.ts` implementation. 

Fixes #264! 

Still to do: 
- [x] Adding in handling of `SELECT_DETAIL_ADDR`, `VIEW_SUMMARY`, and `VIEW_TIMELINE` events
- [x] Getting familiar with binding state interactions to React components (adding the @XState/React library) 
- [x] Refactor all of our main components to hook up with our Machine and no longer call APIs themselves
- [x] Create a state mechanism to handle bbl links
- [ ] Add tests! (Maybe build them as we go?) 
- [x] Figure out what to do with all of the `window.gtag` events we removed...
- [x] Make sure all "not found" type issues direct the user to the "NotFound" page component
- [ ] Figure out how to deal with the `Warning: Event "SEARCH" was sent to uninitialized service "wow" and is deferred. Make sure .start() is called for this service.` error. (Update: this might actually be a bug w/ xstate that was just fixed?  See https://github.com/davidkpiano/xstate/issues/1132#issuecomment-663869567)

Once merged:
- [ ] File an issue regarding the use of `as any` on our updated API Client `getIndicatorHistory` function.
