### PR TITLE
Handle CSV export when ownernames is null.

### DIFF
--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -1,5 +1,5 @@
 import csv
-from typing import List
+from typing import Any, Dict, List
 from io import StringIO
 from django.urls import path
 from django.test import Client
@@ -127,7 +127,7 @@ class TestAddressExport(ApiTest):
 
 class TestFixupAddrForCsv:
     def test_it_works_when_ownernames_is_none(self):
-        addr = {'ownernames': None, 'recentcomplaintsbytype': []}
+        addr: Dict[str, Any] = {'ownernames': None, 'recentcomplaintsbytype': []}
         _fixup_addr_for_csv(addr)
         assert addr == {
             'ownernames': '',

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -7,6 +7,7 @@ import pytest
 
 from wow.apiutil import api
 from project.urls import handler500  # noqa
+from wow.views import _fixup_addr_for_csv
 
 
 @api
@@ -122,6 +123,16 @@ class TestAddressExport(ApiTest):
         res = client.get('/api/address/export?bbl=1234567890')
         assert res.status_code == 404
         assert 'Access-Control-Allow-Origin' in res
+
+
+class TestFixupAddrForCsv:
+    def test_it_works_when_ownernames_is_none(self):
+        addr = {'ownernames': None, 'recentcomplaintsbytype': []}
+        _fixup_addr_for_csv(addr)
+        assert addr == {
+            'ownernames': '',
+            'recentcomplaintsbytype': '',
+        }
 
 
 class TestServerError:

--- a/wow/views.py
+++ b/wow/views.py
@@ -1,7 +1,7 @@
 import csv
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 from django.http import HttpResponse, JsonResponse
 
 from .dbutil import call_db_func, exec_db_query

--- a/wow/views.py
+++ b/wow/views.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 from pathlib import Path
+from typing import Any, Dict, List
 from django.http import HttpResponse, JsonResponse
 
 from .dbutil import call_db_func, exec_db_query
@@ -119,6 +120,14 @@ def address_indicatorhistory(request):
     return JsonResponse({'result': result})
 
 
+def _fixup_addr_for_csv(addr: Dict[str, Any]):
+    addr['ownernames'] = csvutil.stringify_owners(addr['ownernames'] or [])
+    addr['recentcomplaintsbytype'] = csvutil.stringify_complaints(
+        addr['recentcomplaintsbytype']
+    )
+    csvutil.stringify_lists(addr)
+
+
 @api
 def address_export(request):
     log_unsupported_request_args(request)
@@ -131,11 +140,7 @@ def address_export(request):
     first_row = addrs[0]
 
     for addr in addrs:
-        addr['ownernames'] = csvutil.stringify_owners(addr['ownernames'])
-        addr['recentcomplaintsbytype'] = csvutil.stringify_complaints(
-            addr['recentcomplaintsbytype']
-        )
-        csvutil.stringify_lists(addr)
+        _fixup_addr_for_csv(addr)
 
     # https://docs.djangoproject.com/en/3.0/howto/outputting-csv/
     response = HttpResponse(content_type='text/csv')


### PR DESCRIPTION
Sometimes the `ownernames` field of the query used to export CSVs is `NULL`, which we haven't been accounting for until now.