### PR TITLE
Add Corporation as an HPD Contact type

### DIFF
--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/util/helpers.ts:240
+#: src/util/helpers.ts:241
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
@@ -212,6 +212,10 @@ msgstr "Complaints Issued"
 #: src/util/helpers.ts:64
 msgid "Corporate Owner"
 msgstr "Corporate Owner"
+
+#: src/util/helpers.ts:72
+msgid "Corporation"
+msgstr "Corporation"
 
 #: src/components/UsefulLinks.tsx:33
 #: src/containers/NotRegisteredPage.tsx:155

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
-#: src/util/helpers.ts:240
+#: src/util/helpers.ts:241
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
@@ -217,6 +217,10 @@ msgstr "Quejas Emitidas"
 #: src/util/helpers.ts:64
 msgid "Corporate Owner"
 msgstr "Dueño Corporativo"
+
+#: src/util/helpers.ts:72
+msgid "Corporation"
+msgstr ""
 
 #: src/components/UsefulLinks.tsx:33
 #: src/containers/NotRegisteredPage.tsx:155

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -220,7 +220,7 @@ msgstr "Dueño Corporativo"
 
 #: src/util/helpers.ts:72
 msgid "Corporation"
-msgstr ""
+msgstr "Corporación"
 
 #: src/components/UsefulLinks.tsx:33
 #: src/containers/NotRegisteredPage.tsx:155

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -75,6 +75,7 @@ const hpdContactTitleTranslations = new Map([
   ["Lessee", t`Lessee`],
   ["Officer", t`Officer`],
   ["Shareholder", t`Shareholder`],
+  ["Corporation", t`Corporation`],
 ]);
 
 export const longDateOptions = { year: "numeric", month: "short", day: "numeric" };


### PR DESCRIPTION
Shoot! We totally forgot to add "Corporation" as an addition title for an HPD contact. Good thing our rollbar caught this very quickly and we had a good fallback mechanism. Anyway, fixing this for now and adding in the translation manually for expediency.