### PR TITLE
Restructure how landlord contact info is displayed on the Overview Tab

### DIFF
--- a/client/src/assets/img/accordionchevron.svg
+++ b/client/src/assets/img/accordionchevron.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="13px" height="6px" viewBox="0 0 13 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>accordionchevron</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="accordionchevron" transform="translate(7.000000, 3.000000) scale(1, -1) translate(-7.000000, -3.000000) translate(1.000000, 0.000000)" stroke="#454D5D">
+            <polyline id="Path" points="0 5.65674 5.65685 -0.000117 11.3137 5.65674"></polyline>
+        </g>
+    </g>
+</svg>

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -19,15 +19,17 @@ type HpdOwnerContact = {
   value: string;
 };
 
-type HpdFullContact = HpdOwnerContact & {
-  address: {
-    housenumber: string | null;
-    streetname: string;
-    apartment: string | null;
-    city: string | null;
-    state: string | null;
-    zip: string | null;
-  } | null;
+type HpdContactAddress = {
+  housenumber: string | null;
+  streetname: string;
+  apartment: string | null;
+  city: string | null;
+  state: string | null;
+  zip: string | null;
+}
+
+export type HpdFullContact = HpdOwnerContact & {
+  address: HpdContactAddress | null;
 };
 
 export type HpdComplaintCount = {

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -26,7 +26,7 @@ type HpdContactAddress = {
   city: string | null;
   state: string | null;
   zip: string | null;
-}
+};
 
 export type HpdFullContact = HpdOwnerContact & {
   address: HpdContactAddress | null;

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -19,7 +19,7 @@ type HpdOwnerContact = {
   value: string;
 };
 
-type HpdContactAddress = {
+export type HpdContactAddress = {
   housenumber: string | null;
   streetname: string;
   apartment: string | null;

--- a/client/src/components/Accordion.tsx
+++ b/client/src/components/Accordion.tsx
@@ -3,14 +3,31 @@ import React from "react";
 import chevron from "../assets/img/accordionchevron.svg";
 import "styles/Accordion.scss";
 
-export const Accordion = (props: { question: string; children: React.ReactNode }) => {
+type AccordionProps = {
+  title: string;
+  /**
+   * Alternate text to show as the "title" part of the accordion,
+   * once it has been opened.
+   */
+  titleOnOpen?: string;
+  children: React.ReactNode;
+};
+
+export const Accordion: React.FC<AccordionProps> = ({ title, titleOnOpen, children }) => {
   return (
-    <details className="Accordion">
+    <details className="accordion">
       <summary>
-        {props.question}
+        {titleOnOpen ? (
+          <>
+            <span className="title-default">{title}</span>
+            <span className="title-on-open">{titleOnOpen}</span>
+          </>
+        ) : (
+          title
+        )}
         <img src={chevron} className="icon mx-1 float-right" alt="Open" />
       </summary>
-      <div>{props.children}</div>
+      <div>{children}</div>
     </details>
   );
 };

--- a/client/src/components/Accordion.tsx
+++ b/client/src/components/Accordion.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import chevron from "../assets/img/accordionchevron.svg";
+import "styles/Accordion.scss";
+
+export const Accordion = (props: { question: string; children: React.ReactNode }) => {
+  return (
+    <details className="Accordion">
+      <summary>
+        {props.question}
+        <img src={chevron} className="icon mx-1 float-right" alt="Open" />
+      </summary>
+      <div>{props.children}</div>
+    </details>
+  );
+};

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -173,7 +173,18 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                           </ul>
                         </div>
                       </div>
-                      <Accordion question="MAGGIE MCCORMICK">Landlord</Accordion>
+                      <div className="card-body-landlord">
+                        <b>
+                          <Trans>Who’s the landlord of this building?</Trans>
+                        </b>
+                        <div>
+                          <Accordion question="MAGGIE MCCORMICK">
+                            <span className="text-bold text-dark">Head Officer</span>
+                            <br />
+                            1065 AVENUE OF THE AMERICAS 31FLOOR 10018
+                          </Accordion>
+                        </div>
+                      </div>
                       <div className="card-body-registration">
                         <p>
                           <b>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -40,8 +40,8 @@ const formatHpdContactAddress = (address: HpdContactAddress) => {
   const cityFormatted = city && state ? `${city},` : city;
   return (
     <>
-      {[housenumber, streetname, apartment].join(" ")} <br />
-      {[cityFormatted, state, zip].join(" ")}
+      {[housenumber, streetname, apartment].join(" ").toUpperCase()} <br />
+      {[cityFormatted, state, zip].join(" ").toUpperCase()}
     </>
   );
 };

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -18,7 +18,8 @@ import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
 import { SupportedLocale } from "../i18n-base";
 import { withMachineInStateProps } from "state-machine";
 import { Accordion } from "./Accordion";
-import { HpdContactAddress } from "./APIDataTypes";
+import { HpdContactAddress, HpdFullContact } from "./APIDataTypes";
+import _groupBy from "lodash/groupBy";
 
 type Props = withI18nProps &
   withMachineInStateProps<"portfolioFound"> & {
@@ -82,6 +83,8 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const isMobile = Browser.isMobile();
     const locale = (this.props.i18n.language as SupportedLocale) || "en";
     const { assocAddrs, detailAddr, searchAddr } = this.props.state.context.portfolioData;
+
+    console.log(groupHpdContacts(detailAddr.allcontacts || []));
 
     // Let's save some variables that will be helpful in rendering the front-end component
     let takeActionURL, formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
@@ -191,17 +194,23 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                             <Trans>Who’s the landlord of this building?</Trans>
                           </b>
                           <div>
-                            {detailAddr.allcontacts.map((contact, i) => (
-                              <Accordion question={contact.value} key={i}>
-                                <span className="text-bold text-dark">{contact.title}</span>
-                                {contact.address && (
-                                  <>
-                                    <br />
-                                    {formatHpdContactAddress(contact.address)}
-                                  </>
-                                )}
-                              </Accordion>
-                            ))}
+                            {Object.entries(_groupBy(detailAddr.allcontacts, "value")).map(
+                              (contact, i) => (
+                                <Accordion question={contact[0]} key={i}>
+                                  {contact[1].map((info, j) => (
+                                    <div key={j}>
+                                      <span className="text-bold text-dark">{info.title}</span>
+                                      {info.address && (
+                                        <>
+                                          <br />
+                                          {formatHpdContactAddress(info.address)}
+                                        </>
+                                      )}
+                                    </div>
+                                  ))}
+                                </Accordion>
+                              )
+                            )}
                           </div>
                         </div>
                       )}

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -173,18 +173,24 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                           </ul>
                         </div>
                       </div>
-                      <div className="card-body-landlord">
+                      {detailAddr.allcontacts && <div className="card-body-landlord">
                         <b>
                           <Trans>Who’s the landlord of this building?</Trans>
                         </b>
                         <div>
-                          <Accordion question="MAGGIE MCCORMICK">
-                            <span className="text-bold text-dark">Head Officer</span>
+                          {(detailAddr.allcontacts).map( (contact, i) => 
+                          <Accordion question={contact.value} key={i}>
+                            <span className="text-bold text-dark">{contact.title}</span>
+                            {contact.address &&
+                            <>
                             <br />
-                            1065 AVENUE OF THE AMERICAS 31FLOOR 10018
-                          </Accordion>
+                            {Object.values(contact.address).filter(x => x).join(' ')}
+                            </>
+  }
+                          </Accordion>)
+  }
                         </div>
-                      </div>
+                      </div>}
                       <div className="card-body-registration">
                         <p>
                           <b>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -17,6 +17,7 @@ import BuildingStatsTable from "./BuildingStatsTable";
 import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
 import { SupportedLocale } from "../i18n-base";
 import { withMachineInStateProps } from "state-machine";
+import { Accordion } from "./Accordion";
 
 type Props = withI18nProps &
   withMachineInStateProps<"portfolioFound"> & {
@@ -172,44 +173,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                           </ul>
                         </div>
                       </div>
-                      <div className="card-body-landlord">
-                        <div className="columns">
-                          <div className="column col-xs-12 col-6">
-                            <b>
-                              <Trans>Business Entities</Trans>
-                            </b>
-                            <ul>
-                              {detailAddr.corpnames &&
-                                detailAddr.corpnames.map((corp, idx) => <li key={idx}>{corp}</li>)}
-                            </ul>
-                          </div>
-                          <div className="column col-xs-12 col-6">
-                            <b>
-                              <Trans>Business Addresses</Trans>
-                            </b>
-                            <ul>
-                              {detailAddr.businessaddrs &&
-                                detailAddr.businessaddrs.map((rba, idx) => (
-                                  <li key={idx}>{rba}</li>
-                                ))}
-                            </ul>
-                          </div>
-                        </div>
-                        {ownernames && (
-                          <div>
-                            <b>
-                              <Trans>People</Trans>
-                            </b>
-                            <ul>
-                              {ownernames.map((owner, idx) => (
-                                <li key={idx}>
-                                  {owner.title.split(/(?=[A-Z])/).join(" ")}: {owner.value}
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                        )}
-                      </div>
+                      <Accordion question="MAGGIE MCCORMICK">Landlord</Accordion>
                       <div className="card-body-registration">
                         <p>
                           <b>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -18,6 +18,7 @@ import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
 import { SupportedLocale } from "../i18n-base";
 import { withMachineInStateProps } from "state-machine";
 import { Accordion } from "./Accordion";
+import { UsefulLinks } from "./UsefulLinks";
 import _groupBy from "lodash/groupBy";
 
 type Props = withI18nProps &
@@ -96,8 +97,6 @@ class DetailViewWithoutI18n extends Component<Props, State> {
 
     // Let's save some variables that will be helpful in rendering the front-end component
     let takeActionURL, formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
-
-    const { boro, block, lot } = Helpers.splitBBL(detailAddr.bbl);
 
     takeActionURL = Helpers.createTakeActionURL(detailAddr, "detail_view");
 
@@ -294,79 +293,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                   <div className="column col-lg-12 col-5">
                     <div className="card-image hide-lg">{streetView}</div>
                     <div className="card-body column-right">
-                      <div className="card-body-links">
-                        <b>
-                          <Trans>Useful links</Trans>
-                        </b>
-                        <ul>
-                          <li>
-                            View documents on{" "}
-                            <a
-                              onClick={() => {
-                                window.gtag("event", "acris-overview-tab");
-                              }}
-                              href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              <Trans>ACRIS</Trans>
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              onClick={() => {
-                                window.gtag("event", "hpd-overview-tab");
-                              }}
-                              href={`https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${
-                                detailAddr.housenumber
-                              }&p3=${Helpers.formatStreetNameForHpdLink(
-                                detailAddr.streetname
-                              )}&SearchButton=Search`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              <Trans>HPD Building Profile</Trans>
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              onClick={() => {
-                                window.gtag("event", "dob-overview-tab");
-                              }}
-                              href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              <Trans>DOB Building Profile</Trans>
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              onClick={() => {
-                                window.gtag("event", "dof-overview-tab");
-                              }}
-                              href={`https://a836-pts-access.nyc.gov/care/search/commonsearch.aspx?mode=persprop`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              <Trans>DOF Property Tax Bills</Trans>
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              onClick={() => {
-                                window.gtag("event", "dap-overview-tab");
-                              }}
-                              href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              <Trans>ANHD DAP Portal</Trans>
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-
+                      <UsefulLinks addrForLinks={detailAddr} location="overview-tab" />
                       <div className="card-body-prompt">
                         <h6 className="DetailView__subtitle">
                           <Trans>Are you having issues in this building?</Trans>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -173,24 +173,28 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                           </ul>
                         </div>
                       </div>
-                      {detailAddr.allcontacts && <div className="card-body-landlord">
-                        <b>
-                          <Trans>Who’s the landlord of this building?</Trans>
-                        </b>
-                        <div>
-                          {(detailAddr.allcontacts).map( (contact, i) => 
-                          <Accordion question={contact.value} key={i}>
-                            <span className="text-bold text-dark">{contact.title}</span>
-                            {contact.address &&
-                            <>
-                            <br />
-                            {Object.values(contact.address).filter(x => x).join(' ')}
-                            </>
-  }
-                          </Accordion>)
-  }
+                      {detailAddr.allcontacts && (
+                        <div className="card-body-landlord">
+                          <b>
+                            <Trans>Who’s the landlord of this building?</Trans>
+                          </b>
+                          <div>
+                            {detailAddr.allcontacts.map((contact, i) => (
+                              <Accordion question={contact.value} key={i}>
+                                <span className="text-bold text-dark">{contact.title}</span>
+                                {contact.address && (
+                                  <>
+                                    <br />
+                                    {Object.values(contact.address)
+                                      .filter((x) => x)
+                                      .join(" ")}
+                                  </>
+                                )}
+                              </Accordion>
+                            ))}
+                          </div>
                         </div>
-                      </div>}
+                      )}
                       <div className="card-body-registration">
                         <p>
                           <b>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -54,7 +54,10 @@ const SocialShareDetailView = () => (
  * A set of HpdFullContacts grouped by contact name. Will contain exactly one name but can contain
  * one or many full contact entries (with title and address) that have the same matching name.
  */
-type GroupedContact = [string, HpdFullContact[]];
+type GroupedContact = [
+  string, // Contact name
+  HpdFullContact[] // Array of all contact entries with the same name
+];
 
 /**
  * This comparison function, to be used inside the Array.sort() method,

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -18,6 +18,7 @@ import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
 import { SupportedLocale } from "../i18n-base";
 import { withMachineInStateProps } from "state-machine";
 import { Accordion } from "./Accordion";
+import { HpdContactAddress } from "./APIDataTypes";
 
 type Props = withI18nProps &
   withMachineInStateProps<"portfolioFound"> & {
@@ -32,6 +33,17 @@ type State = {
 };
 
 const getTodaysDate = () => new Date();
+
+const formatHpdContactAddress = (address: HpdContactAddress) => {
+  const { housenumber, streetname, apartment, city, state, zip } = address;
+  const cityFormatted = city && state ? `${city},` : city;
+  return (
+    <>
+      {[housenumber, streetname, apartment].join(" ")} <br />
+      {[cityFormatted, state, zip].join(" ")}
+    </>
+  );
+};
 
 const SocialShareDetailView = () => (
   <SocialShareAddressPage
@@ -185,9 +197,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                                 {contact.address && (
                                   <>
                                     <br />
-                                    {Object.values(contact.address)
-                                      .filter((x) => x)
-                                      .join(" ")}
+                                    {formatHpdContactAddress(contact.address)}
                                   </>
                                 )}
                               </Accordion>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -7,7 +7,7 @@ import Browser from "../util/browser";
 import Modal from "../components/Modal";
 
 import "styles/DetailView.css";
-import { withI18n, withI18nProps } from "@lingui/react";
+import { withI18n, withI18nProps, I18n } from "@lingui/react";
 import { t, Trans } from "@lingui/macro";
 import { SocialShareAddressPage } from "./SocialShare";
 import { isPartOfGroupSale } from "./PropertiesList";
@@ -44,6 +44,28 @@ const SocialShareDetailView = () => (
         t`I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: ${url}`,
     }}
   />
+);
+
+const LearnMoreAccordion = () => (
+  <I18n>
+    {({ i18n }) => (
+      <Accordion title={i18n._(t`Learn more`)} titleOnOpen={i18n._(t`Close`)}>
+        <br />
+        <Trans>
+          <p>
+            While the legal owner of a building is often an “LLC” company, these names and business
+            addresses registered with HPD offer a clearer picture of who the landlord really is.
+          </p>
+          <p>
+            People listed here as “Head Officer” or “Owner” usually have ties to building ownership,
+            while “Site Managers” are part of management. That being said, these names are self
+            reported, so they can be misleading.
+          </p>
+          <p>Learn more about HPD registrations and how they power this tool on the About page.</p>
+        </Trans>
+      </Accordion>
+    )}
+  </I18n>
 );
 
 const NUM_COMPLAINT_TYPES_TO_SHOW = 3;
@@ -180,27 +202,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                             <b>
                               <Trans>Who’s the landlord of this building?</Trans>
                             </b>
-
-                            <Accordion title="Learn more" titleOnOpen="Close">
-                              <br />
-                              <Trans>
-                                <p>
-                                  While the legal owner of a building is often an “LLC” company,
-                                  these names and business addresses registered with HPD offer a
-                                  clearer picture of who the landlord really is.
-                                </p>
-                                <p>
-                                  People listed here as “Head Officer” or “Owner” usually have ties
-                                  to building ownership, while “Site Managers” are part of
-                                  management. That being said, these names are self reported, so
-                                  they can be misleading.
-                                </p>
-                                <p>
-                                  Learn more about HPD registrations and how they power this tool on
-                                  the About page.
-                                </p>
-                              </Trans>
-                            </Accordion>
+                            <LearnMoreAccordion />
                           </div>
                           <div>
                             {

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -176,9 +176,32 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                       </div>
                       {detailAddr.allcontacts && (
                         <div className="card-body-landlord">
-                          <b>
-                            <Trans>Who’s the landlord of this building?</Trans>
-                          </b>
+                          <div className="card-title-landlord">
+                            <b>
+                              <Trans>Who’s the landlord of this building?</Trans>
+                            </b>
+
+                            <Accordion title="Learn more" titleOnOpen="Close">
+                              <br />
+                              <Trans>
+                                <p>
+                                  While the legal owner of a building is often an “LLC” company,
+                                  these names and business addresses registered with HPD offer a
+                                  clearer picture of who the landlord really is.
+                                </p>
+                                <p>
+                                  People listed here as “Head Officer” or “Owner” usually have ties
+                                  to building ownership, while “Site Managers” are part of
+                                  management. That being said, these names are self reported, so
+                                  they can be misleading.
+                                </p>
+                                <p>
+                                  Learn more about HPD registrations and how they power this tool on
+                                  the About page.
+                                </p>
+                              </Trans>
+                            </Accordion>
+                          </div>
                           <div>
                             {
                               // Group all contact info by the name of each person/corporate entity
@@ -192,7 +215,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                                     : 0
                                 )
                                 .map((contact, i) => (
-                                  <Accordion question={contact[0]} key={i}>
+                                  <Accordion title={contact[0]} key={i}>
                                     {contact[1].map((info, j) => (
                                       <div className="landlord-contact-info" key={j}>
                                         <span className="text-bold text-dark">{info.title}</span>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -84,8 +84,6 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const locale = (this.props.i18n.language as SupportedLocale) || "en";
     const { assocAddrs, detailAddr, searchAddr } = this.props.state.context.portfolioData;
 
-    console.log(groupHpdContacts(detailAddr.allcontacts || []));
-
     // Let's save some variables that will be helpful in rendering the front-end component
     let takeActionURL, formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
 

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -35,17 +35,6 @@ type State = {
 
 const getTodaysDate = () => new Date();
 
-const formatHpdContactAddress = (address: HpdContactAddress) => {
-  const { housenumber, streetname, apartment, city, state, zip } = address;
-  const cityFormatted = city && state ? `${city},` : city;
-  return (
-    <>
-      {[housenumber, streetname, apartment].join(" ").toUpperCase()} <br />
-      {[cityFormatted, state, zip].join(" ").toUpperCase()}
-    </>
-  );
-};
-
 const SocialShareDetailView = () => (
   <SocialShareAddressPage
     location="overview-tab"
@@ -206,12 +195,20 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                                 .map((contact, i) => (
                                   <Accordion question={contact[0]} key={i}>
                                     {contact[1].map((info, j) => (
-                                      <div key={j}>
+                                      <div className="landlord-contact-info" key={j}>
                                         <span className="text-bold text-dark">{info.title}</span>
                                         {info.address && (
                                           <>
                                             <br />
-                                            {formatHpdContactAddress(info.address)}
+                                            {
+                                              Helpers.formatHpdContactAddress(info.address)
+                                                .addressLine1
+                                            }
+                                            <br />
+                                            {
+                                              Helpers.formatHpdContactAddress(info.address)
+                                                .addressLine2
+                                            }
                                           </>
                                         )}
                                       </div>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -18,7 +18,7 @@ import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
 import { SupportedLocale } from "../i18n-base";
 import { withMachineInStateProps } from "state-machine";
 import { Accordion } from "./Accordion";
-import { HpdContactAddress, HpdFullContact } from "./APIDataTypes";
+import { HpdContactAddress } from "./APIDataTypes";
 import _groupBy from "lodash/groupBy";
 
 type Props = withI18nProps &

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -18,7 +18,6 @@ import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
 import { SupportedLocale } from "../i18n-base";
 import { withMachineInStateProps } from "state-machine";
 import { Accordion } from "./Accordion";
-import { HpdContactAddress } from "./APIDataTypes";
 import _groupBy from "lodash/groupBy";
 
 type Props = withI18nProps &

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -192,23 +192,33 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                             <Trans>Who’s the landlord of this building?</Trans>
                           </b>
                           <div>
-                            {Object.entries(_groupBy(detailAddr.allcontacts, "value")).map(
-                              (contact, i) => (
-                                <Accordion question={contact[0]} key={i}>
-                                  {contact[1].map((info, j) => (
-                                    <div key={j}>
-                                      <span className="text-bold text-dark">{info.title}</span>
-                                      {info.address && (
-                                        <>
-                                          <br />
-                                          {formatHpdContactAddress(info.address)}
-                                        </>
-                                      )}
-                                    </div>
-                                  ))}
-                                </Accordion>
-                              )
-                            )}
+                            {
+                              // Group all contact info by the name of each person/corporate entity
+                              Object.entries(_groupBy(detailAddr.allcontacts, "value"))
+                                // Move head officers and owners to the top of the list
+                                .sort((contact) =>
+                                  contact[1].find(
+                                    (o) => o.title === "HeadOfficer" || o.title.includes("Owner")
+                                  )
+                                    ? -1
+                                    : 0
+                                )
+                                .map((contact, i) => (
+                                  <Accordion question={contact[0]} key={i}>
+                                    {contact[1].map((info, j) => (
+                                      <div key={j}>
+                                        <span className="text-bold text-dark">{info.title}</span>
+                                        {info.address && (
+                                          <>
+                                            <br />
+                                            {formatHpdContactAddress(info.address)}
+                                          </>
+                                        )}
+                                      </div>
+                                    ))}
+                                  </Accordion>
+                                ))
+                            }
                           </div>
                         </div>
                       )}

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -169,7 +169,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                             window.gtag("event", "view-data-over-time-overview-tab");
                           }}
                         >
-                          <Trans render="span">View data over time</Trans> &#8599;&#xFE0E;
+                          <Trans render="span">View data over time &#8599;&#xFE0E;</Trans>
                         </Link>
                       </div>
                       <div className="card-body-complaints">
@@ -289,15 +289,89 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                           </p>
                         )}
                       </div>
+                    </div>
+                  </div>
+                  <div className="column col-lg-12 col-5">
+                    <div className="card-image hide-lg">{streetView}</div>
+                    <div className="card-body column-right">
+                      <div className="card-body-links">
+                        <b>
+                          <Trans>Useful links</Trans>
+                        </b>
+                        <ul>
+                          <li>
+                            View documents on{" "}
+                            <a
+                              onClick={() => {
+                                window.gtag("event", "acris-overview-tab");
+                              }}
+                              href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <Trans>ACRIS</Trans>
+                            </a>
+                          </li>
+                          <li>
+                            <a
+                              onClick={() => {
+                                window.gtag("event", "hpd-overview-tab");
+                              }}
+                              href={`https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${
+                                detailAddr.housenumber
+                              }&p3=${Helpers.formatStreetNameForHpdLink(
+                                detailAddr.streetname
+                              )}&SearchButton=Search`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <Trans>HPD Building Profile</Trans>
+                            </a>
+                          </li>
+                          <li>
+                            <a
+                              onClick={() => {
+                                window.gtag("event", "dob-overview-tab");
+                              }}
+                              href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <Trans>DOB Building Profile</Trans>
+                            </a>
+                          </li>
+                          <li>
+                            <a
+                              onClick={() => {
+                                window.gtag("event", "dof-overview-tab");
+                              }}
+                              href={`https://a836-pts-access.nyc.gov/care/search/commonsearch.aspx?mode=persprop`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <Trans>DOF Property Tax Bills</Trans>
+                            </a>
+                          </li>
+                          <li>
+                            <a
+                              onClick={() => {
+                                window.gtag("event", "dap-overview-tab");
+                              }}
+                              href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <Trans>ANHD DAP Portal</Trans>
+                            </a>
+                          </li>
+                        </ul>
+                      </div>
 
-                      <div className="card-body-prompt hide-lg">
+                      <div className="card-body-prompt">
                         <h6 className="DetailView__subtitle">
                           <Trans>Are you having issues in this building?</Trans>
                         </h6>
                         <a
-                          onClick={() => {
-                            window.gtag("event", "take-action-overview-tab");
-                          }}
                           href={takeActionURL}
                           target="_blank"
                           rel="noopener noreferrer"
@@ -307,119 +381,11 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                         </a>
                       </div>
 
-                      <div className="card-body-social social-group hide-lg">
+                      <div className="card-body-social social-group">
                         <h6 className="DetailView__subtitle">
                           <Trans>Share this page with your neighbors</Trans>
                         </h6>
                         <SocialShareDetailView />
-                      </div>
-                    </div>
-                  </div>
-                  <div className="column col-lg-12 col-5">
-                    <div className="card-image hide-lg">{streetView}</div>
-                    <div className="card-body column-right">
-                      <div className="card-body-resources">
-                        <span className="card-body-resources__title show-lg">
-                          <Trans render="em">Useful links</Trans>
-                        </span>
-
-                        <div className="card-body-links">
-                          <h6 className="DetailView__subtitle hide-lg">
-                            <Trans>Useful links</Trans>
-                          </h6>
-                          <div className="columns">
-                            <div className="column col-12">
-                              <a
-                                onClick={() => {
-                                  window.gtag("event", "acris-overview-tab");
-                                }}
-                                href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="btn btn-block"
-                              >
-                                <Trans>View documents on ACRIS</Trans> &#8599;&#xFE0E;
-                              </a>
-                            </div>
-                            <div className="column col-12">
-                              <a
-                                onClick={() => {
-                                  window.gtag("event", "hpd-overview-tab");
-                                }}
-                                href={`https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${
-                                  detailAddr.housenumber
-                                }&p3=${Helpers.formatStreetNameForHpdLink(
-                                  detailAddr.streetname
-                                )}&SearchButton=Search`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="btn btn-block"
-                              >
-                                <Trans>HPD Building Profile</Trans> &#8599;&#xFE0E;
-                              </a>
-                            </div>
-                            <div className="column col-12">
-                              <a
-                                onClick={() => {
-                                  window.gtag("event", "dob-overview-tab");
-                                }}
-                                href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="btn btn-block"
-                              >
-                                <Trans>DOB Building Profile</Trans> &#8599;&#xFE0E;
-                              </a>
-                            </div>
-                            <div className="column col-12">
-                              <a
-                                onClick={() => {
-                                  window.gtag("event", "dof-overview-tab");
-                                }}
-                                href={`https://a836-pts-access.nyc.gov/care/search/commonsearch.aspx?mode=persprop`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="btn btn-block"
-                              >
-                                <Trans>DOF Property Tax Bills</Trans> &#8599;&#xFE0E;
-                              </a>
-                            </div>
-                            <div className="column col-12">
-                              <a
-                                onClick={() => {
-                                  window.gtag("event", "dap-overview-tab");
-                                }}
-                                href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="btn btn-block"
-                              >
-                                <Trans>ANHD DAP Portal</Trans> &#8599;&#xFE0E;
-                              </a>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="card-body-prompt show-lg">
-                          <h6 className="DetailView__subtitle">
-                            <Trans>Are you having issues in this building?</Trans>
-                          </h6>
-                          <a
-                            href={takeActionURL}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="btn btn-justfix btn-block"
-                          >
-                            <Trans>Take action on JustFix.nyc!</Trans>
-                          </a>
-                        </div>
-
-                        <div className="card-body-social social-group show-lg">
-                          <h6 className="DetailView__subtitle">
-                            <Trans>Share this page with your neighbors</Trans>
-                          </h6>
-                          <SocialShareDetailView />
-                        </div>
                       </div>
                     </div>
                   </div>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -241,6 +241,9 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                                 ))
                             }
                           </div>
+                          <div className="card-footer-landlord">
+                            <LearnMoreAccordion />
+                          </div>
                         </div>
                       )}
                       <div className="card-body-registration">

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -5,6 +5,7 @@ import Helpers from "../util/helpers";
 import IndicatorsViz from "../components/IndicatorsViz";
 import Loader from "../components/Loader";
 import LegalFooter from "../components/LegalFooter";
+import { UsefulLinks } from "./UsefulLinks";
 import { withI18n } from "@lingui/react";
 import { Trans } from "@lingui/macro";
 
@@ -170,10 +171,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
       const { state, send } = this.props;
 
       const { detailAddr } = state.context.portfolioData;
-      const { housenumber, streetname, bbl } = detailAddr;
-      const boro = bbl.slice(0, 1);
-      const block = bbl.slice(1, 6);
-      const lot = bbl.slice(6, 10);
+      const { bbl } = detailAddr;
 
       const { activeVis } = this.state;
       const activeData = state.context.timelineData[activeVis];
@@ -366,84 +364,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                   </div>
                 </div>
 
-                <div className="card card-links">
-                  <div className="card-body card-body-links">
-                    <Trans render="h6">Useful links</Trans>
-                    <div className="columns">
-                      <div className="column col-12">
-                        <a
-                          onClick={() => {
-                            window.gtag("event", "acris-timeline-tab");
-                          }}
-                          href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="btn btn-block"
-                        >
-                          <Trans>View documents on ACRIS</Trans> &#8599;&#xFE0E;
-                        </a>
-                      </div>
-                      <div className="column col-12">
-                        <a
-                          onClick={() => {
-                            window.gtag("event", "hpd-timeline-tab");
-                          }}
-                          href={
-                            housenumber && streetname
-                              ? `https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${housenumber}&p3=${Helpers.formatStreetNameForHpdLink(
-                                  streetname
-                                )}&SearchButton=Search`
-                              : `https://hpdonline.hpdnyc.org/HPDonline/provide_address.aspx`
-                          }
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="btn btn-block"
-                        >
-                          <Trans>HPD Building Profile</Trans> &#8599;&#xFE0E;
-                        </a>
-                      </div>
-                      <div className="column col-12">
-                        <a
-                          onClick={() => {
-                            window.gtag("event", "dob-timeline-tab");
-                          }}
-                          href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="btn btn-block"
-                        >
-                          <Trans>DOB Building Profile</Trans> &#8599;&#xFE0E;
-                        </a>
-                      </div>
-                      <div className="column col-12">
-                        <a
-                          onClick={() => {
-                            window.gtag("event", "dof-timeline-tab");
-                          }}
-                          href={`https://a836-pts-access.nyc.gov/care/search/commonsearch.aspx?mode=persprop`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="btn btn-block"
-                        >
-                          <Trans>DOF Property Tax Bills</Trans> &#8599;&#xFE0E;
-                        </a>
-                      </div>
-                      <div className="column col-12">
-                        <a
-                          onClick={() => {
-                            window.gtag("event", "dap-timeline-tab");
-                          }}
-                          href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="btn btn-block"
-                        >
-                          <Trans>ANHD DAP Portal</Trans> &#8599;&#xFE0E;
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+                <UsefulLinks addrForLinks={detailAddr} location="timeline-tab" />
 
                 <div className="Indicators__feedback show-lg">
                   <Trans render="i">Have thoughts about this page?</Trans>

--- a/client/src/components/UsefulLinks.tsx
+++ b/client/src/components/UsefulLinks.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { Trans } from "@lingui/macro";
+import Helpers from "../util/helpers";
+import { AddressRecord } from "./APIDataTypes";
+
+type UsefulLinksProps = {
+  addrForLinks: AddressRecord;
+  location: "overview-tab" | "timeline-tab";
+};
+
+export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location }) => {
+  const { bbl, housenumber, streetname } = addrForLinks;
+  const { boro, block, lot } = Helpers.splitBBL(bbl);
+  return (
+    <div className="card-body-links">
+      <b>
+        <Trans>Useful links</Trans>
+      </b>
+      <ul>
+        <li>
+          View documents on{" "}
+          <a
+            onClick={() => {
+              window.gtag("event", `acris-${location}`);
+            }}
+            href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Trans>ACRIS</Trans>
+          </a>
+        </li>
+        <li>
+          <a
+            onClick={() => {
+              window.gtag("event", `hpd-${location}`);
+            }}
+            href={`https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${housenumber}&p3=${Helpers.formatStreetNameForHpdLink(
+              streetname
+            )}&SearchButton=Search`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Trans>HPD Building Profile</Trans>
+          </a>
+        </li>
+        <li>
+          <a
+            onClick={() => {
+              window.gtag("event", `dob-${location}`);
+            }}
+            href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Trans>DOB Building Profile</Trans>
+          </a>
+        </li>
+        <li>
+          <a
+            onClick={() => {
+              window.gtag("event", `dof-${location}`);
+            }}
+            href={`https://a836-pts-access.nyc.gov/care/search/commonsearch.aspx?mode=persprop`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Trans>DOF Property Tax Bills</Trans>
+          </a>
+        </li>
+        <li>
+          <a
+            onClick={() => {
+              window.gtag("event", `dap-${location}`);
+            }}
+            href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Trans>ANHD DAP Portal</Trans>
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+};

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/components/DetailView.tsx:170
+#: src/components/DetailView.tsx:187
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:152
+#: src/components/DetailView.tsx:169
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:155
+#: src/components/DetailView.tsx:172
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -41,7 +41,11 @@ msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
-#: src/components/DetailView.tsx:240
+#: src/components/DetailView.tsx:28
+msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the About page.</2>"
+msgstr "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the About page.</2>"
+
+#: src/components/DetailView.tsx:257
 #: src/components/Indicators.tsx:283
 #: src/containers/NotRegisteredPage.tsx:158
 #: src/containers/NychaPage.tsx:168
@@ -69,7 +73,7 @@ msgstr "Additional links"
 msgid "Address"
 msgstr "Address"
 
-#: src/components/Subscribe.tsx:39
+#: src/components/Subscribe.tsx:43
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
@@ -81,8 +85,8 @@ msgstr "All the public info on your landlord"
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/DetailView.tsx:178
-#: src/components/DetailView.tsx:248
+#: src/components/DetailView.tsx:195
+#: src/components/DetailView.tsx:265
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -94,7 +98,7 @@ msgstr "Are you having issues in this development?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:77
+#: src/components/DetailView.tsx:96
 #: src/components/Indicators.tsx:147
 msgid "BUILDING:"
 msgstr "BUILDING:"
@@ -135,16 +139,14 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:125
-#: src/components/DetailView.tsx:313
-#: src/components/DetailView.tsx:322
+#: src/components/DetailView.tsx:330
+#: src/components/DetailView.tsx:339
 #: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:116
-#: src/components/DetailView.tsx:293
-#: src/components/DetailView.tsx:302
+#: src/components/DetailView.tsx:310
+#: src/components/DetailView.tsx:319
 #: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Business Entities"
@@ -165,7 +167,7 @@ msgstr "CONSTRUCTION"
 msgid "COOKING GAS"
 msgstr "COOKING GAS"
 
-#: src/components/DetailView.tsx:20
+#: src/components/DetailView.tsx:22
 msgid "Check out the issues in this building"
 msgstr "Check out the issues in this building"
 
@@ -189,6 +191,10 @@ msgstr "Class C"
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
+#: src/components/DetailView.tsx:26
+msgid "Close"
+msgstr "Close"
+
 #: src/components/PropertiesMap.tsx:193
 msgid "Close legend"
 msgstr "Close legend"
@@ -197,13 +203,13 @@ msgstr "Close legend"
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
-#: src/components/DetailView.tsx:226
+#: src/components/DetailView.tsx:243
 #: src/components/Indicators.tsx:269
 #: src/containers/NotRegisteredPage.tsx:155
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
-#: src/components/DetailView.tsx:233
+#: src/components/DetailView.tsx:250
 #: src/components/Indicators.tsx:276
 #: src/containers/NotRegisteredPage.tsx:150
 msgid "DOF Property Tax Bills"
@@ -258,7 +264,7 @@ msgstr "Emergency"
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Enter an NYC address and find other buildings your landlord might own:"
 
-#: src/components/Subscribe.tsx:72
+#: src/components/Subscribe.tsx:76
 msgid "Enter email"
 msgstr "Enter email"
 
@@ -317,7 +323,7 @@ msgstr "HEAT/HOT WATER"
 msgid "HEATING"
 msgstr "HEATING"
 
-#: src/components/DetailView.tsx:219
+#: src/components/DetailView.tsx:236
 #: src/components/Indicators.tsx:262
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
@@ -353,8 +359,8 @@ msgstr "Have thoughts about this page?"
 msgid "Home"
 msgstr "Home"
 
-#: src/components/DetailView.tsx:83
-#: src/components/DetailView.tsx:268
+#: src/components/DetailView.tsx:102
+#: src/components/DetailView.tsx:285
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
@@ -363,11 +369,11 @@ msgstr "How is this building associated to this portfolio?"
 msgid "How to use"
 msgstr "How to use"
 
-#: src/components/DetailView.tsx:21
+#: src/components/DetailView.tsx:23
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 
-#: src/components/DetailView.tsx:19
+#: src/components/DetailView.tsx:21
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
@@ -424,13 +430,17 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:147
+#: src/components/DetailView.tsx:164
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:160
+#: src/components/DetailView.tsx:177
 msgid "Last sold:"
 msgstr "Last sold:"
+
+#: src/components/DetailView.tsx:26
+msgid "Learn more"
+msgstr "Learn more"
 
 #: src/components/PropertiesMap.tsx:193
 msgid "Legend"
@@ -486,7 +496,7 @@ msgstr "Methodology"
 msgid "Month"
 msgstr "Month"
 
-#: src/components/DetailView.tsx:100
+#: src/components/DetailView.tsx:119
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -535,7 +545,7 @@ msgstr "No registration found!"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:108
+#: src/components/DetailView.tsx:127
 msgid "None"
 msgstr "None"
 
@@ -552,12 +562,12 @@ msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
 #: src/components/NetworkErrorMessage.tsx:5
-#: src/components/Subscribe.tsx:50
-#: src/components/Subscribe.tsx:56
+#: src/components/Subscribe.tsx:54
+#: src/components/Subscribe.tsx:60
 msgid "Oops! A network error occurred. Try again later."
 msgstr "Oops! A network error occurred. Try again later."
 
-#: src/components/Subscribe.tsx:44
+#: src/components/Subscribe.tsx:48
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
@@ -593,14 +603,13 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/DetailView.tsx:135
-#: src/components/DetailView.tsx:333
-#: src/components/DetailView.tsx:343
+#: src/components/DetailView.tsx:350
+#: src/components/DetailView.tsx:360
 #: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "People"
 
-#: src/components/Subscribe.tsx:21
+#: src/components/Subscribe.tsx:22
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
@@ -668,8 +677,8 @@ msgstr "Send us feedback!"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:189
-#: src/components/DetailView.tsx:257
+#: src/components/DetailView.tsx:206
+#: src/components/DetailView.tsx:274
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
 #: src/containers/App.tsx:105
@@ -677,7 +686,7 @@ msgstr "Share"
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
 
-#: src/components/Subscribe.tsx:73
+#: src/components/Subscribe.tsx:77
 msgid "Sign up"
 msgstr "Sign up"
 
@@ -717,8 +726,8 @@ msgstr "Summary"
 msgid "TENANT HARASSMENT"
 msgstr "TENANT HARASSMENT"
 
-#: src/components/DetailView.tsx:183
-#: src/components/DetailView.tsx:251
+#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:268
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
@@ -884,8 +893,8 @@ msgstr "Units"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 
-#: src/components/DetailView.tsx:200
-#: src/components/DetailView.tsx:205
+#: src/components/DetailView.tsx:217
+#: src/components/DetailView.tsx:222
 #: src/components/Indicators.tsx:247
 #: src/containers/NotRegisteredPage.tsx:143
 #: src/containers/NychaPage.tsx:153
@@ -900,7 +909,7 @@ msgstr "VENTILATION SYSTEM"
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:94
+#: src/components/DetailView.tsx:113
 msgid "View data over time"
 msgstr "View data over time"
 
@@ -909,7 +918,7 @@ msgstr "View data over time"
 msgid "View detail"
 msgstr "View detail"
 
-#: src/components/DetailView.tsx:212
+#: src/components/DetailView.tsx:229
 #: src/components/Indicators.tsx:253
 #: src/containers/NotRegisteredPage.tsx:147
 msgid "View documents on ACRIS"
@@ -925,7 +934,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:69
+#: src/components/DetailView.tsx:88
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -953,7 +962,7 @@ msgstr "WINDOWS"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
-#: src/components/DetailView.tsx:270
+#: src/components/DetailView.tsx:287
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -984,6 +993,10 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
+#: src/components/DetailView.tsx:134
+msgid "Who’s the landlord of this building?"
+msgstr "Who’s the landlord of this building?"
+
 #: src/components/Indicators.tsx:192
 msgid "Year"
 msgstr "Year"
@@ -1012,7 +1025,7 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:181
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/components/DetailView.tsx:187
+#: src/components/DetailView.tsx:203
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:169
+#: src/components/DetailView.tsx:185
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:172
+#: src/components/DetailView.tsx:188
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -41,12 +41,15 @@ msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
-#: src/components/DetailView.tsx:28
-msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the About page.</2>"
-msgstr "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the About page.</2>"
+#: src/components/DetailView.tsx:50
+msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the <3>About page</3>.</2>"
+msgstr "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the <3>About page</3>.</2>"
 
-#: src/components/DetailView.tsx:257
-#: src/components/Indicators.tsx:283
+#: src/components/UsefulLinks.tsx:17
+msgid "ACRIS"
+msgstr "ACRIS"
+
+#: src/components/UsefulLinks.tsx:45
 #: src/containers/NotRegisteredPage.tsx:158
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
@@ -85,8 +88,7 @@ msgstr "All the public info on your landlord"
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/DetailView.tsx:195
-#: src/components/DetailView.tsx:265
+#: src/components/DetailView.tsx:216
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -98,12 +100,12 @@ msgstr "Are you having issues in this development?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:96
-#: src/components/Indicators.tsx:147
+#: src/components/DetailView.tsx:124
+#: src/components/Indicators.tsx:145
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/Indicators.tsx:152
+#: src/components/Indicators.tsx:150
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
@@ -139,14 +141,14 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:330
-#: src/components/DetailView.tsx:339
+#: src/components/DetailView.tsx:280
+#: src/components/DetailView.tsx:289
 #: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:310
-#: src/components/DetailView.tsx:319
+#: src/components/DetailView.tsx:260
+#: src/components/DetailView.tsx:269
 #: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Business Entities"
@@ -167,7 +169,7 @@ msgstr "CONSTRUCTION"
 msgid "COOKING GAS"
 msgstr "COOKING GAS"
 
-#: src/components/DetailView.tsx:22
+#: src/components/DetailView.tsx:24
 msgid "Check out the issues in this building"
 msgstr "Check out the issues in this building"
 
@@ -191,7 +193,7 @@ msgstr "Class C"
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
-#: src/components/DetailView.tsx:26
+#: src/components/DetailView.tsx:48
 msgid "Close"
 msgstr "Close"
 
@@ -203,14 +205,12 @@ msgstr "Close legend"
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
-#: src/components/DetailView.tsx:243
-#: src/components/Indicators.tsx:269
+#: src/components/UsefulLinks.tsx:31
 #: src/containers/NotRegisteredPage.tsx:155
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
-#: src/components/DetailView.tsx:250
-#: src/components/Indicators.tsx:276
+#: src/components/UsefulLinks.tsx:38
 #: src/containers/NotRegisteredPage.tsx:150
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
@@ -323,8 +323,7 @@ msgstr "HEAT/HOT WATER"
 msgid "HEATING"
 msgstr "HEATING"
 
-#: src/components/DetailView.tsx:236
-#: src/components/Indicators.tsx:262
+#: src/components/UsefulLinks.tsx:24
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
@@ -350,8 +349,8 @@ msgstr "HPD Violations occur when an official City Inspector finds the condition
 msgid "HUD Complaint Form 958"
 msgstr "HUD Complaint Form 958"
 
-#: src/components/Indicators.tsx:224
-#: src/components/Indicators.tsx:291
+#: src/components/Indicators.tsx:222
+#: src/components/Indicators.tsx:246
 msgid "Have thoughts about this page?"
 msgstr "Have thoughts about this page?"
 
@@ -359,8 +358,8 @@ msgstr "Have thoughts about this page?"
 msgid "Home"
 msgstr "Home"
 
-#: src/components/DetailView.tsx:102
-#: src/components/DetailView.tsx:285
+#: src/components/DetailView.tsx:130
+#: src/components/DetailView.tsx:235
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
@@ -369,11 +368,11 @@ msgstr "How is this building associated to this portfolio?"
 msgid "How to use"
 msgstr "How to use"
 
-#: src/components/DetailView.tsx:23
+#: src/components/DetailView.tsx:25
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 
-#: src/components/DetailView.tsx:21
+#: src/components/DetailView.tsx:23
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
@@ -430,15 +429,15 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:180
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:177
+#: src/components/DetailView.tsx:193
 msgid "Last sold:"
 msgstr "Last sold:"
 
-#: src/components/DetailView.tsx:26
+#: src/components/DetailView.tsx:48
 msgid "Learn more"
 msgstr "Learn more"
 
@@ -451,7 +450,7 @@ msgstr "Legend"
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
-#: src/components/Indicators.tsx:119
+#: src/components/Indicators.tsx:120
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:62
 #: src/containers/AddressPage.tsx:165
@@ -492,11 +491,11 @@ msgstr "May be issued official Orders"
 msgid "Methodology"
 msgstr "Methodology"
 
-#: src/components/Indicators.tsx:176
+#: src/components/Indicators.tsx:174
 msgid "Month"
 msgstr "Month"
 
-#: src/components/DetailView.tsx:119
+#: src/components/DetailView.tsx:147
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -545,7 +544,7 @@ msgstr "No registration found!"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:127
+#: src/components/DetailView.tsx:155
 msgid "None"
 msgstr "None"
 
@@ -603,8 +602,8 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/DetailView.tsx:350
-#: src/components/DetailView.tsx:360
+#: src/components/DetailView.tsx:300
+#: src/components/DetailView.tsx:310
 #: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "People"
@@ -626,7 +625,7 @@ msgstr "Privacy policy"
 msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
-#: src/components/Indicators.tsx:184
+#: src/components/Indicators.tsx:182
 msgid "Quarter"
 msgstr "Quarter"
 
@@ -660,7 +659,7 @@ msgstr "STAIRS"
 msgid "Search for a different address"
 msgstr "Search for a different address"
 
-#: src/components/Indicators.tsx:159
+#: src/components/Indicators.tsx:157
 msgid "Select a Dataset:"
 msgstr "Select a Dataset:"
 
@@ -668,8 +667,8 @@ msgstr "Select a Dataset:"
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/components/Indicators.tsx:227
-#: src/components/Indicators.tsx:294
+#: src/components/Indicators.tsx:225
+#: src/components/Indicators.tsx:249
 msgid "Send us feedback!"
 msgstr "Send us feedback!"
 
@@ -677,8 +676,7 @@ msgstr "Send us feedback!"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:206
-#: src/components/DetailView.tsx:274
+#: src/components/DetailView.tsx:225
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
 #: src/containers/App.tsx:105
@@ -726,8 +724,7 @@ msgstr "Summary"
 msgid "TENANT HARASSMENT"
 msgstr "TENANT HARASSMENT"
 
-#: src/components/DetailView.tsx:200
-#: src/components/DetailView.tsx:268
+#: src/components/DetailView.tsx:219
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
@@ -893,9 +890,7 @@ msgstr "Units"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 
-#: src/components/DetailView.tsx:217
-#: src/components/DetailView.tsx:222
-#: src/components/Indicators.tsx:247
+#: src/components/UsefulLinks.tsx:9
 #: src/containers/NotRegisteredPage.tsx:143
 #: src/containers/NychaPage.tsx:153
 msgid "Useful links"
@@ -905,21 +900,19 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
-#: src/components/Indicators.tsx:168
+#: src/components/Indicators.tsx:166
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:113
-msgid "View data over time"
-msgstr "View data over time"
+#: src/components/DetailView.tsx:141
+msgid "View data over time ↗︎"
+msgstr "View data over time ↗︎"
 
 #: src/components/PropertiesList.tsx:206
 #: src/components/PropertiesList.tsx:211
 msgid "View detail"
 msgstr "View detail"
 
-#: src/components/DetailView.tsx:229
-#: src/components/Indicators.tsx:253
 #: src/containers/NotRegisteredPage.tsx:147
 msgid "View documents on ACRIS"
 msgstr "View documents on ACRIS"
@@ -934,7 +927,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:88
+#: src/components/DetailView.tsx:116
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -962,11 +955,11 @@ msgstr "WINDOWS"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
-#: src/components/DetailView.tsx:287
+#: src/components/DetailView.tsx:237
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
-#: src/components/Indicators.tsx:236
+#: src/components/Indicators.tsx:234
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
@@ -993,11 +986,11 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:134
+#: src/components/DetailView.tsx:162
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
-#: src/components/Indicators.tsx:192
+#: src/components/Indicators.tsx:190
 msgid "Year"
 msgstr "Year"
 
@@ -1025,7 +1018,7 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:181
+#: src/components/DetailView.tsx:197
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -22,15 +22,15 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
-#: src/components/DetailView.tsx:187
+#: src/components/DetailView.tsx:203
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:169
+#: src/components/DetailView.tsx:185
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:172
+#: src/components/DetailView.tsx:188
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -46,12 +46,15 @@ msgstr "({browserType, select, mobile {pulsa} other {haz clic}} para ver detalle
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de portafolios de edificios:"
 
-#: src/components/DetailView.tsx:28
-msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the About page.</2>"
+#: src/components/DetailView.tsx:50
+msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the <3>About page</3>.</2>"
 msgstr ""
 
-#: src/components/DetailView.tsx:257
-#: src/components/Indicators.tsx:283
+#: src/components/UsefulLinks.tsx:17
+msgid "ACRIS"
+msgstr ""
+
+#: src/components/UsefulLinks.tsx:45
 #: src/containers/NotRegisteredPage.tsx:158
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
@@ -90,8 +93,7 @@ msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 msgid "Amount"
 msgstr "Importe"
 
-#: src/components/DetailView.tsx:195
-#: src/components/DetailView.tsx:265
+#: src/components/DetailView.tsx:216
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -103,12 +105,12 @@ msgstr "¿Tienes problemas en tu edificio?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:96
-#: src/components/Indicators.tsx:147
+#: src/components/DetailView.tsx:124
+#: src/components/Indicators.tsx:145
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/Indicators.tsx:152
+#: src/components/Indicators.tsx:150
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
@@ -144,14 +146,14 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:330
-#: src/components/DetailView.tsx:339
+#: src/components/DetailView.tsx:280
+#: src/components/DetailView.tsx:289
 #: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:310
-#: src/components/DetailView.tsx:319
+#: src/components/DetailView.tsx:260
+#: src/components/DetailView.tsx:269
 #: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
@@ -172,7 +174,7 @@ msgstr "CONSTRUCCIÓN"
 msgid "COOKING GAS"
 msgstr "GAS DE COCINA"
 
-#: src/components/DetailView.tsx:22
+#: src/components/DetailView.tsx:24
 msgid "Check out the issues in this building"
 msgstr "Mira los problemas en este edificio"
 
@@ -196,7 +198,7 @@ msgstr "Clase C"
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
-#: src/components/DetailView.tsx:26
+#: src/components/DetailView.tsx:48
 msgid "Close"
 msgstr ""
 
@@ -208,14 +210,12 @@ msgstr "Cerrar leyenda"
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
-#: src/components/DetailView.tsx:243
-#: src/components/Indicators.tsx:269
+#: src/components/UsefulLinks.tsx:31
 #: src/containers/NotRegisteredPage.tsx:155
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
-#: src/components/DetailView.tsx:250
-#: src/components/Indicators.tsx:276
+#: src/components/UsefulLinks.tsx:38
 #: src/containers/NotRegisteredPage.tsx:150
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
@@ -328,8 +328,7 @@ msgstr "CALEFACCIÓN/AGUA CALIENTE"
 msgid "HEATING"
 msgstr "CALEFACCIÓN"
 
-#: src/components/DetailView.tsx:236
-#: src/components/Indicators.tsx:262
+#: src/components/UsefulLinks.tsx:24
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
@@ -355,8 +354,8 @@ msgstr "Infracciones del HPD se dan cuando un Inspector oficial de la Ciudad det
 msgid "HUD Complaint Form 958"
 msgstr "Formulario de queja HUD 958"
 
-#: src/components/Indicators.tsx:224
-#: src/components/Indicators.tsx:291
+#: src/components/Indicators.tsx:222
+#: src/components/Indicators.tsx:246
 msgid "Have thoughts about this page?"
 msgstr "¿Tienes ideas sobre esta página?"
 
@@ -364,8 +363,8 @@ msgstr "¿Tienes ideas sobre esta página?"
 msgid "Home"
 msgstr "Inicio"
 
-#: src/components/DetailView.tsx:102
-#: src/components/DetailView.tsx:285
+#: src/components/DetailView.tsx:130
+#: src/components/DetailView.tsx:235
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
@@ -374,11 +373,11 @@ msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 msgid "How to use"
 msgstr "Cómo se usa"
 
-#: src/components/DetailView.tsx:23
+#: src/components/DetailView.tsx:25
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc que hace que la información sobre los dueños de edificios sea más transparente para los inquilinos. Sería bueno si buscaras tu edificio también. Míralo aquí: {url}"
 
-#: src/components/DetailView.tsx:21
+#: src/components/DetailView.tsx:23
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
@@ -435,15 +434,15 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:180
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:177
+#: src/components/DetailView.tsx:193
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
-#: src/components/DetailView.tsx:26
+#: src/components/DetailView.tsx:48
 msgid "Learn more"
 msgstr ""
 
@@ -456,7 +455,7 @@ msgstr "Leyenda"
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
-#: src/components/Indicators.tsx:119
+#: src/components/Indicators.tsx:120
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:62
 #: src/containers/AddressPage.tsx:165
@@ -497,11 +496,11 @@ msgstr "Pueden emitirse órdenes oficiales"
 msgid "Methodology"
 msgstr "Metodología"
 
-#: src/components/Indicators.tsx:176
+#: src/components/Indicators.tsx:174
 msgid "Month"
 msgstr "Mes"
 
-#: src/components/DetailView.tsx:119
+#: src/components/DetailView.tsx:147
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -550,7 +549,7 @@ msgstr "¡No se ha encontrado nigún registro!"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:127
+#: src/components/DetailView.tsx:155
 msgid "None"
 msgstr "Ninguna"
 
@@ -608,8 +607,8 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/DetailView.tsx:350
-#: src/components/DetailView.tsx:360
+#: src/components/DetailView.tsx:300
+#: src/components/DetailView.tsx:310
 #: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "Personas (Encontrarás definiciones en español de los tipos de personas asociadas al edificio en la página \"Como se usa\".)"
@@ -631,7 +630,7 @@ msgstr "Política de privacidad"
 msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
-#: src/components/Indicators.tsx:184
+#: src/components/Indicators.tsx:182
 msgid "Quarter"
 msgstr "Trimestre"
 
@@ -665,7 +664,7 @@ msgstr "ESCALERAS"
 msgid "Search for a different address"
 msgstr "Buscar otra dirección"
 
-#: src/components/Indicators.tsx:159
+#: src/components/Indicators.tsx:157
 msgid "Select a Dataset:"
 msgstr "Seleccione un conjunto de datos:"
 
@@ -673,8 +672,8 @@ msgstr "Seleccione un conjunto de datos:"
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/components/Indicators.tsx:227
-#: src/components/Indicators.tsx:294
+#: src/components/Indicators.tsx:225
+#: src/components/Indicators.tsx:249
 msgid "Send us feedback!"
 msgstr "¡Comparte tu opinión con nosotros!"
 
@@ -682,8 +681,7 @@ msgstr "¡Comparte tu opinión con nosotros!"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:206
-#: src/components/DetailView.tsx:274
+#: src/components/DetailView.tsx:225
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
 #: src/containers/App.tsx:105
@@ -731,8 +729,7 @@ msgstr "Resúmen"
 msgid "TENANT HARASSMENT"
 msgstr "ACOSO DE INQUILINO"
 
-#: src/components/DetailView.tsx:200
-#: src/components/DetailView.tsx:268
+#: src/components/DetailView.tsx:219
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
@@ -898,9 +895,7 @@ msgstr "Unidades Residenciales"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edificio e investigar a los arrendadores de Nueva York! Utilizamos el mapeo de propiedad para identificar el portafolio de edificios de un arrendador y proporcionar datos para revelar posibles casos de hostigamiento y desplazamiento de inquilinos."
 
-#: src/components/DetailView.tsx:217
-#: src/components/DetailView.tsx:222
-#: src/components/Indicators.tsx:247
+#: src/components/UsefulLinks.tsx:9
 #: src/containers/NotRegisteredPage.tsx:143
 #: src/containers/NychaPage.tsx:153
 msgid "Useful links"
@@ -910,21 +905,19 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
-#: src/components/Indicators.tsx:168
+#: src/components/Indicators.tsx:166
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:113
-msgid "View data over time"
-msgstr "Ver datos a lo largo del tiempo"
+#: src/components/DetailView.tsx:141
+msgid "View data over time ↗︎"
+msgstr ""
 
 #: src/components/PropertiesList.tsx:206
 #: src/components/PropertiesList.tsx:211
 msgid "View detail"
 msgstr "Ver detalles"
 
-#: src/components/DetailView.tsx:229
-#: src/components/Indicators.tsx:253
 #: src/containers/NotRegisteredPage.tsx:147
 msgid "View documents on ACRIS"
 msgstr "Ver documentos en ACRIS"
@@ -939,7 +932,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:88
+#: src/components/DetailView.tsx:116
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
@@ -967,11 +960,11 @@ msgstr "VENTANAS"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
-#: src/components/DetailView.tsx:287
+#: src/components/DetailView.tsx:237
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
-#: src/components/Indicators.tsx:236
+#: src/components/Indicators.tsx:234
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
@@ -998,11 +991,11 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:134
+#: src/components/DetailView.tsx:162
 msgid "Who’s the landlord of this building?"
 msgstr ""
 
-#: src/components/Indicators.tsx:192
+#: src/components/Indicators.tsx:190
 msgid "Year"
 msgstr "Año"
 
@@ -1030,7 +1023,7 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:181
+#: src/components/DetailView.tsx:197
 msgid "for ${0}"
 msgstr "por ${0}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -22,15 +22,15 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
-#: src/components/DetailView.tsx:170
+#: src/components/DetailView.tsx:187
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:152
+#: src/components/DetailView.tsx:169
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:155
+#: src/components/DetailView.tsx:172
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -46,7 +46,11 @@ msgstr "({browserType, select, mobile {pulsa} other {haz clic}} para ver detalle
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de portafolios de edificios:"
 
-#: src/components/DetailView.tsx:240
+#: src/components/DetailView.tsx:28
+msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the About page.</2>"
+msgstr ""
+
+#: src/components/DetailView.tsx:257
 #: src/components/Indicators.tsx:283
 #: src/containers/NotRegisteredPage.tsx:158
 #: src/containers/NychaPage.tsx:168
@@ -74,7 +78,7 @@ msgstr "Enlaces adicionales"
 msgid "Address"
 msgstr "Dirección"
 
-#: src/components/Subscribe.tsx:39
+#: src/components/Subscribe.tsx:43
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
@@ -86,8 +90,8 @@ msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 msgid "Amount"
 msgstr "Importe"
 
-#: src/components/DetailView.tsx:178
-#: src/components/DetailView.tsx:248
+#: src/components/DetailView.tsx:195
+#: src/components/DetailView.tsx:265
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -99,7 +103,7 @@ msgstr "¿Tienes problemas en tu edificio?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:77
+#: src/components/DetailView.tsx:96
 #: src/components/Indicators.tsx:147
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
@@ -140,16 +144,14 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:125
-#: src/components/DetailView.tsx:313
-#: src/components/DetailView.tsx:322
+#: src/components/DetailView.tsx:330
+#: src/components/DetailView.tsx:339
 #: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:116
-#: src/components/DetailView.tsx:293
-#: src/components/DetailView.tsx:302
+#: src/components/DetailView.tsx:310
+#: src/components/DetailView.tsx:319
 #: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
@@ -170,7 +172,7 @@ msgstr "CONSTRUCCIÓN"
 msgid "COOKING GAS"
 msgstr "GAS DE COCINA"
 
-#: src/components/DetailView.tsx:20
+#: src/components/DetailView.tsx:22
 msgid "Check out the issues in this building"
 msgstr "Mira los problemas en este edificio"
 
@@ -194,6 +196,10 @@ msgstr "Clase C"
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
+#: src/components/DetailView.tsx:26
+msgid "Close"
+msgstr ""
+
 #: src/components/PropertiesMap.tsx:193
 msgid "Close legend"
 msgstr "Cerrar leyenda"
@@ -202,13 +208,13 @@ msgstr "Cerrar leyenda"
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
-#: src/components/DetailView.tsx:226
+#: src/components/DetailView.tsx:243
 #: src/components/Indicators.tsx:269
 #: src/containers/NotRegisteredPage.tsx:155
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
-#: src/components/DetailView.tsx:233
+#: src/components/DetailView.tsx:250
 #: src/components/Indicators.tsx:276
 #: src/containers/NotRegisteredPage.tsx:150
 msgid "DOF Property Tax Bills"
@@ -263,7 +269,7 @@ msgstr "Emergencia"
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
 
-#: src/components/Subscribe.tsx:72
+#: src/components/Subscribe.tsx:76
 msgid "Enter email"
 msgstr "Introducir email"
 
@@ -322,7 +328,7 @@ msgstr "CALEFACCIÓN/AGUA CALIENTE"
 msgid "HEATING"
 msgstr "CALEFACCIÓN"
 
-#: src/components/DetailView.tsx:219
+#: src/components/DetailView.tsx:236
 #: src/components/Indicators.tsx:262
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
@@ -358,8 +364,8 @@ msgstr "¿Tienes ideas sobre esta página?"
 msgid "Home"
 msgstr "Inicio"
 
-#: src/components/DetailView.tsx:83
-#: src/components/DetailView.tsx:268
+#: src/components/DetailView.tsx:102
+#: src/components/DetailView.tsx:285
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
@@ -368,11 +374,11 @@ msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 msgid "How to use"
 msgstr "Cómo se usa"
 
-#: src/components/DetailView.tsx:21
+#: src/components/DetailView.tsx:23
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc que hace que la información sobre los dueños de edificios sea más transparente para los inquilinos. Sería bueno si buscaras tu edificio también. Míralo aquí: {url}"
 
-#: src/components/DetailView.tsx:19
+#: src/components/DetailView.tsx:21
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
@@ -429,13 +435,17 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:147
+#: src/components/DetailView.tsx:164
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:160
+#: src/components/DetailView.tsx:177
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
+
+#: src/components/DetailView.tsx:26
+msgid "Learn more"
+msgstr ""
 
 #: src/components/PropertiesMap.tsx:193
 msgid "Legend"
@@ -491,7 +501,7 @@ msgstr "Metodología"
 msgid "Month"
 msgstr "Mes"
 
-#: src/components/DetailView.tsx:100
+#: src/components/DetailView.tsx:119
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -540,7 +550,7 @@ msgstr "¡No se ha encontrado nigún registro!"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:108
+#: src/components/DetailView.tsx:127
 msgid "None"
 msgstr "Ninguna"
 
@@ -557,12 +567,12 @@ msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
 #: src/components/NetworkErrorMessage.tsx:5
-#: src/components/Subscribe.tsx:50
-#: src/components/Subscribe.tsx:56
+#: src/components/Subscribe.tsx:54
+#: src/components/Subscribe.tsx:60
 msgid "Oops! A network error occurred. Try again later."
 msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 
-#: src/components/Subscribe.tsx:44
+#: src/components/Subscribe.tsx:48
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
@@ -598,14 +608,13 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/DetailView.tsx:135
-#: src/components/DetailView.tsx:333
-#: src/components/DetailView.tsx:343
+#: src/components/DetailView.tsx:350
+#: src/components/DetailView.tsx:360
 #: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "Personas (Encontrarás definiciones en español de los tipos de personas asociadas al edificio en la página \"Como se usa\".)"
 
-#: src/components/Subscribe.tsx:21
+#: src/components/Subscribe.tsx:22
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
@@ -673,8 +682,8 @@ msgstr "¡Comparte tu opinión con nosotros!"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:189
-#: src/components/DetailView.tsx:257
+#: src/components/DetailView.tsx:206
+#: src/components/DetailView.tsx:274
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
 #: src/containers/App.tsx:105
@@ -682,7 +691,7 @@ msgstr "Compartir"
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
 
-#: src/components/Subscribe.tsx:73
+#: src/components/Subscribe.tsx:77
 msgid "Sign up"
 msgstr "Regístrate"
 
@@ -722,8 +731,8 @@ msgstr "Resúmen"
 msgid "TENANT HARASSMENT"
 msgstr "ACOSO DE INQUILINO"
 
-#: src/components/DetailView.tsx:183
-#: src/components/DetailView.tsx:251
+#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:268
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
@@ -889,8 +898,8 @@ msgstr "Unidades Residenciales"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edificio e investigar a los arrendadores de Nueva York! Utilizamos el mapeo de propiedad para identificar el portafolio de edificios de un arrendador y proporcionar datos para revelar posibles casos de hostigamiento y desplazamiento de inquilinos."
 
-#: src/components/DetailView.tsx:200
-#: src/components/DetailView.tsx:205
+#: src/components/DetailView.tsx:217
+#: src/components/DetailView.tsx:222
 #: src/components/Indicators.tsx:247
 #: src/containers/NotRegisteredPage.tsx:143
 #: src/containers/NychaPage.tsx:153
@@ -905,7 +914,7 @@ msgstr "SISTEMA DE VENTILACIÓN"
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:94
+#: src/components/DetailView.tsx:113
 msgid "View data over time"
 msgstr "Ver datos a lo largo del tiempo"
 
@@ -914,7 +923,7 @@ msgstr "Ver datos a lo largo del tiempo"
 msgid "View detail"
 msgstr "Ver detalles"
 
-#: src/components/DetailView.tsx:212
+#: src/components/DetailView.tsx:229
 #: src/components/Indicators.tsx:253
 #: src/containers/NotRegisteredPage.tsx:147
 msgid "View documents on ACRIS"
@@ -930,7 +939,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:69
+#: src/components/DetailView.tsx:88
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
@@ -958,7 +967,7 @@ msgstr "VENTANAS"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
-#: src/components/DetailView.tsx:270
+#: src/components/DetailView.tsx:287
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -989,6 +998,10 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
+#: src/components/DetailView.tsx:134
+msgid "Who’s the landlord of this building?"
+msgstr ""
+
 #: src/components/Indicators.tsx:192
 msgid "Year"
 msgstr "Año"
@@ -1017,7 +1030,7 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:181
 msgid "for ${0}"
 msgstr "por ${0}"
 
@@ -1040,4 +1053,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:34
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Infracción del HPD emitida desde el 2010} other {# Infracciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/styles/Accordion.scss
+++ b/client/src/styles/Accordion.scss
@@ -2,6 +2,13 @@
 
 details.Accordion {
   padding: 1.6rem 1.6rem 1.6rem 0.8rem;
+  &:not(:last-child) {
+    border-bottom: 1px solid #e5e5e5;
+  }
+
+  &[open] summary ~ * {
+    animation: sweep 0.5s ease-in-out;
+  }
 
   &[open] summary .icon {
     transition: transform 0.2s linear;
@@ -13,8 +20,11 @@ details.Accordion {
     transform: rotateX(0deg) translateY(0px);
   }
 
+  > div {
+    margin-top: 1.8rem;
+  }
+
   summary {
-    margin-bottom: 1.8rem;
     // Make question box feel clickable to user
     cursor: pointer;
     // Remove default marker
@@ -23,5 +33,16 @@ details.Accordion {
       width: 11.3px;
       margin-top: 2px;
     }
+  }
+}
+
+@keyframes sweep {
+  0% {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/client/src/styles/Accordion.scss
+++ b/client/src/styles/Accordion.scss
@@ -1,0 +1,24 @@
+@import "_vars.scss";
+
+.Accordion {
+  summary {
+    // Make question box feel clickable to user
+    cursor: pointer;
+    // Remove default marker
+    list-style-type: none;
+    .icon {
+      width: 20px;
+    }
+  }
+}
+
+// Default animation for details/summary expand icons:
+details[open] summary .icon {
+  transition: transform 0.2s linear;
+  transform: rotateX(180deg) translateY(-3px);
+}
+
+details:not([open]) summary .icon {
+  transition: transform 0.2s linear;
+  transform: rotateX(0deg) translateY(0px);
+}

--- a/client/src/styles/Accordion.scss
+++ b/client/src/styles/Accordion.scss
@@ -1,7 +1,18 @@
 @import "_vars.scss";
 
-.Accordion {
+details.Accordion {
   padding: 1.6rem 1.6rem 1.6rem 0.8rem;
+  
+  &[open] summary .icon {
+    transition: transform 0.2s linear;
+    transform: rotateX(180deg) translateY(-3px);
+  }
+  
+  &:not([open]) summary .icon {
+    transition: transform 0.2s linear;
+    transform: rotateX(0deg) translateY(0px);
+  }
+
   summary {
     margin-bottom: 1.8rem;
     // Make question box feel clickable to user
@@ -9,18 +20,8 @@
     // Remove default marker
     list-style-type: none;
     .icon {
+      width: 11.3px;
       margin-top: 2px;
     }
   }
-}
-
-// Default animation for details/summary expand icons:
-details[open] summary .icon {
-  transition: transform 0.2s linear;
-  transform: rotateX(180deg) translateY(-3px);
-}
-
-details:not([open]) summary .icon {
-  transition: transform 0.2s linear;
-  transform: rotateX(0deg) translateY(0px);
 }

--- a/client/src/styles/Accordion.scss
+++ b/client/src/styles/Accordion.scss
@@ -2,12 +2,12 @@
 
 details.Accordion {
   padding: 1.6rem 1.6rem 1.6rem 0.8rem;
-  
+
   &[open] summary .icon {
     transition: transform 0.2s linear;
     transform: rotateX(180deg) translateY(-3px);
   }
-  
+
   &:not([open]) summary .icon {
     transition: transform 0.2s linear;
     transform: rotateX(0deg) translateY(0px);

--- a/client/src/styles/Accordion.scss
+++ b/client/src/styles/Accordion.scss
@@ -1,6 +1,6 @@
 @import "_vars.scss";
 
-details.Accordion {
+details.accordion {
   padding: 1.6rem 1.6rem 1.6rem 0.8rem;
   &:not(:last-child) {
     border-bottom: 1px solid #e5e5e5;
@@ -10,14 +10,24 @@ details.Accordion {
     animation: sweep 0.5s ease-in-out;
   }
 
-  &[open] summary .icon {
-    transition: transform 0.2s linear;
-    transform: rotateX(180deg) translateY(-3px);
+  &[open] summary {
+    .title-default {
+      display: none;
+    }
+    .icon {
+      transition: transform 0.2s linear;
+      transform: rotateX(180deg) translateY(-3px);
+    }
   }
 
-  &:not([open]) summary .icon {
-    transition: transform 0.2s linear;
-    transform: rotateX(0deg) translateY(0px);
+  &:not([open]) summary {
+    .title-on-open {
+      display: none;
+    }
+    .icon {
+      transition: transform 0.2s linear;
+      transform: rotateX(0deg) translateY(0px);
+    }
   }
 
   > div {

--- a/client/src/styles/Accordion.scss
+++ b/client/src/styles/Accordion.scss
@@ -2,6 +2,10 @@
 
 details.accordion {
   padding: 1.6rem 1.6rem 1.6rem 0.8rem;
+  @include for-phone-only() {
+    padding-left: 0;
+    padding-right: 0;
+  }
   &:not(:last-child) {
     border-bottom: 1px solid #e5e5e5;
   }

--- a/client/src/styles/Accordion.scss
+++ b/client/src/styles/Accordion.scss
@@ -1,13 +1,15 @@
 @import "_vars.scss";
 
 .Accordion {
+  padding: 1.6rem 1.6rem 1.6rem 0.8rem;
   summary {
+    margin-bottom: 1.8rem;
     // Make question box feel clickable to user
     cursor: pointer;
     // Remove default marker
     list-style-type: none;
     .icon {
-      width: 20px;
+      margin-top: 2px;
     }
   }
 }

--- a/client/src/styles/Accordion.scss
+++ b/client/src/styles/Accordion.scss
@@ -43,6 +43,9 @@ details.accordion {
     cursor: pointer;
     // Remove default marker
     list-style-type: none;
+    &::-webkit-details-marker {
+      display: none;
+    }
     .icon {
       width: 11.3px;
       margin-top: 2px;

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -10,7 +10,8 @@
   }
 
   // Standard inline-link focus class:
-  a:not(.btn):not(.image):focus, summary:focus-visible {
+  a:not(.btn):not(.image):focus,
+  summary:focus-visible {
     box-shadow: none;
     outline: 2px solid $gray-dark;
     outline-offset: 2px;

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -10,7 +10,7 @@
   }
 
   // Standard inline-link focus class:
-  a:not(.btn):not(.image):focus {
+  a:not(.btn):not(.image):focus, summary:focus-visible {
     box-shadow: none;
     outline: 2px solid $gray-dark;
     outline-offset: 2px;

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -220,7 +220,8 @@
           summary {
             width: fit-content;
             float: right;
-            margin-top: -20px;
+            // Move summary text up by one standard line height:
+            margin-top: calc(-1 * #{$html-line-height} * #{$font-size});
             padding: 0;
           }
           .icon {

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -230,6 +230,12 @@
             display: none;
           }
 
+          // Do not show expandable "Learn More" button on IE11
+          // https://stackoverflow.com/questions/43528940/how-to-detect-ie-and-edge-browsers-in-css
+          @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+            display: none;
+          }
+
           div {
             margin: 0;
             padding: 0 0.8rem;

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -234,6 +234,24 @@
           }
         }
       }
+
+      .card-footer-landlord {
+        @include for-tablet-portrait-up {
+          display: none;
+        }
+        details.accordion {
+          padding: 0.5rem 0 0 0;
+          div {
+            margin: 0;
+          }
+          .icon {
+            display: none;
+          }
+          summary {
+            text-decoration: underline;
+          }
+        }
+      }
     }
 
     .card-body-registration {

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -213,6 +213,11 @@
         border-bottom: 1px solid $gray-dark;
         details.accordion {
           padding: 0;
+
+          @include for-phone-only() {
+            display: none;
+          }
+
           div {
             margin: 0;
             padding: 0 0.8rem;

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -192,17 +192,24 @@
 
     .card-body-timeline-link,
     .card-body-landlord,
-    .card-body-complaints {
-      margin-top: 2.5rem;
+    .card-body-complaints,
+    .card-body-links {
+      margin-top: 2.4rem;
     }
 
     .card-body-timeline-link {
       padding-top: 1rem;
     }
 
-    .card-body-complaints b {
-      display: block;
-      border-bottom: 1px solid $gray-dark;
+    .card-body-complaints,
+    .card-body-links {
+      b {
+        display: block;
+        border-bottom: 1px solid $gray-dark;
+      }
+      li {
+        line-height: 1.8rem;
+      }
     }
 
     .card-body-landlord {
@@ -263,57 +270,16 @@
       }
     }
 
-    .card-body-resources {
-      margin-bottom: 24px;
-
-      border: 1px solid $gray;
-      padding-left: 1.5rem;
-      padding-right: 1.5rem;
-      margin-right: -1.5rem;
-      position: relative;
-
-      @include for-tablet-landscape-up() {
-        margin-top: 56px;
-        margin-right: 0;
-      }
-
-      .chip {
-        background-color: $gray-light;
-        color: $dark;
-        max-height: 1.8rem;
-        border-radius: 25px;
-      }
-
-      .card-body-resources__title {
-        position: absolute;
-        top: -19px;
-        left: 7px;
-        padding: 8px 9px 4px 8px;
-        background-color: #fff;
+    .card-body-links {
+      @include for-tablet-landscape-down() {
+        margin-top: 0;
       }
     }
 
-    .card-body-links,
     .card-body-prompt,
     .card-body-social {
-      margin-top: 24px;
-      margin-bottom: 24px;
-    }
-
-    .card-body-prompt {
-      @include for-tablet-landscape-up() {
-        margin-top: 48px;
-      }
-    }
-
-    .card-body-links {
-      .columns {
-        margin-top: -1rem;
-      }
-
-      a.btn:not(:first-child) {
-        margin-top: 10px;
-      }
+      margin-top: 2.4rem;
+      margin-bottom: 2.4rem;
     }
 
     h6.DetailView__subtitle {

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -205,6 +205,12 @@
       }
     }
 
+    .card-body-landlord {
+      .landlord-contact-info:not(:last-child) {
+        margin-bottom: 1.8rem;
+      }
+    }
+
     .card-body-registration {
       margin-top: 2.5rem;
 
@@ -264,9 +270,6 @@
 
       a.btn:not(:first-child) {
         margin-top: 10px;
-      }
-
-      .btn {
       }
     }
 

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -190,24 +190,43 @@
       }
     }
 
-    .card-body-timeline-link {
-      margin-top: 2.5rem;
-      padding-top: 1rem;
-    }
-
+    .card-body-timeline-link,
     .card-body-landlord,
     .card-body-complaints {
       margin-top: 2.5rem;
+    }
 
-      b {
-        display: block;
-        border-bottom: 1px solid $gray-dark;
-      }
+    .card-body-timeline-link {
+      padding-top: 1rem;
+    }
+
+    .card-body-complaints b {
+      display: block;
+      border-bottom: 1px solid $gray-dark;
     }
 
     .card-body-landlord {
       .landlord-contact-info:not(:last-child) {
         margin-bottom: 1.8rem;
+      }
+      .card-title-landlord {
+        border-bottom: 1px solid $gray-dark;
+        details.accordion {
+          padding: 0;
+          div {
+            margin: 0;
+            padding: 0 0.8rem;
+          }
+          summary {
+            width: fit-content;
+            float: right;
+            margin-top: -20px;
+            padding: 0;
+          }
+          .icon {
+            display: none;
+          }
+        }
       }
     }
 

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -217,6 +217,11 @@
         margin-bottom: 1.8rem;
       }
       .card-title-landlord {
+        b {
+          // Avoid collision with "Learn More" button on small desktops:
+          display: block;
+          max-width: 75%;
+        }
         border-bottom: 1px solid $gray-dark;
         details.accordion {
           padding: 0;

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -64,18 +64,16 @@
       margin-bottom: 3rem;
     }
 
-    .card.card-links {
-      .card-body {
-        h6 {
-          font-weight: bold;
-          margin-bottom: 0.75rem;
-          width: 100%;
-        }
-        .chip {
-          background-color: $gray-light;
-          color: $dark;
-          max-height: 1.8rem;
-          border-radius: 25px;
+    .card-body-links {
+      b {
+        display: block;
+        border-bottom: 1px solid $gray-dark;
+      }
+      ul {
+        margin: 1rem 0.5rem;
+        li {
+          margin-top: 0.5rem;
+          line-height: 1.8rem;
         }
       }
     }

--- a/client/src/styles/spectre.scss
+++ b/client/src/styles/spectre.scss
@@ -40,6 +40,9 @@ a.text-bold {
 .text-light {
   color: lighten($dark, 35%);
 }
+.text-dark {
+  color: $dark;
+}
 
 .text-justfix {
   color: $justfix-blue;

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -168,3 +168,37 @@ describe("formatStreetNameForHpdLink()", () => {
     expect(helpers.formatStreetNameForHpdLink("")).toBe("");
   });
 });
+
+describe("formatHpdContactAddress(), ()", () => {
+  it("works with fully populated addresses", () => {
+    expect(
+      helpers.formatHpdContactAddress({
+        zip: "11205",
+        city: "Brooklyn",
+        state: "NY",
+        apartment: "d",
+        streetname: "BOOP STREET",
+        housenumber: "1",
+      })
+    ).toStrictEqual({
+      addressLine1: "1 BOOP STREET D",
+      addressLine2: "BROOKLYN, NY 11205",
+    });
+  });
+
+  it("works with addresses with missing parts", () => {
+    expect(
+      helpers.formatHpdContactAddress({
+        zip: "11205",
+        city: null,
+        state: null,
+        apartment: null,
+        streetname: "BOOP STREET",
+        housenumber: "1",
+      })
+    ).toStrictEqual({
+      addressLine1: "1 BOOP STREET",
+      addressLine2: "11205",
+    });
+  });
+});

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -4,7 +4,7 @@
 import _pickBy from "lodash/pickBy";
 import { deepEqual as assertDeepEqual } from "assert";
 import { SupportedLocale } from "../i18n-base";
-import { SearchAddressWithoutBbl } from "components/APIDataTypes";
+import { HpdContactAddress, SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { reportError } from "error-reporting";
 import { t } from "@lingui/macro";
 import { I18n } from "@lingui/core";
@@ -226,6 +226,18 @@ export default {
       }
     });
     return arr.join(" ");
+  },
+
+  formatHpdContactAddress(
+    address: HpdContactAddress
+  ): { addressLine1: string; addressLine2: string } {
+    const { housenumber, streetname, apartment, city, state, zip } = address;
+    const cityFormatted = city && state ? `${city},` : city;
+
+    return {
+      addressLine1: [housenumber, streetname, apartment].join(" ").toUpperCase(),
+      addressLine2: [cityFormatted, state, zip].join(" ").toUpperCase(),
+    };
   },
 
   getTranslationOfComplaintType(complaintType: string, i18n: I18n) {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -234,9 +234,15 @@ export default {
     const { housenumber, streetname, apartment, city, state, zip } = address;
     const cityFormatted = city && state ? `${city},` : city;
 
+    const formatArrayAsString = (addrs: (string | null)[]) =>
+      addrs
+        .filter((x) => !!x)
+        .join(" ")
+        .toUpperCase();
+
     return {
-      addressLine1: [housenumber, streetname, apartment].join(" ").toUpperCase(),
-      addressLine2: [cityFormatted, state, zip].join(" ").toUpperCase(),
+      addressLine1: formatArrayAsString([housenumber, streetname, apartment]),
+      addressLine2: formatArrayAsString([cityFormatted, state, zip]),
     };
   },
 

--- a/wow/views.py
+++ b/wow/views.py
@@ -34,7 +34,6 @@ def log_unsupported_request_args(request):
 
 
 def clean_addr_dict(addr):
-    print("UM", addr)
     return {
         **addr,
         "bin": str(addr['bin']),


### PR DESCRIPTION
This PR implements [Tahnee's designs](https://www.figma.com/file/w2eo2tq6YEbVW06rFF0jA4/Summer-2021-Sprints?node-id=47%3A2) that more clearly organize and spell out all of the contact names and corporations associated with a building on WOW. While mostly a styling and html structure change, this PR makes use of #477 in that it properly shows all entity names with their associated business addresses (unlike before).

Beyond updating the Detail View on the overview tab, this PR changes the look and feel of the "useful links" section to make it more compact, which shows up on both the overview and timeline tabs.

One small win: the various expandable menus and text boxes in this PR were ALL implemented with the `<summary><details>` native HTML elements! No special JS needed! Also they are all accessible via tab focus. 