### PR TITLE
Include Mapbox GL CSS.

### DIFF
--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -7,6 +7,7 @@ import MapHelpers, { LatLng } from "../util/mapping";
 import Loader from "../components/Loader";
 
 import "styles/PropertiesMap.css";
+import "mapbox-gl/src/css/mapbox-gl.css";
 import { Trans, Select } from "@lingui/macro";
 import { AddressRecord } from "./APIDataTypes";
 import { Props as MapboxMapProps } from "react-mapbox-gl/lib/map";


### PR DESCRIPTION
Fixes #191.

When loading the address page, the following annoying warning is always logged:

> This page appears to be missing CSS declarations for Mapbox GL JS, which may cause the map to display incorrectly. Please ensure your page includes mapbox-gl.css, as described in https://www.mapbox.com/mapbox-gl-js/api/.

The actual page doesn't seem to have any visual problems, though... Still, the warning is annoying and according to https://github.com/mapbox/mapbox-gl-js/issues/5785 we need to import the CSS in our code, which this commit does, and the warning goes away.  I just hope it's not adding unnecessary bloat to our page weight...
