### PR TITLE
Remove trailing slash from parseLocale function

### DIFF
--- a/client/src/i18n.test.tsx
+++ b/client/src/i18n.test.tsx
@@ -18,6 +18,10 @@ describe("i18n", () => {
     expect(parseLocaleFromPath("/es/blarf")).toBe("es");
   });
 
+  it("parses locales from paths even when there's no trailing slash", () => {
+    expect(parseLocaleFromPath("/en")).toBe("en");
+  });
+
   it("parses nothing from paths when locale is not present", () => {
     expect(parseLocaleFromPath("/blarf")).toBe(null);
   });

--- a/client/src/i18n.tsx
+++ b/client/src/i18n.tsx
@@ -50,7 +50,7 @@ function getBestDefaultLocale(): SupportedLocale {
  * Return null if there is no locale, or if it's an unsupported one.
  */
 export function parseLocaleFromPath(path: string): SupportedLocale | null {
-  const localeMatch = path.match(/^\/([a-z][a-z])\//);
+  const localeMatch = path.match(/^\/([a-z][a-z])/);
   if (localeMatch) {
     const code = localeMatch[1];
     if (isSupportedLocale(code)) {


### PR DESCRIPTION
This PR fixes a bug where WOW would redirect paths without a trailing slash incorrectly. For example, any url ending in `/en` or `/en?utm....` would be interpreted as not having a locale defined, and then get redirected to `/en/en...` which was not a correct route. We reconfigured our `parseLocale...` code to recognize locales in the pathname even if there is no trailing slash present.