### PR TITLE
Add hpd complaints data to Portfolio Tab

### DIFF
--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -19,7 +19,7 @@ type HpdOwnerContact = {
   value: string;
 };
 
-type HpdComplaintCount = {
+export type HpdComplaintCount = {
   type: string;
   count: number;
 };

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -135,9 +135,9 @@ const PropertiesListWithoutI18n: React.FC<
               {
                 Header: i18n._(t`Top Complaint`),
                 accessor: (d) => {
-                  const complaintType = findMostCommonType(d.recentcomplaintsbytype);
-                  return complaintType
-                    ? Helpers.getTranslationOfComplaintType(complaintType, i18n)
+                  const mostCommonType = findMostCommonType(d.recentcomplaintsbytype);
+                  return mostCommonType
+                    ? Helpers.getTranslationOfComplaintType(mostCommonType, i18n)
                     : null;
                 },
                 id: "recentcomplaintsbytype",

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -136,7 +136,7 @@ const PropertiesListWithoutI18n: React.FC<
                 Header: i18n._(t`Top Complaint`),
                 accessor: (d) => {
                   const complaintType = findMostCommonType(d.recentcomplaintsbytype);
-                  return complaintType ? Helpers.getI18nComplaintType(complaintType, i18n) : null;
+                  return complaintType ? Helpers.getTranslationOfComplaintType(complaintType, i18n) : null;
                 },
                 id: "recentcomplaintsbytype",
                 minWidth: 150,

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -10,7 +10,7 @@ import { t } from "@lingui/macro";
 import { Link } from "react-router-dom";
 import { SupportedLocale } from "../i18n-base";
 import Helpers, { longDateOptions } from "../util/helpers";
-import { AddressRecord } from "./APIDataTypes";
+import { AddressRecord, HpdComplaintCount } from "./APIDataTypes";
 import { withMachineInStateProps } from "state-machine";
 import { AddressPageRoutes } from "routes";
 
@@ -18,6 +18,9 @@ export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
   const addrsWithMatchingSale = addrs.filter((addr) => addr.lastsaleacrisid === saleId);
   return addrsWithMatchingSale.length > 1;
 };
+
+const findMostCommonType = (complaints: HpdComplaintCount[] | null) =>
+  complaints && complaints.length > 0 && complaints[0].type;
 
 const PropertiesListWithoutI18n: React.FC<
   withMachineInStateProps<"portfolioFound"> & {
@@ -111,6 +114,29 @@ const PropertiesListWithoutI18n: React.FC<
                   );
                 },
                 maxWidth: 75,
+              },
+            ],
+          },
+          {
+            Header: i18n._(t`HPD Complaints`),
+            columns: [
+              {
+                Header: i18n._(t`Total`),
+                accessor: (d) => d.totalcomplaints,
+                id: "totalcomplaints",
+                maxWidth: 75,
+              },
+              {
+                Header: i18n._(t`Last 3 Years`),
+                accessor: (d) => d.recentcomplaints,
+                id: "recentcomplaints",
+                maxWidth: 100,
+              },
+              {
+                Header: i18n._(t`Top Complaint`),
+                accessor: (d) => findMostCommonType(d.recentcomplaintsbytype),
+                id: "recentcomplaintsbytype",
+                minWidth: 150,
               },
             ],
           },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -134,7 +134,10 @@ const PropertiesListWithoutI18n: React.FC<
               },
               {
                 Header: i18n._(t`Top Complaint`),
-                accessor: (d) => findMostCommonType(d.recentcomplaintsbytype),
+                accessor: (d) => {
+                  const complaintType = findMostCommonType(d.recentcomplaintsbytype);
+                  return complaintType ? Helpers.getI18nComplaintType(complaintType, i18n) : null;
+                },
                 id: "recentcomplaintsbytype",
                 minWidth: 150,
               },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -136,7 +136,9 @@ const PropertiesListWithoutI18n: React.FC<
                 Header: i18n._(t`Top Complaint`),
                 accessor: (d) => {
                   const complaintType = findMostCommonType(d.recentcomplaintsbytype);
-                  return complaintType ? Helpers.getTranslationOfComplaintType(complaintType, i18n) : null;
+                  return complaintType
+                    ? Helpers.getTranslationOfComplaintType(complaintType, i18n)
+                    : null;
                 },
                 id: "recentcomplaintsbytype",
                 minWidth: 150,

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -61,7 +61,7 @@ msgstr "According to available HPD data, this portfolio has received <0>{totalvi
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:25
+#: src/components/PropertiesList.tsx:26
 msgid "Address"
 msgstr "Address"
 
@@ -73,7 +73,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:145
+#: src/components/PropertiesList.tsx:169
 msgid "Amount"
 msgstr "Amount"
 
