### PR TITLE
Add definition of `anyarray_uniq` function to helpers sql

### DIFF
--- a/sql/helper_functions.sql
+++ b/sql/helper_functions.sql
@@ -1,4 +1,4 @@
--- https://github.com/JDBurnZ/postgresql-anyarray/blob/master/stable/anyarray_uniq.sql
+-- SOURCE: https://github.com/JDBurnZ/postgresql-anyarray/blob/master/stable/anyarray_uniq.sql
 DROP FUNCTION IF EXISTS anyarray_uniq(anyarray);
 CREATE OR REPLACE FUNCTION anyarray_uniq(with_array anyarray)
 	RETURNS anyarray AS
@@ -37,7 +37,7 @@ $BODY$
  END;
 $BODY$ LANGUAGE plpgsql;
 
--- https://github.com/aepyornis/hpd/blob/master/sql/anyarray_remove_null.sql
+-- SOURCE: https://github.com/JDBurnZ/postgresql-anyarray/blob/master/stable/anyarray_remove_null.sql
 DROP FUNCTION IF EXISTS anyarray_remove_null(anyarray);
 CREATE OR REPLACE FUNCTION anyarray_remove_null(from_array anyarray)
         RETURNS anyarray AS
@@ -60,7 +60,8 @@ $BODY$
         END;
 $BODY$ LANGUAGE plpgsql;
 
---  see: https://stackoverflow.com/questions/22677463/how-to-merge-all-integer-arrays-from-all-records-into-single-array-in-postgres/22677955#22677955
+-- HELPFUL LINKS:
+-- https://stackoverflow.com/questions/22677463/how-to-merge-all-integer-arrays-from-all-records-into-single-array-in-postgres/22677955#22677955
 DROP AGGREGATE IF EXISTS array_cat_agg(anyarray);
 CREATE AGGREGATE array_cat_agg(anyarray) (
   SFUNC=array_cat,
@@ -85,7 +86,7 @@ $$ LANGUAGE SQL;
 
 
 
-
+-- HELPFUL LINKS:
 -- http://blog.scoutapp.com/articles/2016/07/12/how-to-make-text-searches-in-postgresql-faster-with-trigram-similarity
 -- http://www.postgresonline.com/journal/archives/169-Fuzzy-string-matching-with-Trigram-and-Trigraphs.html
 

--- a/sql/registrations_with_contacts.sql
+++ b/sql/registrations_with_contacts.sql
@@ -1,31 +1,9 @@
--- https://github.com/aepyornis/hpd/blob/master/sql/anyarray_remove_null.sql
-DROP FUNCTION IF EXISTS anyarray_remove_null(anyarray);
-CREATE OR REPLACE FUNCTION anyarray_remove_null(from_array anyarray)
-        RETURNS anyarray AS
-$BODY$
-        DECLARE
-                -- The variable used to track iteration over "from_array".
-                loop_offset integer;
-
-                -- The array to be returned by this function.
-                return_array from_array%TYPE;
-        BEGIN
-                -- Iterate over each element in "from_array".
-                FOR loop_offset IN ARRAY_LOWER(from_array, 1)..ARRAY_UPPER(from_array, 1) LOOP
-                        IF from_array[loop_offset] IS NOT NULL THEN -- If NULL, will omit from "return_array".
-                                return_array = ARRAY_APPEND(return_array, from_array[loop_offset]);
-                        END IF;
-                END LOOP;
-
-                RETURN return_array;
-        END;
-$BODY$ LANGUAGE plpgsql;
-
-DROP TABLE IF EXISTS hpd_registrations_with_contacts;
-
 -- This is mainly used as an easy way to provide contact info on request, not a replacement
 -- for cross-table analysis. Hence why the corpnames, businessaddrs, and ownernames are simplified
 -- with JSON and such.
+
+DROP TABLE IF EXISTS hpd_registrations_with_contacts;
+
 CREATE TABLE hpd_registrations_with_contacts
 as SELECT
   registrations.housenumber,

--- a/who-owns-what.yml
+++ b/who-owns-what.yml
@@ -17,9 +17,9 @@ api_dependencies:
 sql:
   # These SQL scripts must be executed in order, as
   # some of them depend on others.
+  - helper_functions.sql
   - registrations_with_contacts.sql
   - create_bldgs_table.sql
-  - helper_functions.sql
   - search_function.sql
   - agg_function.sql
   - landlord_contact.sql


### PR DESCRIPTION
So, it turns out that this function `anyarray_uniq` is NOT a pre-loaded array function that we [get for free through the pg_catalog](https://www.postgresql.org/docs/9.4/functions-array.html). This morning, we started seeing this critical error: 
```
function anyarray_uniq(integer[]) does not exist LINE 8: unnest(anyarray_uniq(array_cat_agg(merged.uniqregids... ^ HINT: No function matches the given name and argument types...
```
and it turns out that `anyarray_uniq` was no longer defined. Given that this function lies within the definition of other vital functions that power key WOW interactions, like `get_assoc_addrs_from_bbl`, our search function.

Since `anyarray_uniq` does not get created through any script that powers our auto-updating instance of nycdb, I suspect that somehow this function got deleted during our rebuild and there was no code to recreate it.

So, this PR adds a function definition to our `helpers.sql` file to explicitly build `anyarray_uniq` whenever we rebuild the db.  It also reorders our code a bit to make sure every function declaration runs in the proper order.