### PR TITLE
Remove old feedback form from Timeline Tab

### DIFF
--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -23,7 +23,6 @@ import {
   IndicatorChartShift,
   IndicatorsTimeSpan,
 } from "./IndicatorsTypes";
-import { Nobr } from "./Nobr";
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
 
 class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> {
@@ -337,19 +336,6 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     ›
                   </button>
                 </div>
-
-                <div className="Indicators__feedback hide-lg">
-                  <Trans render="i">Have thoughts about this page?</Trans>
-                  <Nobr>
-                    <a
-                      href="https://airtable.com/shrZ9uL3id6oWEn8T"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Trans>Send us feedback!</Trans>
-                    </a>
-                  </Nobr>
-                </div>
               </div>
               <div className="column column-context col-4 col-lg-12">
                 <div className="card">
@@ -365,19 +351,6 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                 </div>
 
                 <UsefulLinks addrForLinks={detailAddr} location="timeline-tab" />
-
-                <div className="Indicators__feedback show-lg">
-                  <Trans render="i">Have thoughts about this page?</Trans>
-                  <Nobr>
-                    <a
-                      href="https://airtable.com/shrZ9uL3id6oWEn8T"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Trans>Send us feedback!</Trans>
-                    </a>
-                  </Nobr>
-                </div>
               </div>
             </div>
           </div>

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -105,11 +105,11 @@ msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
 #: src/components/DetailView.tsx:130
-#: src/components/Indicators.tsx:145
+#: src/components/Indicators.tsx:144
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/Indicators.tsx:150
+#: src/components/Indicators.tsx:149
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
@@ -359,11 +359,6 @@ msgstr "HPD Violations occur when an official City Inspector finds the condition
 msgid "HUD Complaint Form 958"
 msgstr "HUD Complaint Form 958"
 
-#: src/components/Indicators.tsx:222
-#: src/components/Indicators.tsx:246
-msgid "Have thoughts about this page?"
-msgstr "Have thoughts about this page?"
-
 #: src/util/helpers.ts:63
 msgid "Head Officer"
 msgstr "Head Officer"
@@ -476,7 +471,7 @@ msgstr "Lessee"
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
-#: src/components/Indicators.tsx:120
+#: src/components/Indicators.tsx:119
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:62
 #: src/containers/AddressPage.tsx:165
@@ -517,7 +512,7 @@ msgstr "May be issued official Orders"
 msgid "Methodology"
 msgstr "Methodology"
 
-#: src/components/Indicators.tsx:174
+#: src/components/Indicators.tsx:173
 msgid "Month"
 msgstr "Month"
 
@@ -654,7 +649,7 @@ msgstr "Privacy policy"
 msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
-#: src/components/Indicators.tsx:182
+#: src/components/Indicators.tsx:181
 msgid "Quarter"
 msgstr "Quarter"
 
@@ -688,18 +683,13 @@ msgstr "STAIRS"
 msgid "Search for a different address"
 msgstr "Search for a different address"
 
-#: src/components/Indicators.tsx:157
+#: src/components/Indicators.tsx:156
 msgid "Select a Dataset:"
 msgstr "Select a Dataset:"
 
 #: src/components/PropertiesSummary.tsx:36
 msgid "Send us a data request"
 msgstr "Send us a data request"
-
-#: src/components/Indicators.tsx:225
-#: src/components/Indicators.tsx:249
-msgid "Send us feedback!"
-msgstr "Send us feedback!"
 
 #: src/containers/App.tsx:99
 msgid "Share"
@@ -937,7 +927,7 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
-#: src/components/Indicators.tsx:166
+#: src/components/Indicators.tsx:165
 msgid "View by:"
 msgstr "View by:"
 
@@ -1000,7 +990,7 @@ msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
-#: src/components/Indicators.tsx:234
+#: src/components/Indicators.tsx:224
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
@@ -1031,7 +1021,7 @@ msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWha
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
-#: src/components/Indicators.tsx:190
+#: src/components/Indicators.tsx:189
 msgid "Year"
 msgstr "Year"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -110,11 +110,11 @@ msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
 #: src/components/DetailView.tsx:130
-#: src/components/Indicators.tsx:145
+#: src/components/Indicators.tsx:144
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/Indicators.tsx:150
+#: src/components/Indicators.tsx:149
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
@@ -364,11 +364,6 @@ msgstr "Infracciones del HPD se dan cuando un Inspector oficial de la Ciudad det
 msgid "HUD Complaint Form 958"
 msgstr "Formulario de queja HUD 958"
 
-#: src/components/Indicators.tsx:222
-#: src/components/Indicators.tsx:246
-msgid "Have thoughts about this page?"
-msgstr "¿Tienes ideas sobre esta página?"
-
 #: src/util/helpers.ts:63
 msgid "Head Officer"
 msgstr "Oficial Principal"
@@ -481,7 +476,7 @@ msgstr "Arrendatario"
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
-#: src/components/Indicators.tsx:120
+#: src/components/Indicators.tsx:119
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:62
 #: src/containers/AddressPage.tsx:165
@@ -522,7 +517,7 @@ msgstr "Pueden emitirse órdenes oficiales"
 msgid "Methodology"
 msgstr "Metodología"
 
-#: src/components/Indicators.tsx:174
+#: src/components/Indicators.tsx:173
 msgid "Month"
 msgstr "Mes"
 
@@ -659,7 +654,7 @@ msgstr "Política de privacidad"
 msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
-#: src/components/Indicators.tsx:182
+#: src/components/Indicators.tsx:181
 msgid "Quarter"
 msgstr "Trimestre"
 
@@ -693,18 +688,13 @@ msgstr "ESCALERAS"
 msgid "Search for a different address"
 msgstr "Buscar otra dirección"
 
-#: src/components/Indicators.tsx:157
+#: src/components/Indicators.tsx:156
 msgid "Select a Dataset:"
 msgstr "Seleccione un conjunto de datos:"
 
 #: src/components/PropertiesSummary.tsx:36
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
-
-#: src/components/Indicators.tsx:225
-#: src/components/Indicators.tsx:249
-msgid "Send us feedback!"
-msgstr "¡Comparte tu opinión con nosotros!"
 
 #: src/containers/App.tsx:99
 msgid "Share"
@@ -942,7 +932,7 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
-#: src/components/Indicators.tsx:166
+#: src/components/Indicators.tsx:165
 msgid "View by:"
 msgstr "Visualizar por:"
 
@@ -1005,7 +995,7 @@ msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas 
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
-#: src/components/Indicators.tsx:234
+#: src/components/Indicators.tsx:224
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
@@ -1036,7 +1026,7 @@ msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? 
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
-#: src/components/Indicators.tsx:190
+#: src/components/Indicators.tsx:189
 msgid "Year"
 msgstr "Año"
 

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -161,22 +161,4 @@
       box-shadow: inset -1px -1px 0px 0px #acb3c2, inset 2px 2px 0px 0px #fff;
     }
   }
-
-  .Indicators__feedback {
-    text-align: center;
-
-    @include for-tablet-landscape-up() {
-      padding-top: 4rem;
-    }
-
-    a {
-      color: #454d5d;
-      margin-left: 1.5rem;
-      text-decoration: underline;
-
-      &:hover {
-        text-decoration: none;
-      }
-    }
-  }
 }


### PR DESCRIPTION
This PR removes an old link to an AirTable form that we have had on the Timeline Tab since it's launch many many years ago.