### PR TITLE
remove all instances of geosupportReturnCode inside GeoSearchData

### DIFF
--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -23,7 +23,6 @@ type HpdOwnerContact = {
 type APIDate = string;
 
 export type GeoSearchData = {
-  geosupportReturnCode: string;
   bbl: string;
 };
 

--- a/client/src/state-machine.test.ts
+++ b/client/src/state-machine.test.ts
@@ -98,7 +98,6 @@ describe("wowMachine", () => {
       [NOT_REG_URLS.ADDRESS_URL]: mockJsonResponse<SearchResults>({
         addrs: [],
         geosearch: {
-          geosupportReturnCode: "00",
           bbl: "3002920026",
         },
       }),
@@ -118,7 +117,6 @@ describe("wowMachine", () => {
       [NOT_REG_URLS.ADDRESS_URL]: mockJsonResponse<SearchResults>({
         addrs: [],
         geosearch: {
-          geosupportReturnCode: "00",
           bbl: "3002920026",
         },
       }),
@@ -138,7 +136,6 @@ describe("wowMachine", () => {
       [NYCHA_URLS.ADDRESS_URL]: mockJsonResponse<SearchResults>({
         addrs: [],
         geosearch: {
-          geosupportReturnCode: "00",
           bbl: "3004040001",
         },
       }),
@@ -158,7 +155,6 @@ describe("wowMachine", () => {
       [PORTFOLIO_URLS.ADDRESS_URL]: mockJsonResponse<SearchResults>({
         addrs: SAMPLE_ADDRESS_RECORDS,
         geosearch: {
-          geosupportReturnCode: "00",
           bbl: "3012380016",
         },
       }),

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -51,7 +51,6 @@ class TestAddressQuery(ApiTest):
         assert len(json['addrs']) > 0
         assert json['geosearch'] == {
             'bbl': '3016780054',
-            'geosupportReturnCode': '00',
         }
 
 

--- a/wow/views.py
+++ b/wow/views.py
@@ -53,7 +53,6 @@ def address_query(request):
 
     return JsonResponse({
         "geosearch": {
-            "geosupportReturnCode": "00",
             "bbl": bbl,
         },
         "addrs": list(cleaned_addrs),


### PR DESCRIPTION
This PR fixes #379 by removing an antiquated and useless piece of our GeoSearch response data.