### PR TITLE
Log GTM event when a user subscribes to mailing list.

### DIFF
--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -6,6 +6,7 @@ import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
 import { t } from "@lingui/macro";
 import { reportError } from "error-reporting";
+import { getDataLayer } from "google-tag-manager";
 
 //import 'styles/Subscribe.css';
 
@@ -62,6 +63,9 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
       .then((result) => result.json())
       .then((result) => {
         if (result.status === 200) {
+          getDataLayer().push({
+            event: "jf.subscribeToMailingList",
+          });
           this.setState({
             success: true,
             response: i18n._(t`All set! Thanks for subscribing!`),

--- a/client/src/google-tag-manager.ts
+++ b/client/src/google-tag-manager.ts
@@ -1,0 +1,25 @@
+export interface GTMDataLayer {
+  push(obj: GTMDataLayerObject): void;
+}
+
+declare global {
+  interface Window {
+    /**
+     * A reference to the dataLayer global object, provided by the GTM snippet.
+     *
+     * However, it won't exist if the app hasn't been configured to support GTM.
+     */
+    dataLayer: GTMDataLayer | undefined;
+  }
+}
+
+/** Data layer event to send when a user subscribes to our mailing list. */
+type GTMSubscribeToMailingListEvent = {
+  event: "jf.subscribeToMailingList";
+};
+
+export type GTMDataLayerObject = GTMSubscribeToMailingListEvent;
+
+export function getDataLayer(): GTMDataLayer {
+  return window.dataLayer || [];
+}


### PR DESCRIPTION
This logs a `jf.subscribeToMailingList` event whenever the user successfully subscribes to our mailing list.  It is largely based off https://github.com/JustFixNYC/tenants2/pull/850.