### PR TITLE
Added back ES translation that got overwritten

### DIFF
--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -626,7 +626,7 @@ msgstr "El año en que este edificio fue construido, según el Departamento de P
 
 #: src/components/PropertiesSummary.tsx:45
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
-msgstr ""
+msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
 #: src/components/SocialShare.tsx:50
 msgid "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
@@ -638,7 +638,7 @@ msgstr "Los {buildingCount} edificios que son \"propiedad\" del dueño de mi apa
 
 #: src/components/PropertiesSummary.tsx:34
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
-msgstr ""
+msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
 #: src/containers/NychaPage.tsx:106
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"


### PR DESCRIPTION
This HotFix PR adds back a translation on the Summary Tab that got overwritten during our refactoring in #362. 