### PR TITLE
Add new internationalized AirTable Data Request form to Summary tab

### DIFF
--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -14,13 +14,19 @@ import { withMachineInStateProps } from "state-machine";
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
 import { AddressRecord } from "./APIDataTypes";
 import { I18n } from "@lingui/react";
+import { defaultLocale, SupportedLocale } from "i18n-base";
 
 type Props = withMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
 };
 
-const DATA_REQUEST_FORM_URL_ENGLISH = "https://airtable.com/shruDUDHViainzUBB";
-const DATA_REQUEST_FORM_URL_SPANISH = "https://airtable.com/shrQudDbhUVz5J83u";
+const DATA_REQUEST_FORM_URLS = {
+  en: "https://airtable.com/shruDUDHViainzUBB",
+  es: "https://airtable.com/shrQudDbhUVz5J83u",
+};
+
+const getDataRequestUrlFromLocale = (locale: SupportedLocale) =>
+  DATA_REQUEST_FORM_URLS[locale] || DATA_REQUEST_FORM_URLS[defaultLocale];
 
 const DataRequestButton: React.FC<{
   address: AddressRecord;
@@ -35,9 +41,9 @@ const DataRequestButton: React.FC<{
           onClick={() => {
             window.gtag("event", "data-request");
           }}
-          href={`${
-            i18n.language === "es" ? DATA_REQUEST_FORM_URL_SPANISH : DATA_REQUEST_FORM_URL_ENGLISH
-          }?prefill_Custom+Data+Request=${i18n._(t`BUILDING:`)}+${fullAddress}`}
+          href={`${getDataRequestUrlFromLocale(
+            i18n.language as SupportedLocale
+          )}?prefill_Custom+Data+Request=${i18n._(t`BUILDING:`)}+${fullAddress}`}
           target="_blank"
           rel="noopener noreferrer"
           className="btn btn-block"

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -12,15 +12,44 @@ import { StringifyListWithConjunction } from "./StringifyList";
 import { SocialShareAddressPage } from "./SocialShare";
 import { withMachineInStateProps } from "state-machine";
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
+import { AddressRecord } from "./APIDataTypes";
+import { I18n } from "@lingui/react";
 
 type Props = withMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
 };
 
-const generateLinkToDataRequestForm = (fullAddress: string) =>
-  `https://docs.google.com/forms/d/e/1FAIpQLSfHdokAh4O-vB6jO8Ym0Wv_lL7cVUxsWvxw5rjZ9Ogcht7HxA/viewform?usp=pp_url&entry.1164013846=${encodeURIComponent(
-    fullAddress
-  )}`;
+const DATA_REQUEST_FORM_URL_ENGLISH = "https://airtable.com/shruDUDHViainzUBB";
+const DATA_REQUEST_FORM_URL_SPANISH = "https://airtable.com/shrQudDbhUVz5J83u";
+
+const DataRequestButton: React.FC<{
+  address: AddressRecord;
+}> = ({ address }) => {
+  const fullAddress = encodeURIComponent(
+    `${address.housenumber} ${address.streetname}, ${address.boro}`
+  );
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <a
+          onClick={() => {
+            window.gtag("event", "data-request");
+          }}
+          href={`${
+            i18n.language === "es" ? DATA_REQUEST_FORM_URL_SPANISH : DATA_REQUEST_FORM_URL_ENGLISH
+          }?prefill_Custom+Data+Request=${i18n._(t`BUILDING:`)}+${fullAddress}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn btn-block"
+        >
+          <div>
+            <Trans render="label">Send us a data request</Trans>
+          </div>
+        </a>
+      )}
+    </I18n>
+  );
+};
 
 export default class PropertiesSummary extends Component<Props, {}> {
   updateData() {
@@ -144,21 +173,7 @@ export default class PropertiesSummary extends Component<Props, {}> {
                     <h6 className="PropertiesSummary__linksSubtitle">
                       <Trans>Looking for more information?</Trans>
                     </h6>
-                    <a
-                      onClick={() => {
-                        window.gtag("event", "data-request");
-                      }}
-                      href={generateLinkToDataRequestForm(
-                        `${searchAddr.housenumber} ${searchAddr.streetname}, ${searchAddr.boro}`
-                      )}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="btn btn-block"
-                    >
-                      <div>
-                        <Trans render="label">Send us a data request</Trans>
-                      </div>
-                    </a>
+                    <DataRequestButton address={searchAddr} />
                   </div>
                   <div>
                     <h6 className="PropertiesSummary__linksSubtitle">

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/PropertiesSummary.tsx:123
+#: src/components/PropertiesSummary.tsx:127
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
@@ -61,7 +61,7 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 
-#: src/components/PropertiesSummary.tsx:109
+#: src/components/PropertiesSummary.tsx:113
 msgid "Additional links"
 msgstr "Additional links"
 
@@ -92,7 +92,7 @@ msgstr "Are you having issues in this development?"
 
 #: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
-#: src/components/PropertiesSummary.tsx:20
+#: src/components/PropertiesSummary.tsx:24
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -229,7 +229,7 @@ msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
 #: src/components/PropertiesList.tsx:108
-#: src/components/PropertiesSummary.tsx:102
+#: src/components/PropertiesSummary.tsx:106
 msgid "Evictions"
 msgstr "Evictions"
 
@@ -249,7 +249,7 @@ msgstr "Export Data"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PropertiesSummary.tsx:55
+#: src/components/PropertiesSummary.tsx:59
 msgid "General info"
 msgstr "General info"
 
@@ -310,7 +310,7 @@ msgstr "I just looked up this building on Who Owns What, a free tool built by Ju
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
-#: src/components/PropertiesSummary.tsx:125
+#: src/components/PropertiesSummary.tsx:129
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
@@ -335,7 +335,7 @@ msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
 #: src/components/PropertiesList.tsx:119
-#: src/components/PropertiesSummary.tsx:87
+#: src/components/PropertiesSummary.tsx:91
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -370,7 +370,7 @@ msgstr "Link to Deed"
 
 #: src/components/Indicators.tsx:119
 #: src/components/PropertiesMap.tsx:156
-#: src/components/PropertiesSummary.tsx:48
+#: src/components/PropertiesSummary.tsx:52
 #: src/containers/AddressPage.tsx:165
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
@@ -380,7 +380,7 @@ msgstr "Loading"
 msgid "Location"
 msgstr "Location"
 
-#: src/components/PropertiesSummary.tsx:113
+#: src/components/PropertiesSummary.tsx:117
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
@@ -517,7 +517,7 @@ msgstr "Quarter"
 msgid "RS Units"
 msgstr "RS Units"
 
-#: src/components/PropertiesSummary.tsx:104
+#: src/components/PropertiesSummary.tsx:108
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
@@ -530,7 +530,7 @@ msgstr "Search for a different address"
 msgid "Select a Dataset:"
 msgstr "Select a Dataset:"
 
-#: src/components/PropertiesSummary.tsx:22
+#: src/components/PropertiesSummary.tsx:26
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
@@ -546,7 +546,7 @@ msgstr "Share"
 #: src/components/DetailView.tsx:174
 #: src/components/DetailView.tsx:242
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:119
+#: src/components/PropertiesSummary.tsx:123
 #: src/containers/App.tsx:105
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
@@ -619,11 +619,11 @@ msgstr "The city borough where your search address is located"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
-#: src/components/PropertiesSummary.tsx:95
+#: src/components/PropertiesSummary.tsx:99
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:89
+#: src/components/PropertiesSummary.tsx:93
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
@@ -643,11 +643,11 @@ msgstr "The number of residential units in this building, according to the Dept.
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "The year that this building was originally constructed, according to the Dept. of City Planning."
 
-#: src/components/PropertiesSummary.tsx:68
+#: src/components/PropertiesSummary.tsx:72
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 
-#: src/components/PropertiesSummary.tsx:57
+#: src/components/PropertiesSummary.tsx:61
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
@@ -679,11 +679,11 @@ msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per r
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
-#: src/components/PropertiesSummary.tsx:122
+#: src/components/PropertiesSummary.tsx:126
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 
-#: src/components/PropertiesSummary.tsx:124
+#: src/components/PropertiesSummary.tsx:128
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "This landlord’s buildings average {0} open HPD violations per apartment"
 
@@ -870,7 +870,7 @@ msgstr "for ${0}"
 msgid "search address"
 msgstr "search address"
 
-#: src/components/PropertiesSummary.tsx:78
+#: src/components/PropertiesSummary.tsx:82
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/PropertiesSummary.tsx:127
+#: src/components/PropertiesSummary.tsx:138
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
@@ -61,7 +61,7 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 
-#: src/components/PropertiesSummary.tsx:113
+#: src/components/PropertiesSummary.tsx:124
 msgid "Additional links"
 msgstr "Additional links"
 
@@ -92,7 +92,7 @@ msgstr "Are you having issues in this development?"
 
 #: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
-#: src/components/PropertiesSummary.tsx:24
+#: src/components/PropertiesSummary.tsx:25
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -229,7 +229,7 @@ msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
 #: src/components/PropertiesList.tsx:108
-#: src/components/PropertiesSummary.tsx:106
+#: src/components/PropertiesSummary.tsx:117
 msgid "Evictions"
 msgstr "Evictions"
 
@@ -249,7 +249,7 @@ msgstr "Export Data"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PropertiesSummary.tsx:59
+#: src/components/PropertiesSummary.tsx:70
 msgid "General info"
 msgstr "General info"
 
@@ -310,7 +310,7 @@ msgstr "I just looked up this building on Who Owns What, a free tool built by Ju
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
-#: src/components/PropertiesSummary.tsx:129
+#: src/components/PropertiesSummary.tsx:140
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
@@ -335,7 +335,7 @@ msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
 #: src/components/PropertiesList.tsx:119
-#: src/components/PropertiesSummary.tsx:91
+#: src/components/PropertiesSummary.tsx:102
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -370,7 +370,7 @@ msgstr "Link to Deed"
 
 #: src/components/Indicators.tsx:119
 #: src/components/PropertiesMap.tsx:156
-#: src/components/PropertiesSummary.tsx:52
+#: src/components/PropertiesSummary.tsx:63
 #: src/containers/AddressPage.tsx:165
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
@@ -380,7 +380,7 @@ msgstr "Loading"
 msgid "Location"
 msgstr "Location"
 
-#: src/components/PropertiesSummary.tsx:117
+#: src/components/PropertiesSummary.tsx:128
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
@@ -517,7 +517,7 @@ msgstr "Quarter"
 msgid "RS Units"
 msgstr "RS Units"
 
-#: src/components/PropertiesSummary.tsx:108
+#: src/components/PropertiesSummary.tsx:119
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
@@ -530,7 +530,7 @@ msgstr "Search for a different address"
 msgid "Select a Dataset:"
 msgstr "Select a Dataset:"
 
-#: src/components/PropertiesSummary.tsx:26
+#: src/components/PropertiesSummary.tsx:37
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
@@ -546,7 +546,7 @@ msgstr "Share"
 #: src/components/DetailView.tsx:174
 #: src/components/DetailView.tsx:242
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:123
+#: src/components/PropertiesSummary.tsx:134
 #: src/containers/App.tsx:105
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
@@ -619,11 +619,11 @@ msgstr "The city borough where your search address is located"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
-#: src/components/PropertiesSummary.tsx:99
+#: src/components/PropertiesSummary.tsx:110
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:93
+#: src/components/PropertiesSummary.tsx:104
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
@@ -643,11 +643,11 @@ msgstr "The number of residential units in this building, according to the Dept.
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "The year that this building was originally constructed, according to the Dept. of City Planning."
 
-#: src/components/PropertiesSummary.tsx:72
+#: src/components/PropertiesSummary.tsx:83
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 
-#: src/components/PropertiesSummary.tsx:61
+#: src/components/PropertiesSummary.tsx:72
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
@@ -679,11 +679,11 @@ msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per r
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
-#: src/components/PropertiesSummary.tsx:126
+#: src/components/PropertiesSummary.tsx:137
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 
-#: src/components/PropertiesSummary.tsx:128
+#: src/components/PropertiesSummary.tsx:139
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "This landlord’s buildings average {0} open HPD violations per apartment"
 
@@ -870,7 +870,7 @@ msgstr "for ${0}"
 msgid "search address"
 msgstr "search address"
 
-#: src/components/PropertiesSummary.tsx:82
+#: src/components/PropertiesSummary.tsx:93
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/PropertiesSummary.tsx:115
+#: src/components/PropertiesSummary.tsx:123
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
@@ -61,7 +61,7 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 
-#: src/components/PropertiesSummary.tsx:95
+#: src/components/PropertiesSummary.tsx:109
 msgid "Additional links"
 msgstr "Additional links"
 
@@ -92,6 +92,7 @@ msgstr "Are you having issues in this development?"
 
 #: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
+#: src/components/PropertiesSummary.tsx:20
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -228,7 +229,7 @@ msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
 #: src/components/PropertiesList.tsx:108
-#: src/components/PropertiesSummary.tsx:88
+#: src/components/PropertiesSummary.tsx:102
 msgid "Evictions"
 msgstr "Evictions"
 
@@ -248,7 +249,7 @@ msgstr "Export Data"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PropertiesSummary.tsx:41
+#: src/components/PropertiesSummary.tsx:55
 msgid "General info"
 msgstr "General info"
 
@@ -309,7 +310,7 @@ msgstr "I just looked up this building on Who Owns What, a free tool built by Ju
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
-#: src/components/PropertiesSummary.tsx:117
+#: src/components/PropertiesSummary.tsx:125
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
@@ -334,7 +335,7 @@ msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
 #: src/components/PropertiesList.tsx:119
-#: src/components/PropertiesSummary.tsx:73
+#: src/components/PropertiesSummary.tsx:87
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -369,8 +370,8 @@ msgstr "Link to Deed"
 
 #: src/components/Indicators.tsx:119
 #: src/components/PropertiesMap.tsx:156
-#: src/components/PropertiesSummary.tsx:34
-#: src/containers/AddressPage.tsx:162
+#: src/components/PropertiesSummary.tsx:48
+#: src/containers/AddressPage.tsx:165
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
 msgstr "Loading"
@@ -379,7 +380,7 @@ msgstr "Loading"
 msgid "Location"
 msgstr "Location"
 
-#: src/components/PropertiesSummary.tsx:99
+#: src/components/PropertiesSummary.tsx:113
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
@@ -471,7 +472,7 @@ msgstr "Open"
 msgid "Open Violations"
 msgstr "Open Violations"
 
-#: src/containers/AddressPage.tsx:111
+#: src/containers/AddressPage.tsx:114
 msgid "Overview"
 msgstr "Overview"
 
@@ -479,7 +480,7 @@ msgstr "Overview"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 
-#: src/containers/AddressPage.tsx:103
+#: src/containers/AddressPage.tsx:106
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
@@ -494,7 +495,7 @@ msgstr "People"
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/containers/AddressPage.tsx:125
+#: src/containers/AddressPage.tsx:128
 msgid "Portfolio"
 msgstr "Portfolio"
 
@@ -516,7 +517,7 @@ msgstr "Quarter"
 msgid "RS Units"
 msgstr "RS Units"
 
-#: src/components/PropertiesSummary.tsx:90
+#: src/components/PropertiesSummary.tsx:104
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
@@ -529,7 +530,7 @@ msgstr "Search for a different address"
 msgid "Select a Dataset:"
 msgstr "Select a Dataset:"
 
-#: src/components/PropertiesSummary.tsx:105
+#: src/components/PropertiesSummary.tsx:22
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
@@ -545,7 +546,7 @@ msgstr "Share"
 #: src/components/DetailView.tsx:174
 #: src/components/DetailView.tsx:242
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:111
+#: src/components/PropertiesSummary.tsx:119
 #: src/containers/App.tsx:105
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
@@ -583,7 +584,7 @@ msgstr "Sorry, the page you are looking for doesn't seem to exist."
 msgid "Source code"
 msgstr "Source code"
 
-#: src/containers/AddressPage.tsx:132
+#: src/containers/AddressPage.tsx:135
 msgid "Summary"
 msgstr "Summary"
 
@@ -618,11 +619,11 @@ msgstr "The city borough where your search address is located"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
-#: src/components/PropertiesSummary.tsx:81
+#: src/components/PropertiesSummary.tsx:95
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:75
+#: src/components/PropertiesSummary.tsx:89
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
@@ -642,11 +643,11 @@ msgstr "The number of residential units in this building, according to the Dept.
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "The year that this building was originally constructed, according to the Dept. of City Planning."
 
-#: src/components/PropertiesSummary.tsx:54
+#: src/components/PropertiesSummary.tsx:68
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 
-#: src/components/PropertiesSummary.tsx:43
+#: src/components/PropertiesSummary.tsx:57
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
@@ -678,11 +679,11 @@ msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per r
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
-#: src/components/PropertiesSummary.tsx:114
+#: src/components/PropertiesSummary.tsx:122
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 
-#: src/components/PropertiesSummary.tsx:116
+#: src/components/PropertiesSummary.tsx:124
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "This landlord’s buildings average {0} open HPD violations per apartment"
 
@@ -718,7 +719,7 @@ msgstr "This tracks how rent stabilized units in the building have changed (i.e.
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:118
+#: src/containers/AddressPage.tsx:121
 msgid "Timeline"
 msgstr "Timeline"
 
@@ -869,7 +870,7 @@ msgstr "for ${0}"
 msgid "search address"
 msgstr "search address"
 
-#: src/components/PropertiesSummary.tsx:64
+#: src/components/PropertiesSummary.tsx:78
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 31\n"
 
-#: src/components/PropertiesSummary.tsx:123
+#: src/components/PropertiesSummary.tsx:127
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
@@ -66,7 +66,7 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha recibido un total de <0>{totalviolations}</0> infracciones."
 
-#: src/components/PropertiesSummary.tsx:109
+#: src/components/PropertiesSummary.tsx:113
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
@@ -97,7 +97,7 @@ msgstr "¿Tienes problemas en tu edificio?"
 
 #: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
-#: src/components/PropertiesSummary.tsx:20
+#: src/components/PropertiesSummary.tsx:24
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -234,7 +234,7 @@ msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
 #: src/components/PropertiesList.tsx:108
-#: src/components/PropertiesSummary.tsx:102
+#: src/components/PropertiesSummary.tsx:106
 msgid "Evictions"
 msgstr "Desalojos"
 
@@ -254,7 +254,7 @@ msgstr "Exportar datos"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PropertiesSummary.tsx:55
+#: src/components/PropertiesSummary.tsx:59
 msgid "General info"
 msgstr "Información general"
 
@@ -315,7 +315,7 @@ msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta grat
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
-#: src/components/PropertiesSummary.tsx:125
+#: src/components/PropertiesSummary.tsx:129
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
@@ -340,7 +340,7 @@ msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
 #: src/components/PropertiesList.tsx:119
-#: src/components/PropertiesSummary.tsx:87
+#: src/components/PropertiesSummary.tsx:91
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -375,7 +375,7 @@ msgstr "Enlace a la Escritura"
 
 #: src/components/Indicators.tsx:119
 #: src/components/PropertiesMap.tsx:156
-#: src/components/PropertiesSummary.tsx:48
+#: src/components/PropertiesSummary.tsx:52
 #: src/containers/AddressPage.tsx:165
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
@@ -385,7 +385,7 @@ msgstr "Cargando"
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/PropertiesSummary.tsx:113
+#: src/components/PropertiesSummary.tsx:117
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
@@ -522,7 +522,7 @@ msgstr "Trimestre"
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
-#: src/components/PropertiesSummary.tsx:104
+#: src/components/PropertiesSummary.tsx:108
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
@@ -535,7 +535,7 @@ msgstr "Buscar otra dirección"
 msgid "Select a Dataset:"
 msgstr "Seleccione un conjunto de datos:"
 
-#: src/components/PropertiesSummary.tsx:22
+#: src/components/PropertiesSummary.tsx:26
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
@@ -551,7 +551,7 @@ msgstr "Compartir"
 #: src/components/DetailView.tsx:174
 #: src/components/DetailView.tsx:242
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:119
+#: src/components/PropertiesSummary.tsx:123
 #: src/containers/App.tsx:105
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
@@ -624,11 +624,11 @@ msgstr "El municipio donde se encuentra la dirección que has buscado"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
-#: src/components/PropertiesSummary.tsx:95
+#: src/components/PropertiesSummary.tsx:99
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:89
+#: src/components/PropertiesSummary.tsx:93
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "{0, plural, one {El nombre más común que aparece en este portafolio de edificios es} other {Los nombres más comunes que aparecen en este portafolio de edificios son}} <0/>."
 
@@ -648,11 +648,11 @@ msgstr "El número de unidades residenciales en este edificio, según el Departa
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "El año en que este edificio fue construido, según el Departamento de Planificación de la Ciudad."
 
-#: src/components/PropertiesSummary.tsx:68
+#: src/components/PropertiesSummary.tsx:72
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
-#: src/components/PropertiesSummary.tsx:57
+#: src/components/PropertiesSummary.tsx:61
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
@@ -684,11 +684,11 @@ msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "El identificador oficial del edificio según los registros del Departamento de Finanzas."
 
-#: src/components/PropertiesSummary.tsx:122
+#: src/components/PropertiesSummary.tsx:126
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "Este dueño de edificio posee {0} edificios, y según @NYCHousing, ha recibido un total de {1} violaciones del código de vivienda. ¿Puedes adivinar como se llama el dueño? Encuentra su nombre y ve más estadísticas aquí:"
 
-#: src/components/PropertiesSummary.tsx:124
+#: src/components/PropertiesSummary.tsx:128
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "Los edificios de este dueño tienen un promedio de {0} violaciones abiertas de HPD por cada apartamento"
 
@@ -875,7 +875,7 @@ msgstr "por ${0}"
 msgid "search address"
 msgstr "dirección de búsqueda"
 
-#: src/components/PropertiesSummary.tsx:78
+#: src/components/PropertiesSummary.tsx:82
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una infracción del HPD actual} other {# infracciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 31\n"
 
-#: src/components/PropertiesSummary.tsx:115
+#: src/components/PropertiesSummary.tsx:123
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
@@ -66,7 +66,7 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha recibido un total de <0>{totalviolations}</0> infracciones."
 
-#: src/components/PropertiesSummary.tsx:95
+#: src/components/PropertiesSummary.tsx:109
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
@@ -97,6 +97,7 @@ msgstr "¿Tienes problemas en tu edificio?"
 
 #: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
+#: src/components/PropertiesSummary.tsx:20
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -233,7 +234,7 @@ msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
 #: src/components/PropertiesList.tsx:108
-#: src/components/PropertiesSummary.tsx:88
+#: src/components/PropertiesSummary.tsx:102
 msgid "Evictions"
 msgstr "Desalojos"
 
@@ -253,7 +254,7 @@ msgstr "Exportar datos"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PropertiesSummary.tsx:41
+#: src/components/PropertiesSummary.tsx:55
 msgid "General info"
 msgstr "Información general"
 
@@ -314,7 +315,7 @@ msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta grat
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
-#: src/components/PropertiesSummary.tsx:117
+#: src/components/PropertiesSummary.tsx:125
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
@@ -339,7 +340,7 @@ msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
 #: src/components/PropertiesList.tsx:119
-#: src/components/PropertiesSummary.tsx:73
+#: src/components/PropertiesSummary.tsx:87
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -374,8 +375,8 @@ msgstr "Enlace a la Escritura"
 
 #: src/components/Indicators.tsx:119
 #: src/components/PropertiesMap.tsx:156
-#: src/components/PropertiesSummary.tsx:34
-#: src/containers/AddressPage.tsx:162
+#: src/components/PropertiesSummary.tsx:48
+#: src/containers/AddressPage.tsx:165
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
 msgstr "Cargando"
@@ -384,7 +385,7 @@ msgstr "Cargando"
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/PropertiesSummary.tsx:99
+#: src/components/PropertiesSummary.tsx:113
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
@@ -476,7 +477,7 @@ msgstr "Abrir"
 msgid "Open Violations"
 msgstr "Infracciones Actuales"
 
-#: src/containers/AddressPage.tsx:111
+#: src/containers/AddressPage.tsx:114
 msgid "Overview"
 msgstr "General"
 
@@ -484,7 +485,7 @@ msgstr "General"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/> Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
 
-#: src/containers/AddressPage.tsx:103
+#: src/containers/AddressPage.tsx:106
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
@@ -499,7 +500,7 @@ msgstr "Personas (Encontrarás definiciones en español de los tipos de personas
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/containers/AddressPage.tsx:125
+#: src/containers/AddressPage.tsx:128
 msgid "Portfolio"
 msgstr "Portafolio"
 
@@ -521,7 +522,7 @@ msgstr "Trimestre"
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
-#: src/components/PropertiesSummary.tsx:90
+#: src/components/PropertiesSummary.tsx:104
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
@@ -534,7 +535,7 @@ msgstr "Buscar otra dirección"
 msgid "Select a Dataset:"
 msgstr "Seleccione un conjunto de datos:"
 
-#: src/components/PropertiesSummary.tsx:105
+#: src/components/PropertiesSummary.tsx:22
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
@@ -550,7 +551,7 @@ msgstr "Compartir"
 #: src/components/DetailView.tsx:174
 #: src/components/DetailView.tsx:242
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:111
+#: src/components/PropertiesSummary.tsx:119
 #: src/containers/App.tsx:105
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
@@ -588,7 +589,7 @@ msgstr "Lo sentimos, la página que estás buscando no existe."
 msgid "Source code"
 msgstr "Código fuente"
 
-#: src/containers/AddressPage.tsx:132
+#: src/containers/AddressPage.tsx:135
 msgid "Summary"
 msgstr "Resúmen"
 
@@ -623,11 +624,11 @@ msgstr "El municipio donde se encuentra la dirección que has buscado"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
-#: src/components/PropertiesSummary.tsx:81
+#: src/components/PropertiesSummary.tsx:95
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:75
+#: src/components/PropertiesSummary.tsx:89
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "{0, plural, one {El nombre más común que aparece en este portafolio de edificios es} other {Los nombres más comunes que aparecen en este portafolio de edificios son}} <0/>."
 
@@ -647,11 +648,11 @@ msgstr "El número de unidades residenciales en este edificio, según el Departa
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "El año en que este edificio fue construido, según el Departamento de Planificación de la Ciudad."
 
-#: src/components/PropertiesSummary.tsx:54
+#: src/components/PropertiesSummary.tsx:68
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
-#: src/components/PropertiesSummary.tsx:43
+#: src/components/PropertiesSummary.tsx:57
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
@@ -683,11 +684,11 @@ msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "El identificador oficial del edificio según los registros del Departamento de Finanzas."
 
-#: src/components/PropertiesSummary.tsx:114
+#: src/components/PropertiesSummary.tsx:122
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "Este dueño de edificio posee {0} edificios, y según @NYCHousing, ha recibido un total de {1} violaciones del código de vivienda. ¿Puedes adivinar como se llama el dueño? Encuentra su nombre y ve más estadísticas aquí:"
 
-#: src/components/PropertiesSummary.tsx:116
+#: src/components/PropertiesSummary.tsx:124
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "Los edificios de este dueño tienen un promedio de {0} violaciones abiertas de HPD por cada apartamento"
 
@@ -723,7 +724,7 @@ msgstr "El cambio en apartamentos de renta estabilizada que hay en el edificio (
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:118
+#: src/containers/AddressPage.tsx:121
 msgid "Timeline"
 msgstr "Cronología"
 
@@ -874,7 +875,7 @@ msgstr "por ${0}"
 msgid "search address"
 msgstr "dirección de búsqueda"
 
-#: src/components/PropertiesSummary.tsx:64
+#: src/components/PropertiesSummary.tsx:78
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una infracción del HPD actual} other {# infracciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 
@@ -889,4 +890,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:34
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Infracción del HPD emitida desde el 2010} other {# Infracciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 31\n"
 
-#: src/components/PropertiesSummary.tsx:127
+#: src/components/PropertiesSummary.tsx:138
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
@@ -66,7 +66,7 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha recibido un total de <0>{totalviolations}</0> infracciones."
 
-#: src/components/PropertiesSummary.tsx:113
+#: src/components/PropertiesSummary.tsx:124
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
@@ -97,7 +97,7 @@ msgstr "¿Tienes problemas en tu edificio?"
 
 #: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
-#: src/components/PropertiesSummary.tsx:24
+#: src/components/PropertiesSummary.tsx:25
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -234,7 +234,7 @@ msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
 #: src/components/PropertiesList.tsx:108
-#: src/components/PropertiesSummary.tsx:106
+#: src/components/PropertiesSummary.tsx:117
 msgid "Evictions"
 msgstr "Desalojos"
 
@@ -254,7 +254,7 @@ msgstr "Exportar datos"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PropertiesSummary.tsx:59
+#: src/components/PropertiesSummary.tsx:70
 msgid "General info"
 msgstr "Información general"
 
@@ -315,7 +315,7 @@ msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta grat
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
-#: src/components/PropertiesSummary.tsx:129
+#: src/components/PropertiesSummary.tsx:140
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
@@ -340,7 +340,7 @@ msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
 #: src/components/PropertiesList.tsx:119
-#: src/components/PropertiesSummary.tsx:91
+#: src/components/PropertiesSummary.tsx:102
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -375,7 +375,7 @@ msgstr "Enlace a la Escritura"
 
 #: src/components/Indicators.tsx:119
 #: src/components/PropertiesMap.tsx:156
-#: src/components/PropertiesSummary.tsx:52
+#: src/components/PropertiesSummary.tsx:63
 #: src/containers/AddressPage.tsx:165
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
@@ -385,7 +385,7 @@ msgstr "Cargando"
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/PropertiesSummary.tsx:117
+#: src/components/PropertiesSummary.tsx:128
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
@@ -522,7 +522,7 @@ msgstr "Trimestre"
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
-#: src/components/PropertiesSummary.tsx:108
+#: src/components/PropertiesSummary.tsx:119
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
@@ -535,7 +535,7 @@ msgstr "Buscar otra dirección"
 msgid "Select a Dataset:"
 msgstr "Seleccione un conjunto de datos:"
 
-#: src/components/PropertiesSummary.tsx:26
+#: src/components/PropertiesSummary.tsx:37
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
@@ -551,7 +551,7 @@ msgstr "Compartir"
 #: src/components/DetailView.tsx:174
 #: src/components/DetailView.tsx:242
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:123
+#: src/components/PropertiesSummary.tsx:134
 #: src/containers/App.tsx:105
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
@@ -624,11 +624,11 @@ msgstr "El municipio donde se encuentra la dirección que has buscado"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
-#: src/components/PropertiesSummary.tsx:99
+#: src/components/PropertiesSummary.tsx:110
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:93
+#: src/components/PropertiesSummary.tsx:104
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "{0, plural, one {El nombre más común que aparece en este portafolio de edificios es} other {Los nombres más comunes que aparecen en este portafolio de edificios son}} <0/>."
 
@@ -648,11 +648,11 @@ msgstr "El número de unidades residenciales en este edificio, según el Departa
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "El año en que este edificio fue construido, según el Departamento de Planificación de la Ciudad."
 
-#: src/components/PropertiesSummary.tsx:72
+#: src/components/PropertiesSummary.tsx:83
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
-#: src/components/PropertiesSummary.tsx:61
+#: src/components/PropertiesSummary.tsx:72
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
@@ -684,11 +684,11 @@ msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "El identificador oficial del edificio según los registros del Departamento de Finanzas."
 
-#: src/components/PropertiesSummary.tsx:126
+#: src/components/PropertiesSummary.tsx:137
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "Este dueño de edificio posee {0} edificios, y según @NYCHousing, ha recibido un total de {1} violaciones del código de vivienda. ¿Puedes adivinar como se llama el dueño? Encuentra su nombre y ve más estadísticas aquí:"
 
-#: src/components/PropertiesSummary.tsx:128
+#: src/components/PropertiesSummary.tsx:139
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "Los edificios de este dueño tienen un promedio de {0} violaciones abiertas de HPD por cada apartamento"
 
@@ -875,7 +875,7 @@ msgstr "por ${0}"
 msgid "search address"
 msgstr "dirección de búsqueda"
 
-#: src/components/PropertiesSummary.tsx:82
+#: src/components/PropertiesSummary.tsx:93
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una infracción del HPD actual} other {# infracciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 


### PR DESCRIPTION
Our new WOW Data Request form is built on AirTable and is available in [English](https://airtable.com/shruDUDHViainzUBB) and in [Spanish](https://airtable.com/shrQudDbhUVz5J83u)! This PR updates our outbound link on the Summary tab with the new form in its full i18n splendor.