### PR TITLE
Factor out createAddressPageRoutes() and add a 404 page.

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -14,7 +14,7 @@ import { isPartOfGroupSale } from "./PropertiesList";
 import { Link } from "react-router-dom";
 import { LocaleLink } from "../i18n";
 import BuildingStatsTable from "./BuildingStatsTable";
-import { createWhoOwnsWhatRoutePaths } from "../routes";
+import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
 import { AddressRecord } from "./APIDataTypes";
 import { SupportedLocale } from "../i18n-base";
 
@@ -25,7 +25,7 @@ type Props = withI18nProps & {
   mobileShow: boolean;
   userAddr: AddressRecord;
   onCloseDetail: () => void;
-  generateBaseUrl: () => string;
+  addressPageRoutes: AddressPageRoutes;
 };
 
 type State = {
@@ -126,7 +126,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                       <BuildingStatsTable addr={addr} />
                       <div className="card-body-timeline-link">
                         <Link
-                          to={this.props.generateBaseUrl() + "/timeline"}
+                          to={this.props.addressPageRoutes.timeline}
                           className="btn btn-primary btn-block"
                           onClick={() => {
                             window.gtag("event", "view-data-over-time-overview-tab");

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -209,7 +209,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     </h4>
                     <br />
                     <Link
-                      to={this.props.generateBaseUrl()}
+                      to={this.props.addressPageRoutes.overview}
                       onClick={() => this.props.onBackToOverview(bbl)}
                     >
                       <Trans>Back to Overview</Trans>

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -1,6 +1,7 @@
 import { IndicatorsDatasetId } from "./IndicatorsDatasets";
 import { withI18nProps } from "@lingui/react";
 import { WithMachineInStateProps } from "state-machine";
+import { AddressPageRoutes } from "routes";
 
 export type IndicatorsTimeSpan = "month" | "quarter" | "year";
 
@@ -121,7 +122,7 @@ export type IndicatorsProps = withI18nProps &
   WithMachineInStateProps<"portfolioFound"> & {
     isVisible: boolean;
     onBackToOverview: (bbl: string) => void;
-    generateBaseUrl: () => string;
+    addressPageRoutes: AddressPageRoutes;
   };
 
 // Other Useful Types and Type-related utilites:

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -12,6 +12,7 @@ import { SupportedLocale } from "../i18n-base";
 import Helpers, { longDateOptions } from "../util/helpers";
 import { AddressRecord } from "./APIDataTypes";
 import { WithMachineInStateProps } from "state-machine";
+import { AddressPageRoutes } from "routes";
 
 export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
   const addrsWithMatchingSale = addrs.filter((addr) => addr.lastsaleacrisid === saleId);
@@ -22,7 +23,7 @@ const PropertiesListWithoutI18n: React.FC<
   WithMachineInStateProps<"portfolioFound"> & {
     i18n: I18n;
     onOpenDetail: (bbl: string) => void;
-    generateBaseUrl: () => string;
+    addressPageRoutes: AddressPageRoutes;
   }
 > = (props) => {
   const { i18n } = props;
@@ -222,7 +223,7 @@ const PropertiesListWithoutI18n: React.FC<
                 Cell: (row) => {
                   return (
                     <Link
-                      to={props.generateBaseUrl()}
+                      to={props.addressPageRoutes.overview}
                       className="btn"
                       aria-label={i18n._(t`View detail`)}
                       onClick={() => props.onOpenDetail(row.original.bbl)}

--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -9,7 +9,7 @@ import { t, Trans } from "@lingui/macro";
 import { withI18n } from "@lingui/react";
 import { FB_APP_ID } from "./Page";
 import { Borough } from "./APIDataTypes";
-import { createRouteForAddressPage, getSiteOrigin } from "../routes";
+import { getSiteOrigin, createAddressPageRoutes } from "../routes";
 
 const SocialShareWithoutI18n: React.FC<{
   i18n: I18n;
@@ -89,22 +89,21 @@ export default SocialShare;
 
 const SocialSharePortfolioWithoutI18n: React.FC<{
   i18n: I18n;
-  location?: string;
+  location: "overview-tab" | "summary-tab";
   addr: { boro: Borough; housenumber?: string; streetname: string };
   buildings: number;
 }> = ({ i18n, location, addr, buildings }) => {
   const buildingCount = buildings || 0;
+  const routes = createAddressPageRoutes(addr);
+  const path = location === "summary-tab" ? routes.summary : routes.overview;
+  const url = getSiteOrigin() + path;
   return (
     <SocialShareWithoutI18n
       i18n={i18n}
       location={location}
-      url={`${getSiteOrigin()}${createRouteForAddressPage({
-        boro: addr.boro,
-        streetname: addr.streetname,
-        housenumber: addr.housenumber,
-      })}${location === "summary-tab" ? "/summary" : ""}`}
+      url={url}
       twitterMessage={i18n._(
-        t`The ${buildingCount} buildings that my landlord "owns" 👀... #WhoOwnsWhat @JustFixNYC`
+        t`The ${buildingCount} buildings that my landlord owns 👀... #WhoOwnsWhat @JustFixNYC`
       )}
       emailMessage={i18n._(
         t`The ${buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)`

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -22,6 +22,7 @@ import { SearchAddress } from "../components/AddressSearch";
 import { WithMachineProps } from "state-machine";
 import NotFoundPage from "./NotFoundPage";
 import { searchAddrsAreEqual } from "util/helpers";
+import { createAddressPageRoutes } from "routes";
 
 type RouteParams = {
   locale?: string;
@@ -50,12 +51,14 @@ const validateRouteParams = (params: RouteParams) => {
     throw new Error("Address Page URL params did not contain a proper streetname!");
   } else {
     const searchAddress: SearchAddress = {
+      // TODO: We really shouldn't be blindly typecasting to Borough here,
+      // params.boro could be anything!
       boro: params.boro as Borough,
       streetname: params.streetname,
       housenumber: params.housenumber,
       bbl: "",
     };
-    return searchAddress;
+    return { ...searchAddress, locale: params.locale };
   }
 };
 
@@ -96,14 +99,6 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     });
   };
 
-  generateBaseUrl = () => {
-    const params = this.props.match.params;
-    return (
-      //:locale/address/:boro/:housenumber/:streetname
-      `/${params.locale}/address/${params.boro}/${params.housenumber}/${params.streetname}`
-    );
-  };
-
   // should this properly live in AddressToolbar? you tell me
   handleExportClick = (bbl: string) => {
     APIClient.getAddressExport(bbl)
@@ -126,6 +121,8 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     } else if (state.matches("portfolioFound")) {
       window.gtag("event", "portfolio-found-page");
       const { detailAddr, assocAddrs, searchAddr } = state.context.portfolioData;
+      const routes = createAddressPageRoutes(validateRouteParams(this.props.match.params));
+
       return (
         <Page
           title={`${this.props.match.params.housenumber} ${this.props.match.params.streetname}`}
@@ -147,7 +144,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 <ul className="tab tab-block">
                   <li className={`tab-item ${this.props.currentTab === 0 ? "active" : ""}`}>
                     <Link
-                      to={this.generateBaseUrl()}
+                      to={routes.overview}
                       tabIndex={this.props.currentTab === 0 ? -1 : 0}
                       onClick={() => {
                         if (Browser.isMobile() && this.state.detailMobileSlide) {
@@ -160,7 +157,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                   </li>
                   <li className={`tab-item ${this.props.currentTab === 1 ? "active" : ""}`}>
                     <Link
-                      to={this.generateBaseUrl() + "/timeline"}
+                      to={routes.timeline}
                       tabIndex={this.props.currentTab === 1 ? -1 : 0}
                       onClick={() => {
                         window.gtag("event", "timeline-tab");
@@ -171,7 +168,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                   </li>
                   <li className={`tab-item ${this.props.currentTab === 2 ? "active" : ""}`}>
                     <Link
-                      to={this.generateBaseUrl() + "/portfolio"}
+                      to={routes.portfolio}
                       tabIndex={this.props.currentTab === 2 ? -1 : 0}
                       onClick={() => {
                         window.gtag("event", "portfolio-tab");
@@ -182,7 +179,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                   </li>
                   <li className={`tab-item ${this.props.currentTab === 3 ? "active" : ""}`}>
                     <Link
-                      to={this.generateBaseUrl() + "/summary"}
+                      to={routes.summary}
                       tabIndex={this.props.currentTab === 3 ? -1 : 0}
                       onClick={() => {
                         window.gtag("event", "summary-tab");
@@ -212,7 +209,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 mobileShow={this.state.detailMobileSlide}
                 userAddr={searchAddr}
                 onCloseDetail={this.handleCloseDetail}
-                generateBaseUrl={this.generateBaseUrl}
+                addressPageRoutes={routes}
               />
             </div>
             <div
@@ -225,7 +222,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 state={state}
                 send={send}
                 onBackToOverview={this.handleAddrChange}
-                generateBaseUrl={this.generateBaseUrl}
+                addressPageRoutes={routes}
               />
             </div>
             <div
@@ -237,7 +234,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 state={state}
                 send={send}
                 onOpenDetail={this.handleAddrChange}
-                generateBaseUrl={this.generateBaseUrl}
+                addressPageRoutes={routes}
               />
             </div>
             <div

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -20,7 +20,7 @@ import Page from "../components/Page";
 import { SearchResults, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
 import { WithMachineProps } from "state-machine";
-import NotFoundPage from "./NotFoundPage";
+import { AddrNotFoundPage } from "./NotFoundPage";
 import { searchAddrsAreEqual } from "util/helpers";
 import { createAddressPageRoutes } from "routes";
 
@@ -111,7 +111,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
 
     if (state.matches("bblNotFound")) {
       window.gtag("event", "bbl-not-found-page");
-      return <NotFoundPage />;
+      return <AddrNotFoundPage />;
     } else if (state.matches("nychaFound")) {
       window.gtag("event", "nycha-page");
       return <NychaPage state={state} send={send} />;

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { Trans, t } from "@lingui/macro";
 
 import "styles/App.css";
@@ -11,8 +11,19 @@ import Modal from "../components/Modal";
 // import top-level containers (i.e. pages)
 import { I18n, LocaleNavLink, LocaleLink as Link, LocaleSwitcher } from "../i18n";
 import { withI18n, withI18nProps } from "@lingui/react";
-import { WhoOwnsWhatRoutes, createWhoOwnsWhatRoutePaths } from "../routes";
+import { createWhoOwnsWhatRoutePaths } from "../routes";
 import { VersionUpgrader } from "./VersionUpgrader";
+import { useMachine } from "@xstate/react";
+import HomePage from "./HomePage";
+import AddressPage from "./AddressPage";
+import BBLPage from "./BBLPage";
+import AboutPage from "./AboutPage";
+import HowToUsePage from "./HowToUsePage";
+import MethodologyPage from "./Methodology";
+import TermsOfUsePage from "./TermsOfUsePage";
+import PrivacyPolicyPage from "./PrivacyPolicyPage";
+import { DevPage } from "./DevPage";
+import { wowMachine } from "state-machine";
 
 type Props = {};
 
@@ -35,6 +46,42 @@ const HomeLink = withI18n()((props: withI18nProps) => {
     </Link>
   );
 });
+
+const WhoOwnsWhatRoutes: React.FC<{}> = () => {
+  const paths = createWhoOwnsWhatRoutePaths("/:locale");
+  const [state, send] = useMachine(wowMachine);
+  const machineProps = { state, send };
+  return (
+    <Switch>
+      <Route exact path={paths.home} component={HomePage} />
+      <Route
+        path={paths.addressPage.overview}
+        render={(props) => <AddressPage currentTab={0} {...machineProps} {...props} />}
+        exact
+      />
+      <Route
+        path={paths.addressPage.timeline}
+        render={(props) => <AddressPage currentTab={1} {...machineProps} {...props} />}
+      />
+      <Route
+        path={paths.addressPage.portfolio}
+        render={(props) => <AddressPage currentTab={2} {...machineProps} {...props} />}
+      />
+      <Route
+        path={paths.addressPage.summary}
+        render={(props) => <AddressPage currentTab={3} {...machineProps} {...props} />}
+      />
+      <Route path={paths.bbl} component={BBLPage} />
+      <Route path={paths.bblWithFullBblInUrl} component={BBLPage} />
+      <Route path={paths.about} component={AboutPage} />
+      <Route path={paths.howToUse} component={HowToUsePage} />
+      <Route path={paths.methodology} component={MethodologyPage} />
+      <Route path={paths.termsOfUse} component={TermsOfUsePage} />
+      <Route path={paths.privacyPolicy} component={PrivacyPolicyPage} />
+      <Route path={paths.dev} component={DevPage} />
+    </Switch>
+  );
+};
 
 export default class App extends Component<Props, State> {
   constructor(props: Props) {

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -24,6 +24,7 @@ import TermsOfUsePage from "./TermsOfUsePage";
 import PrivacyPolicyPage from "./PrivacyPolicyPage";
 import { DevPage } from "./DevPage";
 import { wowMachine } from "state-machine";
+import { NotFoundPage } from "./NotFoundPage";
 
 type Props = {};
 
@@ -79,6 +80,7 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
       <Route path={paths.termsOfUse} component={TermsOfUsePage} />
       <Route path={paths.privacyPolicy} component={PrivacyPolicyPage} />
       <Route path={paths.dev} component={DevPage} />
+      <Route component={NotFoundPage} />
     </Switch>
   );
 };

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -6,7 +6,7 @@ import { RouteComponentProps, useHistory } from "react-router";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
 import { createRouteForAddressPage } from "../routes";
-import NotFoundPage from "./NotFoundPage";
+import { AddrNotFoundPage } from "./NotFoundPage";
 import { reportError } from "error-reporting";
 
 // This will be *either* bbl *or* boro, block, and lot.
@@ -67,7 +67,7 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
   }, [fullBBL, history]);
 
   return isNotFound ? (
-    <NotFoundPage />
+    <AddrNotFoundPage />
   ) : (
     <Page>
       <Loader loading={true} classNames="Loader-map">

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -55,11 +55,7 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
             setIsNotFound(true);
             return;
           }
-          const addressPage = createRouteForAddressPage({
-            boro: results.result[0].boro,
-            housenumber: results.result[0].housenumber,
-            streetname: results.result[0].streetname,
-          });
+          const addressPage = createRouteForAddressPage(results.result[0]);
           history.replace(addressPage);
         })
         .catch(reportError);

--- a/client/src/containers/NotFoundPage.tsx
+++ b/client/src/containers/NotFoundPage.tsx
@@ -13,7 +13,7 @@ export const ErrorPageScaffolding = (props: { children: React.ReactNode }) => (
   </div>
 );
 
-const NotFoundPageWithoutI18n: React.FC<withI18nProps> = (props) => {
+const AddrNotFoundPageWithoutI18n: React.FC<withI18nProps> = (props) => {
   const i18n = props.i18n;
   return (
     <Page title={i18n._(t`No address found`)}>
@@ -24,6 +24,15 @@ const NotFoundPageWithoutI18n: React.FC<withI18nProps> = (props) => {
   );
 };
 
-const NotFoundPage = withI18n()(NotFoundPageWithoutI18n);
+export const AddrNotFoundPage = withI18n()(AddrNotFoundPageWithoutI18n);
 
-export default NotFoundPage;
+export const NotFoundPage = withI18n()((props: withI18nProps) => {
+  const i18n = props.i18n;
+  return (
+    <Page title={i18n._(t`Not found`)}>
+      <ErrorPageScaffolding>
+        <Trans>Sorry, the page you are looking for doesn't seem to exist.</Trans>
+      </ErrorPageScaffolding>
+    </Page>
+  );
+});

--- a/client/src/routes.test.tsx
+++ b/client/src/routes.test.tsx
@@ -1,0 +1,28 @@
+import { createAddressPageRoutes } from "routes";
+
+describe("createAddressPageRoutes()", () => {
+  it("prefixes with string when given one", () => {
+    expect(createAddressPageRoutes("/boop").timeline).toBe("/boop/timeline");
+  });
+
+  it("prefixes with address page params when given one", () => {
+    expect(
+      createAddressPageRoutes({
+        boro: "BROOKLYN",
+        housenumber: "654",
+        streetname: "PARK PLACE",
+      }).timeline
+    ).toBe("/address/BROOKLYN/654/PARK%20PLACE/timeline");
+  });
+
+  it("prefixes with address page params and locale when given one", () => {
+    expect(
+      createAddressPageRoutes({
+        boro: "BROOKLYN",
+        housenumber: "654",
+        streetname: "PARK PLACE",
+        locale: "es",
+      }).timeline
+    ).toBe("/es/address/BROOKLYN/654/PARK%20PLACE/timeline");
+  });
+});

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -1,20 +1,11 @@
-import React from "react";
-import { Switch, Route } from "react-router-dom";
-import HomePage from "./containers/HomePage";
-import AddressPage from "./containers/AddressPage";
-import BBLPage from "./containers/BBLPage";
-import AboutPage from "./containers/AboutPage";
-import HowToUsePage from "./containers/HowToUsePage";
-import MethodologyPage from "./containers/Methodology";
-import TermsOfUsePage from "./containers/TermsOfUsePage";
-import PrivacyPolicyPage from "./containers/PrivacyPolicyPage";
 import { SearchAddressWithoutBbl } from "components/APIDataTypes";
-import { useMachine } from "@xstate/react";
-import { wowMachine } from "state-machine";
-import { DevPage } from "containers/DevPage";
 import { reportError } from "error-reporting";
 
-export type AddressPageUrlParams = SearchAddressWithoutBbl;
+export type AddressPageUrlParams = SearchAddressWithoutBbl & {
+  locale?: string;
+};
+
+export type AddressPageRoutes = ReturnType<typeof createAddressPageRoutes>;
 
 export const createRouteForAddressPage = (params: AddressPageUrlParams) => {
   let route = `/address/${encodeURIComponent(params.boro)}/${encodeURIComponent(
@@ -26,6 +17,10 @@ export const createRouteForAddressPage = (params: AddressPageUrlParams) => {
     route = route.replace(" ", "%20");
   }
 
+  if (params.locale) {
+    route = `/${params.locale}${route}`;
+  }
+
   return route;
 };
 
@@ -33,16 +28,23 @@ export const createRouteForFullBbl = (bbl: string) => {
   return `/bbl/${bbl}`;
 };
 
-const addressPageRouteWithPlaceholders = "/address/:boro/:housenumber/:streetname";
+export const createAddressPageRoutes = (prefix: string | AddressPageUrlParams) => {
+  if (typeof prefix === "object") {
+    prefix = createRouteForAddressPage(prefix);
+  }
+  return {
+    overview: `${prefix}`,
+    timeline: `${prefix}/timeline`,
+    portfolio: `${prefix}/portfolio`,
+    summary: `${prefix}/summary`,
+  };
+};
 
 export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
   const pathPrefix = prefix || "";
   return {
     home: `${pathPrefix}/`,
-    addressPageOverview: `${pathPrefix}${addressPageRouteWithPlaceholders}`,
-    addressPageTimeline: `${pathPrefix}${addressPageRouteWithPlaceholders}/timeline`,
-    addressPagePortfolio: `${pathPrefix}${addressPageRouteWithPlaceholders}/portfolio`,
-    addressPageSummary: `${pathPrefix}${addressPageRouteWithPlaceholders}/summary`,
+    addressPage: createAddressPageRoutes(`${pathPrefix}/address/:boro/:housenumber/:streetname`),
     /** Note: this path doesn't correspond to a stable page on the site. It simply provides an entry point that
      * immediately redirects to an addressPageOverview. This path is helpful for folks who, say, have a list of
      * boro, block, lot values in a spreadsheet and want to easily generate direct links to WhoOwnsWhat.
@@ -68,39 +70,3 @@ export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
  * In other words, get the current site url without its url paths, i.e. `https://whoownswhat.justfix.nyc`
  */
 export const getSiteOrigin = () => `${window.location.protocol}//${window.location.host}`;
-
-export const WhoOwnsWhatRoutes = () => {
-  const paths = createWhoOwnsWhatRoutePaths("/:locale");
-  const [state, send] = useMachine(wowMachine);
-  const machineProps = { state, send };
-  return (
-    <Switch>
-      <Route exact path={paths.home} component={HomePage} />
-      <Route
-        path={paths.addressPageOverview}
-        render={(props) => <AddressPage currentTab={0} {...machineProps} {...props} />}
-        exact
-      />
-      <Route
-        path={paths.addressPageTimeline}
-        render={(props) => <AddressPage currentTab={1} {...machineProps} {...props} />}
-      />
-      <Route
-        path={paths.addressPagePortfolio}
-        render={(props) => <AddressPage currentTab={2} {...machineProps} {...props} />}
-      />
-      <Route
-        path={paths.addressPageSummary}
-        render={(props) => <AddressPage currentTab={3} {...machineProps} {...props} />}
-      />
-      <Route path={paths.bbl} component={BBLPage} />
-      <Route path={paths.bblWithFullBblInUrl} component={BBLPage} />
-      <Route path={paths.about} component={AboutPage} />
-      <Route path={paths.howToUse} component={HowToUsePage} />
-      <Route path={paths.methodology} component={MethodologyPage} />
-      <Route path={paths.termsOfUse} component={TermsOfUsePage} />
-      <Route path={paths.privacyPolicy} component={PrivacyPolicyPage} />
-      <Route path={paths.dev} component={DevPage} />
-    </Switch>
-  );
-};


### PR DESCRIPTION
This factors out a new function called `createAddressPageRoutes()` which cleans up the creation of links to sub-pages of the address page, making them more type-safe and DRY.

It also moves the `WhoOwnsWhatRoutes` component into `App.tsx` to avoid circular imports.  This is also more ideal: `routes.tsx` should be only concerned with routing pathnames, rather than what routes map to what components, making it as dependency-free as possible so that anything that imports it doesn't also end up importing every module in the codebase (this will come in handy with Jest's detection of dependent tests, as well as if/when we decide to do code splitting).

Unrelatedly, it also removes the double quotes around the word "owns" in the Twitter sharing message, because that was really weird.  (This does mean we'll have to re-translate though, so I could always move it to a different PR...)

Finally, it adds a very spartan 404 page, which fixes #389.  The text on the page is taken from the tenant platform so it's easy to localize.