### PR TITLE
Automatically deserialize jsonb in SQL queries.

### DIFF
--- a/wow/datautil.py
+++ b/wow/datautil.py
@@ -1,5 +1,4 @@
-import json
-from typing import List, Optional, Any
+from typing import Optional, Any
 
 
 def int_or_none(val: Any) -> Optional[int]:
@@ -21,10 +20,3 @@ def str_or_none(val: Any) -> Optional[str]:
         return None
     else:
         return str(val)
-
-
-def json_or_none(val: Any) -> Optional[List]:
-    if val is None:
-        return None
-    else:
-        return json.loads(val)

--- a/wow/dbutil.py
+++ b/wow/dbutil.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import List, Dict, Any
 from django.db import connections
+from contextlib import contextmanager
+import psycopg2.extras
 
 
 def dictfetchall(cursor):
@@ -13,14 +15,26 @@ def dictfetchall(cursor):
     ]
 
 
-def call_db_func(name: str, params: List[Any]) -> List[Dict[str, Any]]:
+@contextmanager
+def get_wow_cursor():
     with connections['wow'].cursor() as cursor:
+        # This is a workaround for https://code.djangoproject.com/ticket/31991.
+        psycopg2.extras.register_default_jsonb(cursor.cursor)
+
+        yield cursor
+
+
+def call_db_func(name: str, params: List[Any]) -> List[Dict[str, Any]]:
+    with get_wow_cursor() as cursor:
         cursor.callproc(name, params)
         return dictfetchall(cursor)
 
 
-def exec_db_query(sql_file: Path, params: Dict[str, Any]) -> List[Dict[str, Any]]:
-    sql = sql_file.read_text()
-    with connections['wow'].cursor() as cursor:
+def exec_sql(sql: str, params: Dict[str, Any] = {}) -> List[Dict[str, Any]]:
+    with get_wow_cursor() as cursor:
         cursor.execute(sql, params)
         return dictfetchall(cursor)
+
+
+def exec_db_query(sql_file: Path, params: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return exec_sql(sql_file.read_text(), params)

--- a/wow/tests/test_datautils.py
+++ b/wow/tests/test_datautils.py
@@ -1,5 +1,5 @@
 import pytest
-from ..datautil import int_or_none, json_or_none, str_or_none, float_or_none
+from ..datautil import int_or_none, str_or_none, float_or_none
 
 
 sample_json_string = '[{"foo": "bar", "beep": { "boop": "blah"}}]'
@@ -30,19 +30,3 @@ class TestDataUtilsWork:
     ])
     def test_str_or_none_works(self, input, expected):
         assert str_or_none(input) == expected
-
-    @pytest.mark.parametrize("input,expected", [
-        (None, None),
-        (sample_json_string, [{
-            "foo": "bar",
-            "beep": {
-                "boop": "blah"
-            }
-        }]),
-        (sample_json_string_with_null, [{
-            "foo": "bar",
-            "beep": None
-        }])
-    ])
-    def test_json_or_none_works(self, input, expected):
-        assert json_or_none(input) == expected

--- a/wow/tests/test_dbutil.py
+++ b/wow/tests/test_dbutil.py
@@ -1,0 +1,7 @@
+from wow import dbutil
+
+
+class TestExecSql:
+    def test_jsonb_is_retrieved_as_json(self, db):
+        result = dbutil.exec_sql("""select '{"a":"b"}'::jsonb as value""")
+        assert result == [{'value': {"a": "b"}}]

--- a/wow/views.py
+++ b/wow/views.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 from django.http import HttpResponse, JsonResponse
 
 from .dbutil import call_db_func, exec_db_query
-from .datautil import int_or_none, float_or_none, json_or_none
+from .datautil import int_or_none, float_or_none
 from . import csvutil, apiutil
 from .apiutil import api, get_validated_form_data
 from .forms import PaddedBBLForm, SeparatedBBLForm
@@ -34,18 +34,12 @@ def log_unsupported_request_args(request):
 
 
 def clean_addr_dict(addr):
+    print("UM", addr)
     return {
         **addr,
         "bin": str(addr['bin']),
         "lastsaleamount": int_or_none(addr['lastsaleamount']),
         "registrationid": str(addr['registrationid']),
-        '''
-        Sadly, our django backend interprets the `allcontacts` json field from nycdb
-        as a string instead of a json object, which means we need o recast it here.
-        This perhaps has to do with nycdb saving this field as a 'jsonb' type, or
-        this documented django bug (https://code.djangoproject.com/ticket/31991).
-        '''
-        "allcontacts": json_or_none(addr['allcontacts'])
     }
 
 
@@ -132,8 +126,7 @@ def _fixup_addr_for_csv(addr: Dict[str, Any]):
     addr['recentcomplaintsbytype'] = csvutil.stringify_complaints(
         addr['recentcomplaintsbytype']
     )
-    allcontacts = json_or_none(addr['allcontacts'])
-    addr['allcontacts'] = csvutil.stringify_full_contacts(allcontacts or [])
+    addr['allcontacts'] = csvutil.stringify_full_contacts(addr['allcontacts'] or [])
     csvutil.stringify_lists(addr)
 
 


### PR DESCRIPTION
This builds upon #478 by modifying the underlying database cursor to properly deserialize jsonb content from Postgres.  This is actually the default behavior of Python's Postgres package, psycopg2, but it's [overridden by Django][1]; this restores the default behavior within the scope of a single cursor.

A regression test has also been added to ensure that we'll know if this fix ever breaks (which could happen if Django decides to change its implementation somehow).

[1]: https://code.djangoproject.com/ticket/31991