### PR TITLE
Close DetailView on mobile for every new address search

### DIFF
--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -79,6 +79,9 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     )
       return;
     send({ type: "SEARCH", address: validateRouteParams(match.params) });
+    /* When searching for user's address, let's reset the DetailView to the "closed" state 
+    so it can pop into view once the address is found */
+    this.handleCloseDetail();
   }
 
   handleOpenDetail = () => {


### PR DESCRIPTION
This PR fixes an important but hard to reproduce bug where Mobile users couldn't use the Overview tab if they were to search ANOTHER address after their initial search. What was happening is that the "detailMobileSlide" state on the AddressPage component was pre-configured, so when the user returned to the AddressPage after searching a second address, it was not properly retriggering the opening of the DetailView slide and so users could only view the property map and not see any details. This PR fixes this issue by making sure the DetailView slide is "closed" every time a new address search is conducted.