### PR TITLE
Clean up DetailView component 

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -15,7 +15,6 @@ import { Link } from "react-router-dom";
 import { LocaleLink } from "../i18n";
 import BuildingStatsTable from "./BuildingStatsTable";
 import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
-import { AddressRecord } from "./APIDataTypes";
 import { SupportedLocale } from "../i18n-base";
 import { withMachineInStateProps } from "state-machine";
 

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -17,10 +17,10 @@ import BuildingStatsTable from "./BuildingStatsTable";
 import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
 import { AddressRecord } from "./APIDataTypes";
 import { SupportedLocale } from "../i18n-base";
-import { WithMachineInStateProps } from "state-machine";
+import { withMachineInStateProps } from "state-machine";
 
 type Props = withI18nProps &
-  WithMachineInStateProps<"portfolioFound"> & {
+  withMachineInStateProps<"portfolioFound"> & {
     mobileShow: boolean;
     onCloseDetail: () => void;
     addressPageRoutes: AddressPageRoutes;

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -98,7 +98,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     );
 
     return (
-      <CSSTransition in={this.props.mobileShow} timeout={500} classNames="DetailView">
+      <CSSTransition in={!isMobile || this.props.mobileShow} timeout={500} classNames="DetailView">
         <div className={`DetailView`}>
           <div className="DetailView__wrapper">
             {detailAddr && (

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -58,40 +58,31 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const portfolioSize = assocAddrs.length;
 
     // Let's save some variables that will be helpful in rendering the front-end component
-    let boro,
-      block,
-      lot,
-      takeActionURL,
-      formattedRegEndDate,
-      streetViewAddr,
-      ownernames,
-      userOwnernames;
+    let takeActionURL, formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
 
-    if (detailAddr) {
-      ({ boro, block, lot } = Helpers.splitBBL(detailAddr.bbl));
+    const { boro, block, lot } = Helpers.splitBBL(detailAddr.bbl);
 
-      takeActionURL = Helpers.createTakeActionURL(detailAddr, "detail_view");
+    takeActionURL = Helpers.createTakeActionURL(detailAddr, "detail_view");
 
-      formattedRegEndDate = Helpers.formatDate(
-        detailAddr.registrationenddate,
-        longDateOptions,
-        locale
-      );
+    formattedRegEndDate = Helpers.formatDate(
+      detailAddr.registrationenddate,
+      longDateOptions,
+      locale
+    );
 
-      streetViewAddr =
-        detailAddr.lat && detailAddr.lng
-          ? {
-              lat: detailAddr.lat,
-              lng: detailAddr.lng,
-            }
-          : null;
+    streetViewAddr =
+      detailAddr.lat && detailAddr.lng
+        ? {
+            lat: detailAddr.lat,
+            lng: detailAddr.lng,
+          }
+        : null;
 
-      if (detailAddr.ownernames && detailAddr.ownernames.length)
-        ownernames = Helpers.uniq(detailAddr.ownernames);
+    if (detailAddr.ownernames && detailAddr.ownernames.length)
+      ownernames = Helpers.uniq(detailAddr.ownernames);
 
-      if (searchAddr.ownernames && searchAddr.ownernames.length)
-        userOwnernames = Helpers.uniq(searchAddr.ownernames);
-    }
+    if (searchAddr.ownernames && searchAddr.ownernames.length)
+      userOwnernames = Helpers.uniq(searchAddr.ownernames);
 
     const streetView = streetViewAddr ? (
       <LazyLoadWhenVisible>
@@ -371,109 +362,107 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                 </div>
               </div>
             )}
-            {detailAddr && (
-              <Modal
-                showModal={this.state.showCompareModal}
-                width={70}
-                onClose={() => this.setState({ showCompareModal: false })}
-              >
-                <h6>
-                  <Trans render="b">How is this building associated to this portfolio?</Trans>
-                </h6>
-                <Trans render="p">
-                  We compare your search address with a database of over 200k buildings to identify
-                  a landlord or management company's portfolio. To learn more, check out{" "}
-                  <LocaleLink to={createWhoOwnsWhatRoutePaths().methodology}>
-                    our methodology
-                  </LocaleLink>
-                  .
-                </Trans>
-                <table className="DetailView__compareTable">
-                  <thead>
-                    <tr>
-                      <th>
-                        {searchAddr.housenumber} {searchAddr.streetname}, {searchAddr.boro}
-                      </th>
-                      <th>
-                        {detailAddr.housenumber} {detailAddr.streetname}, {detailAddr.boro}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>
-                        <div>
-                          <Trans>Business Entities</Trans>
-                        </div>
+            <Modal
+              showModal={this.state.showCompareModal}
+              width={70}
+              onClose={() => this.setState({ showCompareModal: false })}
+            >
+              <h6>
+                <Trans render="b">How is this building associated to this portfolio?</Trans>
+              </h6>
+              <Trans render="p">
+                We compare your search address with a database of over 200k buildings to identify a
+                landlord or management company's portfolio. To learn more, check out{" "}
+                <LocaleLink to={createWhoOwnsWhatRoutePaths().methodology}>
+                  our methodology
+                </LocaleLink>
+                .
+              </Trans>
+              <table className="DetailView__compareTable">
+                <thead>
+                  <tr>
+                    <th>
+                      {searchAddr.housenumber} {searchAddr.streetname}, {searchAddr.boro}
+                    </th>
+                    <th>
+                      {detailAddr.housenumber} {detailAddr.streetname}, {detailAddr.boro}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <div>
+                        <Trans>Business Entities</Trans>
+                      </div>
+                      <ul>
+                        {searchAddr.corpnames &&
+                          searchAddr.corpnames.map((corp, idx) => <li key={idx}>{corp}</li>)}
+                      </ul>
+                    </td>
+                    <td>
+                      <div>
+                        <Trans>Business Entities</Trans>
+                      </div>
+                      <ul>
+                        {detailAddr.corpnames &&
+                          detailAddr.corpnames.map((corp, idx) => <li key={idx}>{corp}</li>)}
+                      </ul>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div>
+                        <Trans>Business Addresses</Trans>
+                      </div>
+                      <ul>
+                        {searchAddr.businessaddrs &&
+                          searchAddr.businessaddrs.map((rba, idx) => <li key={idx}>{rba}</li>)}
+                      </ul>
+                    </td>
+                    <td>
+                      <div>
+                        <Trans>Business Addresses</Trans>
+                      </div>
+                      <ul>
+                        {detailAddr.businessaddrs &&
+                          detailAddr.businessaddrs.map((rba, idx) => <li key={idx}>{rba}</li>)}
+                      </ul>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div>
+                        <Trans>People</Trans>
+                      </div>
+                      {userOwnernames && (
                         <ul>
-                          {searchAddr.corpnames &&
-                            searchAddr.corpnames.map((corp, idx) => <li key={idx}>{corp}</li>)}
+                          {userOwnernames.map((owner, idx) => (
+                            <li key={idx}>
+                              {owner.title.split(/(?=[A-Z])/).join(" ")}: {owner.value}
+                            </li>
+                          ))}
                         </ul>
-                      </td>
-                      <td>
-                        <div>
-                          <Trans>Business Entities</Trans>
-                        </div>
+                      )}
+                    </td>
+                    <td>
+                      <div>
+                        <Trans>People</Trans>
+                      </div>
+                      {ownernames && (
                         <ul>
-                          {detailAddr.corpnames &&
-                            detailAddr.corpnames.map((corp, idx) => <li key={idx}>{corp}</li>)}
+                          {ownernames.map((owner, idx) => (
+                            <li key={idx}>
+                              {owner.title.split(/(?=[A-Z])/).join(" ")}: {owner.value}
+                            </li>
+                          ))}
                         </ul>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <div>
-                          <Trans>Business Addresses</Trans>
-                        </div>
-                        <ul>
-                          {searchAddr.businessaddrs &&
-                            searchAddr.businessaddrs.map((rba, idx) => <li key={idx}>{rba}</li>)}
-                        </ul>
-                      </td>
-                      <td>
-                        <div>
-                          <Trans>Business Addresses</Trans>
-                        </div>
-                        <ul>
-                          {detailAddr.businessaddrs &&
-                            detailAddr.businessaddrs.map((rba, idx) => <li key={idx}>{rba}</li>)}
-                        </ul>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <div>
-                          <Trans>People</Trans>
-                        </div>
-                        {userOwnernames && (
-                          <ul>
-                            {userOwnernames.map((owner, idx) => (
-                              <li key={idx}>
-                                {owner.title.split(/(?=[A-Z])/).join(" ")}: {owner.value}
-                              </li>
-                            ))}
-                          </ul>
-                        )}
-                      </td>
-                      <td>
-                        <div>
-                          <Trans>People</Trans>
-                        </div>
-                        {ownernames && (
-                          <ul>
-                            {ownernames.map((owner, idx) => (
-                              <li key={idx}>
-                                {owner.title.split(/(?=[A-Z])/).join(" ")}: {owner.value}
-                              </li>
-                            ))}
-                          </ul>
-                        )}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </Modal>
-            )}
+                      )}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </Modal>
           </div>
         </div>
       </CSSTransition>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -22,6 +22,7 @@ import { withMachineInStateProps } from "state-machine";
 type Props = withI18nProps &
   withMachineInStateProps<"portfolioFound"> & {
     mobileShow: boolean;
+    onOpenDetail: () => void;
     onCloseDetail: () => void;
     addressPageRoutes: AddressPageRoutes;
   };
@@ -39,6 +40,10 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     this.state = {
       showCompareModal: false,
     };
+  }
+
+  componentDidMount() {
+    this.props.onOpenDetail();
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -1,6 +1,6 @@
 import { IndicatorsDatasetId } from "./IndicatorsDatasets";
 import { withI18nProps } from "@lingui/react";
-import { WithMachineInStateProps } from "state-machine";
+import { withMachineInStateProps } from "state-machine";
 import { AddressPageRoutes } from "routes";
 
 export type IndicatorsTimeSpan = "month" | "quarter" | "year";
@@ -119,7 +119,7 @@ export const indicatorsInitialState: IndicatorsState = {
 // Types Relating to the Props of the Indicators Component:
 
 export type IndicatorsProps = withI18nProps &
-  WithMachineInStateProps<"portfolioFound"> & {
+  withMachineInStateProps<"portfolioFound"> & {
     isVisible: boolean;
     onBackToOverview: (bbl: string) => void;
     addressPageRoutes: AddressPageRoutes;

--- a/client/src/components/IndicatorsViz.tsx
+++ b/client/src/components/IndicatorsViz.tsx
@@ -16,12 +16,12 @@ import "styles/Indicators.css";
 import { IndicatorsState } from "./IndicatorsTypes";
 import { SupportedLocale } from "../i18n-base";
 import { ChartOptions } from "chart.js";
-import { WithMachineInStateProps } from "state-machine";
+import { withMachineInStateProps } from "state-machine";
 
 const DEFAULT_ANIMATION_MS = 1000;
 const MONTH_ANIMATION_MS = 2500;
 
-type IndicatorVizProps = WithMachineInStateProps<{ portfolioFound: { timeline: "success" } }> &
+type IndicatorVizProps = withMachineInStateProps<{ portfolioFound: { timeline: "success" } }> &
   IndicatorsState;
 
 type IndicatorVizState = IndicatorsState & {
@@ -108,7 +108,7 @@ function makeAnnotations(
 }
 
 type IndicatorVizImplementationProps = withI18nProps &
-  WithMachineInStateProps<{ portfolioFound: { timeline: "success" } }> &
+  withMachineInStateProps<{ portfolioFound: { timeline: "success" } }> &
   IndicatorVizState;
 
 class IndicatorsVizImplementation extends Component<IndicatorVizImplementationProps> {

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -11,7 +11,7 @@ import { Link } from "react-router-dom";
 import { SupportedLocale } from "../i18n-base";
 import Helpers, { longDateOptions } from "../util/helpers";
 import { AddressRecord } from "./APIDataTypes";
-import { WithMachineInStateProps } from "state-machine";
+import { withMachineInStateProps } from "state-machine";
 import { AddressPageRoutes } from "routes";
 
 export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
@@ -20,7 +20,7 @@ export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
 };
 
 const PropertiesListWithoutI18n: React.FC<
-  WithMachineInStateProps<"portfolioFound"> & {
+  withMachineInStateProps<"portfolioFound"> & {
     i18n: I18n;
     onOpenDetail: (bbl: string) => void;
     addressPageRoutes: AddressPageRoutes;

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -12,9 +12,9 @@ import { Trans, Select } from "@lingui/macro";
 import { AddressRecord } from "./APIDataTypes";
 import { Props as MapboxMapProps } from "react-mapbox-gl/lib/map";
 import { Events as MapboxMapEvents } from "react-mapbox-gl/lib/map-events";
-import { WithMachineInStateProps } from "state-machine";
+import { withMachineInStateProps } from "state-machine";
 
-type Props = WithMachineInStateProps<"portfolioFound"> & {
+type Props = withMachineInStateProps<"portfolioFound"> & {
   onAddrChange: (bbl: string) => void;
   isVisible: boolean;
 };

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -10,10 +10,10 @@ import { RentstabSummary } from "./RentstabSummary";
 import { ViolationsSummary } from "./ViolationsSummary";
 import { StringifyListWithConjunction } from "./StringifyList";
 import { SocialSharePortfolio } from "./SocialShare";
-import { WithMachineInStateProps } from "state-machine";
+import { withMachineInStateProps } from "state-machine";
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
 
-type Props = WithMachineInStateProps<"portfolioFound"> & {
+type Props = withMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
 };
 

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -86,7 +86,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     this.setState({
       detailMobileSlide: true,
     });
-  }
+  };
 
   handleCloseDetail = () => {
     this.setState({
@@ -125,7 +125,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
       return <NotRegisteredPage state={state} send={send} />;
     } else if (state.matches("portfolioFound")) {
       window.gtag("event", "portfolio-found-page");
-      const { detailAddr, assocAddrs, searchAddr } = state.context.portfolioData;
+      const { assocAddrs, searchAddr } = state.context.portfolioData;
       const routes = createAddressPageRoutes(validateRouteParams(this.props.match.params));
 
       return (

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import FileSaver from "file-saver";
-import Browser from "../util/browser";
 
 import AddressToolbar from "../components/AddressToolbar";
 import PropertiesMap from "../components/PropertiesMap";

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -148,15 +148,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 </h1>
                 <ul className="tab tab-block">
                   <li className={`tab-item ${this.props.currentTab === 0 ? "active" : ""}`}>
-                    <Link
-                      to={routes.overview}
-                      tabIndex={this.props.currentTab === 0 ? -1 : 0}
-                      onClick={() => {
-                        if (Browser.isMobile() && this.state.detailMobileSlide) {
-                          this.handleCloseDetail();
-                        }
-                      }}
-                    >
+                    <Link to={routes.overview} tabIndex={this.props.currentTab === 0 ? -1 : 0}>
                       <Trans>Overview</Trans>
                     </Link>
                   </li>

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -19,7 +19,7 @@ import { Link, RouteComponentProps } from "react-router-dom";
 import Page from "../components/Page";
 import { SearchResults, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
-import { WithMachineProps } from "state-machine";
+import { withMachineProps } from "state-machine";
 import { AddrNotFoundPage } from "./NotFoundPage";
 import { searchAddrsAreEqual } from "util/helpers";
 import { NetworkErrorMessage } from "components/NetworkErrorMessage";
@@ -37,7 +37,7 @@ type RouteState = {
 };
 
 type AddressPageProps = RouteComponentProps<RouteParams, {}, RouteState> &
-  WithMachineProps & {
+  withMachineProps & {
     currentTab: number;
   };
 

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -82,6 +82,18 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     send({ type: "SEARCH", address: validateRouteParams(match.params) });
   }
 
+  handleOpenDetail = () => {
+    this.setState({
+      detailMobileSlide: true,
+    });
+  }
+
+  handleCloseDetail = () => {
+    this.setState({
+      detailMobileSlide: false,
+    });
+  };
+
   handleAddrChange = (newFocusBbl: string) => {
     if (!this.props.state.matches("portfolioFound")) {
       throw new Error("A change of detail address was attempted without any portfolio data found.");
@@ -89,15 +101,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     const detailBbl = this.props.state.context.portfolioData.detailAddr.bbl;
     if (newFocusBbl !== detailBbl)
       this.props.send({ type: "SELECT_DETAIL_ADDR", bbl: newFocusBbl });
-    this.setState({
-      detailMobileSlide: true,
-    });
-  };
-
-  handleCloseDetail = () => {
-    this.setState({
-      detailMobileSlide: false,
-    });
+    this.handleOpenDetail();
   };
 
   // should this properly live in AddressToolbar? you tell me
@@ -207,6 +211,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 state={state}
                 send={send}
                 mobileShow={this.state.detailMobileSlide}
+                onOpenDetail={this.handleOpenDetail}
                 onCloseDetail={this.handleCloseDetail}
                 addressPageRoutes={routes}
               />

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -204,11 +204,9 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 isVisible={this.props.currentTab === 0}
               />
               <DetailView
-                addrs={assocAddrs}
-                addr={detailAddr}
-                portfolioSize={assocAddrs.length}
+                state={state}
+                send={send}
                 mobileShow={this.state.detailMobileSlide}
-                userAddr={searchAddr}
                 onCloseDetail={this.handleCloseDetail}
                 addressPageRoutes={routes}
               />

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -13,7 +13,7 @@ import AddressSearch, { SearchAddress } from "../components/AddressSearch";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
 import { createRouteForAddressPage } from "../routes";
-import { WithMachineProps } from "state-machine";
+import { withMachineProps } from "state-machine";
 import { useHistory } from "react-router-dom";
 import { CovidMoratoriumBanner } from "@justfixnyc/react-common";
 import { withI18n, withI18nProps } from "@lingui/react";
@@ -68,7 +68,7 @@ const getSampleUrls = () => [
   }),
 ];
 
-const HomePage: React.FC<WithMachineProps> = (props) => {
+const HomePage: React.FC<withMachineProps> = (props) => {
   const handleFormSubmit = (searchAddress: SearchAddress, error: any) => {
     window.gtag("event", "search");
 

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -9,10 +9,10 @@ import LegalFooter from "../components/LegalFooter";
 import Helpers from "../util/helpers";
 import SocialShare from "../components/SocialShare";
 import { Nobr } from "../components/Nobr";
-import { WithMachineInStateProps } from "state-machine";
+import { withMachineInStateProps } from "state-machine";
 import Page from "components/Page";
 
-type Props = WithMachineInStateProps<"unregisteredFound">;
+type Props = withMachineInStateProps<"unregisteredFound">;
 
 type State = {
   showModal: boolean;

--- a/client/src/containers/NychaPage.tsx
+++ b/client/src/containers/NychaPage.tsx
@@ -9,7 +9,7 @@ import { Trans, t } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { Nobr } from "../components/Nobr";
 import { SocialShareForNotRegisteredPage } from "./NotRegisteredPage";
-import { WithMachineInStateProps } from "state-machine";
+import { withMachineInStateProps } from "state-machine";
 import Page from "components/Page";
 
 export type NychaData = {
@@ -19,7 +19,7 @@ export type NychaData = {
   dev_unitsres: number;
 };
 
-type NychaPageProps = WithMachineInStateProps<"nychaFound"> & withI18nProps;
+type NychaPageProps = withMachineInStateProps<"nychaFound"> & withI18nProps;
 
 const NychaPageWithoutI18n: React.FC<NychaPageProps> = (props) => {
   const { i18n, state } = props;

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -152,12 +152,12 @@ type WowMachineInState<
   WowStateByAnotherName
 >;
 
-export type WithMachineProps = {
+export type withMachineProps = {
   state: WowMachineEverything;
   send: (event: WowEvent) => WowMachineEverything;
 };
 
-export type WithMachineInStateProps<TSV extends WowState["value"]> = {
+export type withMachineInStateProps<TSV extends WowState["value"]> = {
   state: WowMachineInState<TSV>;
   send: (event: WowEvent) => WowMachineEverything;
 };


### PR DESCRIPTION
This PR fixes #409 and #410— namely, it refactors the DetailView component like we did other AddressPage child components so we don't have to pass it the addr and addrs props down from its parent. It also introduces a new handler called `onOpenDetail` that makes sure to bring in the DetailView on mobile when a user mounts the address page for the first time.