@@ -95,7 +95,7 @@ msgstr "BUILDING:"
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
-#: src/components/PropertiesList.tsx:40
+#: src/components/PropertiesList.tsx:41
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -123,7 +123,7 @@ msgstr "Building Permits Applied For"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:55
+#: src/components/PropertiesList.tsx:56
 msgid "Built"
 msgstr "Built"
 
@@ -185,7 +185,7 @@ msgstr "DOB Building Profile"
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
-#: src/components/PropertiesList.tsx:137
+#: src/components/PropertiesList.tsx:161
 msgid "Date"
 msgstr "Date"
 
@@ -223,7 +223,7 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:108
+#: src/components/PropertiesList.tsx:132
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -249,7 +249,7 @@ msgstr "Failure to register a building with HPD"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:161
+#: src/components/PropertiesList.tsx:185
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -259,6 +259,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:6
+#: src/components/PropertiesList.tsx:92
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -267,7 +268,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:91
+#: src/components/PropertiesList.tsx:115
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -314,7 +315,7 @@ msgstr "I was checking out this building on Who Owns What, a free landlord resea
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:52
+#: src/components/PropertiesList.tsx:53
 msgid "Information"
 msgstr "Information"
 
@@ -330,7 +331,7 @@ msgstr "Join the fight for tenant rights!"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
-#: src/components/PropertiesList.tsx:119
+#: src/components/PropertiesList.tsx:143
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Landlord"
@@ -339,7 +340,11 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:134
+#: src/components/PropertiesList.tsx:101
+msgid "Last 3 Years"
+msgstr "Last 3 Years"
+
+#: src/components/PropertiesList.tsx:158
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -359,8 +364,8 @@ msgstr "Last sold:"
 msgid "Legend"
 msgstr "Legend"
 
-#: src/components/PropertiesList.tsx:153
-#: src/components/PropertiesList.tsx:155
+#: src/components/PropertiesList.tsx:177
+#: src/components/PropertiesList.tsx:179
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -372,7 +377,7 @@ msgstr "Link to Deed"
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:22
+#: src/components/PropertiesList.tsx:23
 msgid "Location"
 msgstr "Location"
 
@@ -417,7 +422,7 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:170
+#: src/components/PropertiesList.tsx:194
 msgid "No"
 msgstr "No"
 
@@ -446,7 +451,7 @@ msgstr "Non-Emergency"
 msgid "Not found"
 msgstr "Not found"
 
-#: src/components/PropertiesList.tsx:122
+#: src/components/PropertiesList.tsx:146
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -460,7 +465,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:94
+#: src/components/PropertiesList.tsx:118
 msgid "Open"
 msgstr "Open"
 
@@ -509,7 +514,7 @@ msgid "Quarter"
 msgstr "Quarter"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:69
+#: src/components/PropertiesList.tsx:70
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -556,7 +561,7 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:111
+#: src/components/PropertiesList.tsx:135
 msgid "Since 2017"
 msgstr "Since 2017"
 
@@ -719,8 +724,13 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
+#: src/components/PropertiesList.tsx:107
+msgid "Top Complaint"
+msgstr "Top Complaint"
+
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:100
+#: src/components/PropertiesList.tsx:95
+#: src/components/PropertiesList.tsx:124
 msgid "Total"
 msgstr "Total"
 
@@ -737,7 +747,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:61
+#: src/components/PropertiesList.tsx:62
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -762,8 +772,8 @@ msgstr "View by:"
 msgid "View data over time"
 msgstr "View data over time"
 
-#: src/components/PropertiesList.tsx:177
-#: src/components/PropertiesList.tsx:182
+#: src/components/PropertiesList.tsx:201
+#: src/components/PropertiesList.tsx:206
 msgid "View detail"
 msgstr "View detail"
 
@@ -838,7 +848,7 @@ msgstr "Year"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:169
+#: src/components/PropertiesList.tsx:193
 msgid "Yes"
 msgstr "Yes"
 
@@ -846,7 +856,7 @@ msgstr "Yes"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:34
+#: src/components/PropertiesList.tsx:35
 msgid "Zipcode"
 msgstr "Zipcode"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -48,6 +48,10 @@ msgstr "... or view some sample portfolios:"
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
 
+#: src/util/helpers.ts:53
+msgid "APPLIANCE"
+msgstr "APPLIANCE"
+
 #: src/containers/AboutPage.tsx:13
 #: src/containers/App.tsx:89
 msgid "About"
@@ -73,7 +77,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:169
+#: src/components/PropertiesList.tsx:172
 msgid "Amount"
 msgstr "Amount"
 
