### PR TITLE
Add feature flag to disable old browser warning banner

### DIFF
--- a/client/.env.local.sample
+++ b/client/.env.local.sample
@@ -86,3 +86,13 @@ REACT_APP_TENANT_PLATFORM_SITE_ORIGIN=
 # uncommenting the following line.
 
 # REACT_APP_API_BASE_URL=
+
+# =========================
+# ENABLE OLD BROWSER WARNING (OPTIONAL)
+# =========================
+#
+# This feature flag determines whether to enable a warning banner
+# for old versions of the Safari broswer that some functionality may not work properly.
+# The content for this banner is defined in `App.tsx`
+
+# REACT_APP_ENABLE_OLD_BROWSER_WARNING=

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -97,6 +97,7 @@ export default class App extends Component<Props, State> {
   render() {
     const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
     const version = process.env.REACT_APP_VERSION;
+    const warnAboutOldBrowser = process.env.REACT_APP_ENABLE_OLD_BROWSER_WARNING;
     const paths = createWhoOwnsWhatRoutePaths();
     return (
       <Router>
@@ -110,12 +111,14 @@ export default class App extends Component<Props, State> {
               />
             )}
             <div className="App">
-              <div className="App__warning old_safari_only">
-                <Trans render="h3">
-                  Warning! This site doesn't fully work on older versions of Safari. Try a{" "}
-                  <a href="http://outdatedbrowser.com/en">modern browser</a>.
-                </Trans>
-              </div>
+              {warnAboutOldBrowser && (
+                <div className="App__warning old_safari_only">
+                  <Trans render="h3">
+                    Warning! This site doesn't fully work on older versions of Safari. Try a{" "}
+                    <a href="http://outdatedbrowser.com/en">modern browser</a>.
+                  </Trans>
+                </div>
+              )}
               <div className="App__header">
                 <HomeLink />
                 {isDemoSite && (


### PR DESCRIPTION
So, I noticed this morning that Who Owns What was showing the warning about using an "older version of Safari" on my newly updated Chrome browser. 
![image](https://user-images.githubusercontent.com/12834575/105585876-d104e500-5d5e-11eb-8052-41944bb6a738.png)
I then checked the CSS logic for how this banner shows up and while I didn't have the time to fully investigate, it did seem a bit thrown together and perhaps not relevant to a new updates of modern browsers like Chrome. 

Of course, we should look in to this more in depth but for now, I'm adding a feature flag so we can disable this banner altogether while we investigate the issue.
