### PR TITLE
Add hpd_complaints data to wow_bldgs table

### DIFF
--- a/sql/create_bldgs_table.sql
+++ b/sql/create_bldgs_table.sql
@@ -70,7 +70,7 @@ select distinct on (registrations.bbl)
   registrations.*,
   coalesce(violations.total, 0)::int as totalviolations,
   coalesce(violations.opentotal, 0)::int as openviolations,
-  coalesce(complaints.totalcomplaints, 0):: int as totalcomplaints,
+  coalesce(complaints.totalcomplaints, 0)::int as totalcomplaints,
   complaints.complaintsbytype,
   pluto.unitsres,
   pluto.yearbuilt,

--- a/tests/factories/hpd_complaint_problems.py
+++ b/tests/factories/hpd_complaint_problems.py
@@ -1,0 +1,22 @@
+from typing import NamedTuple
+
+
+class HpdComplaintProblems(NamedTuple):
+    ProblemID: str = '17307278'
+    ComplaintID: str = '8412850'
+    UnitTypeID: str = '91'
+    UnitType: str = 'APARTMENT'
+    SpaceTypeID : str = '543'
+    SpaceType: str = 'ENTIRE APARTMENT'
+    TypeID: str = '1'
+    Type: str = 'EMERGENCY'
+    MajorCategoryID: str = '56'
+    MajorCategory: str = 'DOOR/WINDOW'
+    MinorCategoryID: str = '337'
+    MinorCategory: str = 'WINDOW FRAME'
+    CodeID: str = '2836'
+    Code: str = 'LOOSE OR DEFECTIVE'
+    StatusID: str = '2'
+    Status: str = 'CLOSE'
+    StatusDate: str = '03/31/2017'
+    StatusDescription: str = 'The Department of Housing Preservation and Development inspected the following conditions. No violations were issued. The complaint has been closed.'

--- a/tests/factories/hpd_complaints.py
+++ b/tests/factories/hpd_complaints.py
@@ -1,0 +1,19 @@
+from typing import NamedTuple
+
+
+class HpdComplaints(NamedTuple):
+    ComplaintID: str = '6960137'
+    BuildingID: str = '3418'
+    BoroughID: str = '1'
+    Borough: str = 'MANHATTAN'
+    HouseNumber: str = '1989'
+    StreetName: str = 'ADAM C POWELL BOULEVARD'
+    Zip: str = '10026'
+    Block: str = '1904'
+    Lot: str = '4'
+    Apartment: str = '12D'
+    CommunityBoard: str = '10'
+    ReceivedDate: str = '07/07/2014'
+    StatusID: str = '2'
+    Status: str = 'CLOSE'
+    StatusDate: str = '07/29/2014'

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -2,6 +2,8 @@ import pytest
 
 from .factories.hpd_contacts import HpdContacts
 from .factories.hpd_registrations import HpdRegistrations
+from .factories.hpd_complaints import HpdComplaints
+from .factories.hpd_complaint_problems import HpdComplaintProblems
 from .factories.marshal_evictions_17 import MarshalEvictions17
 from .factories.marshal_evictions_18 import MarshalEvictions18
 from .factories.marshal_evictions_19 import MarshalEvictions19
@@ -121,6 +123,8 @@ class TestSQL:
             'PLUTO_for_WEB/BK_19v2.csv': [Pluto19v2()]
         })
         nycdb_ctx.write_csv('hpd_violations.csv', [HpdViolations()])
+        nycdb_ctx.write_csv('hpd_complaints.csv', [HpdComplaints()])
+        nycdb_ctx.write_csv('hpd_complaint_problems.csv', [HpdComplaintProblems()])
         nycdb_ctx.write_csv('changes-summary.csv', [ChangesSummary()])
         nycdb_ctx.write_csv('marshal_evictions_17.csv', [MarshalEvictions17()])
         nycdb_ctx.write_csv('marshal_evictions_18.csv', [MarshalEvictions18()])

--- a/who-owns-what.yml
+++ b/who-owns-what.yml
@@ -7,6 +7,7 @@ dependencies:
   - marshal_evictions
   - hpd_registrations
   - hpd_violations
+  - hpd_complaints
   - acris
   - nycha_bbls
 api_dependencies:


### PR DESCRIPTION
This adds three new columns to the `wow_bldgs` table that we use to source all the data presented on the "overview" tab. The three columns are:
- `totalcomplaints`: total hpd_complaints received by 311 ever
- `recentcomplaints`: total hpd_complaints received by 311 over the last 3 years
- `recentcomplaintsbytype`: an array of complaint _types_ and their frequency, ordered from most frequent to least, over the last 3 years

Note that I chose the 3 year cutoff totally arbitrarily. My thinking was that folks would want to know what kinds of complaints have been issued most recently, but that's obviously subjective...