### PR TITLE
Make sure "Learn More" content is visible on IE

### DIFF
--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -232,12 +232,6 @@
             display: none;
           }
 
-          // Do not show expandable "Learn More" button on IE11
-          // https://stackoverflow.com/questions/43528940/how-to-detect-ie-and-edge-browsers-in-css
-          @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-            display: none;
-          }
-
           div {
             margin: 0;
             padding: 0 0.8rem;
@@ -249,6 +243,12 @@
             margin-top: calc(-1 * #{$html-line-height} * #{$font-size});
             padding: 0;
             font-style: italic;
+
+            // Do not show expandable "Learn More" button on IE11
+            // https://stackoverflow.com/questions/43528940/how-to-detect-ie-and-edge-browsers-in-css
+            @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+              display: none;
+            }
           }
           .icon {
             display: none;


### PR DESCRIPTION
This PR tweaks some CSS to make sure that on Internet Explorer, we are hiding the "Summary" part of the `Learn more` accordion menu on the Detail View but still showing the full text.