### PR TITLE
Deal semi-gracefully with BBLs not in PLUTO.

### DIFF
--- a/client/src/state-machine.test.ts
+++ b/client/src/state-machine.test.ts
@@ -112,6 +112,26 @@ describe("wowMachine", () => {
     await waitUntilStateMatches(wm, "unregisteredFound");
   });
 
+  it("should deal w/ unregistered addresses not in PLUTO", async () => {
+    mockResponses({
+      [SEARCH_URL]: mockJsonResponse(NOT_REG_URLS.GEOCODING_EXAMPLE_SEARCH),
+      [NOT_REG_URLS.ADDRESS_URL]: mockJsonResponse<SearchResults>({
+        addrs: [],
+        geosearch: {
+          geosupportReturnCode: "00",
+          bbl: "3002920026",
+        },
+      }),
+      [NOT_REG_URLS.BUILDINGINFO_URL]: mockJsonResponse<BuildingInfoResults>({
+        result: [],
+      }),
+    });
+
+    const wm = interpret(wowMachine).start();
+    wm.send(SEARCH_EVENT);
+    await waitUntilStateMatches(wm, "bblNotFound");
+  });
+
   it("should deal w/ nycha addresses", async () => {
     mockResponses({
       [SEARCH_URL]: mockJsonResponse(NYCHA_URLS.GEOCODING_EXAMPLE_SEARCH),

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -180,6 +180,20 @@ async function getSearchResult(addr: SearchAddressWithoutBbl): Promise<WowState>
   } else if (apiResults.addrs.length === 0) {
     const buildingInfoResults = await APIClient.getBuildingInfo(apiResults.geosearch.bbl);
     const nychaData = getNychaData(apiResults.geosearch.bbl);
+    const buildingInfo = buildingInfoResults.result[0];
+
+    if (!buildingInfo) {
+      // Apparently PLUTO doesn't have data for some buildings,
+      // e.g. 77 Park Avenue (at the time of this writing).
+      //
+      // For now we'll just respond as though the address is
+      // invalid; although that's still far from ideal, at least
+      // it won't clog up our error logs...
+      return {
+        value: "bblNotFound",
+        context: { searchAddrParams: addr, searchAddrBbl: undefined },
+      };
+    }
 
     return nychaData
       ? {
@@ -189,7 +203,7 @@ async function getSearchResult(addr: SearchAddressWithoutBbl): Promise<WowState>
             searchAddrBbl: apiResults.geosearch.bbl,
             portfolioData: undefined,
             nychaData,
-            buildingInfo: buildingInfoResults.result[0],
+            buildingInfo,
           },
         }
       : {
@@ -198,7 +212,7 @@ async function getSearchResult(addr: SearchAddressWithoutBbl): Promise<WowState>
             searchAddrParams: addr,
             searchAddrBbl: apiResults.geosearch.bbl,
             portfolioData: undefined,
-            buildingInfo: buildingInfoResults.result[0],
+            buildingInfo,
           },
         };
   } else {


### PR DESCRIPTION
Apparently there are some addresses that map to actual BBLs in GeoSearch and represent real buildings, but which PLUTO doesn't have entries for.

An example of one (at the time of this writing) is 77 Park Place in Manhattan, which [exists according to StreetEasy](https://streeteasy.com/building/the-griffon) and has BBL 1008940201 according to NYC GeoSearch, but which apparently PLUTO 19v2 has no information about.  Because of this, the API request for building info returns an empty array, which the `NotRegisteredPage` component chokes on (currently with an exception of `Cannot get property 'charAt' of undefined or null`).

(Interestingly [ZoLa chokes on this address as well](https://zola.planning.nyc.gov/l/lot/1/894/201).)

I'm not sure what the best fix for this is, but this PR basically makes WoW act as though it can't find the BBL for the address, so it will respond with a page that says "No address found", which seems at least somewhat honest since we can't find the address in PLUTO...