@@ -85,6 +89,10 @@ msgstr "Are you having issues in this building?"
 #: src/containers/NychaPage.tsx:175
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
+
+#: src/util/helpers.ts:33
+msgid "BELL/BUZZER/INTERCOM"
+msgstr "BELL/BUZZER/INTERCOM"
 
 #: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
@@ -141,6 +149,22 @@ msgstr "Business Addresses"
 msgid "Business Entities"
 msgstr "Business Entities"
 
+#: src/util/helpers.ts:42
+msgid "CABINET"
+msgstr "CABINET"
+
+#: src/util/helpers.ts:55
+msgid "CERAMIC TILE"
+msgstr "CERAMIC TILE"
+
+#: src/util/helpers.ts:30
+msgid "CONSTRUCTION"
+msgstr "CONSTRUCTION"
+
+#: src/util/helpers.ts:56
+msgid "COOKING GAS"
+msgstr "COOKING GAS"
+
 #: src/components/DetailView.tsx:20
 msgid "Check out the issues in this building"
 msgstr "Check out the issues in this building"
@@ -185,7 +209,15 @@ msgstr "DOB Building Profile"
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
-#: src/components/PropertiesList.tsx:161
+#: src/util/helpers.ts:27
+msgid "DOOR/WINDOW"
+msgstr "DOOR/WINDOW"
+
+#: src/util/helpers.ts:59
+msgid "DOORS"
+msgstr "DOORS"
+
+#: src/components/PropertiesList.tsx:164
 msgid "Date"
 msgstr "Date"
 
@@ -206,6 +238,14 @@ msgstr "Donate"
 msgid "Download"
 msgstr "Download"
 
+#: src/util/helpers.ts:50
+msgid "ELECTRIC"
+msgstr "ELECTRIC"
+
+#: src/util/helpers.ts:40
+msgid "ELEVATOR"
+msgstr "ELEVATOR"
+
 #: src/components/SocialShare.tsx:39
 msgid "Email"
 msgstr "Email"
@@ -223,7 +263,7 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:132
+#: src/components/PropertiesList.tsx:135
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -241,17 +281,41 @@ msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD 
 msgid "Export Data"
 msgstr "Export Data"
 
+#: src/util/helpers.ts:35
+msgid "FIRE ESCAPE"
+msgstr "FIRE ESCAPE"
+
+#: src/util/helpers.ts:45
+msgid "FLOOR"
+msgstr "FLOOR"
+
+#: src/util/helpers.ts:51
+msgid "FLOORING/STAIRS"
+msgstr "FLOORING/STAIRS"
+
 #: src/containers/NotRegisteredPage.tsx:173
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
+
+#: src/util/helpers.ts:41
+msgid "GARBAGE/RECYCLING STORAGE"
+msgstr "GARBAGE/RECYCLING STORAGE"
 
 #: src/components/PropertiesSummary.tsx:69
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:185
+#: src/components/PropertiesList.tsx:188
 msgid "Group Sale?"
 msgstr "Group Sale?"
+
+#: src/util/helpers.ts:58
+msgid "HEAT/HOT WATER"
+msgstr "HEAT/HOT WATER"
+
+#: src/util/helpers.ts:28
+msgid "HEATING"
+msgstr "HEATING"
 
 #: src/components/DetailView.tsx:204
 #: src/components/Indicators.tsx:262
@@ -268,7 +332,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:115
+#: src/components/PropertiesList.tsx:118
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -323,6 +387,10 @@ msgstr "Information"
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "It doesn't seem like this property is required to register with HPD."
 
+#: src/util/helpers.ts:31
+msgid "JANITOR/SUPER"
+msgstr "JANITOR/SUPER"
+
 #: src/components/EngagementPanel.tsx:8
 msgid "Join the fight for tenant rights!"
 msgstr "Join the fight for tenant rights!"
@@ -331,7 +399,11 @@ msgstr "Join the fight for tenant rights!"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
-#: src/components/PropertiesList.tsx:143
+#: src/util/helpers.ts:60
+msgid "LOCKS"
+msgstr "LOCKS"
+
+#: src/components/PropertiesList.tsx:146
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Landlord"
@@ -344,7 +416,7 @@ msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, 
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PropertiesList.tsx:158
+#: src/components/PropertiesList.tsx:161
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -364,8 +436,8 @@ msgstr "Last sold:"
 msgid "Legend"
 msgstr "Legend"
 
-#: src/components/PropertiesList.tsx:177
-#: src/components/PropertiesList.tsx:179
+#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:182
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -384,6 +456,14 @@ msgstr "Location"
 #: src/components/PropertiesSummary.tsx:127
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
+
+#: src/util/helpers.ts:38
+msgid "MAILBOX"
+msgstr "MAILBOX"
+
+#: src/util/helpers.ts:48
+msgid "MOLD"
+msgstr "MOLD"
 
 #: src/components/LegalFooter.tsx:27
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
@@ -410,6 +490,10 @@ msgstr "Month"
 msgid "MyNYCHA App"
 msgstr "MyNYCHA App"
 
