### PR TITLE
Add hamburger menu to header on mobile

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "contentful": "^7.11.0",
     "downshift": "^3.2.2",
     "file-saver": "^1.3.3",
+    "focus-trap-react": "^8.6.0",
     "leaflet": "^1.1.0",
     "lodash": "^4.17.21",
     "mapbox-gl": "^1.12.0",

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -19,8 +19,7 @@ const Modal = (props: ModalProps) => {
       left: 0,
       right: 0,
       bottom: 0,
-      backgroundColor: "rgba(255, 255, 255, 0.75)",
-      //backgroundColor: "rgba(69, 77, 93, 0.6)", // rgba equivalent of the $dark color (#454D5D)
+      backgroundColor: "rgba(69, 77, 93, 0.6)", // rgba equivalent of the $dark color (#454D5D)
     },
     content: {
       position: "absolute",

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -20,6 +20,7 @@ const Modal = (props: ModalProps) => {
       right: 0,
       bottom: 0,
       backgroundColor: "rgba(255, 255, 255, 0.75)",
+      //backgroundColor: "rgba(69, 77, 93, 0.6)", // rgba equivalent of the $dark color (#454D5D)
     },
     content: {
       position: "absolute",

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -41,7 +41,14 @@ const Modal = (props: ModalProps) => {
   };
 
   return (
-    <ReactModal isOpen={props.showModal} contentLabel="Modal" style={styles}>
+    <ReactModal
+      isOpen={props.showModal}
+      contentLabel="Modal"
+      style={styles}
+      onRequestClose={props.onClose}
+      shouldCloseOnOverlayClick={true}
+      shouldCloseOnEsc={true}
+    >
       <button className="ReactModal__Close btn btn-link" onClick={(e) => props.onClose(e)}>
         [ x ]
       </button>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { Trans, t } from "@lingui/macro";
+import FocusTrap from "focus-trap-react";
 
 import "styles/App.css";
 
@@ -155,38 +156,45 @@ const App = () => {
                   </a>
                   <LocaleSwitcher />
                 </span>
-                <div className="dropdown dropdown-right show-lg">
-                  <button
-                    tabIndex={0}
-                    aria-label="menu"
-                    aria-expanded={isDropdownVisible}
-                    className={
-                      "btn btn-link dropdown-toggle m-2" + (isDropdownVisible ? " active" : "")
-                    }
-                    onClick={() => toggleDropdown()}
-                  >
-                    <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
-                  </button>
-                  <ul
-                    onClick={() => setDropdownVisibility(false)}
-                    className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
-                  >
-                    {getMainNavLinks().map((link, i) => (
-                      <li className="menu-item" key={i}>
-                        {link}
+                <FocusTrap
+                  active={isDropdownVisible}
+                  focusTrapOptions={{
+                    clickOutsideDeactivates: true,
+                    returnFocusOnDeactivate: false,
+                  }}
+                >
+                  <div className="dropdown dropdown-right show-lg">
+                    <button
+                      aria-label="menu"
+                      aria-expanded={isDropdownVisible}
+                      className={
+                        "btn btn-link dropdown-toggle m-2" + (isDropdownVisible ? " active" : "")
+                      }
+                      onClick={() => toggleDropdown()}
+                    >
+                      <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
+                    </button>
+                    <ul
+                      onClick={() => setDropdownVisibility(false)}
+                      className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
+                    >
+                      {getMainNavLinks().map((link, i) => (
+                        <li className="menu-item" key={i}>
+                          {link}
+                        </li>
+                      ))}
+                      <li className="menu-item">
+                        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                        <a href="#" onClick={() => setEngageModalVisibility(true)}>
+                          <Trans>Share</Trans>
+                        </a>
                       </li>
-                    ))}
-                    <li className="menu-item">
-                      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                      <a href="#" onClick={() => setEngageModalVisibility(true)}>
-                        <Trans>Share</Trans>
-                      </a>
-                    </li>
-                    <li className="menu-item">
-                      <LocaleSwitcherWithFullLanguageName />
-                    </li>
-                  </ul>
-                </div>
+                      <li className="menu-item">
+                        <LocaleSwitcherWithFullLanguageName />
+                      </li>
+                    </ul>
+                  </div>
+                </FocusTrap>
               </nav>
 
               <Modal

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -90,7 +90,7 @@ const getMainNavLinks = () => {
   const paths = createWhoOwnsWhatRoutePaths();
   return [
     <LocaleNavLink exact to={paths.home} key={1}>
-      <Trans>Home</Trans>
+      <Trans>Search</Trans>
     </LocaleNavLink>,
     <LocaleNavLink to={paths.about} key={2}>
       <Trans>About</Trans>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { Trans, t } from "@lingui/macro";
 
@@ -9,7 +9,13 @@ import SocialShare from "../components/SocialShare";
 import Modal from "../components/Modal";
 
 // import top-level containers (i.e. pages)
-import { I18n, LocaleNavLink, LocaleLink as Link, LocaleSwitcher } from "../i18n";
+import {
+  I18n,
+  LocaleNavLink,
+  LocaleLink as Link,
+  LocaleSwitcher,
+  LocaleSwitcherWithFullLanguageName,
+} from "../i18n";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { createWhoOwnsWhatRoutePaths } from "../routes";
 import { VersionUpgrader } from "./VersionUpgrader";
@@ -25,12 +31,6 @@ import PrivacyPolicyPage from "./PrivacyPolicyPage";
 import { DevPage } from "./DevPage";
 import { wowMachine } from "state-machine";
 import { NotFoundPage } from "./NotFoundPage";
-
-type Props = {};
-
-type State = {
-  showEngageModal: boolean;
-};
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -85,48 +85,48 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
   );
 };
 
-export default class App extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
+const App = () => {
+  const [isEngageModalVisible, setEngageModalVisibility] = useState(false);
+  const [isDropdownVisible, setDropdownVisibility] = useState(false);
 
-    this.state = {
-      showEngageModal: false,
-    };
-  }
+  const toggleDropdown = () => {
+    isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
+  };
 
-  render() {
-    const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
-    const version = process.env.REACT_APP_VERSION;
-    const warnAboutOldBrowser = process.env.REACT_APP_ENABLE_OLD_BROWSER_WARNING;
-    const paths = createWhoOwnsWhatRoutePaths();
-    return (
-      <Router>
-        <I18n>
-          <ScrollToTop>
-            {version && (
-              <VersionUpgrader
-                currentVersion={version}
-                latestVersionUrl="/version.txt"
-                checkIntervalSecs={300}
-              />
+  const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
+  const version = process.env.REACT_APP_VERSION;
+  const warnAboutOldBrowser = process.env.REACT_APP_ENABLE_OLD_BROWSER_WARNING;
+  const paths = createWhoOwnsWhatRoutePaths();
+
+  return (
+    <Router>
+      <I18n>
+        <ScrollToTop>
+          {version && (
+            <VersionUpgrader
+              currentVersion={version}
+              latestVersionUrl="/version.txt"
+              checkIntervalSecs={300}
+            />
+          )}
+          <div className="App">
+            {warnAboutOldBrowser && (
+              <div className="App__warning old_safari_only">
+                <Trans render="h3">
+                  Warning! This site doesn't fully work on older versions of Safari. Try a{" "}
+                  <a href="http://outdatedbrowser.com/en">modern browser</a>.
+                </Trans>
+              </div>
             )}
-            <div className="App">
-              {warnAboutOldBrowser && (
-                <div className="App__warning old_safari_only">
-                  <Trans render="h3">
-                    Warning! This site doesn't fully work on older versions of Safari. Try a{" "}
-                    <a href="http://outdatedbrowser.com/en">modern browser</a>.
-                  </Trans>
-                </div>
+            <div className="App__header navbar">
+              <HomeLink />
+              {isDemoSite && (
+                <span className="label label-warning ml-2 text-uppercase">
+                  <Trans>Demo Site</Trans>
+                </span>
               )}
-              <div className="App__header">
-                <HomeLink />
-                {isDemoSite && (
-                  <span className="label label-warning ml-2 text-uppercase">
-                    <Trans>Demo Site</Trans>
-                  </span>
-                )}
-                <nav className="inline">
+              <nav className="inline">
+                <span className="hide-lg">
                   <LocaleNavLink exact to={paths.home}>
                     <Trans>Home</Trans>
                   </LocaleNavLink>
@@ -140,28 +140,73 @@ export default class App extends Component<Props, State> {
                     <Trans>Donate</Trans>
                   </a>
                   {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                  <a href="#" onClick={() => this.setState({ showEngageModal: true })}>
+                  <a href="#" onClick={() => setEngageModalVisibility(true)}>
                     <Trans>Share</Trans>
                   </a>
                   <LocaleSwitcher />
-                </nav>
-                <Modal
-                  showModal={this.state.showEngageModal}
-                  onClose={() => this.setState({ showEngageModal: false })}
-                >
-                  <h5 className="first-header">
-                    <Trans>Share this page with your neighbors</Trans>
-                  </h5>
-                  <SocialShare location="share-modal" />
-                </Modal>
-              </div>
-              <div className="App__body">
-                <WhoOwnsWhatRoutes />
-              </div>
+                </span>
+
+                <div className="dropdown dropdown-right show-lg">
+                  <button
+                    className={
+                      "btn btn-link dropdown-toggle m-2" + (isDropdownVisible ? " active" : "")
+                    }
+                    onClick={() => toggleDropdown()}
+                  >
+                    <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
+                  </button>
+                  <ul className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}>
+                    <li className="menu-item">
+                      <LocaleNavLink exact to={paths.home}>
+                        <Trans>Home</Trans>
+                      </LocaleNavLink>
+                    </li>
+                    <li className="menu-item">
+                      <LocaleNavLink to={paths.about}>
+                        <Trans>About</Trans>
+                      </LocaleNavLink>
+                    </li>
+                    <li className="menu-item">
+                      <LocaleNavLink to={paths.howToUse}>
+                        <Trans>How to use</Trans>
+                      </LocaleNavLink>
+                    </li>
+                    <li className="menu-item">
+                      <a href="https://www.justfix.nyc/donate">
+                        <Trans>Donate</Trans>
+                      </a>
+                    </li>
+                    <li className="menu-item">
+                      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                      <a href="#" onClick={() => setEngageModalVisibility(true)}>
+                        <Trans>Share</Trans>
+                      </a>
+                    </li>
+                    <li className="menu-item">
+                      <LocaleSwitcherWithFullLanguageName />
+                    </li>
+                  </ul>
+                </div>
+              </nav>
+
+              <Modal
+                showModal={isEngageModalVisible}
+                onClose={() => setEngageModalVisibility(false)}
+              >
+                <h5 className="first-header">
+                  <Trans>Share this page with your neighbors</Trans>
+                </h5>
+                <SocialShare location="share-modal" />
+              </Modal>
             </div>
-          </ScrollToTop>
-        </I18n>
-      </Router>
-    );
-  }
-}
+            <div className="App__body">
+              <WhoOwnsWhatRoutes />
+            </div>
+          </div>
+        </ScrollToTop>
+      </I18n>
+    </Router>
+  );
+};
+
+export default App;

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -127,6 +127,10 @@ const App = () => {
             />
           )}
           <div className="App">
+            <div
+              onClick={() => setDropdownVisibility(false)}
+              className={"dropdown-overlay" + (isDropdownVisible ? "" : " hidden")}
+            />
             {warnAboutOldBrowser && (
               <div className="App__warning old_safari_only">
                 <Trans render="h3">
@@ -151,7 +155,6 @@ const App = () => {
                   </a>
                   <LocaleSwitcher />
                 </span>
-
                 <div className="dropdown dropdown-right show-lg">
                   <button
                     tabIndex={0}
@@ -163,7 +166,7 @@ const App = () => {
                     <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
                   </button>
                   <ul
-                    onClick={() => toggleDropdown()}
+                    onClick={() => setDropdownVisibility(false)}
                     className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
                   >
                     {getMainNavLinks().map((link, i) => (

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -107,7 +107,6 @@ const App = () => {
   const [isEngageModalVisible, setEngageModalVisibility] = useState(false);
   const [isDropdownVisible, setDropdownVisibility] = useState(false);
 
-  const closeDropdown = () => setDropdownVisibility(false);
   const toggleDropdown = () => {
     isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
   };
@@ -129,7 +128,7 @@ const App = () => {
           )}
           <div className="App">
             <div
-              onClick={closeDropdown}
+              onClick={() => setDropdownVisibility(false)}
               className={"dropdown-overlay" + (isDropdownVisible ? "" : " hidden")}
             />
             {warnAboutOldBrowser && (
@@ -141,14 +140,12 @@ const App = () => {
               </div>
             )}
             <div className="App__header navbar">
-              <div className="header-logo" onFocus={closeDropdown}>
-                <HomeLink />
-                {isDemoSite && (
-                  <span className="label label-warning ml-2 text-uppercase">
-                    <Trans>Demo Site</Trans>
-                  </span>
-                )}
-              </div>
+              <HomeLink />
+              {isDemoSite && (
+                <span className="label label-warning ml-2 text-uppercase">
+                  <Trans>Demo Site</Trans>
+                </span>
+              )}
               <nav className="inline">
                 <span className="hide-lg">
                   {getMainNavLinks()}
@@ -171,7 +168,7 @@ const App = () => {
                     <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
                   </button>
                   <ul
-                    onClick={closeDropdown}
+                    onClick={() => setDropdownVisibility(false)}
                     className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
                   >
                     {getMainNavLinks().map((link, i) => (
@@ -202,7 +199,7 @@ const App = () => {
                 <SocialShare location="share-modal" />
               </Modal>
             </div>
-            <div className="App__body" onFocus={closeDropdown}>
+            <div className="App__body">
               <WhoOwnsWhatRoutes />
             </div>
           </div>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -108,6 +108,7 @@ const App = () => {
   const [isEngageModalVisible, setEngageModalVisibility] = useState(false);
   const [isDropdownVisible, setDropdownVisibility] = useState(false);
 
+  const closeDropdown = () => setDropdownVisibility(false);
   const toggleDropdown = () => {
     isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
   };
@@ -129,7 +130,7 @@ const App = () => {
           )}
           <div className="App">
             <div
-              onClick={() => setDropdownVisibility(false)}
+              onClick={closeDropdown}
               className={"dropdown-overlay" + (isDropdownVisible ? "" : " hidden")}
             />
             {warnAboutOldBrowser && (
@@ -161,6 +162,7 @@ const App = () => {
                   focusTrapOptions={{
                     clickOutsideDeactivates: true,
                     returnFocusOnDeactivate: false,
+                    onDeactivate: closeDropdown,
                   }}
                 >
                   <div className="dropdown dropdown-right show-lg">
@@ -175,7 +177,7 @@ const App = () => {
                       <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
                     </button>
                     <ul
-                      onClick={() => setDropdownVisibility(false)}
+                      onClick={closeDropdown}
                       className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
                     >
                       {getMainNavLinks().map((link, i) => (

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -88,16 +88,16 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
 const getMainNavLinks = () => {
   const paths = createWhoOwnsWhatRoutePaths();
   return [
-    <LocaleNavLink exact to={paths.home}>
+    <LocaleNavLink exact to={paths.home} key={1}>
       <Trans>Home</Trans>
     </LocaleNavLink>,
-    <LocaleNavLink to={paths.about}>
+    <LocaleNavLink to={paths.about} key={2}>
       <Trans>About</Trans>
     </LocaleNavLink>,
-    <LocaleNavLink to={paths.howToUse}>
+    <LocaleNavLink to={paths.howToUse} key={3}>
       <Trans>How to use</Trans>
     </LocaleNavLink>,
-    <a href="https://www.justfix.nyc/donate">
+    <a href="https://www.justfix.nyc/donate" key={4}>
       <Trans>Donate</Trans>
     </a>,
   ];
@@ -154,6 +154,7 @@ const App = () => {
 
                 <div className="dropdown dropdown-right show-lg">
                   <button
+                    tabIndex={0}
                     className={
                       "btn btn-link dropdown-toggle m-2" + (isDropdownVisible ? " active" : "")
                     }
@@ -161,7 +162,10 @@ const App = () => {
                   >
                     <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
                   </button>
-                  <ul className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}>
+                  <ul
+                    onClick={() => toggleDropdown()}
+                    className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
+                  >
                     {getMainNavLinks().map((link, i) => (
                       <li className="menu-item" key={i}>
                         {link}

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -114,7 +114,6 @@ const App = () => {
   const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
   const version = process.env.REACT_APP_VERSION;
   const warnAboutOldBrowser = process.env.REACT_APP_ENABLE_OLD_BROWSER_WARNING;
-  const paths = createWhoOwnsWhatRoutePaths();
 
   return (
     <Router>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -85,6 +85,24 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
   );
 };
 
+const getMainNavLinks = () => {
+  const paths = createWhoOwnsWhatRoutePaths();
+  return [
+    <LocaleNavLink exact to={paths.home}>
+      <Trans>Home</Trans>
+    </LocaleNavLink>,
+    <LocaleNavLink to={paths.about}>
+      <Trans>About</Trans>
+    </LocaleNavLink>,
+    <LocaleNavLink to={paths.howToUse}>
+      <Trans>How to use</Trans>
+    </LocaleNavLink>,
+    <a href="https://www.justfix.nyc/donate">
+      <Trans>Donate</Trans>
+    </a>,
+  ];
+};
+
 const App = () => {
   const [isEngageModalVisible, setEngageModalVisibility] = useState(false);
   const [isDropdownVisible, setDropdownVisibility] = useState(false);
@@ -127,18 +145,7 @@ const App = () => {
               )}
               <nav className="inline">
                 <span className="hide-lg">
-                  <LocaleNavLink exact to={paths.home}>
-                    <Trans>Home</Trans>
-                  </LocaleNavLink>
-                  <LocaleNavLink to={paths.about}>
-                    <Trans>About</Trans>
-                  </LocaleNavLink>
-                  <LocaleNavLink to={paths.howToUse}>
-                    <Trans>How to use</Trans>
-                  </LocaleNavLink>
-                  <a href="https://www.justfix.nyc/donate">
-                    <Trans>Donate</Trans>
-                  </a>
+                  {getMainNavLinks()}
                   {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                   <a href="#" onClick={() => setEngageModalVisibility(true)}>
                     <Trans>Share</Trans>
@@ -156,26 +163,11 @@ const App = () => {
                     <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
                   </button>
                   <ul className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}>
-                    <li className="menu-item">
-                      <LocaleNavLink exact to={paths.home}>
-                        <Trans>Home</Trans>
-                      </LocaleNavLink>
-                    </li>
-                    <li className="menu-item">
-                      <LocaleNavLink to={paths.about}>
-                        <Trans>About</Trans>
-                      </LocaleNavLink>
-                    </li>
-                    <li className="menu-item">
-                      <LocaleNavLink to={paths.howToUse}>
-                        <Trans>How to use</Trans>
-                      </LocaleNavLink>
-                    </li>
-                    <li className="menu-item">
-                      <a href="https://www.justfix.nyc/donate">
-                        <Trans>Donate</Trans>
-                      </a>
-                    </li>
+                    {getMainNavLinks().map((link, i) => (
+                      <li className="menu-item" key={i}>
+                        {link}
+                      </li>
+                    ))}
                     <li className="menu-item">
                       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                       <a href="#" onClick={() => setEngageModalVisibility(true)}>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -158,6 +158,8 @@ const App = () => {
                 <div className="dropdown dropdown-right show-lg">
                   <button
                     tabIndex={0}
+                    aria-label="menu"
+                    aria-expanded={isDropdownVisible}
                     className={
                       "btn btn-link dropdown-toggle m-2" + (isDropdownVisible ? " active" : "")
                     }

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -107,6 +107,7 @@ const App = () => {
   const [isEngageModalVisible, setEngageModalVisibility] = useState(false);
   const [isDropdownVisible, setDropdownVisibility] = useState(false);
 
+  const closeDropdown = () => setDropdownVisibility(false);
   const toggleDropdown = () => {
     isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
   };
@@ -128,7 +129,7 @@ const App = () => {
           )}
           <div className="App">
             <div
-              onClick={() => setDropdownVisibility(false)}
+              onClick={closeDropdown}
               className={"dropdown-overlay" + (isDropdownVisible ? "" : " hidden")}
             />
             {warnAboutOldBrowser && (
@@ -140,12 +141,14 @@ const App = () => {
               </div>
             )}
             <div className="App__header navbar">
-              <HomeLink />
-              {isDemoSite && (
-                <span className="label label-warning ml-2 text-uppercase">
-                  <Trans>Demo Site</Trans>
-                </span>
-              )}
+              <div className="header-logo" onFocus={closeDropdown}>
+                <HomeLink />
+                {isDemoSite && (
+                  <span className="label label-warning ml-2 text-uppercase">
+                    <Trans>Demo Site</Trans>
+                  </span>
+                )}
+              </div>
               <nav className="inline">
                 <span className="hide-lg">
                   {getMainNavLinks()}
@@ -168,7 +171,7 @@ const App = () => {
                     <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
                   </button>
                   <ul
-                    onClick={() => setDropdownVisibility(false)}
+                    onClick={closeDropdown}
                     className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
                   >
                     {getMainNavLinks().map((link, i) => (
@@ -199,7 +202,7 @@ const App = () => {
                 <SocialShare location="share-modal" />
               </Modal>
             </div>
-            <div className="App__body">
+            <div className="App__body" onFocus={closeDropdown}>
               <WhoOwnsWhatRoutes />
             </div>
           </div>

--- a/client/src/i18n.tsx
+++ b/client/src/i18n.tsx
@@ -150,6 +150,26 @@ export const LocaleSwitcher = withRouter(function LocaleSwitcher(props: RouteCom
 });
 
 /**
+ * A UI affordance that allows the user to switch to the locale that isn't currently present.
+ *
+ * Since we currently only have two locales, this just offers a toggle to the
+ * other language.
+ */
+export const LocaleSwitcherWithFullLanguageName = withRouter(function LocaleSwitcher(
+  props: RouteComponentProps
+) {
+  const to = (toLocale: SupportedLocale) =>
+    `/${toLocale}${removeLocalePrefix(props.location.pathname)}`;
+  const currentLocale = localeFromRouter(props);
+
+  return currentLocale === "en" ? (
+    <NavLink to={to("es")}>Español</NavLink>
+  ) : (
+    <NavLink to={to("en")}>English</NavLink>
+  );
+});
+
+/**
  * Like React Router's <NavLink>, but it prefixes the passed-in `to` prop with
  * the current locale.
  *

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -237,7 +237,7 @@ msgstr "DOORS"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:97
+#: src/containers/App.tsx:99
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -691,15 +691,15 @@ msgstr "Select a Dataset:"
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:104
-#: src/containers/App.tsx:120
+#: src/containers/App.tsx:107
+#: src/containers/App.tsx:122
 msgid "Share"
 msgstr "Share"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:132
+#: src/containers/App.tsx:134
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -983,7 +983,7 @@ msgstr "WINDOW GUARDS"
 msgid "WINDOWS"
 msgstr "WINDOWS"
 
-#: src/containers/App.tsx:89
+#: src/containers/App.tsx:90
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -60,7 +60,7 @@ msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:89
+#: src/containers/App.tsx:63
 msgid "About"
 msgstr "About"
 
@@ -237,7 +237,7 @@ msgstr "DOORS"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:82
+#: src/containers/App.tsx:97
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -246,7 +246,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:95
+#: src/containers/App.tsx:69
 msgid "Donate"
 msgstr "Donate"
 
@@ -363,7 +363,7 @@ msgstr "HUD Complaint Form 958"
 msgid "Head Officer"
 msgstr "Head Officer"
 
-#: src/containers/App.tsx:86
+#: src/containers/App.tsx:60
 msgid "Home"
 msgstr "Home"
 
@@ -372,7 +372,7 @@ msgstr "Home"
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:92
+#: src/containers/App.tsx:66
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -691,14 +691,15 @@ msgstr "Select a Dataset:"
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:99
+#: src/containers/App.tsx:104
+#: src/containers/App.tsx:120
 msgid "Share"
 msgstr "Share"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:105
+#: src/containers/App.tsx:132
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -982,7 +983,7 @@ msgstr "WINDOW GUARDS"
 msgid "WINDOWS"
 msgstr "WINDOWS"
 
-#: src/containers/App.tsx:74
+#: src/containers/App.tsx:89
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -60,7 +60,7 @@ msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:63
+#: src/containers/App.tsx:64
 msgid "About"
 msgstr "About"
 
@@ -246,7 +246,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:69
+#: src/containers/App.tsx:70
 msgid "Donate"
 msgstr "Donate"
 
@@ -363,16 +363,12 @@ msgstr "HUD Complaint Form 958"
 msgid "Head Officer"
 msgstr "Head Officer"
 
-#: src/containers/App.tsx:60
-msgid "Home"
-msgstr "Home"
-
 #: src/components/DetailView.tsx:136
 #: src/components/DetailView.tsx:241
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:66
+#: src/containers/App.tsx:67
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -678,6 +674,10 @@ msgstr "SIGNAGE MISSING"
 msgid "STAIRS"
 msgstr "STAIRS"
 
+#: src/containers/App.tsx:61
+msgid "Search"
+msgstr "Search"
+
 #: src/containers/NotRegisteredPage.tsx:169
 #: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
@@ -691,15 +691,15 @@ msgstr "Select a Dataset:"
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:107
-#: src/containers/App.tsx:122
+#: src/containers/App.tsx:106
+#: src/containers/App.tsx:126
 msgid "Share"
 msgstr "Share"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:134
+#: src/containers/App.tsx:139
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -983,7 +983,7 @@ msgstr "WINDOW GUARDS"
 msgid "WINDOWS"
 msgstr "WINDOWS"
 
-#: src/containers/App.tsx:90
+#: src/containers/App.tsx:91
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
@@ -1003,14 +1003,14 @@ msgstr "What happens if the landlord has failed to register?"
 msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 
-#: src/containers/App.tsx:29
+#: src/containers/App.tsx:30
 msgid "Who owns what in n y c?"
 msgstr "Who owns what in n y c?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:20
 #: src/components/Page.tsx:21
-#: src/containers/App.tsx:32
+#: src/containers/App.tsx:33
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -242,7 +242,7 @@ msgstr "PUERTAS"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:97
+#: src/containers/App.tsx:99
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -696,15 +696,15 @@ msgstr "Seleccione un conjunto de datos:"
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:104
-#: src/containers/App.tsx:120
+#: src/containers/App.tsx:107
+#: src/containers/App.tsx:122
 msgid "Share"
 msgstr "Compartir"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:132
+#: src/containers/App.tsx:134
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -988,7 +988,7 @@ msgstr "PROTECTORES DE VENTANA"
 msgid "WINDOWS"
 msgstr "VENTANAS"
 
-#: src/containers/App.tsx:89
+#: src/containers/App.tsx:90
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -65,7 +65,7 @@ msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:63
+#: src/containers/App.tsx:64
 msgid "About"
 msgstr "Acerca de"
 
@@ -251,7 +251,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:69
+#: src/containers/App.tsx:70
 msgid "Donate"
 msgstr "Donar"
 
@@ -368,16 +368,12 @@ msgstr "Formulario de queja HUD 958"
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
-#: src/containers/App.tsx:60
-msgid "Home"
-msgstr "Inicio"
-
 #: src/components/DetailView.tsx:136
 #: src/components/DetailView.tsx:241
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:66
+#: src/containers/App.tsx:67
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
@@ -683,6 +679,10 @@ msgstr "FALTA DE SEÑALIZACIÓN"
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
+#: src/containers/App.tsx:61
+msgid "Search"
+msgstr ""
+
 #: src/containers/NotRegisteredPage.tsx:169
 #: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
@@ -696,15 +696,15 @@ msgstr "Seleccione un conjunto de datos:"
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:107
-#: src/containers/App.tsx:122
+#: src/containers/App.tsx:106
+#: src/containers/App.tsx:126
 msgid "Share"
 msgstr "Compartir"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:134
+#: src/containers/App.tsx:139
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -988,7 +988,7 @@ msgstr "PROTECTORES DE VENTANA"
 msgid "WINDOWS"
 msgstr "VENTANAS"
 
-#: src/containers/App.tsx:90
+#: src/containers/App.tsx:91
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
@@ -1008,14 +1008,14 @@ msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Quién Es El Dueño es una herramienta gratis construida por JustFix.nyc para investigar los dueños de edificios en NYC. Ha asistido más de 200.000 neoyorquinos a enterarse quien realmente son los responsables por su edificio, cuáles otros edificios su dueño o compañía de administración poseen, y otra información crítica sobre violaciones del código de vivienda, desalojos, apartamentos con renta estabilizada y mucho más en cualquier edificio. Puedes buscar información sobre cualquier edificio residencial, también incluyen viviendas públicas (NYCHA). Busca tu dirección aquí: {url}"
 
-#: src/containers/App.tsx:29
+#: src/containers/App.tsx:30
 msgid "Who owns what in n y c?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:20
 #: src/components/Page.tsx:21
-#: src/containers/App.tsx:32
+#: src/containers/App.tsx:33
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -65,7 +65,7 @@ msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:89
+#: src/containers/App.tsx:63
 msgid "About"
 msgstr "Acerca de"
 
@@ -242,7 +242,7 @@ msgstr "PUERTAS"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:82
+#: src/containers/App.tsx:97
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -251,7 +251,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:95
+#: src/containers/App.tsx:69
 msgid "Donate"
 msgstr "Donar"
 
@@ -368,7 +368,7 @@ msgstr "Formulario de queja HUD 958"
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
-#: src/containers/App.tsx:86
+#: src/containers/App.tsx:60
 msgid "Home"
 msgstr "Inicio"
 
@@ -377,7 +377,7 @@ msgstr "Inicio"
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:92
+#: src/containers/App.tsx:66
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
@@ -696,14 +696,15 @@ msgstr "Seleccione un conjunto de datos:"
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:99
+#: src/containers/App.tsx:104
+#: src/containers/App.tsx:120
 msgid "Share"
 msgstr "Compartir"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:105
+#: src/containers/App.tsx:132
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -987,7 +988,7 @@ msgstr "PROTECTORES DE VENTANA"
 msgid "WINDOWS"
 msgstr "VENTANAS"
 
-#: src/containers/App.tsx:74
+#: src/containers/App.tsx:89
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
@@ -1077,4 +1078,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:34
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Infracción del HPD emitida desde el 2010} other {# Infracciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -14,7 +14,7 @@
     height: 100%;
     background-color: $dark;
     opacity: 0.6;
-    z-index: 100;
+    z-index: 10;
   }
 
   & > div {
@@ -57,7 +57,7 @@
     padding: 10px 8px 8px;
   }
   .dropdown.dropdown-right {
-    z-index: 200;
+    z-index: 20;
     // Remove default border on focus:
     button.dropdown-toggle:focus {
       border: none;

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -5,6 +5,18 @@
   display: flex;
   flex-direction: column;
 
+  .dropdown-overlay {
+    &.hidden {
+      display: none;
+    }
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    background-color: $dark;
+    opacity: 0.6;
+    z-index: 100;
+  }
+
   & > div {
     box-sizing: border-box;
   }
@@ -44,8 +56,8 @@
   @include for-phone-only {
     padding: 10px 8px 8px;
   }
-
   .dropdown.dropdown-right {
+    z-index: 200;
     // Remove default border on focus:
     button.dropdown-toggle:focus {
       border: none;

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -40,8 +40,17 @@
   align-items: center;
   position: relative;
 
-  @include for-desktop-down {
-    padding: 10px 15px;
+  @include for-phone-only {
+    padding: 10px 8px 8px;
+  }
+
+  .dropdown.dropdown-right {
+    .menu.d-block {
+      display: block;
+      .menu.d-none {
+        display: none;
+      }
+    }
   }
 
   .label.label-warning {
@@ -53,12 +62,6 @@
     }
   }
 
-  @include for-phone-only {
-    flex-direction: column;
-    justify-content: center;
-    padding: 10px 8px 8px;
-  }
-
   & > a,
   a:hover,
   a:focus {
@@ -66,13 +69,14 @@
   }
 
   & > a {
-    @include for-tablet-portrait-up {
-      display: block;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    }
+    display: block;
+    position: absolute;
+    width: fit-content;
+    max-width: 75%;
+    text-align: center;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 
     h4 {
       margin-bottom: 0;
@@ -88,34 +92,17 @@
 
   nav {
     margin-left: auto;
-    display: flex;
     flex-wrap: wrap;
-    justify-content: flex-end;
+    text-align: end;
 
     @include for-desktop-down {
-      max-width: 240px;
-    }
-
-    @include for-tablet-landscape-down {
-      max-width: 140px;
-    }
-
-    @include for-phone-only {
-      margin-left: 0;
-      max-width: none;
-      width: 100%;
-      justify-content: center;
-      margin-top: 8px;
+      max-width: 200px;
     }
 
     a {
+      display: inline-block;
       margin-left: 10px;
       color: #454d5d;
-
-      @include for-phone-only {
-        margin-left: 7px;
-        margin-right: 7px;
-      }
 
       &.active {
         text-decoration: none;

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -75,10 +75,12 @@
 
   .label.label-warning {
     color: $dark;
-    margin-top: 0.75rem;
-    @include for-tablet-portrait-up {
-      transform: rotate(-4deg);
-      margin-top: 0rem;
+    transform: rotate(-4deg);
+    margin-top: 0rem;
+    height: min-content;
+    @include for-phone-only {
+      font-size: 1rem;
+      width: min-content;
     }
   }
 

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -14,7 +14,7 @@
     height: 100%;
     background-color: $dark;
     opacity: 0.6;
-    z-index: 10;
+    z-index: 100;
   }
 
   & > div {
@@ -57,7 +57,7 @@
     padding: 10px 8px 8px;
   }
   .dropdown.dropdown-right {
-    z-index: 20;
+    z-index: 110;
     // Remove default border on focus:
     button.dropdown-toggle:focus {
       border: none;

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -96,13 +96,13 @@
     }
   }
 
-  .header-logo > a,
+  & > a,
   a:hover,
   a:focus {
     text-decoration: none !important;
   }
 
-  .header-logo > a {
+  & > a {
     display: block;
     position: absolute;
     width: fit-content;

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -45,11 +45,26 @@
   }
 
   .dropdown.dropdown-right {
-    .menu.d-block {
-      display: block;
-    }
-    .menu.d-none {
-      display: none;
+    .menu {
+      padding: 0.25rem 0.5rem;
+      font-size: 1.6rem;
+
+      .menu-item a {
+        &:focus {
+          outline-offset: 0px;
+        }
+        &:active,
+        &.active {
+          background: $gray-light;
+        }
+      }
+
+      &.d-block {
+        display: block;
+      }
+      &.d-none {
+        display: none;
+      }
     }
   }
 

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -96,13 +96,13 @@
     }
   }
 
-  & > a,
+  .header-logo > a,
   a:hover,
   a:focus {
     text-decoration: none !important;
   }
 
-  & > a {
+  .header-logo > a {
     display: block;
     position: absolute;
     width: fit-content;

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -47,9 +47,9 @@
   .dropdown.dropdown-right {
     .menu.d-block {
       display: block;
-      .menu.d-none {
-        display: none;
-      }
+    }
+    .menu.d-none {
+      display: none;
     }
   }
 
@@ -96,7 +96,7 @@
     text-align: end;
 
     @include for-desktop-down {
-      max-width: 200px;
+      max-width: 250px;
     }
 
     a {

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -11,7 +11,8 @@
 
   // Standard inline-link focus class:
   a:not(.btn):not(.image):focus,
-  summary:focus-visible {
+  summary:focus-visible,
+  button.dropdown-toggle:focus {
     box-shadow: none;
     outline: 2px solid $gray-dark;
     outline-offset: 2px;
@@ -45,6 +46,10 @@
   }
 
   .dropdown.dropdown-right {
+    // Remove default border on focus:
+    button.dropdown-toggle:focus {
+      border: none;
+    }
     .menu {
       padding: 0.25rem 0.5rem;
       font-size: 1.6rem;

--- a/client/src/styles/Modal.scss
+++ b/client/src/styles/Modal.scss
@@ -1,7 +1,7 @@
 @import "_vars.scss";
 
 .ReactModal__Overlay--after-open {
-  z-index: 100;
+  z-index: 120;
 
   .ReactModal__Close {
     position: absolute;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6496,6 +6496,20 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-trap-react@^8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-8.6.0.tgz#1f5062e6c1f190c878558b2234267c3fb91a5db5"
+  integrity sha512-6NJf1mNlXatRJttJmvTRsnGRblERhyVS0YC54JlTZVIID0VafFkMFYv37JLzow7cMOeamT7W31qMuZ7LwTpEQw==
+  dependencies:
+    focus-trap "^6.5.1"
+
+focus-trap@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.5.1.tgz#2d2bb91198f17e8bc52070f1fb48ac36be4230b5"
+  integrity sha512-q57JebeQXVThn9DWvWLP2rUwuArvk8w3PyqZLSddto0thmVmklFzYJQO97Aq3pUcWkTXjflUa88fT0CrASsaHQ==
+  dependencies:
+    tabbable "^5.2.0"
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -13199,6 +13213,11 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
+
+tabbable@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
+  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
This PR replaces our standard navbar of links in the header with a hamburger menu once the viewport is smaller than a desktop or landscape tablet. The hamburger menu includes all original links from the navbar, with the only difference being that instead of the `EN/ES` toggle, we now show the full language name of whatever language the user is _not_ currently seeing on the site (see the new `<LocaleSwitcherWithFullLanguageName>` component). I also added an overlay to gray out the main content of the page when the user has the hamburger menu open. 

TODO:
- [x] Decide whether to match styling between the menu overlay and the modal overlay, or keep them different