### PR TITLE
Improve format for `recentcomplaintsbytype` column in CSV export

### DIFF
--- a/wow/csvutil.py
+++ b/wow/csvutil.py
@@ -8,7 +8,7 @@ def stringify_owners(owners: List[Dict[str, str]]) -> str:
     ])
 
 
-def stringify_complaint_types(complaints: List[Dict[str, str]]) -> str:
+def stringify_complaints(complaints: List[Dict[str, str]]) -> str:
     return ', '.join([
         f"{complaint['type']} ({complaint['title']})"
         for complaint in complaints

--- a/wow/csvutil.py
+++ b/wow/csvutil.py
@@ -9,10 +9,13 @@ def stringify_owners(owners: List[Dict[str, str]]) -> str:
 
 
 def stringify_complaints(complaints: List[Dict[str, str]]) -> str:
-    return ', '.join([
-        f"{complaint['type']} ({complaint['count']})"
-        for complaint in complaints
-    ])
+    if complaints:
+        return ', '.join([
+            f"{complaint['type']} ({complaint['count']})"
+            for complaint in complaints
+        ])
+    else:
+        return ''
 
 
 def stringify_lists(d: Dict[str, Any]):

--- a/wow/csvutil.py
+++ b/wow/csvutil.py
@@ -8,6 +8,13 @@ def stringify_owners(owners: List[Dict[str, str]]) -> str:
     ])
 
 
+def stringify_complaint_types(complaints: List[Dict[str, str]]) -> str:
+    return ', '.join([
+        f"{complaint['type']} ({complaint['title']})"
+        for complaint in complaints
+    ])
+
+
 def stringify_lists(d: Dict[str, Any]):
     for key, value in d.items():
         if isinstance(value, list):

--- a/wow/csvutil.py
+++ b/wow/csvutil.py
@@ -10,7 +10,7 @@ def stringify_owners(owners: List[Dict[str, str]]) -> str:
 
 def stringify_complaints(complaints: List[Dict[str, str]]) -> str:
     return ', '.join([
-        f"{complaint['type']} ({complaint['title']})"
+        f"{complaint['type']} ({complaint['count']})"
         for complaint in complaints
     ])
 

--- a/wow/views.py
+++ b/wow/views.py
@@ -131,8 +131,10 @@ def address_export(request):
     first_row = addrs[0]
 
     for addr in addrs:
-        addr['ownernames'] = csvutil.stringify_owners(addr['ownernames'])
-        addr['recentcomplaintsbytype'] = csvutil.stringify_complaint_types(addr['recentcomplaintsbytype'])
+        addr["ownernames"] = csvutil.stringify_owners(addr["ownernames"])
+        addr["recentcomplaintsbytype"] = csvutil.stringify_complaints(
+            addr["recentcomplaintsbytype"]
+        )
         csvutil.stringify_lists(addr)
 
     # https://docs.djangoproject.com/en/3.0/howto/outputting-csv/

--- a/wow/views.py
+++ b/wow/views.py
@@ -131,9 +131,9 @@ def address_export(request):
     first_row = addrs[0]
 
     for addr in addrs:
-        addr["ownernames"] = csvutil.stringify_owners(addr["ownernames"])
-        addr["recentcomplaintsbytype"] = csvutil.stringify_complaints(
-            addr["recentcomplaintsbytype"]
+        addr['ownernames'] = csvutil.stringify_owners(addr['ownernames'])
+        addr['recentcomplaintsbytype'] = csvutil.stringify_complaints(
+            addr['recentcomplaintsbytype']
         )
         csvutil.stringify_lists(addr)
 

--- a/wow/views.py
+++ b/wow/views.py
@@ -132,6 +132,7 @@ def address_export(request):
 
     for addr in addrs:
         addr['ownernames'] = csvutil.stringify_owners(addr['ownernames'])
+        addr['recentcomplaintsbytype'] = csvutil.stringify_complaint_types(addr['recentcomplaintsbytype'])
         csvutil.stringify_lists(addr)
 
     # https://docs.djangoproject.com/en/3.0/howto/outputting-csv/


### PR DESCRIPTION
So, given that #457 has been merged and deployed to our auto-updating instance of NYCDB, the new hpd_complaints data that we added is now, by default, part of the CSV data export that users receive when clicking on the "Export Data" button on WOW. We can think of this as a nice little "soft launch" (or even an "easter egg") of the new data before we actually bake it in to our front-end somewhere.

In the meantime, though, I want to format the `recentcomplaintsbytype` column as the default json structure is hard to read.