+#: src/util/helpers.ts:54
+msgid "NON-CONSTRUCTION"
+msgstr "NON-CONSTRUCTION"
+
 #: src/containers/NychaPage.tsx:160
 msgid "NYCHA Directory"
 msgstr "NYCHA Directory"
@@ -422,7 +506,7 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:194
+#: src/components/PropertiesList.tsx:197
 msgid "No"
 msgstr "No"
 
@@ -451,7 +535,11 @@ msgstr "Non-Emergency"
 msgid "Not found"
 msgstr "Not found"
 
-#: src/components/PropertiesList.tsx:146
+#: src/util/helpers.ts:32
+msgid "OUTSIDE BUILDING"
+msgstr "OUTSIDE BUILDING"
+
+#: src/components/PropertiesList.tsx:149
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -465,7 +553,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:118
+#: src/components/PropertiesList.tsx:121
 msgid "Open"
 msgstr "Open"
 
@@ -480,6 +568,18 @@ msgstr "Overview"
 #: src/components/IndicatorsDatasets.tsx:67
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
+
+#: src/util/helpers.ts:52
+msgid "PAINT/PLASTER"
+msgstr "PAINT/PLASTER"
+
+#: src/util/helpers.ts:37
+msgid "PESTS"
+msgstr "PESTS"
+
+#: src/util/helpers.ts:46
+msgid "PLUMBING"
+msgstr "PLUMBING"
 
 #: src/containers/AddressPage.tsx:106
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
@@ -522,6 +622,22 @@ msgstr "RS Units"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
+#: src/util/helpers.ts:57
+msgid "SAFETY"
+msgstr "SAFETY"
+
+#: src/util/helpers.ts:34
+msgid "SEWAGE"
+msgstr "SEWAGE"
+
+#: src/util/helpers.ts:36
+msgid "SIGNAGE MISSING"
+msgstr "SIGNAGE MISSING"
+
+#: src/util/helpers.ts:29
+msgid "STAIRS"
+msgstr "STAIRS"
+
 #: src/containers/NotRegisteredPage.tsx:169
 #: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
@@ -561,7 +677,7 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:135
+#: src/components/PropertiesList.tsx:138
 msgid "Since 2017"
 msgstr "Since 2017"
 
@@ -588,6 +704,10 @@ msgstr "Source code"
 #: src/containers/AddressPage.tsx:135
 msgid "Summary"
 msgstr "Summary"
+
+#: src/util/helpers.ts:43
+msgid "TENANT HARASSMENT"
+msgstr "TENANT HARASSMENT"
 
 #: src/components/DetailView.tsx:168
 #: src/components/DetailView.tsx:236
@@ -730,7 +850,7 @@ msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:313
 #: src/components/PropertiesList.tsx:95
-#: src/components/PropertiesList.tsx:124
+#: src/components/PropertiesList.tsx:127
 msgid "Total"
 msgstr "Total"
 
@@ -764,6 +884,10 @@ msgstr "Use this free tool from JustFix.nyc to research your building and invest
 msgid "Useful links"
 msgstr "Useful links"
 
+#: src/util/helpers.ts:47
+msgid "VENTILATION SYSTEM"
+msgstr "VENTILATION SYSTEM"
+
 #: src/components/Indicators.tsx:168
 msgid "View by:"
 msgstr "View by:"
@@ -772,8 +896,8 @@ msgstr "View by:"
 msgid "View data over time"
 msgstr "View data over time"
 
-#: src/components/PropertiesList.tsx:201
-#: src/components/PropertiesList.tsx:206
+#: src/components/PropertiesList.tsx:204
+#: src/components/PropertiesList.tsx:209
 msgid "View detail"
 msgstr "View detail"
 
@@ -804,6 +928,18 @@ msgstr "Violations Issued"
 #: src/components/EngagementPanel.tsx:24
 msgid "Visit our website"
 msgstr "Visit our website"
+
+#: src/util/helpers.ts:49
+msgid "WATER LEAK"
+msgstr "WATER LEAK"
+
+#: src/util/helpers.ts:44
+msgid "WINDOW GUARDS"
+msgstr "WINDOW GUARDS"
+
+#: src/util/helpers.ts:39
+msgid "WINDOWS"
+msgstr "WINDOWS"
 
 #: src/containers/App.tsx:74
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
@@ -848,7 +984,7 @@ msgstr "Year"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:193
+#: src/components/PropertiesList.tsx:196
 msgid "Yes"
 msgstr "Yes"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -66,7 +66,7 @@ msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha re
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:25
+#: src/components/PropertiesList.tsx:26
 msgid "Address"
 msgstr "Dirección"
 
