### PR TITLE
Add /dev/ page with developer docs, manual tests.

### DIFF
--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -50,7 +50,7 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
           housenumber: results.result[0].housenumber,
           streetname: results.result[0].streetname,
         });
-        history.push(addressPage);
+        history.replace(addressPage);
       })
       .catch((err) => {
         window.Rollbar.error("API error from BBL page: Building Info", err, fullBBL);

--- a/client/src/containers/DevPage.tsx
+++ b/client/src/containers/DevPage.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import Page from "components/Page";
+import { SearchAddressWithoutBbl } from "components/APIDataTypes";
+import { Link } from "react-router-dom";
+import { createRouteForAddressPage } from "routes";
+
+type AddressExample = SearchAddressWithoutBbl & {
+  desc: string;
+};
+
+const ADDRESS_EXAMPLES: AddressExample[] = [
+  {
+    desc: "HPD registered",
+    housenumber: "654",
+    streetname: "PARK PLACE",
+    boro: "BROOKLYN",
+  },
+  {
+    desc: "Not HPD registered, and shouldn't be",
+    housenumber: "150",
+    streetname: "COURT STREET",
+    boro: "BROOKLYN",
+  },
+  {
+    desc: "Not HPD registered, and possibly should be",
+    housenumber: "70",
+    streetname: "POILLON AVENUE",
+    boro: "STATEN ISLAND",
+  },
+  {
+    desc: "NYCHA",
+    housenumber: "237",
+    streetname: "NASSAU STREET",
+    boro: "BROOKLYN",
+  },
+  {
+    desc: "RAD-Converted NYCHA",
+    housenumber: "510",
+    streetname: "EAST 144 STREET",
+    boro: "BRONX",
+  },
+];
+
+const AddressExample: React.FC<AddressExample> = (props) => {
+  return (
+    <p>
+      <strong>{props.desc}</strong> -{" "}
+      <Link to={createRouteForAddressPage(props)}>
+        {props.housenumber} {props.streetname}, {props.boro}
+      </Link>
+    </p>
+  );
+};
+
+export const DevPage: React.FC<{}> = () => {
+  return (
+    <Page title="Developer tools">
+      <div className="AboutPage Page">
+        <div className="Page__content">
+          <h1>Developer tools</h1>
+          <h2>A panoply of addresses</h2>
+          <p>
+            The following addresses cover a wide range of data that WoW will present to users in
+            different ways. Make sure that they all behave as expected!
+          </p>
+          <ul>
+            {ADDRESS_EXAMPLES.map((ae) => (
+              <li key={ae.desc}>
+                <AddressExample {...ae} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </Page>
+  );
+};

--- a/client/src/containers/DevPage.tsx
+++ b/client/src/containers/DevPage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Page from "components/Page";
 import { SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { Link } from "react-router-dom";
-import { createRouteForAddressPage } from "routes";
+import { createRouteForAddressPage, createRouteForFullBbl } from "routes";
 
 type AddressExample = SearchAddressWithoutBbl & {
   desc: string;
@@ -53,12 +53,25 @@ const AddressExample: React.FC<AddressExample> = (props) => {
 };
 
 export const DevPage: React.FC<{}> = () => {
+  const fullBllUrl = createRouteForFullBbl("3012380016");
+
   return (
-    <Page title="Developer tools">
+    <Page title="Developer documentation">
       <div className="AboutPage Page">
         <div className="Page__content">
-          <h1>Developer tools</h1>
-          <h2>A panoply of addresses</h2>
+          <h1>Developer documentation</h1>
+          <p>
+            If you're having trouble developing the app, check out the{" "}
+            <a href="https://github.com/JustFixNYC/who-owns-what#readme">README</a> and{" "}
+            <a href="https://github.com/JustFixNYC/who-owns-what/wiki">project wiki</a>! Also feel
+            free to <a href="https://github.com/JustFixNYC/who-owns-what/issues">file an issue</a>.
+          </p>
+          <h2>Things to try</h2>
+          <p>
+            The following can be used to help develop Who Owns What and roughly constitute a manual
+            test suite for the app.
+          </p>
+          <h3>A panoply of addresses</h3>
           <p>
             The following addresses cover a wide range of data that WoW will present to users in
             different ways. Make sure that they all behave as expected!
@@ -70,6 +83,14 @@ export const DevPage: React.FC<{}> = () => {
               </li>
             ))}
           </ul>
+          <h3>BBL routes</h3>
+          <p>
+            Who Owns What offers a BBL-based route that can be used by housing organizers and other
+            websites to link to WoW if they only have a BBL. Here's an example:
+          </p>
+          <p>
+            <Link to={fullBllUrl}>{fullBllUrl}</Link>
+          </p>
         </div>
       </div>
     </Page>

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -30,6 +30,10 @@ export const createRouteForAddressPage = (params: AddressPageUrlParams) => {
   return route;
 };
 
+export const createRouteForFullBbl = (bbl: string) => {
+  return `/bbl/${bbl}`;
+};
+
 const addressPageRouteWithPlaceholders = "/address/:boro/:housenumber/:streetname";
 
 export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -11,6 +11,7 @@ import PrivacyPolicyPage from "./containers/PrivacyPolicyPage";
 import { SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { useMachine } from "@xstate/react";
 import { wowMachine } from "state-machine";
+import { DevPage } from "containers/DevPage";
 
 export type AddressPageUrlParams = SearchAddressWithoutBbl;
 
@@ -56,6 +57,7 @@ export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
     methodology: `${pathPrefix}/how-it-works`,
     termsOfUse: `${pathPrefix}/terms-of-use`,
     privacyPolicy: `${pathPrefix}/privacy-policy`,
+    dev: `${pathPrefix}/dev`,
   };
 };
 
@@ -95,6 +97,7 @@ export const WhoOwnsWhatRoutes = () => {
       <Route path={paths.methodology} component={MethodologyPage} />
       <Route path={paths.termsOfUse} component={TermsOfUsePage} />
       <Route path={paths.privacyPolicy} component={PrivacyPolicyPage} />
+      <Route path={paths.dev} component={DevPage} />
     </Switch>
   );
 };


### PR DESCRIPTION
This adds a page at `/dev/` that contains a panoply of addresses (cribbed from the [tenants2 wiki](https://github.com/JustFixNYC/tenants2/wiki/Useful-NYC-addresses)).

It also changes `history.push()` in the BBL endpoint to `history.replace()` as otherwise the user's back button breaks.