### PR TITLE
Added spaces back into the Data Request URL

### DIFF
--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -149,7 +149,7 @@ export default class PropertiesSummary extends Component<Props, {}> {
                         window.gtag("event", "data-request");
                       }}
                       href={generateLinkToDataRequestForm(
-                        `${searchAddr.housenumber}${searchAddr.streetname},${searchAddr.boro}`
+                        `${searchAddr.housenumber} ${searchAddr.streetname}, ${searchAddr.boro}`
                       )}
                       target="_blank"
                       rel="noopener noreferrer"


### PR DESCRIPTION
This PR adds in some spaces into the "full address" parameter we include in the URL to our Data Request Google Form. It fixes an issue where addresses would show up on the form improperly formatted, like `921EAST 145TH STREET,BRONX`.