@@ -78,7 +78,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:145
+#: src/components/PropertiesList.tsx:169
 msgid "Amount"
 msgstr "Importe"
 
@@ -100,7 +100,7 @@ msgstr "EDIFICIO:"
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
-#: src/components/PropertiesList.tsx:40
+#: src/components/PropertiesList.tsx:41
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -128,7 +128,7 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:55
+#: src/components/PropertiesList.tsx:56
 msgid "Built"
 msgstr "Construido"
 
@@ -190,7 +190,7 @@ msgstr "Perfil de edificio en DOB"
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
-#: src/components/PropertiesList.tsx:137
+#: src/components/PropertiesList.tsx:161
 msgid "Date"
 msgstr "Fecha"
 
@@ -228,7 +228,7 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:108
+#: src/components/PropertiesList.tsx:132
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -254,7 +254,7 @@ msgstr "Si no se registra un edificio con el HPD"
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:161
+#: src/components/PropertiesList.tsx:185
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -264,6 +264,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:6
+#: src/components/PropertiesList.tsx:92
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -272,7 +273,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:91
+#: src/components/PropertiesList.tsx:115
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
@@ -319,7 +320,7 @@ msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta g
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
-#: src/components/PropertiesList.tsx:52
+#: src/components/PropertiesList.tsx:53
 msgid "Information"
 msgstr "Información"
 
@@ -335,7 +336,7 @@ msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: src/components/PropertiesList.tsx:119
+#: src/components/PropertiesList.tsx:143
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Dueño del edificio"
@@ -344,7 +345,11 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:134
+#: src/components/PropertiesList.tsx:101
+msgid "Last 3 Years"
+msgstr ""
+
+#: src/components/PropertiesList.tsx:158
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -364,8 +369,8 @@ msgstr "Vendido por última vez:"
 msgid "Legend"
 msgstr "Leyenda"
 
-#: src/components/PropertiesList.tsx:153
-#: src/components/PropertiesList.tsx:155
+#: src/components/PropertiesList.tsx:177
+#: src/components/PropertiesList.tsx:179
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -377,7 +382,7 @@ msgstr "Enlace a la Escritura"
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:22
+#: src/components/PropertiesList.tsx:23
 msgid "Location"
 msgstr "Ubicación"
 
@@ -422,7 +427,7 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:170
+#: src/components/PropertiesList.tsx:194
 msgid "No"
 msgstr "No"
 
@@ -451,7 +456,7 @@ msgstr "No Emergencia"
 msgid "Not found"
 msgstr "No encontrado"
 
-#: src/components/PropertiesList.tsx:122
+#: src/components/PropertiesList.tsx:146
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -465,7 +470,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:94
+#: src/components/PropertiesList.tsx:118
 msgid "Open"
 msgstr "Abrir"
 
@@ -514,7 +519,7 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:69
+#: src/components/PropertiesList.tsx:70
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
@@ -561,7 +566,7 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:111
+#: src/components/PropertiesList.tsx:135
 msgid "Since 2017"
 msgstr "Desde 2017"
 
@@ -724,8 +729,13 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
+#: src/components/PropertiesList.tsx:107
+msgid "Top Complaint"
+msgstr ""
+
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:100
+#: src/components/PropertiesList.tsx:95
+#: src/components/PropertiesList.tsx:124
 msgid "Total"
 msgstr "Total"
 
@@ -742,7 +752,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:61
+#: src/components/PropertiesList.tsx:62
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades Residenciales"
@@ -767,8 +777,8 @@ msgstr "Visualizar por:"
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
-#: src/components/PropertiesList.tsx:177
-#: src/components/PropertiesList.tsx:182
+#: src/components/PropertiesList.tsx:201
+#: src/components/PropertiesList.tsx:206
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -843,7 +853,7 @@ msgstr "Año"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:169
+#: src/components/PropertiesList.tsx:193
 msgid "Yes"
 msgstr "Si"
 
