### PR TITLE
Return HTTP 404 for nonexistent files under /static/.

### DIFF
--- a/client/public/_redirects
+++ b/client/public/_redirects
@@ -1,1 +1,2 @@
-/*  /index.html  200
+/static/* /not-found.html 404
+/*        /index.html     200

--- a/client/public/not-found.html
+++ b/client/public/not-found.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Not Found</title>
+<h1>Not Found</h1>


### PR DESCRIPTION
It seems #169 re-emerged when we moved the front-end over to Netlify, because Netlify is currently returning the WoW index page with a status of 200 for _every_ URL, including static assets.  This modifies our `_redirects` to actually return 404 for such files, which should hopefully result in less spurious syntax errors coming from Rollbar.