### PR TITLE
Improve error handling.

### DIFF
--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -5,6 +5,7 @@ import "styles/Subscribe.css";
 import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
 import { t } from "@lingui/macro";
+import { reportError } from "error-reporting";
 
 //import 'styles/Subscribe.css';
 
@@ -70,9 +71,7 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
             response: i18n._(t`Oops! That email is invalid.`),
           });
         } else {
-          window.Rollbar.error(
-            `Mailchimp email signup responded with error code ${result.errorCode}.`
-          );
+          reportError(`Mailchimp email signup responded with error code ${result.errorCode}.`);
           this.setState({
             response: i18n._(t`Oops! A network error occurred. Try again later.`),
           });

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -7,6 +7,7 @@ import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
 import { createRouteForAddressPage } from "../routes";
 import NotFoundPage from "./NotFoundPage";
+import { reportError } from "error-reporting";
 
 // This will be *either* bbl *or* boro, block, and lot.
 export type BBLPageParams = {
@@ -55,9 +56,7 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
         });
         history.replace(addressPage);
       })
-      .catch((err) => {
-        window.Rollbar.error("API error from BBL page: Building Info", err, fullBBL);
-      });
+      .catch(reportError);
 
     return () => {
       isMounted = false;

--- a/client/src/error-reporting.test.tsx
+++ b/client/src/error-reporting.test.tsx
@@ -1,0 +1,38 @@
+import { reportError, NetworkError, HTTPError } from "error-reporting";
+
+describe("reportError()", () => {
+  let errMock = jest.fn();
+
+  beforeEach(() => {
+    console.error = errMock = jest.fn();
+  });
+
+  it("reports strings", () => {
+    reportError("blah");
+    expect(errMock).toHaveBeenCalledWith("blah");
+  });
+
+  it("reports network errors we want to report", () => {
+    const e = new NetworkError("oof", true);
+    reportError(e);
+    expect(errMock).toHaveBeenCalledWith(e);
+  });
+
+  it("ignores network errors we don't want to report", () => {
+    const e = new NetworkError("doh", false);
+    reportError(e);
+    expect(errMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("HTTPError", () => {
+  const makeHttpError = (status: number) => new HTTPError({ status } as any);
+
+  it("Identifies 500 as not being reportable", () => {
+    expect(makeHttpError(500).shouldReport).toBe(false);
+  });
+
+  it("Identifies 400 as being reportable", () => {
+    expect(makeHttpError(400).shouldReport).toBe(true);
+  });
+});

--- a/client/src/error-reporting.ts
+++ b/client/src/error-reporting.ts
@@ -1,0 +1,48 @@
+/**
+ * A generic network error. It could be because the network is down, or because
+ * a server returned a HTTP response like 404 or 500.
+ *
+ * Note that we need to define this ourselves because `fetch()` will actually
+ * reject with a `TypeError` on network failure, which is awfully ambiguous.
+ */
+export class NetworkError extends Error {
+  constructor(message: string, readonly shouldReport: boolean = false) {
+    super(message);
+  }
+}
+
+/**
+ * A network error that happened because the HTTP status code is not in
+ * the range 200-299.
+ */
+export class HTTPError extends NetworkError {
+  statusText: string;
+  status: number;
+
+  constructor(readonly response: Response) {
+    super(
+      `HTTP Error ${response.statusText}`,
+      // If the response status is 4xx, we want to report it
+      // because it's our "fault" as a client--i.e., we should change
+      // our client-side code to never make the request in the
+      // first place.
+      response.status >= 400 && response.status < 500
+    );
+    this.statusText = response.statusText;
+    this.status = response.status;
+  }
+}
+
+/**
+ * Report the given error to our error-reporting service, as long
+ * as it's not a network error that we think shouldn't be reported.
+ *
+ * The error can also be a string, in which case it's logged as-is.
+ */
+export function reportError(error: string | Error) {
+  if (error instanceof NetworkError && !error.shouldReport) return;
+  console.error(error);
+  if (window.Rollbar) {
+    window.Rollbar.error(error);
+  }
+}

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -12,6 +12,7 @@ import { SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { useMachine } from "@xstate/react";
 import { wowMachine } from "state-machine";
 import { DevPage } from "containers/DevPage";
+import { reportError } from "error-reporting";
 
 export type AddressPageUrlParams = SearchAddressWithoutBbl;
 
@@ -21,9 +22,7 @@ export const createRouteForAddressPage = (params: AddressPageUrlParams) => {
   )}/${encodeURIComponent(params.streetname)}`;
 
   if (route.includes(" ")) {
-    window.Rollbar.error(
-      "An Address Page URL was not encoded properly! There's a space in the URL."
-    );
+    reportError("An Address Page URL was not encoded properly! There's a space in the URL.");
     route = route.replace(" ", "%20");
   }
 

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,11 +1,5 @@
 process.env.REACT_APP_API_BASE_URL = "https://wowapi";
 
-window.Rollbar = {
-  error() {
-    console.error.apply(this, arguments);
-  },
-};
-
 require("jest-fetch-mock").enableMocks();
 
 // NOTE: there is some piece of the MapBox GL library that doesn't mesh well with our Jest testing platform.

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -7,12 +7,13 @@ import {
   SummaryResults,
 } from "components/APIDataTypes";
 import { NychaData } from "containers/NychaPage";
-import APIClient, { NetworkError } from "components/APIClient";
+import APIClient from "components/APIClient";
 import { assertNotUndefined } from "util/helpers";
 import nycha_bbls from "data/nycha_bbls.json";
 
 import _find from "lodash/find";
 import { IndicatorsDataFromAPI } from "components/IndicatorsTypes";
+import { reportError } from "error-reporting";
 
 export type WowState =
   | { value: "noData"; context: {} }
@@ -234,15 +235,8 @@ const handleSearchEvent: TransitionsConfig<WowContext, WowEvent> = {
   },
 };
 
-function maybeReportError(context: unknown, event: DoneInvokeEvent<any>) {
-  const { data } = event;
-  if (data instanceof Error && !(data instanceof NetworkError)) {
-    if (window.Rollbar) {
-      window.Rollbar.error(data);
-    } else {
-      console.error(data);
-    }
-  }
+function reportEventError(context: unknown, event: DoneInvokeEvent<any>) {
+  reportError(event.data);
 }
 
 export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
@@ -287,7 +281,7 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
         ],
         onError: {
           target: "networkErrorOccurred",
-          actions: [maybeReportError],
+          actions: [reportEventError],
         },
       },
     },
@@ -330,7 +324,7 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
                 },
                 onError: {
                   target: "error",
-                  actions: [maybeReportError],
+                  actions: [reportEventError],
                 },
               },
             },
@@ -357,7 +351,7 @@ export const wowMachine = createMachine<WowContext, WowEvent, WowState>({
                 },
                 onError: {
                   target: "error",
-                  actions: [maybeReportError],
+                  actions: [reportEventError],
                 },
               },
             },

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -5,6 +5,7 @@ import _pickBy from "lodash/pickBy";
 import { deepEqual as assertDeepEqual } from "assert";
 import { SupportedLocale } from "../i18n-base";
 import { SearchAddressWithoutBbl } from "components/APIDataTypes";
+import { reportError } from "error-reporting";
 
 /**
  * An array consisting of Who Owns What's standard enumerations for street names,
@@ -128,7 +129,7 @@ export default {
         )}&utm_source=whoownswhat&utm_content=take_action&utm_medium=${utm_medium}`;
       }
     } else {
-      window.Rollbar.error("Address improperly formatted for DDO:", addr || "<falsy value>");
+      reportError(`Address improperly formatted for DDO: ${addr || "<falsy value>"}`);
       return `https://${subdomain}.justfix.nyc/?utm_source=whoownswhat&utm_content=take_action_failed_attempt&utm_medium=${utm_medium}`;
     }
   },


### PR DESCRIPTION
This adds a new module called `error-reporting.ts` which introduces a new function, `reportError()`, that we should use to report errors from now on (rather than calling `window.Rollbar.error()` or `console.error()` directly).  In doing so, it decouples us a bit more from Rollbar.

It also fixes #378, in part by adding a new `NetworkError` exception (it looks like the default errors raised by `fetch` are just `TypeError` which is awfully ambiguous).  A `NetworkError` has a `shouldReport` property which defaults to false, but it can be changed to true if it's something that we'd like to know about.  For example, we don't want to report HTTP 500 errors from our own API servers because we know they will report the errors to us from their end, and with more helpful contextual information.  But we _do_ want to know about HTTP 400 errors, because in this case we're somehow issuing bad requests to the API server.