@@ -851,7 +861,7 @@ msgstr "Si"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:34
+#: src/components/PropertiesList.tsx:35
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -886,4 +896,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:34
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Infracción del HPD emitida desde el 2010} other {# Infracciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -53,6 +53,10 @@ msgstr "... o descubre ejemplos de portafolios de edificios:"
 msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
 
+#: src/util/helpers.ts:53
+msgid "APPLIANCE"
+msgstr ""
+
 #: src/containers/AboutPage.tsx:13
 #: src/containers/App.tsx:89
 msgid "About"
@@ -78,7 +82,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:169
+#: src/components/PropertiesList.tsx:172
 msgid "Amount"
 msgstr "Importe"
 
@@ -90,6 +94,10 @@ msgstr "¿Tienes problemas en este edificio?"
 #: src/containers/NychaPage.tsx:175
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
+
+#: src/util/helpers.ts:33
+msgid "BELL/BUZZER/INTERCOM"
+msgstr ""
 
 #: src/components/DetailView.tsx:76
 #: src/components/Indicators.tsx:147
@@ -146,6 +154,22 @@ msgstr "Dirección Comercial"
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
+#: src/util/helpers.ts:42
+msgid "CABINET"
+msgstr ""
+
+#: src/util/helpers.ts:55
+msgid "CERAMIC TILE"
+msgstr ""
+
+#: src/util/helpers.ts:30
+msgid "CONSTRUCTION"
+msgstr ""
+
+#: src/util/helpers.ts:56
+msgid "COOKING GAS"
+msgstr ""
+
 #: src/components/DetailView.tsx:20
 msgid "Check out the issues in this building"
 msgstr "Mira los problemas en este edificio"
@@ -190,7 +214,15 @@ msgstr "Perfil de edificio en DOB"
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
-#: src/components/PropertiesList.tsx:161
+#: src/util/helpers.ts:27
+msgid "DOOR/WINDOW"
+msgstr ""
+
+#: src/util/helpers.ts:59
+msgid "DOORS"
+msgstr ""
+
+#: src/components/PropertiesList.tsx:164
 msgid "Date"
 msgstr "Fecha"
 
@@ -211,6 +243,14 @@ msgstr "Donar"
 msgid "Download"
 msgstr "Descargar"
 
+#: src/util/helpers.ts:50
+msgid "ELECTRIC"
+msgstr ""
+
+#: src/util/helpers.ts:40
+msgid "ELEVATOR"
+msgstr ""
+
 #: src/components/SocialShare.tsx:39
 msgid "Email"
 msgstr "Email"
@@ -228,7 +268,7 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:132
+#: src/components/PropertiesList.tsx:135
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -246,17 +286,41 @@ msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 20
 msgid "Export Data"
 msgstr "Exportar datos"
 
+#: src/util/helpers.ts:35
+msgid "FIRE ESCAPE"
+msgstr ""
+
+#: src/util/helpers.ts:45
+msgid "FLOOR"
+msgstr ""
+
+#: src/util/helpers.ts:51
+msgid "FLOORING/STAIRS"
+msgstr ""
+
 #: src/containers/NotRegisteredPage.tsx:173
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
+
+#: src/util/helpers.ts:41
+msgid "GARBAGE/RECYCLING STORAGE"
+msgstr ""
 
 #: src/components/PropertiesSummary.tsx:69
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:185
+#: src/components/PropertiesList.tsx:188
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
+
+#: src/util/helpers.ts:58
+msgid "HEAT/HOT WATER"
+msgstr ""
+
+#: src/util/helpers.ts:28
+msgid "HEATING"
+msgstr ""
 
 #: src/components/DetailView.tsx:204
 #: src/components/Indicators.tsx:262
@@ -273,7 +337,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:115
+#: src/components/PropertiesList.tsx:118
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
@@ -328,6 +392,10 @@ msgstr "Información"
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "Parece que esta propiedad no necesita estar registrada con el HPD."
 
+#: src/util/helpers.ts:31
+msgid "JANITOR/SUPER"
+msgstr ""
+
 #: src/components/EngagementPanel.tsx:8
 msgid "Join the fight for tenant rights!"
 msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
@@ -336,7 +404,11 @@ msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: src/components/PropertiesList.tsx:143
+#: src/util/helpers.ts:60
+msgid "LOCKS"
+msgstr ""
+
+#: src/components/PropertiesList.tsx:146
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Dueño del edificio"
@@ -349,7 +421,7 @@ msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva Y
 msgid "Last 3 Years"
 msgstr ""
 
-#: src/components/PropertiesList.tsx:158
+#: src/components/PropertiesList.tsx:161
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -369,8 +441,8 @@ msgstr "Vendido por última vez:"
 msgid "Legend"
 msgstr "Leyenda"
 
-#: src/components/PropertiesList.tsx:177
-#: src/components/PropertiesList.tsx:179
+#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:182
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -389,6 +461,14 @@ msgstr "Ubicación"
 #: src/components/PropertiesSummary.tsx:127
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
+
+#: src/util/helpers.ts:38
+msgid "MAILBOX"
+msgstr ""
+
+#: src/util/helpers.ts:48
+msgid "MOLD"
+msgstr ""
 
 #: src/components/LegalFooter.tsx:27
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
@@ -415,6 +495,10 @@ msgstr "Mes"
 msgid "MyNYCHA App"
 msgstr "App MyNYCHA"
 
+#: src/util/helpers.ts:54
+msgid "NON-CONSTRUCTION"
+msgstr ""
+
 #: src/containers/NychaPage.tsx:160
 msgid "NYCHA Directory"
 msgstr "Directorio de NYCHA"
@@ -427,7 +511,7 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:194
+#: src/components/PropertiesList.tsx:197
 msgid "No"
 msgstr "No"
 
@@ -456,7 +540,11 @@ msgstr "No Emergencia"
 msgid "Not found"
 msgstr "No encontrado"
 
-#: src/components/PropertiesList.tsx:146
+#: src/util/helpers.ts:32
+msgid "OUTSIDE BUILDING"
+msgstr ""
+
+#: src/components/PropertiesList.tsx:149
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -470,7 +558,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:118
+#: src/components/PropertiesList.tsx:121
 msgid "Open"
 msgstr "Abrir"
 
@@ -485,6 +573,18 @@ msgstr "General"
 #: src/components/IndicatorsDatasets.tsx:67
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/> Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
+
+#: src/util/helpers.ts:52
+msgid "PAINT/PLASTER"
+msgstr ""
+
+#: src/util/helpers.ts:37
+msgid "PESTS"
+msgstr ""
+
+#: src/util/helpers.ts:46
+msgid "PLUMBING"
+msgstr ""
 
 #: src/containers/AddressPage.tsx:106
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
@@ -527,6 +627,22 @@ msgstr "Unidades Residenciales RS"
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
+#: src/util/helpers.ts:57
+msgid "SAFETY"
+msgstr ""
+
+#: src/util/helpers.ts:34
+msgid "SEWAGE"
+msgstr ""
+
+#: src/util/helpers.ts:36
+msgid "SIGNAGE MISSING"
+msgstr ""
+
+#: src/util/helpers.ts:29
+msgid "STAIRS"
+msgstr ""
+
 #: src/containers/NotRegisteredPage.tsx:169
 #: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
@@ -566,7 +682,7 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:135
+#: src/components/PropertiesList.tsx:138
 msgid "Since 2017"
 msgstr "Desde 2017"
 
@@ -593,6 +709,10 @@ msgstr "Código fuente"
 #: src/containers/AddressPage.tsx:135
 msgid "Summary"
 msgstr "Resúmen"
+
+#: src/util/helpers.ts:43
+msgid "TENANT HARASSMENT"
+msgstr ""
 
 #: src/components/DetailView.tsx:168
 #: src/components/DetailView.tsx:236
@@ -735,7 +855,7 @@ msgstr ""
 
 #: src/components/IndicatorsViz.tsx:313
 #: src/components/PropertiesList.tsx:95
-#: src/components/PropertiesList.tsx:124
+#: src/components/PropertiesList.tsx:127
 msgid "Total"
 msgstr "Total"
 
@@ -769,6 +889,10 @@ msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edif
 msgid "Useful links"
 msgstr "Enlaces útiles"
 
+#: src/util/helpers.ts:47
+msgid "VENTILATION SYSTEM"
+msgstr ""
+
 #: src/components/Indicators.tsx:168
 msgid "View by:"
 msgstr "Visualizar por:"
@@ -777,8 +901,8 @@ msgstr "Visualizar por:"
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
-#: src/components/PropertiesList.tsx:201
-#: src/components/PropertiesList.tsx:206
+#: src/components/PropertiesList.tsx:204
+#: src/components/PropertiesList.tsx:209
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -809,6 +933,18 @@ msgstr "Infracciones emitidas"
 #: src/components/EngagementPanel.tsx:24
 msgid "Visit our website"
 msgstr "Visite nuestro sitio web"
+
+#: src/util/helpers.ts:49
+msgid "WATER LEAK"
+msgstr ""
+
+#: src/util/helpers.ts:44
+msgid "WINDOW GUARDS"
+msgstr ""
+
+#: src/util/helpers.ts:39
+msgid "WINDOWS"
+msgstr ""
 
 #: src/containers/App.tsx:74
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
@@ -853,7 +989,7 @@ msgstr "Año"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:193
+#: src/components/PropertiesList.tsx:196
 msgid "Yes"
 msgstr "Si"
 

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -228,7 +228,7 @@ export default {
     return arr.join(" ");
   },
 
-  getI18nComplaintType(complaintType: string, i18n: I18n) {
+  getTranslationOfComplaintType(complaintType: string, i18n: I18n) {
     const translatedType = hpdComplaintTypeTranslations.get(complaintType);
     if (!translatedType) {
       reportError(`The HPD Complaint type called "${complaintType}" doesn't have a translation.`);

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -230,8 +230,9 @@ export default {
 
   getI18nComplaintType(complaintType: string, i18n: I18n) {
     const translatedType = hpdComplaintTypeTranslations.get(complaintType);
-    if (translatedType) {
-      return i18n._(translatedType);
-    } else return complaintType;
+    if (!translatedType) {
+      reportError(`The HPD Complaint type called "${complaintType}" doesn't have a translation.`);
+      return complaintType;
+    } else return i18n._(translatedType);
   },
 };

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -231,7 +231,7 @@ export default {
   getTranslationOfComplaintType(complaintType: string, i18n: I18n) {
     const translatedType = hpdComplaintTypeTranslations.get(complaintType);
     if (!translatedType) {
-      reportError(`The HPD Complaint type called "${complaintType}" doesn't have a translation.`);
+      reportError(`The HPD Complaint type "${complaintType}" isn't internationalized`);
       return complaintType;
     } else return i18n._(translatedType);
   },

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -6,6 +6,8 @@ import { deepEqual as assertDeepEqual } from "assert";
 import { SupportedLocale } from "../i18n-base";
 import { SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { reportError } from "error-reporting";
+import { t } from "@lingui/macro";
+import { I18n } from "@lingui/core";
 
 /**
  * An array consisting of Who Owns What's standard enumerations for street names,
@@ -25,6 +27,43 @@ const hpdNumberTransformations = [
   ["NINTH", "9"],
   ["TENTH", "10"],
 ];
+
+const hpdComplaintTypeTranslations = new Map([
+  ["DOOR/WINDOW", t`DOOR/WINDOW`],
+  ["HEATING", t`HEATING`],
+  ["STAIRS", t`STAIRS`],
+  ["CONSTRUCTION", t`CONSTRUCTION`],
+  ["JANITOR/SUPER", t`JANITOR/SUPER`],
+  ["OUTSIDE BUILDING", t`OUTSIDE BUILDING`],
+  ["BELL/BUZZER/INTERCOM", t`BELL/BUZZER/INTERCOM`],
+  ["SEWAGE", t`SEWAGE`],
+  ["FIRE-ESCAPE", t`FIRE ESCAPE`],
+  ["SIGNAGE MISSING", t`SIGNAGE MISSING`],
+  ["PESTS", t`PESTS`],
+  ["MAILBOX", t`MAILBOX`],
+  ["WINDOWS", t`WINDOWS`],
+  ["ELEVATOR", t`ELEVATOR`],
+  ["GARBAGE/RECYCLING STORAGE", t`GARBAGE/RECYCLING STORAGE`],
+  ["CABINET", t`CABINET`],
+  ["TENANT HARASSMENT", t`TENANT HARASSMENT`],
+  ["WINDOW GUARDS", t`WINDOW GUARDS`],
+  ["FLOOR", t`FLOOR`],
+  ["PLUMBING", t`PLUMBING`],
+  ["VENTILATION SYSTEM", t`VENTILATION SYSTEM`],
+  ["MOLD", t`MOLD`],
+  ["WATER LEAK", t`WATER LEAK`],
+  ["ELECTRIC", t`ELECTRIC`],
+  ["FLOORING/STAIRS", t`FLOORING/STAIRS`],
+  ["PAINT/PLASTER", t`PAINT/PLASTER`],
+  ["APPLIANCE", t`APPLIANCE`],
+  ["NONCONST", t`NON-CONSTRUCTION`],
+  ["CERAMIC-TILE", t`CERAMIC TILE`],
+  ["COOKING GAS", t`COOKING GAS`],
+  ["SAFETY", t`SAFETY`],
+  ["HEAT/HOT WATER", t`HEAT/HOT WATER`],
+  ["DOORS", t`DOORS`],
+  ["LOCKS", t`LOCKS`],
+]);
 
 export const longDateOptions = { year: "numeric", month: "short", day: "numeric" };
 export const mediumDateOptions = { year: "numeric", month: "long" };
@@ -187,5 +226,12 @@ export default {
       }
     });
     return arr.join(" ");
+  },
+
+  getI18nComplaintType(complaintType: string, i18n: I18n) {
+    const translatedType = hpdComplaintTypeTranslations.get(complaintType);
+    if (translatedType) {
+      return i18n._(translatedType);
+    } else return complaintType;
   },
 };


### PR DESCRIPTION
This PR adds a new section to the react table on the Portfolio Tab called "HPD Complaints", that includes 3 new columns of data:
- **Total**: count of all complaints ever called in to 311
- **Last 3 Years**: count from just last 3 years
- **Top Complaint**: most common complaint type from last 3 years

One funky thing that this PR does is [add a new function to our helpers.ts file](https://github.com/JustFixNYC/who-owns-what/pull/461/files#diff-a7c84dff5c3235f5b41a5d1a818116d17fd0f0edb64977c68ab99a3fe97d660c) that internationalizes the complaint types that show up in open data.