### PR TITLE
Add `allcontacts` field to registration_with_contacts table

### DIFF
--- a/sql/registrations_with_contacts.sql
+++ b/sql/registrations_with_contacts.sql
@@ -80,14 +80,16 @@ LEFT JOIN (
         jsonb_build_object(
           'title', type, 
           'value', (firstname || ' ' || lastname),
-          'address', jsonb_build_object(
-            'housenumber', businesshousenumber,
-            'streetname', businessstreetname, 
-            'apartment', businessapartment, 
-            'city', businesscity,
-            'state', businessstate,
-            'zip', businesszip
-          )
+          'address', case when businessstreetname is not null then 
+	          jsonb_build_object(
+	            'housenumber', businesshousenumber,
+	            'streetname', businessstreetname, 
+	            'apartment', businessapartment, 
+	            'city', businesscity,
+	            'state', businessstate,
+	            'zip', businesszip
+	          ) 
+	        else null end
         )
       )     	
       FILTER (
@@ -104,14 +106,16 @@ LEFT JOIN (
         jsonb_build_object(
           'title', 'Corporation',
           'value',  corporationname,
-          'address', jsonb_build_object(
-            'housenumber', businesshousenumber,
-            'streetname', businessstreetname, 
-            'apartment', businessapartment, 
-            'city', businesscity,
-            'state', businessstate,
-            'zip', businesszip
-          )
+          'address', case when businessstreetname is not null then 
+	          jsonb_build_object(
+	            'housenumber', businesshousenumber,
+	            'streetname', businessstreetname, 
+	            'apartment', businessapartment, 
+	            'city', businesscity,
+	            'state', businessstate,
+	            'zip', businesszip
+	          ) 
+	        else null end
         )
       )
       FILTER (WHERE corporationname IS NOT NULL), 

--- a/sql/registrations_with_contacts.sql
+++ b/sql/registrations_with_contacts.sql
@@ -80,7 +80,14 @@ LEFT JOIN (
         jsonb_build_object(
           'title', type, 
           'value', (firstname || ' ' || lastname),
-          'address', nullif(concat_ws(' ', businesshousenumber, businessstreetname, businessapartment, businesszip), '')
+          'address', jsonb_build_object(
+            'housenumber', businesshousenumber,
+            'streetname', businessstreetname, 
+            'apartment', businessapartment, 
+            'city', businesscity,
+            'state', businessstate,
+            'zip', businesszip
+          )
         )
       )     	
       FILTER (
@@ -97,7 +104,14 @@ LEFT JOIN (
         jsonb_build_object(
           'title', 'Corporation',
           'value',  corporationname,
-          'address', nullif(concat_ws(' ', businesshousenumber, businessstreetname, businessapartment, businesszip), '')
+          'address', jsonb_build_object(
+            'housenumber', businesshousenumber,
+            'streetname', businessstreetname, 
+            'apartment', businessapartment, 
+            'city', businesscity,
+            'state', businessstate,
+            'zip', businesszip
+          )
         )
       )
       FILTER (WHERE corporationname IS NOT NULL), 

--- a/sql/registrations_with_contacts.sql
+++ b/sql/registrations_with_contacts.sql
@@ -100,7 +100,7 @@ LEFT JOIN (
           'address', nullif(concat_ws(' ', businesshousenumber, businessstreetname, businessapartment, businesszip), '')
         )
       )
-      FILTER (WHERE corporationname is not null), 
+      FILTER (WHERE corporationname IS NOT NULL), 
       '[]'::jsonb) 
     AS corpnameswithaddr,
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -226,3 +226,29 @@ class TestSQL:
             'title': 'HeadOfficer',
             'value': 'Lobot Jones',
         }]
+        assert r['allcontacts'] == [
+            {
+            'title': 'HeadOfficer', 
+            'value': 'Lobot Jones', 
+            'address': {
+                'zip': '11231', 
+                'city': 'BROKLYN', 
+                'state': 'NY', 
+                'apartment': None, 
+                'streetname': 'BESPIN AVENUE', 
+                'housenumber': '5'
+                }
+            },
+            {
+            'title': 'Corporation', 
+            'value': '1 FUNKY STREET LLC',
+            'address': {
+                'zip': '11231', 
+                'city': 'BROKLYN', 
+                'state': 'NY', 
+                'apartment': None, 
+                'streetname': 'BESPIN AVENUE', 
+                'housenumber': '5'
+                }
+            }
+        ]

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -226,29 +226,26 @@ class TestSQL:
             'title': 'HeadOfficer',
             'value': 'Lobot Jones',
         }]
-        assert r['allcontacts'] == [
-            {
-            'title': 'HeadOfficer', 
-            'value': 'Lobot Jones', 
-            'address': {
-                'zip': '11231', 
-                'city': 'BROKLYN', 
-                'state': 'NY', 
-                'apartment': None, 
-                'streetname': 'BESPIN AVENUE', 
-                'housenumber': '5'
-                }
+        assert r["allcontacts"] == [{
+            "title": "HeadOfficer",
+            "value": "Lobot Jones",
+            "address": {
+                "zip": "11231",
+                "city": "BROKLYN",
+                "state": "NY",
+                "apartment": None,
+                "streetname": "BESPIN AVENUE",
+                "housenumber": "5",
             },
-            {
-            'title': 'Corporation', 
-            'value': '1 FUNKY STREET LLC',
-            'address': {
-                'zip': '11231', 
-                'city': 'BROKLYN', 
-                'state': 'NY', 
-                'apartment': None, 
-                'streetname': 'BESPIN AVENUE', 
-                'housenumber': '5'
-                }
-            }
-        ]
+        }, {
+            "title": "Corporation",
+            "value": "1 FUNKY STREET LLC",
+            "address": {
+                "zip": "11231",
+                "city": "BROKLYN",
+                "state": "NY",
+                "apartment": None,
+                "streetname": "BESPIN AVENUE",
+                "housenumber": "5",
+            },
+        }]


### PR DESCRIPTION
In preparation for implementing Tahnee's new redesign of "Landlord Info" on the WOW Overview Tab, this PR adds a new column to the `registration_with_contacts` custom table that includes _all_ HPD contact names and corporation names, with associated addresses, in one single json object. 

In turn, this PR will subsequently add this new field called `allcontacts` to the end of the `wow_bldgs` table, since the SQL to generate the `wow_bldgs` table arbitrarily selects all columns from the `registration_with_contacts` table. Therefore, we should be able to start using this new column of data on the front-end right away.