### PR TITLE
Stop using psycopg2-binary and use psycopg2 with a higher version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # This only contains dependencies for running the API
 # server. For all other dependencies, see requirements-dev.txt.
-psycopg2-binary==2.7.7
+psycopg2==2.8.6
 django==3.1.6
 rollbar==0.14.5
 dj-database-url==0.5.0


### PR DESCRIPTION
Previously, who-owns-what tests were failing with the error "AttributeError: module 'psycopg2.errors' has no attribute 'UndefinedTable'".

They were failing because they used syntax that only works if you have psycopg2 v 2.8.6 installed, but that wasn't explicitly stated as a dependency. The computer the tests were written on 8 months ago actually had 2.8.6 installed instead of the expected 2.7.7. It had 2.8.6 installed because nycdb's requirements.txt asks for nycdb >= 2.7, and whenever WOW's requirements-dev.txt gets loaded, it fetches the latest version of psycopg2.

We thought we had pinned psycopg2 to version 2.7.7, but instead we had psycopg2-binary pinned to 2.7.7, which was ineffective at preventing arbitrary library updates from its dependencies (i.e. nycdb).

This makes it so we're actually pinning psycopg2 to 2.8.6.