### PR TITLE
Update content in our SocialShare component

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -8,8 +8,8 @@ import Modal from "../components/Modal";
 
 import "styles/DetailView.css";
 import { withI18n, withI18nProps } from "@lingui/react";
-import { Trans } from "@lingui/macro";
-import { SocialSharePortfolio } from "./SocialShare";
+import { t, Trans } from "@lingui/macro";
+import { SocialShareAddressPage } from "./SocialShare";
 import { isPartOfGroupSale } from "./PropertiesList";
 import { Link } from "react-router-dom";
 import { LocaleLink } from "../i18n";
@@ -31,6 +31,18 @@ type State = {
 };
 
 const getTodaysDate = () => new Date();
+
+const SocialShareDetailView = () => (
+  <SocialShareAddressPage
+    location="overview-tab"
+    customContent={{
+      tweet: t`I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info: `,
+      emailSubject: t`Check out the issues in this building`,
+      getEmailBody: (url: string) =>
+        t`I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: ${url}.`,
+    }}
+  />
+);
 
 class DetailViewWithoutI18n extends Component<Props, State> {
   constructor(props: Props) {
@@ -55,7 +67,6 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const isMobile = Browser.isMobile();
     const locale = (this.props.i18n.language as SupportedLocale) || "en";
     const { assocAddrs, detailAddr, searchAddr } = this.props.state.context.portfolioData;
-    const portfolioSize = assocAddrs.length;
 
     // Let's save some variables that will be helpful in rendering the front-end component
     let takeActionURL, formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
@@ -239,11 +250,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                         <h6 className="DetailView__subtitle">
                           <Trans>Share this page with your neighbors</Trans>
                         </h6>
-                        <SocialSharePortfolio
-                          location="overview-tab"
-                          addr={detailAddr}
-                          buildings={portfolioSize}
-                        />
+                        <SocialShareDetailView />
                       </div>
                     </div>
                   </div>
@@ -350,7 +357,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                           <h6 className="DetailView__subtitle">
                             <Trans>Share this page with your neighbors</Trans>
                           </h6>
-                          <SocialSharePortfolio location="overview-tab" addr={detailAddr} />
+                          <SocialShareDetailView />
                         </div>
                       </div>
                     </div>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -350,11 +350,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                           <h6 className="DetailView__subtitle">
                             <Trans>Share this page with your neighbors</Trans>
                           </h6>
-                          <SocialSharePortfolio
-                            location="overview-tab"
-                            addr={detailAddr}
-                            buildings={portfolioSize}
-                          />
+                          <SocialSharePortfolio location="overview-tab" addr={detailAddr} />
                         </div>
                       </div>
                     </div>

--- a/client/src/components/EngagementPanel.tsx
+++ b/client/src/components/EngagementPanel.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import Subscribe from "./Subscribe";
-import SocialShare from "./SocialShare";
+import SocialShare, { SocialShareLocation } from "./SocialShare";
 
 import "styles/EngagementPanel.css";
 import { Trans } from "@lingui/macro";
 
 const EngagementPanel: React.FC<{
-  location?: string;
+  location: SocialShareLocation;
 }> = (props) => {
   return (
     <div className="EngagementPanel">

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -168,6 +168,8 @@ export default class PropertiesSummary extends Component<Props, {}> {
                       location="summary-tab"
                       addr={searchAddr}
                       buildings={agg.bldgs}
+                      portfolioViolations={agg.totalviolations}
+                      violationsPerUnit={agg.openviolationsperresunit}
                     />
                   </div>
                 </div>

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Trans, Plural } from "@lingui/macro";
+import { Trans, Plural, t } from "@lingui/macro";
 
 import Loader from "../components/Loader";
 import LegalFooter from "../components/LegalFooter";
@@ -9,7 +9,7 @@ import { EvictionsSummary } from "./EvictionsSummary";
 import { RentstabSummary } from "./RentstabSummary";
 import { ViolationsSummary } from "./ViolationsSummary";
 import { StringifyListWithConjunction } from "./StringifyList";
-import { SocialSharePortfolio } from "./SocialShare";
+import { SocialShareAddressPage } from "./SocialShare";
 import { withMachineInStateProps } from "state-machine";
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
 
@@ -164,12 +164,15 @@ export default class PropertiesSummary extends Component<Props, {}> {
                     <h6 className="PropertiesSummary__linksSubtitle">
                       <Trans>Share this page with your neighbors</Trans>
                     </h6>
-                    <SocialSharePortfolio
+                    <SocialShareAddressPage
                       location="summary-tab"
-                      addr={searchAddr}
-                      buildings={agg.bldgs}
-                      portfolioViolations={agg.totalviolations}
-                      violationsPerUnit={agg.openviolationsperresunit}
+                      customContent={{
+                        tweet: t`This landlord owns ${agg.bldgs} buildings, and according to @NYCHousing, has received a total of ${agg.totalviolations} violations. See more data analysis here: `,
+                        tweetCloseout: t`#WhoOwnsWhat via @JustFixNYC`,
+                        emailSubject: t` This landlord’s buildings average ${agg.openviolationsperresunit} open HPD violations per apartment`,
+                        getEmailBody: (url: string) =>
+                          t`I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: ${url}.`,
+                      }}
                     />
                   </div>
                 </div>

--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -14,7 +14,7 @@ import { getSiteOrigin, createAddressPageRoutes } from "../routes";
 const DEFAULT_TWEET = t`Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here: `;
 const DEFAULT_EMAIL_SUBJECT = t`All the public info on your landlord`;
 const getDefaultEmailBody = (url: string) =>
-  t`Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: ${url}`;
+  t`Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: ${url}.`;
 
 const SocialShareWithoutI18n: React.FC<{
   i18n: I18n;
@@ -98,9 +98,10 @@ const SocialSharePortfolioWithoutI18n: React.FC<{
   i18n: I18n;
   location: "overview-tab" | "summary-tab";
   addr: { boro: Borough; housenumber?: string; streetname: string };
-  buildings: number;
-}> = ({ i18n, location, addr, buildings }) => {
-  const buildingCount = buildings || 0;
+  buildings?: number;
+  portfolioViolations?: number;
+  violationsPerUnit?: number;
+}> = ({ i18n, location, addr, buildings = 0, portfolioViolations = 0, violationsPerUnit = 0 }) => {
   const routes = createAddressPageRoutes(addr);
   const path = location === "summary-tab" ? routes.summary : routes.overview;
   const url = getSiteOrigin() + path;
@@ -109,12 +110,31 @@ const SocialSharePortfolioWithoutI18n: React.FC<{
       i18n={i18n}
       location={location}
       url={url}
-      twitterMessage={i18n._(
-        t`The ${buildingCount} buildings that my landlord owns 👀... #WhoOwnsWhat @JustFixNYC`
-      )}
-      emailSubject={i18n._(
-        t`The ${buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)`
-      )}
+      twitterMessage={
+        location === "summary-tab"
+          ? i18n._(
+              t`This landlord owns ${buildings} buildings, and according to @NYCHousing, has received a total of ${portfolioViolations} violations. See more data analysis here (#WhoOwnsWhat via @JustFixNYC): `
+            )
+          : i18n._(
+              t`I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info: `
+            )
+      }
+      emailSubject={
+        location === "summary-tab"
+          ? i18n._(
+              t` This landlord’s buildings average ${violationsPerUnit} open HPD violations per apartment`
+            )
+          : i18n._(`Check out the issues in this building`)
+      }
+      emailBody={
+        location === "summary-tab"
+          ? i18n._(
+              t`I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: ${url}.`
+            )
+          : i18n._(
+              t`I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: ${url}.`
+            )
+      }
     />
   );
 };

--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -21,6 +21,11 @@ const SocialShareWithoutI18n: React.FC<{
   location?: string;
   url?: string;
   twitterMessage?: string;
+  /**
+   * (Optional) This piece of text shows up at the end of the tweet,
+   * *after* any url included in the message.
+   */
+  tweetCloseout?: string;
   emailSubject?: string;
   emailBody?: string;
 }> = (props) => {
@@ -49,7 +54,9 @@ const SocialShareWithoutI18n: React.FC<{
         }}
         className="btn btn-steps"
         windowOptions={["width=400", "height=200"]}
-        url={props.url || localizedSiteOrigin}
+        url={
+          (props.url || localizedSiteOrigin) + (!!props.tweetCloseout && ` ${props.tweetCloseout}`)
+        }
         message={props.twitterMessage || i18n._(DEFAULT_TWEET)}
       >
         <img src={twitterIcon} className="icon mx-1" alt="Twitter" />
@@ -113,11 +120,14 @@ const SocialSharePortfolioWithoutI18n: React.FC<{
       twitterMessage={
         location === "summary-tab"
           ? i18n._(
-              t`This landlord owns ${buildings} buildings, and according to @NYCHousing, has received a total of ${portfolioViolations} violations. See more data analysis here (#WhoOwnsWhat via @JustFixNYC): `
+              t`This landlord owns ${buildings} buildings, and according to @NYCHousing, has received a total of ${portfolioViolations} violations. See more data analysis here: `
             )
           : i18n._(
               t`I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info: `
             )
+      }
+      tweetCloseout={
+        location === "summary-tab" ? i18n._(t`#WhoOwnsWhat via @JustFixNYC`) : undefined
       }
       emailSubject={
         location === "summary-tab"

--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -4,45 +4,68 @@ import { isMobile, isAndroid } from "react-device-detect";
 
 import fbIcon from "../assets/img/fb.svg";
 import twitterIcon from "../assets/img/twitter.svg";
-import { I18n } from "@lingui/core";
+import { I18n, MessageDescriptor } from "@lingui/core";
 import { t, Trans } from "@lingui/macro";
 import { withI18n } from "@lingui/react";
 import { FB_APP_ID } from "./Page";
-import { Borough } from "./APIDataTypes";
-import { getSiteOrigin, createAddressPageRoutes } from "../routes";
+import { getSiteOrigin } from "../routes";
+import { useLocation } from "react-router-dom";
 
-const DEFAULT_TWEET = t`Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here: `;
-const DEFAULT_EMAIL_SUBJECT = t`All the public info on your landlord`;
-const getDefaultEmailBody = (url: string) =>
-  t`Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: ${url}.`;
-
-const SocialShareWithoutI18n: React.FC<{
-  i18n: I18n;
-  location?: string;
-  url?: string;
-  twitterMessage?: string;
+export type SocialShareContent = {
+  tweet: MessageDescriptor;
   /**
    * (Optional) This piece of text shows up at the end of the tweet,
    * *after* any url included in the message.
    */
-  tweetCloseout?: string;
-  emailSubject?: string;
-  emailBody?: string;
-}> = (props) => {
-  const { i18n } = props;
+  tweetCloseout?: MessageDescriptor;
+  emailSubject: MessageDescriptor;
+  getEmailBody: (url: string) => MessageDescriptor;
+};
 
+const defaultSocialContent: SocialShareContent = {
+  tweet: t`Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here: `,
+  emailSubject: t`All the public info on your landlord`,
+  getEmailBody: (url: string) =>
+    t`Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: ${url}`,
+};
+
+export type SocialShareLocation =
+  | "homepage"
+  | "share-modal"
+  | "overview-tab"
+  | "summary-tab"
+  | "not-registered-page"
+  | "about-page"
+  | "how-to-use"
+  | "methodology";
+
+type SocialShareProps = {
+  i18n: I18n;
+  location: SocialShareLocation;
+  customUrl?: string;
+  customContent?: SocialShareContent;
+};
+
+const SocialShareWithoutI18n: React.FC<SocialShareProps> = ({
+  i18n,
+  location,
+  customUrl,
+  customContent,
+}) => {
+  const content = customContent || defaultSocialContent;
   const localizedSiteOrigin = `${getSiteOrigin()}/${i18n.language}`;
+  const url = customUrl || localizedSiteOrigin;
 
   return (
     <div className="btn-group btns-social btn-group-block">
       <FacebookButton
         onClick={() => {
-          window.gtag("event", "facebook-" + props.location);
+          window.gtag("event", "facebook-" + location);
         }}
         className="btn btn-steps"
         sharer={true}
         windowOptions={["width=400", "height=200"]}
-        url={props.url || localizedSiteOrigin}
+        url={url}
         appId={FB_APP_ID}
       >
         <img src={fbIcon} className="icon mx-1" alt="Facebook" />
@@ -50,27 +73,25 @@ const SocialShareWithoutI18n: React.FC<{
       </FacebookButton>
       <TwitterButton
         onClick={() => {
-          window.gtag("event", "twitter-" + props.location);
+          window.gtag("event", "twitter-" + location);
         }}
         className="btn btn-steps"
         windowOptions={["width=400", "height=200"]}
-        url={
-          (props.url || localizedSiteOrigin) + (!!props.tweetCloseout && ` ${props.tweetCloseout}`)
-        }
-        message={props.twitterMessage || i18n._(DEFAULT_TWEET)}
+        url={url + (!!content.tweetCloseout ? ` ${i18n._(content.tweetCloseout)}` : "")}
+        message={i18n._(content.tweet)}
       >
         <img src={twitterIcon} className="icon mx-1" alt="Twitter" />
         <span>Twitter</span>
       </TwitterButton>
       <EmailButton
         onClick={() => {
-          window.gtag("event", "email-" + props.location);
+          window.gtag("event", "email-" + location);
         }}
         className="btn btn-steps"
         // NOTE: EmailButton components use the `url` prop for the full body of the email.
-        url={props.emailBody || i18n._(getDefaultEmailBody(localizedSiteOrigin))}
+        url={i18n._(content.getEmailBody(url))}
         target="_blank"
-        message={props.emailSubject || i18n._(DEFAULT_EMAIL_SUBJECT)}
+        message={i18n._(content.emailSubject)}
       >
         <i className="icon icon-mail mx-2" />
         <Trans render="span">Email</Trans>
@@ -79,14 +100,9 @@ const SocialShareWithoutI18n: React.FC<{
         <a
           className="btn btn-steps"
           onClick={() => {
-            window.gtag("event", "twitter-" + props.location);
+            window.gtag("event", "twitter-" + location);
           }}
-          href={
-            "sms: " +
-            (isAndroid ? "?" : "&") +
-            "body=" +
-            encodeURIComponent(props.url || localizedSiteOrigin)
-          }
+          href={"sms: " + (isAndroid ? "?" : "&") + "body=" + encodeURIComponent(url)}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -101,52 +117,9 @@ const SocialShare = withI18n()(SocialShareWithoutI18n);
 
 export default SocialShare;
 
-const SocialSharePortfolioWithoutI18n: React.FC<{
-  i18n: I18n;
-  location: "overview-tab" | "summary-tab";
-  addr: { boro: Borough; housenumber?: string; streetname: string };
-  buildings?: number;
-  portfolioViolations?: number;
-  violationsPerUnit?: number;
-}> = ({ i18n, location, addr, buildings = 0, portfolioViolations = 0, violationsPerUnit = 0 }) => {
-  const routes = createAddressPageRoutes(addr);
-  const path = location === "summary-tab" ? routes.summary : routes.overview;
-  const url = getSiteOrigin() + path;
-  return (
-    <SocialShareWithoutI18n
-      i18n={i18n}
-      location={location}
-      url={url}
-      twitterMessage={
-        location === "summary-tab"
-          ? i18n._(
-              t`This landlord owns ${buildings} buildings, and according to @NYCHousing, has received a total of ${portfolioViolations} violations. See more data analysis here: `
-            )
-          : i18n._(
-              t`I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info: `
-            )
-      }
-      tweetCloseout={
-        location === "summary-tab" ? i18n._(t`#WhoOwnsWhat via @JustFixNYC`) : undefined
-      }
-      emailSubject={
-        location === "summary-tab"
-          ? i18n._(
-              t` This landlord’s buildings average ${violationsPerUnit} open HPD violations per apartment`
-            )
-          : i18n._(`Check out the issues in this building`)
-      }
-      emailBody={
-        location === "summary-tab"
-          ? i18n._(
-              t`I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: ${url}.`
-            )
-          : i18n._(
-              t`I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: ${url}.`
-            )
-      }
-    />
-  );
+const SocialShareAddressPageWithoutI18n: React.FC<SocialShareProps> = (props) => {
+  const url = getSiteOrigin() + encodeURI(useLocation().pathname);
+  return <SocialShareWithoutI18n {...props} customUrl={url} />;
 };
 
-export const SocialSharePortfolio = withI18n()(SocialSharePortfolioWithoutI18n);
+export const SocialShareAddressPage = withI18n()(SocialShareAddressPageWithoutI18n);

--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -11,14 +11,22 @@ import { FB_APP_ID } from "./Page";
 import { Borough } from "./APIDataTypes";
 import { getSiteOrigin, createAddressPageRoutes } from "../routes";
 
+const DEFAULT_TWEET = t`Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here: `;
+const DEFAULT_EMAIL_SUBJECT = t`All the public info on your landlord`;
+const getDefaultEmailBody = (url: string) =>
+  t`Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: ${url}`;
+
 const SocialShareWithoutI18n: React.FC<{
   i18n: I18n;
   location?: string;
   url?: string;
   twitterMessage?: string;
-  emailMessage?: string;
+  emailSubject?: string;
+  emailBody?: string;
 }> = (props) => {
   const { i18n } = props;
+
+  const localizedSiteOrigin = `${getSiteOrigin()}/${i18n.language}`;
 
   return (
     <div className="btn-group btns-social btn-group-block">
@@ -29,7 +37,7 @@ const SocialShareWithoutI18n: React.FC<{
         className="btn btn-steps"
         sharer={true}
         windowOptions={["width=400", "height=200"]}
-        url={props.url || getSiteOrigin()}
+        url={props.url || localizedSiteOrigin}
         appId={FB_APP_ID}
       >
         <img src={fbIcon} className="icon mx-1" alt="Facebook" />
@@ -41,8 +49,8 @@ const SocialShareWithoutI18n: React.FC<{
         }}
         className="btn btn-steps"
         windowOptions={["width=400", "height=200"]}
-        url={props.url || getSiteOrigin()}
-        message={props.twitterMessage || `#WhoOwnsWhat @JustFixNYC`}
+        url={props.url || localizedSiteOrigin}
+        message={props.twitterMessage || i18n._(DEFAULT_TWEET)}
       >
         <img src={twitterIcon} className="icon mx-1" alt="Twitter" />
         <span>Twitter</span>
@@ -52,11 +60,10 @@ const SocialShareWithoutI18n: React.FC<{
           window.gtag("event", "email-" + props.location);
         }}
         className="btn btn-steps"
-        url={props.url || getSiteOrigin()}
+        // NOTE: EmailButton components use the `url` prop for the full body of the email.
+        url={props.emailBody || i18n._(getDefaultEmailBody(localizedSiteOrigin))}
         target="_blank"
-        message={
-          props.emailMessage || i18n._(t`New JustFix.nyc tool helps research on NYC landlords`)
-        }
+        message={props.emailSubject || i18n._(DEFAULT_EMAIL_SUBJECT)}
       >
         <i className="icon icon-mail mx-2" />
         <Trans render="span">Email</Trans>
@@ -71,7 +78,7 @@ const SocialShareWithoutI18n: React.FC<{
             "sms: " +
             (isAndroid ? "?" : "&") +
             "body=" +
-            encodeURIComponent(props.url || getSiteOrigin())
+            encodeURIComponent(props.url || localizedSiteOrigin)
           }
           target="_blank"
           rel="noopener noreferrer"
@@ -105,7 +112,7 @@ const SocialSharePortfolioWithoutI18n: React.FC<{
       twitterMessage={i18n._(
         t`The ${buildingCount} buildings that my landlord owns 👀... #WhoOwnsWhat @JustFixNYC`
       )}
-      emailMessage={i18n._(
+      emailSubject={i18n._(
         t`The ${buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)`
       )}
     />

--- a/client/src/containers/AboutPage.tsx
+++ b/client/src/containers/AboutPage.tsx
@@ -18,7 +18,7 @@ const AboutPage = withI18n()((props: withI18nProps) => {
         <div className="Page__content">
           <ContentfulPage locales={{ en, es }} />
         </div>
-        <EngagementPanel />
+        <EngagementPanel location="about-page" />
         <LegalFooter />
       </div>
     </Page>

--- a/client/src/containers/HowToUsePage.tsx
+++ b/client/src/containers/HowToUsePage.tsx
@@ -18,7 +18,7 @@ const HowToUsePage = withI18n()((props: withI18nProps) => {
         <div className="Page__content">
           <ContentfulPage locales={{ en, es }} />
         </div>
-        <EngagementPanel />
+        <EngagementPanel location="how-to-use" />
         <LegalFooter />
       </div>
     </Page>

--- a/client/src/containers/Methodology.tsx
+++ b/client/src/containers/Methodology.tsx
@@ -19,7 +19,7 @@ const MethodologyPage = withI18n()((props: withI18nProps) => {
         <div className="Page__content">
           <ContentfulPage locales={{ en, es }} />
         </div>
-        <EngagementPanel />
+        <EngagementPanel location="methodology" />
         <LegalFooter />
       </div>
     </Page>

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -3,11 +3,11 @@ import { LocaleLink as Link } from "../i18n";
 
 import "styles/NotRegisteredPage.css";
 import { Trans } from "@lingui/macro";
-import { createRouteForAddressPage, getSiteOrigin, AddressPageUrlParams } from "../routes";
+import { AddressPageUrlParams } from "../routes";
 import Modal from "../components/Modal";
 import LegalFooter from "../components/LegalFooter";
 import Helpers from "../util/helpers";
-import SocialShare from "../components/SocialShare";
+import { SocialShareAddressPage } from "../components/SocialShare";
 import { Nobr } from "../components/Nobr";
 import { withMachineInStateProps } from "state-machine";
 import Page from "components/Page";
@@ -23,10 +23,7 @@ export const SocialShareForNotRegisteredPage = (props: { addr?: AddressPageUrlPa
     <p>
       <Trans>Share this page with your neighbors</Trans>
     </p>
-    <SocialShare
-      location="not-registered-page"
-      url={props.addr ? `${getSiteOrigin()}${createRouteForAddressPage(props.addr)}` : undefined}
-    />
+    <SocialShareAddressPage location="not-registered-page" />
   </div>
 );
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -50,7 +50,7 @@ msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:88
+#: src/containers/App.tsx:89
 msgid "About"
 msgstr "About"
 
@@ -69,6 +69,10 @@ msgstr "Address"
 #: src/components/Subscribe.tsx:39
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
+
+#: src/components/SocialShare.tsx:11
+msgid "All the public info on your landlord"
+msgstr "All the public info on your landlord"
 
 #: src/components/PropertiesList.tsx:145
 msgid "Amount"
@@ -182,7 +186,7 @@ msgstr "DOF Property Tax Bills"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:81
+#: src/containers/App.tsx:82
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -191,7 +195,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:94
+#: src/containers/App.tsx:95
 msgid "Donate"
 msgstr "Donate"
 
@@ -199,7 +203,7 @@ msgstr "Donate"
 msgid "Download"
 msgstr "Download"
 
-#: src/components/SocialShare.tsx:29
+#: src/components/SocialShare.tsx:35
 msgid "Email"
 msgstr "Email"
 
@@ -275,7 +279,7 @@ msgstr "HUD Complaint Form 958"
 msgid "Have thoughts about this page?"
 msgstr "Have thoughts about this page?"
 
-#: src/containers/App.tsx:85
+#: src/containers/App.tsx:86
 msgid "Home"
 msgstr "Home"
 
@@ -284,10 +288,22 @@ msgstr "Home"
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:91
+#: src/containers/App.tsx:92
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
+
+#: src/components/SocialShare.tsx:59
+msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}."
+msgstr "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}."
+
+#: src/components/SocialShare.tsx:55
+msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
+msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
+
+#: src/components/SocialShare.tsx:58
+msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}."
+msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}."
 
 #: src/components/EvictionsSummary.tsx:8
 msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
@@ -391,10 +407,6 @@ msgstr "MyNYCHA App"
 #: src/containers/NychaPage.tsx:160
 msgid "NYCHA Directory"
 msgstr "NYCHA Directory"
-
-#: src/components/SocialShare.tsx:27
-msgid "New JustFix.nyc tool helps research on NYC landlords"
-msgstr "New JustFix.nyc tool helps research on NYC landlords"
 
 #: src/components/AddressToolbar.tsx:26
 msgid "New Search"
@@ -522,7 +534,7 @@ msgstr "Send us a data request"
 msgid "Send us feedback!"
 msgstr "Send us feedback!"
 
-#: src/containers/App.tsx:98
+#: src/containers/App.tsx:99
 msgid "Share"
 msgstr "Share"
 
@@ -530,7 +542,7 @@ msgstr "Share"
 #: src/components/DetailView.tsx:238
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:111
-#: src/containers/App.tsx:104
+#: src/containers/App.tsx:105
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -622,14 +634,6 @@ msgstr "The year that this building was originally constructed, according to the
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 
-#: src/components/SocialShare.tsx:48
-msgid "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
-msgstr "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
-
-#: src/components/SocialShare.tsx:48
-msgid "The {buildingCount} buildings that my landlord owns 👀... #WhoOwnsWhat @JustFixNYC"
-msgstr "The {buildingCount} buildings that my landlord owns 👀... #WhoOwnsWhat @JustFixNYC"
-
 #: src/components/PropertiesSummary.tsx:43
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
@@ -661,6 +665,14 @@ msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per r
 #: src/components/BuildingStatsTable.tsx:19
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
+
+#: src/components/SocialShare.tsx:54
+msgid "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here (#WhoOwnsWhat via @JustFixNYC):"
+msgstr "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here (#WhoOwnsWhat via @JustFixNYC):"
+
+#: src/components/SocialShare.tsx:56
+msgid "This landlord’s buildings average {violationsPerUnit} open HPD violations per apartment"
+msgstr "This landlord’s buildings average {violationsPerUnit} open HPD violations per apartment"
 
 #: src/components/RentstabSummary.tsx:14
 msgid "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
@@ -774,7 +786,7 @@ msgstr "Violations Issued"
 msgid "Visit our website"
 msgstr "Visit our website"
 
-#: src/containers/App.tsx:73
+#: src/containers/App.tsx:74
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
@@ -790,6 +802,10 @@ msgstr "What are {0}?"
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 
+#: src/components/SocialShare.tsx:12
+msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}."
+msgstr "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}."
+
 #: src/containers/App.tsx:29
 msgid "Who owns what in n y c?"
 msgstr "Who owns what in n y c?"
@@ -800,6 +816,10 @@ msgstr "Who owns what in n y c?"
 #: src/containers/App.tsx:32
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
+
+#: src/components/SocialShare.tsx:10
+msgid "Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here:"
+msgstr "Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here:"
 
 #: src/components/Indicators.tsx:192
 msgid "Year"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/SocialShare.tsx:55
+#: src/components/PropertiesSummary.tsx:115
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/components/DetailView.tsx:151
+#: src/components/DetailView.tsx:155
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:133
+#: src/components/DetailView.tsx:137
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:136
+#: src/components/DetailView.tsx:140
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -46,9 +46,9 @@ msgstr "... or view some sample portfolios:"
 msgid "2019 Evictions"
 msgstr "2019 Evictions"
 
-#: src/components/DetailView.tsx:221
+#: src/components/DetailView.tsx:225
 #: src/components/Indicators.tsx:283
-#: src/containers/NotRegisteredPage.tsx:159
+#: src/containers/NotRegisteredPage.tsx:158
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
@@ -74,7 +74,7 @@ msgstr "Address"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: src/components/SocialShare.tsx:11
+#: src/components/SocialShare.tsx:13
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
@@ -82,8 +82,8 @@ msgstr "All the public info on your landlord"
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/DetailView.tsx:159
-#: src/components/DetailView.tsx:229
+#: src/components/DetailView.tsx:163
+#: src/components/DetailView.tsx:233
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -91,7 +91,7 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/components/DetailView.tsx:72
+#: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
 msgid "BUILDING:"
 msgstr "BUILDING:"
@@ -109,9 +109,9 @@ msgstr "Borough"
 msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
-#: src/containers/NotRegisteredPage.tsx:65
-#: src/containers/NotRegisteredPage.tsx:85
-#: src/containers/NotRegisteredPage.tsx:104
+#: src/containers/NotRegisteredPage.tsx:64
+#: src/containers/NotRegisteredPage.tsx:84
+#: src/containers/NotRegisteredPage.tsx:103
 msgid "Building Classification"
 msgstr "Building Classification"
 
@@ -124,7 +124,7 @@ msgstr "Building Permit Applications"
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
-#: src/containers/NotRegisteredPage.tsx:175
+#: src/containers/NotRegisteredPage.tsx:174
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
@@ -132,21 +132,25 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:105
-#: src/components/DetailView.tsx:294
-#: src/components/DetailView.tsx:303
+#: src/components/DetailView.tsx:109
+#: src/components/DetailView.tsx:298
+#: src/components/DetailView.tsx:307
 #: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:96
-#: src/components/DetailView.tsx:274
-#: src/components/DetailView.tsx:283
+#: src/components/DetailView.tsx:100
+#: src/components/DetailView.tsx:278
+#: src/components/DetailView.tsx:287
 #: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Business Entities"
 
-#: src/containers/NotRegisteredPage.tsx:179
+#: src/components/DetailView.tsx:20
+msgid "Check out the issues in this building"
+msgstr "Check out the issues in this building"
+
+#: src/containers/NotRegisteredPage.tsx:178
 msgid "Civil penalties of $250-$500"
 msgstr "Civil penalties of $250-$500"
 
@@ -162,7 +166,7 @@ msgstr "Class B"
 msgid "Class C"
 msgstr "Class C"
 
-#: src/containers/NotRegisteredPage.tsx:188
+#: src/containers/NotRegisteredPage.tsx:187
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
@@ -174,15 +178,15 @@ msgstr "Close legend"
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
-#: src/components/DetailView.tsx:207
+#: src/components/DetailView.tsx:211
 #: src/components/Indicators.tsx:269
-#: src/containers/NotRegisteredPage.tsx:156
+#: src/containers/NotRegisteredPage.tsx:155
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
-#: src/components/DetailView.tsx:214
+#: src/components/DetailView.tsx:218
 #: src/components/Indicators.tsx:276
-#: src/containers/NotRegisteredPage.tsx:151
+#: src/containers/NotRegisteredPage.tsx:150
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
@@ -207,7 +211,7 @@ msgstr "Donate"
 msgid "Download"
 msgstr "Download"
 
-#: src/components/SocialShare.tsx:35
+#: src/components/SocialShare.tsx:39
 msgid "Email"
 msgstr "Email"
 
@@ -240,7 +244,7 @@ msgstr "Evictions executed in this development by NYC Marshals in 2019. ANHD and
 msgid "Export Data"
 msgstr "Export Data"
 
-#: src/containers/NotRegisteredPage.tsx:174
+#: src/containers/NotRegisteredPage.tsx:173
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
@@ -252,7 +256,7 @@ msgstr "General info"
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:204
 #: src/components/Indicators.tsx:262
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
@@ -287,8 +291,8 @@ msgstr "Have thoughts about this page?"
 msgid "Home"
 msgstr "Home"
 
-#: src/components/DetailView.tsx:78
-#: src/components/DetailView.tsx:249
+#: src/components/DetailView.tsx:82
+#: src/components/DetailView.tsx:253
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
@@ -297,15 +301,15 @@ msgstr "How is this building associated to this portfolio?"
 msgid "How to use"
 msgstr "How to use"
 
-#: src/components/SocialShare.tsx:59
+#: src/components/DetailView.tsx:21
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}."
 msgstr "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}."
 
-#: src/components/SocialShare.tsx:55
+#: src/components/DetailView.tsx:19
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
-#: src/components/SocialShare.tsx:58
+#: src/components/PropertiesSummary.tsx:117
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}."
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}."
 
@@ -313,7 +317,7 @@ msgstr "I was checking out this building on Who Owns What, a free landlord resea
 msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/containers/NotRegisteredPage.tsx:181
+#: src/containers/NotRegisteredPage.tsx:180
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
@@ -321,7 +325,7 @@ msgstr "Ineligible to certify violations"
 msgid "Information"
 msgstr "Information"
 
-#: src/containers/NotRegisteredPage.tsx:99
+#: src/containers/NotRegisteredPage.tsx:98
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "It doesn't seem like this property is required to register with HPD."
 
@@ -350,11 +354,11 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:128
+#: src/components/DetailView.tsx:132
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:141
+#: src/components/DetailView.tsx:145
 msgid "Last sold:"
 msgstr "Last sold:"
 
@@ -391,7 +395,7 @@ msgstr "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgid "Maintenance code violations"
 msgstr "Maintenance code violations"
 
-#: src/containers/NotRegisteredPage.tsx:180
+#: src/containers/NotRegisteredPage.tsx:179
 msgid "May be issued official Orders"
 msgstr "May be issued official Orders"
 
@@ -433,11 +437,11 @@ msgstr "No address found"
 msgid "No data available"
 msgstr "No data available"
 
-#: src/containers/NotRegisteredPage.tsx:123
+#: src/containers/NotRegisteredPage.tsx:122
 msgid "No registration found for {usersInputAddressFragment}!"
 msgstr "No registration found for {usersInputAddressFragment}!"
 
-#: src/containers/NotRegisteredPage.tsx:123
+#: src/containers/NotRegisteredPage.tsx:122
 msgid "No registration found!"
 msgstr "No registration found!"
 
@@ -483,9 +487,9 @@ msgstr "Owners submit Building Permit Applications to the Department of Building
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/DetailView.tsx:115
-#: src/components/DetailView.tsx:314
-#: src/components/DetailView.tsx:324
+#: src/components/DetailView.tsx:119
+#: src/components/DetailView.tsx:318
+#: src/components/DetailView.tsx:328
 #: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "People"
@@ -520,7 +524,7 @@ msgstr "RS Units"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/containers/NotRegisteredPage.tsx:170
+#: src/containers/NotRegisteredPage.tsx:169
 #: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
 msgstr "Search for a different address"
@@ -542,12 +546,12 @@ msgstr "Send us feedback!"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:170
-#: src/components/DetailView.tsx:238
+#: src/components/DetailView.tsx:174
+#: src/components/DetailView.tsx:242
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:111
 #: src/containers/App.tsx:105
-#: src/containers/NotRegisteredPage.tsx:14
+#: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
 
@@ -579,8 +583,8 @@ msgstr "Source code"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/components/DetailView.tsx:164
-#: src/components/DetailView.tsx:232
+#: src/components/DetailView.tsx:168
+#: src/components/DetailView.tsx:236
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
@@ -646,7 +650,7 @@ msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "This building is owned by the NYC Housing Authority (NYCHA)"
 
-#: src/containers/NotRegisteredPage.tsx:80
+#: src/containers/NotRegisteredPage.tsx:79
 msgid "This building seems like it should be registered with HPD!"
 msgstr "This building seems like it should be registered with HPD!"
 
@@ -670,13 +674,13 @@ msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per r
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
-#: src/components/SocialShare.tsx:54
-msgid "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here:"
-msgstr "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here:"
+#: src/components/PropertiesSummary.tsx:114
+msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. See more data analysis here:"
+msgstr "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. See more data analysis here:"
 
-#: src/components/SocialShare.tsx:56
-msgid "This landlord’s buildings average {violationsPerUnit} open HPD violations per apartment"
-msgstr "This landlord’s buildings average {violationsPerUnit} open HPD violations per apartment"
+#: src/components/PropertiesSummary.tsx:116
+msgid "This landlord’s buildings average {0} open HPD violations per apartment"
+msgstr "This landlord’s buildings average {0} open HPD violations per apartment"
 
 #: src/components/RentstabSummary.tsx:14
 msgid "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
@@ -698,7 +702,7 @@ msgstr "This represents <0>{rsProportion}%</0> of the total size of this portfol
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 
-#: src/containers/NotRegisteredPage.tsx:57
+#: src/containers/NotRegisteredPage.tsx:56
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 
@@ -723,11 +727,11 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Total Violations"
 
-#: src/containers/NotRegisteredPage.tsx:183
+#: src/containers/NotRegisteredPage.tsx:182
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "Unable to initiate a court action for nonpayment of rent."
 
-#: src/containers/NotRegisteredPage.tsx:182
+#: src/containers/NotRegisteredPage.tsx:181
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
@@ -741,10 +745,10 @@ msgstr "Units"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 
-#: src/components/DetailView.tsx:181
-#: src/components/DetailView.tsx:186
+#: src/components/DetailView.tsx:185
+#: src/components/DetailView.tsx:190
 #: src/components/Indicators.tsx:247
-#: src/containers/NotRegisteredPage.tsx:144
+#: src/containers/NotRegisteredPage.tsx:143
 #: src/containers/NychaPage.tsx:153
 msgid "Useful links"
 msgstr "Useful links"
@@ -753,7 +757,7 @@ msgstr "Useful links"
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:89
+#: src/components/DetailView.tsx:93
 msgid "View data over time"
 msgstr "View data over time"
 
@@ -762,9 +766,9 @@ msgstr "View data over time"
 msgid "View detail"
 msgstr "View detail"
 
-#: src/components/DetailView.tsx:193
+#: src/components/DetailView.tsx:197
 #: src/components/Indicators.tsx:253
-#: src/containers/NotRegisteredPage.tsx:148
+#: src/containers/NotRegisteredPage.tsx:147
 msgid "View documents on ACRIS"
 msgstr "View documents on ACRIS"
 
@@ -778,7 +782,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:64
+#: src/components/DetailView.tsx:68
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -794,7 +798,7 @@ msgstr "Visit our website"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
-#: src/components/DetailView.tsx:251
+#: src/components/DetailView.tsx:255
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -802,13 +806,13 @@ msgstr "We compare your search address with a database of over 200k buildings to
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
-#: src/containers/NotRegisteredPage.tsx:44
+#: src/containers/NotRegisteredPage.tsx:43
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 
-#: src/components/SocialShare.tsx:12
-msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}."
-msgstr "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}."
+#: src/components/SocialShare.tsx:14
+msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
+msgstr "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 
 #: src/containers/App.tsx:29
 msgid "Who owns what in n y c?"
@@ -821,7 +825,7 @@ msgstr "Who owns what in n y c?"
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 
-#: src/components/SocialShare.tsx:10
+#: src/components/SocialShare.tsx:12
 msgid "Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here:"
 msgstr "Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here:"
 
@@ -853,7 +857,7 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:145
+#: src/components/DetailView.tsx:149
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/SocialShare.tsx:55
+msgid "#WhoOwnsWhat via @JustFixNYC"
+msgstr "#WhoOwnsWhat via @JustFixNYC"
+
 #: src/components/DetailView.tsx:151
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
@@ -667,8 +671,8 @@ msgid "This is the official identifer for the building according to the Dept. of
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
 #: src/components/SocialShare.tsx:54
-msgid "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here (#WhoOwnsWhat via @JustFixNYC):"
-msgstr "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here (#WhoOwnsWhat via @JustFixNYC):"
+msgid "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here:"
+msgstr "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here:"
 
 #: src/components/SocialShare.tsx:56
 msgid "This landlord’s buildings average {violationsPerUnit} open HPD violations per apartment"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -55,7 +55,7 @@ msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:88
+#: src/containers/App.tsx:89
 msgid "About"
 msgstr "Acerca de"
 
@@ -74,6 +74,10 @@ msgstr "Dirección"
 #: src/components/Subscribe.tsx:39
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
+
+#: src/components/SocialShare.tsx:11
+msgid "All the public info on your landlord"
+msgstr ""
 
 #: src/components/PropertiesList.tsx:145
 msgid "Amount"
@@ -187,7 +191,7 @@ msgstr "Facturas de Impuestos del DOF"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:81
+#: src/containers/App.tsx:82
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -196,7 +200,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:94
+#: src/containers/App.tsx:95
 msgid "Donate"
 msgstr "Donar"
 
@@ -204,7 +208,7 @@ msgstr "Donar"
 msgid "Download"
 msgstr "Descargar"
 
-#: src/components/SocialShare.tsx:29
+#: src/components/SocialShare.tsx:35
 msgid "Email"
 msgstr "Email"
 
@@ -280,7 +284,7 @@ msgstr "Formulario de queja HUD 958"
 msgid "Have thoughts about this page?"
 msgstr "¿Tienes ideas sobre esta página?"
 
-#: src/containers/App.tsx:85
+#: src/containers/App.tsx:86
 msgid "Home"
 msgstr "Inicio"
 
@@ -289,10 +293,22 @@ msgstr "Inicio"
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:91
+#: src/containers/App.tsx:92
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
+
+#: src/components/SocialShare.tsx:59
+msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}."
+msgstr ""
+
+#: src/components/SocialShare.tsx:55
+msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
+msgstr ""
+
+#: src/components/SocialShare.tsx:58
+msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}."
+msgstr ""
 
 #: src/components/EvictionsSummary.tsx:8
 msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
@@ -396,10 +412,6 @@ msgstr "App MyNYCHA"
 #: src/containers/NychaPage.tsx:160
 msgid "NYCHA Directory"
 msgstr "Directorio de NYCHA"
-
-#: src/components/SocialShare.tsx:27
-msgid "New JustFix.nyc tool helps research on NYC landlords"
-msgstr "La nueva herramienta JustFix.nyc te ayuda a investigar a propietarios de NYC"
 
 #: src/components/AddressToolbar.tsx:26
 msgid "New Search"
@@ -527,7 +539,7 @@ msgstr "Envíanos una solicitud de datos"
 msgid "Send us feedback!"
 msgstr "¡Comparte tu opinión con nosotros!"
 
-#: src/containers/App.tsx:98
+#: src/containers/App.tsx:99
 msgid "Share"
 msgstr "Compartir"
 
@@ -535,7 +547,7 @@ msgstr "Compartir"
 #: src/components/DetailView.tsx:238
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:111
-#: src/containers/App.tsx:104
+#: src/containers/App.tsx:105
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -627,14 +639,6 @@ msgstr "El año en que este edificio fue construido, según el Departamento de P
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
-#: src/components/SocialShare.tsx:48
-msgid "The {buildingCount} buildings owned by my landlord (via JustFix's Who Owns What tool)"
-msgstr "Los {buildingCount} edificios que son propiedad del dueño de mi apartamento (a través de la herramienta Quién Es El Dueño de JustFix.nyc)"
-
-#: src/components/SocialShare.tsx:48
-msgid "The {buildingCount} buildings that my landlord owns 👀... #WhoOwnsWhat @JustFixNYC"
-msgstr "Los {buildingCount} edificios que son propiedad del dueño de mi apartamento 👀... #WhoOwnsWhat @JustFixNYC"
-
 #: src/components/PropertiesSummary.tsx:43
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
@@ -667,6 +671,14 @@ msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "El identificador oficial del edificio según los registros del Departamento de Finanzas."
 
+#: src/components/SocialShare.tsx:54
+msgid "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here (#WhoOwnsWhat via @JustFixNYC):"
+msgstr ""
+
+#: src/components/SocialShare.tsx:56
+msgid "This landlord’s buildings average {violationsPerUnit} open HPD violations per apartment"
+msgstr ""
+
 #: src/components/RentstabSummary.tsx:14
 msgid "This portfolio also had an estimated <0>net {changeType, select, gain {gain} other {loss}}</0> of <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {rent stabilized unit} other {rent stabilized units}} since 2007 (gained {absTotalRsGain}, lost {absTotalRsLoss})."
 msgstr "Este portafolio de edificios tuvo una <0>{changeType, select, gain {ganancia} other {perdida}} neta</0> de <1>{absTotalRsDiff}</1> {absTotalRsDiff, plural, one {apartamento de renta estabilizada} other {apartamentos de renta estabilizada}} desde el año 2007 (ganó {absTotalRsGain}, perdió {absTotalRsLoss})."
@@ -693,7 +705,7 @@ msgstr "Este parece ser un edificio residencial pequeño. Si el dueño no reside
 
 #: src/components/BuildingStatsTable.tsx:79
 msgid "This tracks how rent stabilized units in the building have changed (i.e. \"{delta}\") from 2007 to {0}. If the number for {1} is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
-msgstr "El cambio en apartamentos de renta estabilizada que hay en el edificio (es decir, \"{delta}") del 2007 al {0}. Si el número en {1} está en rojo, ¡esto significa que ha habido una pérdida en las cantidad de apartamentos de renta estabilizada! Estos recuentos se calculan a partir de las facturas de impuestos del Departamento de Finanzas."
+msgstr "El cambio en apartamentos de renta estabilizada que hay en el edificio (es decir, \"{delta}\") del 2007 al {0}. Si el número en {1} está en rojo, ¡esto significa que ha habido una pérdida en las cantidad de apartamentos de renta estabilizada! Estos recuentos se calculan a partir de las facturas de impuestos del Departamento de Finanzas."
 
 #: src/components/AddressToolbar.tsx:33
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
@@ -779,7 +791,7 @@ msgstr "Infracciones emitidas"
 msgid "Visit our website"
 msgstr "Visite nuestro sitio web"
 
-#: src/containers/App.tsx:73
+#: src/containers/App.tsx:74
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
@@ -795,6 +807,10 @@ msgstr "¿Qué son {0}?"
 msgid "What happens if the landlord has failed to register?"
 msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 
+#: src/components/SocialShare.tsx:12
+msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}."
+msgstr ""
+
 #: src/containers/App.tsx:29
 msgid "Who owns what in n y c?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
@@ -805,6 +821,10 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 #: src/containers/App.tsx:32
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
+
+#: src/components/SocialShare.tsx:10
+msgid "Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here:"
+msgstr ""
 
 #: src/components/Indicators.tsx:192
 msgid "Year"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -18,19 +18,19 @@ msgstr ""
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 31\n"
 
-#: src/components/SocialShare.tsx:55
+#: src/components/PropertiesSummary.tsx:115
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr ""
 
-#: src/components/DetailView.tsx:151
+#: src/components/DetailView.tsx:155
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:133
+#: src/components/DetailView.tsx:137
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:136
+#: src/components/DetailView.tsx:140
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -51,9 +51,9 @@ msgstr "... o descubre ejemplos de portafolios de edificios:"
 msgid "2019 Evictions"
 msgstr "Desalojos 2019"
 
-#: src/components/DetailView.tsx:221
+#: src/components/DetailView.tsx:225
 #: src/components/Indicators.tsx:283
-#: src/containers/NotRegisteredPage.tsx:159
+#: src/containers/NotRegisteredPage.tsx:158
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
@@ -79,7 +79,7 @@ msgstr "Dirección"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: src/components/SocialShare.tsx:11
+#: src/components/SocialShare.tsx:13
 msgid "All the public info on your landlord"
 msgstr ""
 
@@ -87,8 +87,8 @@ msgstr ""
 msgid "Amount"
 msgstr "Importe"
 
-#: src/components/DetailView.tsx:159
-#: src/components/DetailView.tsx:229
+#: src/components/DetailView.tsx:163
+#: src/components/DetailView.tsx:233
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -96,7 +96,7 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
-#: src/components/DetailView.tsx:72
+#: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
@@ -114,9 +114,9 @@ msgstr "Municipio"
 msgid "Borough Management Office:"
 msgstr "Oficina de Gestión Municipal:"
 
-#: src/containers/NotRegisteredPage.tsx:65
-#: src/containers/NotRegisteredPage.tsx:85
-#: src/containers/NotRegisteredPage.tsx:104
+#: src/containers/NotRegisteredPage.tsx:64
+#: src/containers/NotRegisteredPage.tsx:84
+#: src/containers/NotRegisteredPage.tsx:103
 msgid "Building Classification"
 msgstr "Clasificación del Edificio"
 
@@ -129,7 +129,7 @@ msgstr "Solicitudes de Permisos de Construcción"
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
 
-#: src/containers/NotRegisteredPage.tsx:175
+#: src/containers/NotRegisteredPage.tsx:174
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
@@ -137,21 +137,25 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:105
-#: src/components/DetailView.tsx:294
-#: src/components/DetailView.tsx:303
+#: src/components/DetailView.tsx:109
+#: src/components/DetailView.tsx:298
+#: src/components/DetailView.tsx:307
 #: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:96
-#: src/components/DetailView.tsx:274
-#: src/components/DetailView.tsx:283
+#: src/components/DetailView.tsx:100
+#: src/components/DetailView.tsx:278
+#: src/components/DetailView.tsx:287
 #: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
-#: src/containers/NotRegisteredPage.tsx:179
+#: src/components/DetailView.tsx:20
+msgid "Check out the issues in this building"
+msgstr ""
+
+#: src/containers/NotRegisteredPage.tsx:178
 msgid "Civil penalties of $250-$500"
 msgstr "Sanciones civiles de $250-$500"
 
@@ -167,7 +171,7 @@ msgstr "Clase B"
 msgid "Class C"
 msgstr "Clase C"
 
-#: src/containers/NotRegisteredPage.tsx:188
+#: src/containers/NotRegisteredPage.tsx:187
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
@@ -179,15 +183,15 @@ msgstr "Cerrar leyenda"
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
-#: src/components/DetailView.tsx:207
+#: src/components/DetailView.tsx:211
 #: src/components/Indicators.tsx:269
-#: src/containers/NotRegisteredPage.tsx:156
+#: src/containers/NotRegisteredPage.tsx:155
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
-#: src/components/DetailView.tsx:214
+#: src/components/DetailView.tsx:218
 #: src/components/Indicators.tsx:276
-#: src/containers/NotRegisteredPage.tsx:151
+#: src/containers/NotRegisteredPage.tsx:150
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
@@ -212,7 +216,7 @@ msgstr "Donar"
 msgid "Download"
 msgstr "Descargar"
 
-#: src/components/SocialShare.tsx:35
+#: src/components/SocialShare.tsx:39
 msgid "Email"
 msgstr "Email"
 
@@ -245,7 +249,7 @@ msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC en 2019. AN
 msgid "Export Data"
 msgstr "Exportar datos"
 
-#: src/containers/NotRegisteredPage.tsx:174
+#: src/containers/NotRegisteredPage.tsx:173
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
@@ -257,7 +261,7 @@ msgstr "Información general"
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:204
 #: src/components/Indicators.tsx:262
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
@@ -292,8 +296,8 @@ msgstr "¿Tienes ideas sobre esta página?"
 msgid "Home"
 msgstr "Inicio"
 
-#: src/components/DetailView.tsx:78
-#: src/components/DetailView.tsx:249
+#: src/components/DetailView.tsx:82
+#: src/components/DetailView.tsx:253
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
@@ -302,15 +306,15 @@ msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 msgid "How to use"
 msgstr "Cómo se usa"
 
-#: src/components/SocialShare.tsx:59
+#: src/components/DetailView.tsx:21
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}."
 msgstr ""
 
-#: src/components/SocialShare.tsx:55
+#: src/components/DetailView.tsx:19
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr ""
 
-#: src/components/SocialShare.tsx:58
+#: src/components/PropertiesSummary.tsx:117
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}."
 msgstr ""
 
@@ -318,7 +322,7 @@ msgstr ""
 msgid "In 2019, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "En el 2019, los Mariscales de NYC programaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en este portafolio de edificios."
 
-#: src/containers/NotRegisteredPage.tsx:181
+#: src/containers/NotRegisteredPage.tsx:180
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
@@ -326,7 +330,7 @@ msgstr "Inelegible para certificar infracciones"
 msgid "Information"
 msgstr "Información"
 
-#: src/containers/NotRegisteredPage.tsx:99
+#: src/containers/NotRegisteredPage.tsx:98
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "Parece que esta propiedad no necesita estar registrada con el HPD."
 
@@ -355,11 +359,11 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:128
+#: src/components/DetailView.tsx:132
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:141
+#: src/components/DetailView.tsx:145
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
@@ -396,7 +400,7 @@ msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.nyc</0>"
 msgid "Maintenance code violations"
 msgstr "Infracciones del código de mantenimiento"
 
-#: src/containers/NotRegisteredPage.tsx:180
+#: src/containers/NotRegisteredPage.tsx:179
 msgid "May be issued official Orders"
 msgstr "Pueden emitirse órdenes oficiales"
 
@@ -438,11 +442,11 @@ msgstr "No se encontraron direcciones"
 msgid "No data available"
 msgstr "No hay datos disponibles"
 
-#: src/containers/NotRegisteredPage.tsx:123
+#: src/containers/NotRegisteredPage.tsx:122
 msgid "No registration found for {usersInputAddressFragment}!"
 msgstr "¡No se ha encontrado ningún registro para {usersInputAddressFragment}!"
 
-#: src/containers/NotRegisteredPage.tsx:123
+#: src/containers/NotRegisteredPage.tsx:122
 msgid "No registration found!"
 msgstr "¡No se ha encontrado nigún registro!"
 
@@ -488,9 +492,9 @@ msgstr "Antes de empezar cualquier proyecto de construcción, el propietario som
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/DetailView.tsx:115
-#: src/components/DetailView.tsx:314
-#: src/components/DetailView.tsx:324
+#: src/components/DetailView.tsx:119
+#: src/components/DetailView.tsx:318
+#: src/components/DetailView.tsx:328
 #: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "Personas (Encontrarás definiciones en español de los tipos de personas asociadas al edificio en la página \"Como se usa\".)"
@@ -525,7 +529,7 @@ msgstr "Unidades Residenciales RS"
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
-#: src/containers/NotRegisteredPage.tsx:170
+#: src/containers/NotRegisteredPage.tsx:169
 #: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
 msgstr "Buscar otra dirección"
@@ -547,12 +551,12 @@ msgstr "¡Comparte tu opinión con nosotros!"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:170
-#: src/components/DetailView.tsx:238
+#: src/components/DetailView.tsx:174
+#: src/components/DetailView.tsx:242
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:111
 #: src/containers/App.tsx:105
-#: src/containers/NotRegisteredPage.tsx:14
+#: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
 
@@ -584,8 +588,8 @@ msgstr "Código fuente"
 msgid "Summary"
 msgstr "Resúmen"
 
-#: src/components/DetailView.tsx:164
-#: src/components/DetailView.tsx:232
+#: src/components/DetailView.tsx:168
+#: src/components/DetailView.tsx:236
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
@@ -651,7 +655,7 @@ msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edif
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "Este edificio es propiedad de la NYC Housing Authority (NYCHA)"
 
-#: src/containers/NotRegisteredPage.tsx:80
+#: src/containers/NotRegisteredPage.tsx:79
 msgid "This building seems like it should be registered with HPD!"
 msgstr "¡Parece que este edificio debería estar registrado con el HPD!"
 
@@ -675,12 +679,12 @@ msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "El identificador oficial del edificio según los registros del Departamento de Finanzas."
 
-#: src/components/SocialShare.tsx:54
-msgid "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here:"
+#: src/components/PropertiesSummary.tsx:114
+msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. See more data analysis here:"
 msgstr ""
 
-#: src/components/SocialShare.tsx:56
-msgid "This landlord’s buildings average {violationsPerUnit} open HPD violations per apartment"
+#: src/components/PropertiesSummary.tsx:116
+msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr ""
 
 #: src/components/RentstabSummary.tsx:14
@@ -703,7 +707,7 @@ msgstr "Esto representa el <0>{rsProportion}%</0> del tamaño total de este port
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr "Esto representa el número total de Infracciones del HPD (tanto actuales como cerradas) registradas por la ciudad."
 
-#: src/containers/NotRegisteredPage.tsx:57
+#: src/containers/NotRegisteredPage.tsx:56
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "Este parece ser un edificio residencial pequeño. Si el dueño no reside allí, el edificio debería estar registrado con el HPD."
 
@@ -728,11 +732,11 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Infracciones Totales"
 
-#: src/containers/NotRegisteredPage.tsx:183
+#: src/containers/NotRegisteredPage.tsx:182
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "No es possible iniciar una acción judicial por falta de pago del alquiler."
 
-#: src/containers/NotRegisteredPage.tsx:182
+#: src/containers/NotRegisteredPage.tsx:181
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
@@ -746,10 +750,10 @@ msgstr "Unidades Residenciales"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edificio e investigar a los arrendadores de Nueva York! Utilizamos el mapeo de propiedad para identificar el portafolio de edificios de un arrendador y proporcionar datos para revelar posibles casos de hostigamiento y desplazamiento de inquilinos."
 
-#: src/components/DetailView.tsx:181
-#: src/components/DetailView.tsx:186
+#: src/components/DetailView.tsx:185
+#: src/components/DetailView.tsx:190
 #: src/components/Indicators.tsx:247
-#: src/containers/NotRegisteredPage.tsx:144
+#: src/containers/NotRegisteredPage.tsx:143
 #: src/containers/NychaPage.tsx:153
 msgid "Useful links"
 msgstr "Enlaces útiles"
@@ -758,7 +762,7 @@ msgstr "Enlaces útiles"
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:89
+#: src/components/DetailView.tsx:93
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
@@ -767,9 +771,9 @@ msgstr "Ver datos a lo largo del tiempo"
 msgid "View detail"
 msgstr "Ver detalles"
 
-#: src/components/DetailView.tsx:193
+#: src/components/DetailView.tsx:197
 #: src/components/Indicators.tsx:253
-#: src/containers/NotRegisteredPage.tsx:148
+#: src/containers/NotRegisteredPage.tsx:147
 msgid "View documents on ACRIS"
 msgstr "Ver documentos en ACRIS"
 
@@ -783,7 +787,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:64
+#: src/components/DetailView.tsx:68
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
@@ -799,7 +803,7 @@ msgstr "Visite nuestro sitio web"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
-#: src/components/DetailView.tsx:251
+#: src/components/DetailView.tsx:255
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -807,12 +811,12 @@ msgstr "Comparamos la dirección que buscaste con una base de datos de más de 2
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
-#: src/containers/NotRegisteredPage.tsx:44
+#: src/containers/NotRegisteredPage.tsx:43
 msgid "What happens if the landlord has failed to register?"
 msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 
-#: src/components/SocialShare.tsx:12
-msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}."
+#: src/components/SocialShare.tsx:14
+msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their buildings, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr ""
 
 #: src/containers/App.tsx:29
@@ -826,7 +830,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
-#: src/components/SocialShare.tsx:10
+#: src/components/SocialShare.tsx:12
 msgid "Who’s responsible for issues in your apartment and building? Use #WhoOwnsWhat, a free tool to research property owners in NYC using public, open data. Built by @JustFixNYC, it functions on any device with an internet connection. Search your address here:"
 msgstr ""
 
@@ -858,7 +862,7 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:145
+#: src/components/DetailView.tsx:149
 msgid "for ${0}"
 msgstr "por ${0}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -18,6 +18,10 @@ msgstr ""
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 31\n"
 
+#: src/components/SocialShare.tsx:55
+msgid "#WhoOwnsWhat via @JustFixNYC"
+msgstr ""
+
 #: src/components/DetailView.tsx:151
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
@@ -672,7 +676,7 @@ msgid "This is the official identifer for the building according to the Dept. of
 msgstr "El identificador oficial del edificio según los registros del Departamento de Finanzas."
 
 #: src/components/SocialShare.tsx:54
-msgid "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here (#WhoOwnsWhat via @JustFixNYC):"
+msgid "This landlord owns {buildings} buildings, and according to @NYCHousing, has received a total of {portfolioViolations} violations. See more data analysis here:"
 msgstr ""
 
 #: src/components/SocialShare.tsx:56

--- a/client/src/react-social.d.ts
+++ b/client/src/react-social.d.ts
@@ -5,8 +5,15 @@ module "react-social" {
   type BaseProps = {
     onClick: () => void;
     className: string;
+    /**
+     * For EmailButton components, this prop becomes the BODY of the email itself,
+     * so it can be just a url or a larger string of text.
+     */
     url: string;
     windowOptions?: string[];
+    /**
+     * For EmailButton components, this prop becomes the SUBJECT of the email.
+     */
     message?: string;
   };
 


### PR DESCRIPTION
This PR adds new content to our SocialShare component— specifically the content that gets pre-filled when a user tries to share the tool via email or twitter from the homepage, Overview tab, Summary tab, or elsewhere.