### PR TITLE
Remove widows from title link on navbar

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -65,6 +65,7 @@
     "rollbar": "^2.14.4",
     "spectre.scss": "0.0.2",
     "typescript": "^3.9.7",
+    "widont": "^0.3.3",
     "xstate": "^4.11.0"
   },
   "scripts": {

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -32,11 +32,11 @@ import PrivacyPolicyPage from "./PrivacyPolicyPage";
 import { DevPage } from "./DevPage";
 import { wowMachine } from "state-machine";
 import { NotFoundPage } from "./NotFoundPage";
-import widont from 'widont';
+import widont from "widont";
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
-  const title = i18n._(t`Who owns what in nyc?`)
+  const title = i18n._(t`Who owns what in nyc?`);
   return (
     <Link
       // We need to spell out each letter of "nyc" here for screenreaders to pronounce:
@@ -46,7 +46,6 @@ const HomeLink = withI18n()((props: withI18nProps) => {
       }}
       to="/"
     >
-      
       <h4>{widont(title)}</h4>
     </Link>
   );

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -32,9 +32,11 @@ import PrivacyPolicyPage from "./PrivacyPolicyPage";
 import { DevPage } from "./DevPage";
 import { wowMachine } from "state-machine";
 import { NotFoundPage } from "./NotFoundPage";
+import widont from 'widont';
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
+  const title = i18n._(t`Who owns what in nyc?`)
   return (
     <Link
       // We need to spell out each letter of "nyc" here for screenreaders to pronounce:
@@ -44,7 +46,8 @@ const HomeLink = withI18n()((props: withI18nProps) => {
       }}
       to="/"
     >
-      <Trans render="h4">Who owns what in nyc?</Trans>
+      
+      <h4>{widont(title)}</h4>
     </Link>
   );
 });

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -60,7 +60,7 @@ msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:64
+#: src/containers/App.tsx:66
 msgid "About"
 msgstr "About"
 
@@ -237,7 +237,7 @@ msgstr "DOORS"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:99
+#: src/containers/App.tsx:101
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -246,7 +246,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:70
+#: src/containers/App.tsx:72
 msgid "Donate"
 msgstr "Donate"
 
@@ -368,7 +368,7 @@ msgstr "Head Officer"
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:67
+#: src/containers/App.tsx:69
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -674,7 +674,7 @@ msgstr "SIGNAGE MISSING"
 msgid "STAIRS"
 msgstr "STAIRS"
 
-#: src/containers/App.tsx:61
+#: src/containers/App.tsx:63
 msgid "Search"
 msgstr "Search"
 
@@ -691,15 +691,15 @@ msgstr "Select a Dataset:"
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:106
-#: src/containers/App.tsx:126
+#: src/containers/App.tsx:108
+#: src/containers/App.tsx:128
 msgid "Share"
 msgstr "Share"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:139
+#: src/containers/App.tsx:141
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -983,7 +983,7 @@ msgstr "WINDOW GUARDS"
 msgid "WINDOWS"
 msgstr "WINDOWS"
 
-#: src/containers/App.tsx:91
+#: src/containers/App.tsx:93
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
@@ -1003,14 +1003,14 @@ msgstr "What happens if the landlord has failed to register?"
 msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 
-#: src/containers/App.tsx:30
+#: src/containers/App.tsx:32
 msgid "Who owns what in n y c?"
 msgstr "Who owns what in n y c?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:20
 #: src/components/Page.tsx:21
-#: src/containers/App.tsx:33
+#: src/containers/App.tsx:29
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -65,7 +65,7 @@ msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:64
+#: src/containers/App.tsx:66
 msgid "About"
 msgstr "Acerca de"
 
@@ -242,7 +242,7 @@ msgstr "PUERTAS"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:99
+#: src/containers/App.tsx:101
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -251,7 +251,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:70
+#: src/containers/App.tsx:72
 msgid "Donate"
 msgstr "Donar"
 
@@ -373,7 +373,7 @@ msgstr "Oficial Principal"
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:67
+#: src/containers/App.tsx:69
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
@@ -679,7 +679,7 @@ msgstr "FALTA DE SEÑALIZACIÓN"
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
-#: src/containers/App.tsx:61
+#: src/containers/App.tsx:63
 msgid "Search"
 msgstr "Buscar"
 
@@ -696,15 +696,15 @@ msgstr "Seleccione un conjunto de datos:"
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:106
-#: src/containers/App.tsx:126
+#: src/containers/App.tsx:108
+#: src/containers/App.tsx:128
 msgid "Share"
 msgstr "Compartir"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:139
+#: src/containers/App.tsx:141
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -988,7 +988,7 @@ msgstr "PROTECTORES DE VENTANA"
 msgid "WINDOWS"
 msgstr "VENTANAS"
 
-#: src/containers/App.tsx:91
+#: src/containers/App.tsx:93
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
@@ -1008,14 +1008,14 @@ msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Quién Es El Dueño es una herramienta gratis construida por JustFix.nyc para investigar los dueños de edificios en NYC. Ha asistido más de 200.000 neoyorquinos a enterarse quien realmente son los responsables por su edificio, cuáles otros edificios su dueño o compañía de administración poseen, y otra información crítica sobre violaciones del código de vivienda, desalojos, apartamentos con renta estabilizada y mucho más en cualquier edificio. Puedes buscar información sobre cualquier edificio residencial, también incluyen viviendas públicas (NYCHA). Busca tu dirección aquí: {url}"
 
-#: src/containers/App.tsx:30
+#: src/containers/App.tsx:32
 msgid "Who owns what in n y c?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:20
 #: src/components/Page.tsx:21
-#: src/containers/App.tsx:33
+#: src/containers/App.tsx:29
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -14084,6 +14084,11 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+widont@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/widont/-/widont-0.3.3.tgz#e20743942d02fd6c28ef4d3ff8ee1740146489be"
+  integrity sha512-D0VICcKECbHrlgBmbM/WFKrhMCkt3ys+MxBrm+jLEsXwqM3/b73Yakjlp+bvAAI5hhY5pkYlXAtEbf49rwxa2w==
+
 word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"


### PR DESCRIPTION
This PR makes use of the [widont package](https://www.npmjs.com/package/widont) (that we use on the justfix-website) to remove any single-word second lines from the title link on the header nav bar. This problem specifically arose with the _Spanish_ title as it was too long to fit on one line. Now, instead of looking awkward with a trailing "York" on the second line, it looks much better: 

![image](https://user-images.githubusercontent.com/12834575/123309230-a9bf6900-d4f2-11eb-863d-d4d9d96bcb39.png)
