### PR TITLE
Added test for the bbl page params formatting function

### DIFF
--- a/client/src/containers/BBLPage.test.tsx
+++ b/client/src/containers/BBLPage.test.tsx
@@ -1,0 +1,32 @@
+import { getFullBblFromPageParams, BBLPageParams } from "./BBLPage";
+
+const pageParamsWithFullBbl: BBLPageParams = {
+  bbl: "1003450021",
+};
+
+const pageParamsWithBblBits: BBLPageParams = {
+  boro: "2",
+  block: "43",
+  lot: "1",
+};
+
+const incompletePageParams: BBLPageParams = {
+  boro: "3",
+  lot: "1",
+};
+
+describe("getFullBblFromPageParams()", () => {
+  it("returns true when objects are equal", () => {
+    expect(getFullBblFromPageParams(pageParamsWithFullBbl)).toBe("1003450021");
+  });
+
+  it("returns false when objects are not equal", () => {
+    expect(getFullBblFromPageParams(pageParamsWithBblBits)).toBe("2000430001");
+  });
+
+  it("throws error if params are incomplete", () => {
+    expect(() => getFullBblFromPageParams(incompletePageParams)).toThrowError(
+      "Invalid params, expected either a BBL or boro/block/lot!"
+    );
+  });
+});

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -9,7 +9,7 @@ import { createRouteForAddressPage } from "../routes";
 import NotFoundPage from "./NotFoundPage";
 
 // This will be *either* bbl *or* boro, block, and lot.
-type BBLPageParams = {
+export type BBLPageParams = {
   bbl?: string;
   boro?: string;
   block?: string;
@@ -18,11 +18,7 @@ type BBLPageParams = {
 
 type BBLPageProps = RouteComponentProps<BBLPageParams>;
 
-const BBLPage: React.FC<BBLPageProps> = (props) => {
-  const history = useHistory();
-  const params = props.match.params;
-  const [isNotFound, setIsNotFound] = useState(false);
-
+export const getFullBblFromPageParams = (params: BBLPageParams) => {
   var fullBBL: string;
 
   // handling for when url parameter is separated bbl
@@ -33,6 +29,13 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
   } else {
     throw new Error("Invalid params, expected either a BBL or boro/block/lot!");
   }
+  return fullBBL;
+};
+
+const BBLPage: React.FC<BBLPageProps> = (props) => {
+  const history = useHistory();
+  const fullBBL = getFullBblFromPageParams(props.match.params);
+  const [isNotFound, setIsNotFound] = useState(false);
 
   useEffect(() => {
     window.gtag("event", "bblLink");

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -8,6 +8,7 @@ window.Rollbar = {
 
 require("jest-fetch-mock").enableMocks();
 
-// We need to "mock" this function here as Jest doesn't work well with MapBox GL.
-// Read more here: https://github.com/mapbox/mapbox-gl-js/issues/3436#issuecomment-421117409
+// NOTE: there is some piece of the MapBox GL library that doesn't mesh well with our Jest testing platform.
+// Therefore, to fix this, we needed to "mock" this function here so Jest stops complaining.
+// Read more: https://github.com/mapbox/mapbox-gl-js/issues/3436#issuecomment-421117409
 window.URL.createObjectURL = function () {};

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -7,3 +7,7 @@ window.Rollbar = {
 };
 
 require("jest-fetch-mock").enableMocks();
+
+// We need to "mock" this function here as Jest doesn't work well with MapBox GL.
+// Read more here: https://github.com/mapbox/mapbox-gl-js/issues/3436#issuecomment-421117409
+window.URL.createObjectURL = function () {};


### PR DESCRIPTION
This PR adds tests for our BBLPage component, which, for now, just consists of one test that checks whether we are appropriately reformatting the URL params that the component receives. This specific test makes sure that both url formats for our BBL direct links work— `/bbl/4015640058` and `/bbl/4/1564/58`, for example.
