### PR TITLE
Add a network error page for AddressPage.

### DIFF
--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -23,7 +23,7 @@ import {
   IndicatorsTimeSpan,
 } from "./IndicatorsTypes";
 import { Nobr } from "./Nobr";
-import { ErrorPageScaffolding } from "containers/NotFoundPage";
+import { NetworkErrorMessage } from "./NetworkErrorMessage";
 
 class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> {
   constructor(props: IndicatorsProps) {
@@ -160,9 +160,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
       )
     ) {
       return this.props.state.matches({ portfolioFound: { timeline: "error" } }) ? (
-        <ErrorPageScaffolding>
-          <Trans>Oops! A network error occurred. Try again later.</Trans>
-        </ErrorPageScaffolding>
+        <NetworkErrorMessage />
       ) : (
         <Loader loading={true} classNames="Loader-map">
           <Trans>Loading</Trans>

--- a/client/src/components/NetworkErrorMessage.tsx
+++ b/client/src/components/NetworkErrorMessage.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { ErrorPageScaffolding } from "containers/NotFoundPage";
+import { Trans } from "@lingui/react";
+
+export const NetworkErrorMessage: React.FC<{}> = () => (
+  <ErrorPageScaffolding>
+    <Trans>Oops! A network error occurred. Try again later.</Trans>
+  </ErrorPageScaffolding>
+);

--- a/client/src/components/NetworkErrorMessage.tsx
+++ b/client/src/components/NetworkErrorMessage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ErrorPageScaffolding } from "containers/NotFoundPage";
-import { Trans } from "@lingui/react";
+import { Trans } from "@lingui/macro";
 
 export const NetworkErrorMessage: React.FC<{}> = () => (
   <ErrorPageScaffolding>

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -11,7 +11,7 @@ import { ViolationsSummary } from "./ViolationsSummary";
 import { StringifyListWithConjunction } from "./StringifyList";
 import { SocialSharePortfolio } from "./SocialShare";
 import { WithMachineInStateProps } from "state-machine";
-import { ErrorPageScaffolding } from "containers/NotFoundPage";
+import { NetworkErrorMessage } from "./NetworkErrorMessage";
 
 type Props = WithMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
@@ -45,12 +45,7 @@ export default class PropertiesSummary extends Component<Props, {}> {
     let agg = state.context.summaryData;
     let searchAddr = state.context.portfolioData.searchAddr;
 
-    if (state.matches({ portfolioFound: { summary: "error" } }))
-      return (
-        <ErrorPageScaffolding>
-          <Trans>Oops! A network error occurred. Try again later.</Trans>
-        </ErrorPageScaffolding>
-      );
+    if (state.matches({ portfolioFound: { summary: "error" } })) return <NetworkErrorMessage />;
     else if (!agg) {
       return (
         <Loader loading={true} classNames="Loader-map">

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -20,8 +20,9 @@ import Page from "../components/Page";
 import { SearchResults, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
 import { WithMachineProps } from "state-machine";
-import NotFoundPage, { ErrorPageScaffolding } from "./NotFoundPage";
+import NotFoundPage from "./NotFoundPage";
 import { searchAddrsAreEqual } from "util/helpers";
+import { NetworkErrorMessage } from "components/NetworkErrorMessage";
 
 type RouteParams = {
   locale?: string;
@@ -257,9 +258,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     } else if (state.matches("networkErrorOccurred")) {
       return (
         <Page>
-          <ErrorPageScaffolding>
-            <Trans>Oops! A network error occurred. Try again later.</Trans>
-          </ErrorPageScaffolding>
+          <NetworkErrorMessage />
         </Page>
       );
     } else {

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -20,7 +20,7 @@ import Page from "../components/Page";
 import { SearchResults, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
 import { WithMachineProps } from "state-machine";
-import NotFoundPage from "./NotFoundPage";
+import NotFoundPage, { ErrorPageScaffolding } from "./NotFoundPage";
 import { searchAddrsAreEqual } from "util/helpers";
 
 type RouteParams = {
@@ -252,6 +252,14 @@ export default class AddressPage extends Component<AddressPageProps, State> {
               />
             </div>
           </div>
+        </Page>
+      );
+    } else if (state.matches("networkErrorOccurred")) {
+      return (
+        <Page>
+          <ErrorPageScaffolding>
+            <Trans>Oops! A network error occurred. Try again later.</Trans>
+          </ErrorPageScaffolding>
         </Page>
       );
     } else {


### PR DESCRIPTION
Fixes #384. Fixes #318. Also factors out a `<NetworkErrorMessage>` component to make things more DRY.