### PR TITLE
Cleaned up our helper functions and added full test coverage

### DIFF
--- a/client/src/state-machine.test.ts
+++ b/client/src/state-machine.test.ts
@@ -1,9 +1,22 @@
-import { wowMachine, WowEvent } from "./state-machine";
+import { wowMachine, WowEvent, getNychaData } from "./state-machine";
 import { interpret } from "xstate";
 import { GEO_AUTOCOMPLETE_URL } from "@justfixnyc/geosearch-requester";
 import { waitUntilStateMatches, mockJsonResponse, mockResponses } from "tests/test-util";
 import GEOCODING_EXAMPLE_SEARCH from "./tests/geocoding-example-search.json";
 import { SearchResults, BuildingInfoResults } from "components/APIDataTypes";
+
+// State Machine Helper Functions:
+
+describe("getNychaData()", () => {
+  it("returns null if BBL is not a NYCHA BBL", () => {
+    expect(getNychaData("blarg")).toBe(null);
+  });
+
+  it("returns data if BBL is a NYCHA BBL", () => {
+    const data = getNychaData("4004770049");
+    expect(data && data.development).toBe("QUEENSBRIDGE SOUTH");
+  });
+});
 
 const SEARCH_EVENT: WowEvent = {
   type: "SEARCH",

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -8,7 +8,8 @@ import {
 } from "components/APIDataTypes";
 import { NychaData } from "containers/NychaPage";
 import APIClient from "components/APIClient";
-import helpers, { assertNotUndefined } from "util/helpers";
+import { assertNotUndefined } from "util/helpers";
+import nycha_bbls from "data/nycha_bbls.json";
 
 import _find from "lodash/find";
 import { IndicatorsDataFromAPI } from "components/IndicatorsTypes";
@@ -160,6 +161,14 @@ export type WithMachineInStateProps<TSV extends WowState["value"]> = {
   send: (event: WowEvent) => WowMachineEverything;
 };
 
+export function getNychaData(searchBBL: string) {
+  const bbl = searchBBL.toString();
+  for (var index = 0; index < nycha_bbls.length; index++) {
+    if (nycha_bbls[index].bbl.toString() === bbl) return nycha_bbls[index];
+  }
+  return null;
+}
+
 async function getSearchResult(addr: SearchAddressWithoutBbl): Promise<WowState> {
   const apiResults = await APIClient.searchForAddressWithGeosearch(addr);
   if (!apiResults.geosearch) {
@@ -169,7 +178,7 @@ async function getSearchResult(addr: SearchAddressWithoutBbl): Promise<WowState>
     };
   } else if (apiResults.addrs.length === 0) {
     const buildingInfoResults = await APIClient.getBuildingInfo(apiResults.geosearch.bbl);
-    const nychaData = helpers.getNychaData(apiResults.geosearch.bbl);
+    const nychaData = getNychaData(apiResults.geosearch.bbl);
 
     return nychaData
       ? {

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -1,4 +1,39 @@
-import helpers from "./helpers";
+import helpers, { searchAddrsAreEqual, assertNotUndefined } from "./helpers";
+import { SearchAddressWithoutBbl } from "components/APIDataTypes";
+
+describe("assertNotUndefined()", () => {
+  it("raises exception when undefined", () => {
+    expect(() => assertNotUndefined(undefined)).toThrowError(
+      "expected argument to not be undefined"
+    );
+  });
+
+  it("returns argument when not undefined", () => {
+    expect(assertNotUndefined(null)).toBe(null);
+  });
+});
+
+describe("searchAddrsAreEqual()", () => {
+  const searchAddr1: SearchAddressWithoutBbl = {
+    boro: "BRONX",
+    streetname: "BWAY",
+    housenumber: "1",
+  };
+
+  const searchAddr2: SearchAddressWithoutBbl = {
+    boro: "MANHATTAN",
+    streetname: "SEWER",
+  };
+  it("returns true when addrs are equal", () => {
+    expect(searchAddrsAreEqual(searchAddr1, searchAddr1)).toBe(true);
+  });
+  it("still works if housenumber is not defined", () => {
+    expect(searchAddrsAreEqual(searchAddr2, searchAddr2)).toBe(true);
+  });
+  it("returns false when addrs are different", () => {
+    expect(searchAddrsAreEqual(searchAddr1, searchAddr2)).toBe(false);
+  });
+});
 
 test("uniq() works", () => {
   expect(helpers.uniq([1, 1, 2, 4, 4])).toEqual([1, 2, 4]);
@@ -53,6 +88,23 @@ describe("jsonEqual()", () => {
   });
 });
 
+describe("formatPrice()", () => {
+  it("works with no locale provided", () => {
+    expect(helpers.formatPrice(1000000)).toBe("1,000,000");
+  });
+  it("works with specified locales", () => {
+    expect(helpers.formatPrice(1000000, "es")).toBe("1.000.000");
+  });
+});
+
+test("createTakeActionURL() works", () => {
+  expect(
+    helpers.createTakeActionURL({ boro: "QUEENS", streetname: "BOOP RD", housenumber: "1" }, "boop")
+  ).toBe(
+    "https://app.justfix.nyc/ddo?address=1%20BOOP%20RD&borough=QUEENS&utm_source=whoownswhat&utm_content=take_action&utm_medium=boop"
+  );
+});
+
 test("intersectAddrObjects() works", () => {
   expect(helpers.intersectAddrObjects({ a: 1, b: 2, c: 3, d: 9 }, { a: 5, b: 2, c: 9 })).toEqual({
     b: 2,
@@ -67,49 +119,64 @@ test("titleCase() works", () => {
   expect(helpers.titleCase("boop jones")).toBe("Boop Jones");
 });
 
-test("formatDate() works", () => {
-  expect(helpers.formatDate("2008-01-05", { year: "numeric", month: "long" })).toBe("January 2008");
+describe("formatDate()", () => {
+  it("works", () => {
+    expect(helpers.formatDate("2008-01-05", { year: "numeric", month: "long" })).toBe(
+      "January 2008"
+    );
+  });
+
+  it("works for month abbreviation", () => {
+    expect(helpers.formatDate("2008-01-05", { month: "short" })).toBe("Jan");
+  });
+
+  // Note: Although there is generally good support across modern versions of the usual web browsers,
+  // the "locale" prop in the toLocaleDateString function is not supported until Node 13.
+  // Therefore, I implemented these two tests to match either the localized result or the default.
+  // See more here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
+
+  it("works for non-English locales", () => {
+    expect(helpers.formatDate("2008-01-05", { year: "numeric", month: "long" }, "es")).toMatch(
+      /Enero de 2008|January 2008/i
+    );
+  });
+
+  it("works for month abbreviation in non-English locales", () => {
+    expect(helpers.formatDate("2008-01-05", { month: "short" }, "es")).toMatch(/Ene|Jan/i);
+  });
 });
 
-test("formatDate() works for month abbreviation", () => {
-  expect(helpers.formatDate("2008-01-05", { month: "short" })).toBe("Jan");
+describe("getMonthRangeFromQuarter()", () => {
+  it("works with no locale provided", () => {
+    expect(helpers.getMonthRangeFromQuarter("1")).toBe("Jan - Mar");
+  });
+  it("works with specified locales", () => {
+    expect(helpers.getMonthRangeFromQuarter("1", "es")).toBe("Ene - Mar");
+  });
 });
 
-// Note: Although there is generally good support across modern versions of the usual web browsers,
-// the "locale" prop in the toLocaleDateString function is not supported until Node 13.
-// Therefore, I implemented these two tests to match either the localized result or the default.
-// See more here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
+describe("formatStreetNameForHpdLink()", () => {
+  it("works for directional prefixes", () => {
+    expect(helpers.formatStreetNameForHpdLink("East 21st Street")).toBe("E 21st Street");
+  });
 
-test("formatDate() works for  non-English locales", () => {
-  expect(helpers.formatDate("2008-01-05", { year: "numeric", month: "long" }, "es")).toMatch(
-    /Enero de 2008|January 2008/i
-  );
-});
+  it("works for enumerations", () => {
+    expect(helpers.formatStreetNameForHpdLink("Eighth Avenue")).toBe("8 Avenue");
+  });
 
-test("formatDate() works for timeline in non-English locales", () => {
-  expect(helpers.formatDate("2008-01-05", { month: "short" }, "es")).toMatch(/Ene|Jan/i);
-});
+  it("works for both prefixes and enumerations at once", () => {
+    expect(helpers.formatStreetNameForHpdLink("North Second Street")).toBe("N 2 Street");
+  });
 
-test("formatStreetNameForHpdLink() works for directional prefixes", () => {
-  expect(helpers.formatStreetNameForHpdLink("East 21st Street")).toBe("E 21st Street");
-});
+  it("doesn't change directionals or enumerations within names", () => {
+    expect(helpers.formatStreetNameForHpdLink("Eastonfirst Avenue")).toBe("Eastonfirst Avenue");
+  });
 
-test("formatStreetNameForHpdLink() works for enumerations", () => {
-  expect(helpers.formatStreetNameForHpdLink("Eighth Avenue")).toBe("8 Avenue");
-});
+  it("still works for one-word streetnames", () => {
+    expect(helpers.formatStreetNameForHpdLink("Broadway")).toBe("Broadway");
+  });
 
-test("formatStreetNameForHpdLink() works for both prefixes and enumerations at once", () => {
-  expect(helpers.formatStreetNameForHpdLink("North Second Street")).toBe("N 2 Street");
-});
-
-test("formatStreetNameForHpdLink() doesn't change directionals or enumerations within names", () => {
-  expect(helpers.formatStreetNameForHpdLink("Eastonfirst Avenue")).toBe("Eastonfirst Avenue");
-});
-
-test("formatStreetNameForHpdLink() still works for one-word streetnames", () => {
-  expect(helpers.formatStreetNameForHpdLink("Broadway")).toBe("Broadway");
-});
-
-test("formatStreetNameForHpdLink() still works for empty streetnames", () => {
-  expect(helpers.formatStreetNameForHpdLink("")).toBe("");
+  it("still works for empty streetnames", () => {
+    expect(helpers.formatStreetNameForHpdLink("")).toBe("");
+  });
 });

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -1,18 +1,18 @@
 import helpers from "./helpers";
 
-describe("jsonEqual()", () => {
-  it("returns true when objects are equal", () => {
-    expect(helpers.jsonEqual({ a: 1 }, { a: 1 })).toBe(true);
-    expect(helpers.jsonEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
-  });
-
-  it("returns false when objects are not equal", () => {
-    expect(helpers.jsonEqual({ a: 1 }, { b: 2 })).toBe(false);
-  });
-});
-
 test("uniq() works", () => {
   expect(helpers.uniq([1, 1, 2, 4, 4])).toEqual([1, 2, 4]);
+});
+
+describe("find()", () => {
+  it("returns value if present", () => {
+    const a = { boop: 1 };
+    expect(helpers.find([{ boop: 2 }, a, { boop: 3 }], "boop", 1)).toBe(a);
+  });
+
+  it("returns null if not present", () => {
+    expect(helpers.find([{ boop: 2 }, { boop: 3 }], "boop", 1)).toBe(null);
+  });
 });
 
 describe("maxArray()", () => {
@@ -42,25 +42,14 @@ test("addrsAreEqual() works", () => {
   expect(helpers.addrsAreEqual({ bbl: "yes" }, { bbl: "no" })).toBe(false);
 });
 
-describe("find()", () => {
-  it("returns value if present", () => {
-    const a = { boop: 1 };
-    expect(helpers.find([{ boop: 2 }, a, { boop: 3 }], "boop", 1)).toBe(a);
+describe("jsonEqual()", () => {
+  it("returns true when objects are equal", () => {
+    expect(helpers.jsonEqual({ a: 1 }, { a: 1 })).toBe(true);
+    expect(helpers.jsonEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
   });
 
-  it("returns null if not present", () => {
-    expect(helpers.find([{ boop: 2 }, { boop: 3 }], "boop", 1)).toBe(null);
-  });
-});
-
-describe("getNychaData()", () => {
-  it("returns null if BBL is not a NYCHA BBL", () => {
-    expect(helpers.getNychaData("blarg")).toBe(null);
-  });
-
-  it("returns data if BBL is a NYCHA BBL", () => {
-    const data = helpers.getNychaData("4004770049");
-    expect(data && data.development).toBe("QUEENSBRIDGE SOUTH");
+  it("returns false when objects are not equal", () => {
+    expect(helpers.jsonEqual({ a: 1 }, { b: 2 })).toBe(false);
   });
 });
 

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -93,7 +93,7 @@ describe("formatPrice()", () => {
     expect(helpers.formatPrice(1000000)).toBe("1,000,000");
   });
   it("works with specified locales", () => {
-    expect(helpers.formatPrice(1000000, "es")).toBe("1.000.000");
+    expect(helpers.formatPrice(1000000, "es")).toMatch(/1.000.000|1,000,000/i);
   });
 });
 
@@ -151,7 +151,7 @@ describe("getMonthRangeFromQuarter()", () => {
     expect(helpers.getMonthRangeFromQuarter("1")).toBe("Jan - Mar");
   });
   it("works with specified locales", () => {
-    expect(helpers.getMonthRangeFromQuarter("1", "es")).toBe("Ene - Mar");
+    expect(helpers.getMonthRangeFromQuarter("1", "es")).toMatch(/Ene - Mar|Jan - Mar/i);
   });
 });
 

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -3,10 +3,7 @@
 // import _keys from 'lodash/keys';
 import _pickBy from "lodash/pickBy";
 import { deepEqual as assertDeepEqual } from "assert";
-import nycha_bbls from "../data/nycha_bbls.json";
 import { SupportedLocale } from "../i18n-base";
-import { IndicatorsDatasetId } from "components/IndicatorsDatasets";
-import { IndicatorsData, indicatorsInitialDataStructure } from "components/IndicatorsTypes";
 import { SearchAddressWithoutBbl } from "components/APIDataTypes";
 
 /**
@@ -106,14 +103,6 @@ export default {
     }
   },
 
-  getNychaData(searchBBL: string | number) {
-    const bbl = searchBBL.toString();
-    for (var index = 0; index < nycha_bbls.length; index++) {
-      if (nycha_bbls[index].bbl.toString() === bbl) return nycha_bbls[index];
-    }
-    return null;
-  },
-
   formatPrice(amount: number, locale?: SupportedLocale): string {
     const formatPrice = new Intl.NumberFormat(locale || "en");
     return formatPrice.format(amount);
@@ -142,36 +131,6 @@ export default {
       window.Rollbar.error("Address improperly formatted for DDO:", addr || "<falsy value>");
       return `https://${subdomain}.justfix.nyc/?utm_source=whoownswhat&utm_content=take_action_failed_attempt&utm_medium=${utm_medium}`;
     }
-  },
-
-  /** Reorganizes raw data from API call and then returns an object that matches the data stucture in state  */
-  createVizData(rawJSON: any, vizType: IndicatorsDatasetId): IndicatorsData {
-    // Generate object to hold data for viz
-    // Note: keys in "values" object need to match exact key names in data from API call
-    var vizData: IndicatorsData = Object.assign({}, indicatorsInitialDataStructure[vizType]);
-
-    vizData.labels = [];
-    for (const column in vizData.values) {
-      vizData.values[column] = [];
-    }
-
-    // Generate arrays of data for chart.js visualizations:
-    // Default grouping is by MONTH
-
-    const rawJSONLength = rawJSON.length;
-
-    for (let i = 0; i < rawJSONLength; i++) {
-      vizData.labels.push(rawJSON[i].month);
-
-      for (const column in vizData.values) {
-        const vizTypePlusColumn = vizType + "_" + column;
-        const values = vizData.values[column];
-        if (!values)
-          throw new Error(`Column "${column}" of visualization "${vizType}" is not an array!`);
-        values.push(parseInt(rawJSON[i][vizTypePlusColumn]));
-      }
-    }
-    return vizData;
   },
 
   intersectAddrObjects(a: any, b: any) {


### PR DESCRIPTION
This PR consolidates some duplicate helpers (like `splitBBL`), moves some function declarations around so that helpers.ts only includes globally-relevant helper functions, and adds full test coverage for all. 