### PR TITLE
Fix `<Trans>` tag for ACRIS link, and update text

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -96,16 +96,17 @@ const LearnMoreAccordion = () => (
         <br />
         <Trans>
           <p>
-            While the legal owner of a building is often an “LLC” company, these names and business
-            addresses registered with HPD offer a clearer picture of who the landlord really is.
+            While the legal owner of a building is often a company (usually called an “LLC”), these
+            names and business addresses registered with HPD offer a clearer picture of who the
+            landlord really is.
           </p>
           <p>
             People listed here as “Head Officer” or “Owner” usually have ties to building ownership,
             while “Site Managers” are part of management. That being said, these names are self
-            reported, so they can be misleading.
+            reported by the landlord, so they can be misleading.
           </p>
           <p>
-            Learn more about HPD registrations and how they power this tool on the{" "}
+            Learn more about HPD registrations and how this information powers this tool on the{" "}
             <LocaleLink
               to={createWhoOwnsWhatRoutePaths().about}
               onClick={() => {

--- a/client/src/components/UsefulLinks.tsx
+++ b/client/src/components/UsefulLinks.tsx
@@ -18,17 +18,19 @@ export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location
       </b>
       <ul>
         <li>
-          View documents on{" "}
-          <a
-            onClick={() => {
-              window.gtag("event", `acris-${location}`);
-            }}
-            href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Trans>ACRIS</Trans>
-          </a>
+          <Trans>
+            View documents on{" "}
+            <a
+              onClick={() => {
+                window.gtag("event", `acris-${location}`);
+              }}
+              href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ACRIS
+            </a>
+          </Trans>
         </li>
         <li>
           <a

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/components/DetailView.tsx:203
+#: src/components/DetailView.tsx:204
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:185
+#: src/components/DetailView.tsx:186
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:188
+#: src/components/DetailView.tsx:189
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -42,8 +42,8 @@ msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
 #: src/components/DetailView.tsx:50
-msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the <3>About page</3>.</2>"
-msgstr "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the <3>About page</3>.</2>"
+msgid "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
+msgstr "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 
 #: src/components/UsefulLinks.tsx:47
 #: src/containers/NotRegisteredPage.tsx:158
@@ -84,7 +84,7 @@ msgstr "All the public info on your landlord"
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/DetailView.tsx:216
+#: src/components/DetailView.tsx:217
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -96,7 +96,7 @@ msgstr "Are you having issues in this development?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:124
+#: src/components/DetailView.tsx:125
 #: src/components/Indicators.tsx:145
 msgid "BUILDING:"
 msgstr "BUILDING:"
@@ -137,14 +137,14 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:280
-#: src/components/DetailView.tsx:289
+#: src/components/DetailView.tsx:281
+#: src/components/DetailView.tsx:290
 #: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:260
-#: src/components/DetailView.tsx:269
+#: src/components/DetailView.tsx:261
+#: src/components/DetailView.tsx:270
 #: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Business Entities"
@@ -354,8 +354,8 @@ msgstr "Have thoughts about this page?"
 msgid "Home"
 msgstr "Home"
 
-#: src/components/DetailView.tsx:130
-#: src/components/DetailView.tsx:235
+#: src/components/DetailView.tsx:131
+#: src/components/DetailView.tsx:236
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
@@ -425,11 +425,11 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:180
+#: src/components/DetailView.tsx:181
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:193
+#: src/components/DetailView.tsx:194
 msgid "Last sold:"
 msgstr "Last sold:"
 
@@ -491,7 +491,7 @@ msgstr "Methodology"
 msgid "Month"
 msgstr "Month"
 
-#: src/components/DetailView.tsx:147
+#: src/components/DetailView.tsx:148
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -540,7 +540,7 @@ msgstr "No registration found!"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:155
+#: src/components/DetailView.tsx:156
 msgid "None"
 msgstr "None"
 
@@ -598,8 +598,8 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/DetailView.tsx:300
-#: src/components/DetailView.tsx:310
+#: src/components/DetailView.tsx:301
+#: src/components/DetailView.tsx:311
 #: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "People"
@@ -672,7 +672,7 @@ msgstr "Send us feedback!"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:225
+#: src/components/DetailView.tsx:226
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
 #: src/containers/App.tsx:105
@@ -720,7 +720,7 @@ msgstr "Summary"
 msgid "TENANT HARASSMENT"
 msgstr "TENANT HARASSMENT"
 
-#: src/components/DetailView.tsx:219
+#: src/components/DetailView.tsx:220
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
@@ -900,7 +900,7 @@ msgstr "VENTILATION SYSTEM"
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:141
+#: src/components/DetailView.tsx:142
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
@@ -927,7 +927,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:116
+#: src/components/DetailView.tsx:117
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -955,7 +955,7 @@ msgstr "WINDOWS"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
-#: src/components/DetailView.tsx:237
+#: src/components/DetailView.tsx:238
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -986,7 +986,7 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:162
+#: src/components/DetailView.tsx:163
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -1018,7 +1018,7 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:197
+#: src/components/DetailView.tsx:198
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -45,11 +45,7 @@ msgstr "... or view some sample portfolios:"
 msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the <3>About page</3>.</2>"
 msgstr "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the <3>About page</3>.</2>"
 
-#: src/components/UsefulLinks.tsx:17
-msgid "ACRIS"
-msgstr "ACRIS"
-
-#: src/components/UsefulLinks.tsx:45
+#: src/components/UsefulLinks.tsx:47
 #: src/containers/NotRegisteredPage.tsx:158
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
@@ -205,12 +201,12 @@ msgstr "Close legend"
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
-#: src/components/UsefulLinks.tsx:31
+#: src/components/UsefulLinks.tsx:33
 #: src/containers/NotRegisteredPage.tsx:155
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
-#: src/components/UsefulLinks.tsx:38
+#: src/components/UsefulLinks.tsx:40
 #: src/containers/NotRegisteredPage.tsx:150
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
@@ -323,7 +319,7 @@ msgstr "HEAT/HOT WATER"
 msgid "HEATING"
 msgstr "HEATING"
 
-#: src/components/UsefulLinks.tsx:24
+#: src/components/UsefulLinks.tsx:26
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
@@ -912,6 +908,10 @@ msgstr "View data over time ↗︎"
 #: src/components/PropertiesList.tsx:211
 msgid "View detail"
 msgstr "View detail"
+
+#: src/components/UsefulLinks.tsx:13
+msgid "View documents on <0>ACRIS</0>"
+msgstr "View documents on <0>ACRIS</0>"
 
 #: src/containers/NotRegisteredPage.tsx:147
 msgid "View documents on ACRIS"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -50,11 +50,7 @@ msgstr "... o descubre ejemplos de portafolios de edificios:"
 msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the <3>About page</3>.</2>"
 msgstr ""
 
-#: src/components/UsefulLinks.tsx:17
-msgid "ACRIS"
-msgstr ""
-
-#: src/components/UsefulLinks.tsx:45
+#: src/components/UsefulLinks.tsx:47
 #: src/containers/NotRegisteredPage.tsx:158
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
@@ -210,12 +206,12 @@ msgstr "Cerrar leyenda"
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
-#: src/components/UsefulLinks.tsx:31
+#: src/components/UsefulLinks.tsx:33
 #: src/containers/NotRegisteredPage.tsx:155
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
-#: src/components/UsefulLinks.tsx:38
+#: src/components/UsefulLinks.tsx:40
 #: src/containers/NotRegisteredPage.tsx:150
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
@@ -328,7 +324,7 @@ msgstr "CALEFACCIÓN/AGUA CALIENTE"
 msgid "HEATING"
 msgstr "CALEFACCIÓN"
 
-#: src/components/UsefulLinks.tsx:24
+#: src/components/UsefulLinks.tsx:26
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
@@ -917,6 +913,10 @@ msgstr ""
 #: src/components/PropertiesList.tsx:211
 msgid "View detail"
 msgstr "Ver detalles"
+
+#: src/components/UsefulLinks.tsx:13
+msgid "View documents on <0>ACRIS</0>"
+msgstr ""
 
 #: src/containers/NotRegisteredPage.tsx:147
 msgid "View documents on ACRIS"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -22,15 +22,15 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
-#: src/components/DetailView.tsx:203
+#: src/components/DetailView.tsx:204
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:185
+#: src/components/DetailView.tsx:186
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:188
+#: src/components/DetailView.tsx:189
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -47,7 +47,7 @@ msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de portafolios de edificios:"
 
 #: src/components/DetailView.tsx:50
-msgid "<0>While the legal owner of a building is often an “LLC” company, these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported, so they can be misleading.</1><2>Learn more about HPD registrations and how they power this tool on the <3>About page</3>.</2>"
+msgid "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who the landlord really is.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 msgstr ""
 
 #: src/components/UsefulLinks.tsx:47
@@ -89,7 +89,7 @@ msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 msgid "Amount"
 msgstr "Importe"
 
-#: src/components/DetailView.tsx:216
+#: src/components/DetailView.tsx:217
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -101,7 +101,7 @@ msgstr "¿Tienes problemas en tu edificio?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:124
+#: src/components/DetailView.tsx:125
 #: src/components/Indicators.tsx:145
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
@@ -142,14 +142,14 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:280
-#: src/components/DetailView.tsx:289
+#: src/components/DetailView.tsx:281
+#: src/components/DetailView.tsx:290
 #: src/components/OwnersTable.tsx:14
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:260
-#: src/components/DetailView.tsx:269
+#: src/components/DetailView.tsx:261
+#: src/components/DetailView.tsx:270
 #: src/components/OwnersTable.tsx:20
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
@@ -359,8 +359,8 @@ msgstr "¿Tienes ideas sobre esta página?"
 msgid "Home"
 msgstr "Inicio"
 
-#: src/components/DetailView.tsx:130
-#: src/components/DetailView.tsx:235
+#: src/components/DetailView.tsx:131
+#: src/components/DetailView.tsx:236
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
@@ -430,11 +430,11 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:180
+#: src/components/DetailView.tsx:181
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:193
+#: src/components/DetailView.tsx:194
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
@@ -496,7 +496,7 @@ msgstr "Metodología"
 msgid "Month"
 msgstr "Mes"
 
-#: src/components/DetailView.tsx:147
+#: src/components/DetailView.tsx:148
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -545,7 +545,7 @@ msgstr "¡No se ha encontrado nigún registro!"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:155
+#: src/components/DetailView.tsx:156
 msgid "None"
 msgstr "Ninguna"
 
@@ -603,8 +603,8 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/DetailView.tsx:300
-#: src/components/DetailView.tsx:310
+#: src/components/DetailView.tsx:301
+#: src/components/DetailView.tsx:311
 #: src/components/OwnersTable.tsx:26
 msgid "People"
 msgstr "Personas (Encontrarás definiciones en español de los tipos de personas asociadas al edificio en la página \"Como se usa\".)"
@@ -677,7 +677,7 @@ msgstr "¡Comparte tu opinión con nosotros!"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:225
+#: src/components/DetailView.tsx:226
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
 #: src/containers/App.tsx:105
@@ -725,7 +725,7 @@ msgstr "Resúmen"
 msgid "TENANT HARASSMENT"
 msgstr "ACOSO DE INQUILINO"
 
-#: src/components/DetailView.tsx:219
+#: src/components/DetailView.tsx:220
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
@@ -905,7 +905,7 @@ msgstr "SISTEMA DE VENTILACIÓN"
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:141
+#: src/components/DetailView.tsx:142
 msgid "View data over time ↗︎"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:116
+#: src/components/DetailView.tsx:117
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
@@ -960,7 +960,7 @@ msgstr "VENTANAS"
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
-#: src/components/DetailView.tsx:237
+#: src/components/DetailView.tsx:238
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -991,7 +991,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:162
+#: src/components/DetailView.tsx:163
 msgid "Who’s the landlord of this building?"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:197
+#: src/components/DetailView.tsx:198
 msgid "for ${0}"
 msgstr "por ${0}"
 


### PR DESCRIPTION
Oops! Originally, we were only translating the word "ACRIS" in the link "View documents on ACRIS." This should fix things. This PR also updates some text on the detail view.