### PR TITLE
Update COVID-19 banner

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "@babel/core": "^7.7.2",
     "@contentful/rich-text-react-renderer": "^13.4.0",
     "@justfixnyc/geosearch-requester": "0.0.6",
-    "@justfixnyc/react-common": "0.0.3",
+    "@justfixnyc/react-common": "^0.0.3",
     "@lingui/cli": "^2.8.3",
     "@lingui/macro": "^2.8.3",
     "@lingui/react": "^2.8.3",

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "@babel/core": "^7.7.2",
     "@contentful/rich-text-react-renderer": "^13.4.0",
     "@justfixnyc/geosearch-requester": "0.0.6",
-    "@justfixnyc/react-common": "^0.0.2",
+    "@justfixnyc/react-common": "0.0.3",
     "@lingui/cli": "^2.8.3",
     "@lingui/macro": "^2.8.3",
     "@lingui/react": "^2.8.3",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2244,10 +2244,10 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.6.tgz#af3144a8b599e45ad3ce5c2190fc60da81106475"
   integrity sha512-wHsY9DbiQUp7H/KiQ4+ejTShR6lY3iagiFhw4VoP1kljyem+WIwEkiZNnvUHkOAQIkTtPulLaiKHEMpzaw9xZQ==
 
-"@justfixnyc/react-common@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.2.tgz#180f47ccc31f21baac6813484b5de52f4953cb5c"
-  integrity sha512-YU/lEuEFXKdJtmtzQUG2EkUd9pS/inaZezCqsVFDZbLUC8M2atBTpMIfkFKsQyWf4dGMyUlXvzSqjF1r8DV2Tg==
+"@justfixnyc/react-common@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.3.tgz#c5ae7c7931487ab6256c525339d12bebddf1f482"
+  integrity sha512-HYRPG1NADdr7oQwZ/bl0Hluo0ckaKW2QWnsCYJhrKP4ubDLyNZGzDOTPqO6zUGZZ4mUG4iQmdpSbugNcGFsPjA==
 
 "@lingui/babel-plugin-extract-messages@2.8.3":
   version "2.8.3"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2244,7 +2244,7 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.6.tgz#af3144a8b599e45ad3ce5c2190fc60da81106475"
   integrity sha512-wHsY9DbiQUp7H/KiQ4+ejTShR6lY3iagiFhw4VoP1kljyem+WIwEkiZNnvUHkOAQIkTtPulLaiKHEMpzaw9xZQ==
 
-"@justfixnyc/react-common@0.0.3":
+"@justfixnyc/react-common@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.3.tgz#c5ae7c7931487ab6256c525339d12bebddf1f482"
   integrity sha512-HYRPG1NADdr7oQwZ/bl0Hluo0ckaKW2QWnsCYJhrKP4ubDLyNZGzDOTPqO6zUGZZ4mUG4iQmdpSbugNcGFsPjA==


### PR DESCRIPTION
This is a routine update of our `react-common` package from our justfix-ts monorepo to reflect new changes to our COVID-19 product banner.