### PR TITLE
Support property maps with no pins.

### DIFF
--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import ReactMapboxGl, { Layer, Feature, ZoomControl } from "react-mapbox-gl";
 import Helpers from "../util/helpers";
 import Browser from "../util/browser";
-import MapHelpers, { LatLng } from "../util/mapping";
+import MapHelpers, { LatLng, BoundingBox } from "../util/mapping";
 
 import Loader from "../components/Loader";
 
@@ -38,7 +38,7 @@ const Map = ReactMapboxGl({
   accessToken: MAPBOX_ACCESS_TOKEN,
 });
 
-const DEFAULT_FIT_BOUNDS: number[][] = [
+const DEFAULT_FIT_BOUNDS: BoundingBox = [
   [-74.259087, 40.477398],
   [-73.700172, 40.917576],
 ];
@@ -141,8 +141,7 @@ export default class PropertiesMap extends Component<Props, State> {
     });
     // see getBoundingBox() for deets
     const pointsArray = Array.from(addrsPos) as LatLng[];
-    const newAddrsBounds =
-      pointsArray.length > 0 ? MapHelpers.getBoundingBox(pointsArray) : DEFAULT_FIT_BOUNDS;
+    const newAddrsBounds = MapHelpers.getBoundingBox(pointsArray, DEFAULT_FIT_BOUNDS);
 
     // sets things up, including initial portfolio level map view
     this.setState(

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -38,13 +38,15 @@ const Map = ReactMapboxGl({
   accessToken: MAPBOX_ACCESS_TOKEN,
 });
 
+const DEFAULT_FIT_BOUNDS: number[][] = [
+  [-74.259087, 40.477398],
+  [-73.700172, 40.917576],
+];
+
 const MAP_CONFIGURABLES = {
   style: MAPBOX_STYLE,
   containerStyle: { width: "100%", height: "100%" },
-  fitBounds: [
-    [-74.259087, 40.477398],
-    [-73.700172, 40.917576],
-  ],
+  fitBounds: DEFAULT_FIT_BOUNDS,
   fitBoundsOptions: {
     padding: { top: 50, bottom: 50, left: 50, right: 50 },
     maxZoom: 20,
@@ -139,7 +141,8 @@ export default class PropertiesMap extends Component<Props, State> {
     });
     // see getBoundingBox() for deets
     const pointsArray = Array.from(addrsPos) as LatLng[];
-    const newAddrsBounds = MapHelpers.getBoundingBox(pointsArray);
+    const newAddrsBounds =
+      pointsArray.length > 0 ? MapHelpers.getBoundingBox(pointsArray) : DEFAULT_FIT_BOUNDS;
 
     // sets things up, including initial portfolio level map view
     this.setState(

--- a/client/src/util/mapping.test.ts
+++ b/client/src/util/mapping.test.ts
@@ -7,15 +7,36 @@ test("latLngIsNull() works", () => {
   expect(mapping.latLngIsNull([1, 2])).toBe(false);
 });
 
-test("getBoundingBox() works", () => {
+test("getBoundingBox() calculates bounding box", () => {
   expect(
-    mapping.getBoundingBox([
-      [2, 3],
-      [0.5, 2.2],
-      [0, 1],
-    ])
+    mapping.getBoundingBox(
+      [
+        [2, 3],
+        [0.5, 2.2],
+        [0, 1],
+      ],
+      [
+        [0, 0],
+        [0, 0],
+      ]
+    )
   ).toEqual([
     [0, 1],
     [2, 3],
+  ]);
+});
+
+test("getBoundingBox() returns default if array is empty", () => {
+  expect(
+    mapping.getBoundingBox(
+      [],
+      [
+        [1, 2],
+        [3, 4],
+      ]
+    )
+  ).toEqual([
+    [1, 2],
+    [3, 4],
   ]);
 });

--- a/client/src/util/mapping.ts
+++ b/client/src/util/mapping.ts
@@ -1,12 +1,18 @@
 export type LatLng = [number, number];
 
+export type BoundingBox = [LatLng, LatLng];
+
 export default {
   // need to check if either lat or lng is NaN. Occurs for ~0.5% of addresses
   latLngIsNull(latlng: LatLng): boolean {
     return latlng.filter(isNaN).length > 0;
   },
 
-  getBoundingBox(latlngs: LatLng[]): [LatLng, LatLng] {
+  getBoundingBox(latlngs: LatLng[], defaultBox: BoundingBox): BoundingBox {
+    if (latlngs.length === 0) {
+      return defaultBox;
+    }
+
     let bs = {
       xMin: Infinity,
       yMin: Infinity,


### PR DESCRIPTION
This fixes #405.  The problem arises when a portfolio only contains addresses with `null` latitude/longitude information, such as (at the time of this writing) "3070 Brighton 14th Street, Brooklyn".  This causes our bounding box calculation algorithm to return an _infinite_ bounding box which Mapbox really dislikes.

This resolves the situation by setting the default map bounds to be the NYC area instead of an infinite box.  I'm not sure if it's actually the most user-friendly fix since the user may be confused and wondering where the map pins are, but at least the entire page doesn't crash and the user can see other information about the properties?