### PR TITLE
Enhance Portfolio Tab experience for mobile users

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "babel-polyfill": "^6.26.0",
     "chart.js": "^2.9.4",
     "chartjs-plugin-annotation": "^0.5.7",
+    "classnames": "^2.3.1",
     "concurrently": "^5.2.0",
     "contentful": "^7.11.0",
     "downshift": "^3.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -61,6 +61,7 @@
     "react-scripts": "3.4.1",
     "react-social": "^1.10.0",
     "react-table": "^6.5.3",
+    "react-table-hoc-fixed-columns": "^2.3.3",
     "react-transition-group": "^2.2.1",
     "rollbar": "^2.14.4",
     "spectre.scss": "0.0.2",

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -63,9 +63,10 @@ const PropertiesListWithoutI18n: React.FC<
     <div className={classnames("PropertiesList", isLastColumnVisible && "last-column-visible")}>
       <ReactTableFixedColumns
         data={addrs}
-        minRows={Browser.isMobile() ? 5 : 10}
+        minRows={10}
         defaultPageSize={addrs.length}
         showPagination={false}
+        resizable={!Browser.isMobile()}
         columns={[
           {
             fixed: "left",
@@ -81,7 +82,6 @@ const PropertiesListWithoutI18n: React.FC<
                 id: "address",
                 width: 130,
                 fixed: "left",
-                resizable: false,
                 style: {
                   textAlign: "left",
                   whiteSpace: "unset",

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -17,6 +17,8 @@ import Helpers, { longDateOptions } from "../util/helpers";
 import { AddressRecord, HpdComplaintCount } from "./APIDataTypes";
 import { withMachineInStateProps } from "state-machine";
 import { AddressPageRoutes } from "routes";
+import { createRef } from "react";
+import classnames from "classnames";
 
 export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
   const addrsWithMatchingSale = addrs.filter((addr) => addr.lastsaleacrisid === saleId);
@@ -54,8 +56,11 @@ const PropertiesListWithoutI18n: React.FC<
   const addrs = props.state.context.portfolioData.assocAddrs;
   const rsunitslatestyear = props.state.context.portfolioData.searchAddr.rsunitslatestyear;
 
+  const lastColumnRef = createRef<any>();
+  const isLastColumnVisible = Helpers.useOnScreen(lastColumnRef);
+
   return (
-    <div className="PropertiesList">
+    <div className={classnames("PropertiesList", isLastColumnVisible && "last-column-visible")}>
       <ReactTableFixedColumns
         data={addrs}
         minRows={Browser.isMobile() ? 5 : 10}
@@ -368,7 +373,11 @@ const PropertiesListWithoutI18n: React.FC<
             ],
           },
           {
-            Header: i18n._(t`View detail`),
+            Header: (
+              <div ref={lastColumnRef}>
+                <Trans>View detail</Trans>
+              </div>
+            ),
             accessor: (d) => d.bbl,
             columns: [
               {

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -268,7 +268,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.openviolations,
                 id: "openviolations",
-                width: getWidthFromLabel(i18n._(t`Open`), 80),
+                width: getWidthFromLabel(i18n._(t`Open`), 85),
               },
               {
                 Header: (
@@ -279,7 +279,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.totalviolations,
                 id: "totalviolations",
-                width: getWidthFromLabel(i18n._(t`Total`), 80),
+                width: getWidthFromLabel(i18n._(t`Total`), 85),
               },
             ],
           },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -90,6 +90,9 @@ const PropertiesListWithoutI18n: React.FC<
   const tableRef = useRef<HTMLDivElement>(null);
   const isTableVisible = Helpers.useOnScreen(tableRef);
 
+  // On most browsers, the header has the `position: fixed` CSS property
+  // and needs a defined `top` property along with it.
+  // So, let's keep track of and also update this top spacing whenever the layout of the page changes.
   const [headerTopSpacing, setHeaderTopSpacing] = useState<number | undefined>();
 
   // Make sure to setHeaderTopSpacing whenever

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -43,6 +43,15 @@ const ArrowIcon = () => (
   </span>
 );
 
+const getWidthFromLabel = (label: string, customDefaultWidth?: number) => {
+  const MIN_WIDTH = customDefaultWidth || 70;
+  const LETTER_WIDTH = 7;
+  const ARROW_ICON_WIDTH = 20;
+  const MARGIN_OFFSET = 10;
+
+  return Math.max(label.length * LETTER_WIDTH + ARROW_ICON_WIDTH + MARGIN_OFFSET, MIN_WIDTH);
+};
+
 const PropertiesListWithoutI18n: React.FC<
   withMachineInStateProps<"portfolioFound"> & {
     i18n: I18n;
@@ -102,7 +111,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.zip,
                 id: "zip",
-                width: i18n.language === "es" ? 125 : 85,
+                width: getWidthFromLabel(i18n._(t`Zipcode`)),
               },
               {
                 Header: (
@@ -113,6 +122,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.boro,
                 id: "boro",
+                width: getWidthFromLabel(i18n._(t`Borough`)),
               },
               {
                 Header: (
@@ -123,6 +133,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.bbl,
                 id: "bbl",
+                width: getWidthFromLabel("BBL", 100),
               },
             ],
           },
@@ -138,7 +149,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.yearbuilt,
                 id: "yearbuilt",
-                maxWidth: i18n.language === "es" ? 100 : 75,
+                width: getWidthFromLabel(i18n._(t`Built`)),
               },
               {
                 Header: (
@@ -149,7 +160,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.unitsres,
                 id: "unitsres",
-                maxWidth: i18n.language === "es" ? 85 : 75,
+                width: getWidthFromLabel(i18n._(t`Units`)),
               },
             ],
           },
@@ -165,7 +176,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.rsunits2007,
                 id: "rsunits2007",
-                maxWidth: 75,
+                width: getWidthFromLabel("2007"),
               },
               {
                 Header: (
@@ -187,7 +198,7 @@ const PropertiesListWithoutI18n: React.FC<
                     </span>
                   );
                 },
-                maxWidth: 75,
+                width: getWidthFromLabel("XXXX"),
               },
             ],
           },
@@ -203,7 +214,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.totalcomplaints,
                 id: "totalcomplaints",
-                minWidth: i18n.language === "es" ? 90 : 75,
+                width: getWidthFromLabel(i18n._(t`Total`)),
               },
               {
                 Header: (
@@ -214,7 +225,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.recentcomplaints,
                 id: "recentcomplaints",
-                minWidth: i18n.language === "es" ? 130 : 115,
+                width: getWidthFromLabel(i18n._(t`Last 3 Years`)),
               },
               {
                 Header: (
@@ -230,7 +241,7 @@ const PropertiesListWithoutI18n: React.FC<
                     : null;
                 },
                 id: "recentcomplaintsbytype",
-                minWidth: 150,
+                width: getWidthFromLabel(i18n._(t`Top Complaint`)),
               },
             ],
           },
@@ -246,7 +257,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.openviolations,
                 id: "openviolations",
-                maxWidth: 75,
+                width: getWidthFromLabel(i18n._(t`Open`)),
               },
               {
                 Header: (
@@ -257,7 +268,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.totalviolations,
                 id: "totalviolations",
-                maxWidth: 75,
+                width: getWidthFromLabel(i18n._(t`Total`)),
               },
             ],
           },
@@ -273,7 +284,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.evictions || null,
                 id: "evictions",
-                maxWidth: 100,
+                width: getWidthFromLabel(i18n._(t`Since 2017`)),
               },
             ],
           },
@@ -296,7 +307,7 @@ const PropertiesListWithoutI18n: React.FC<
                   return owner ? owner.value : "";
                 },
                 id: "ownernames",
-                minWidth: i18n.language === "es" ? 165 : 150,
+                width: getWidthFromLabel(i18n._(t`Officer/Owner`)),
               },
             ],
           },
@@ -316,6 +327,7 @@ const PropertiesListWithoutI18n: React.FC<
                     ? Helpers.formatDate(row.original.lastsaledate, longDateOptions, locale)
                     : null,
                 id: "lastsaledate",
+                width: getWidthFromLabel(i18n._(t`Date`), 100),
               },
               {
                 Header: (
@@ -330,6 +342,7 @@ const PropertiesListWithoutI18n: React.FC<
                     ? "$" + Helpers.formatPrice(row.original.lastsaleamount, locale)
                     : null,
                 id: "lastsaleamount",
+                width: getWidthFromLabel(i18n._(t`Amount`), 100),
               },
               {
                 Header: i18n._(t`Link to Deed`),
@@ -347,7 +360,7 @@ const PropertiesListWithoutI18n: React.FC<
                     </a>
                   ) : null,
                 id: "lastsaleacrisid",
-                width: i18n.language === "es" ? 165 : 110,
+                width: getWidthFromLabel(i18n._(t`Link to Deed`)),
               },
               {
                 Header: (
@@ -369,7 +382,7 @@ const PropertiesListWithoutI18n: React.FC<
                       : i18n._(t`No`)
                     : null,
                 id: "lastsaleisgroupsale",
-                minWidth: i18n.language === "es" ? 145 : 110,
+                width: getWidthFromLabel(i18n._(t`Group Sale?`)),
               },
             ],
           },
@@ -394,6 +407,7 @@ const PropertiesListWithoutI18n: React.FC<
                     </Link>
                   );
                 },
+                width: getWidthFromLabel(i18n._(t`View detail`)),
               },
             ],
           },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -263,6 +263,9 @@ const PropertiesListWithoutI18n: React.FC<
                 },
                 id: "recentcomplaintsbytype",
                 width: getWidthFromLabel(i18n._(t`Top Complaint`)),
+                style: {
+                  whiteSpace: "unset",
+                },
               },
             ],
           },
@@ -328,7 +331,10 @@ const PropertiesListWithoutI18n: React.FC<
                   return owner ? owner.value : "";
                 },
                 id: "ownernames",
-                width: getWidthFromLabel(i18n._(t`Officer/Owner`)),
+                width: getWidthFromLabel(i18n._(t`Officer/Owner`), 100),
+                style: {
+                  whiteSpace: "unset",
+                },
               },
             ],
           },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -86,7 +86,7 @@ const PropertiesListWithoutI18n: React.FC<
                 id: "boro",
               },
               {
-                Header: "BBL" + " ⇅",
+                Header: "BBL ⇅",
                 accessor: (d) => d.bbl,
                 id: "bbl",
               },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import ReactTable from "react-table";
 import Browser from "../util/browser";
 
@@ -53,6 +53,7 @@ const getWidthFromLabel = (label: string, customDefaultWidth?: number) => {
 };
 
 const FIRST_COLUMN_WIDTH = 130;
+const HEADER_HEIGHT = 30;
 
 const secondColumnStyle = {
   marginLeft: `${FIRST_COLUMN_WIDTH}px`,
@@ -85,8 +86,18 @@ const PropertiesListWithoutI18n: React.FC<
    */
   const hideScrollFade = isOlderBrowser || isLastColumnVisible;
 
+  const firstHeaderRef = useRef<HTMLDivElement>(null);
+  const [headerTopSpacing, setHeaderTopSpacing] = useState(0);
+
+  useEffect(() => {
+    if (firstHeaderRef?.current?.offsetTop) setHeaderTopSpacing(firstHeaderRef.current.offsetTop);
+  });
+
   return (
-    <div className={classnames("PropertiesList", hideScrollFade && "hide-scroll-fade")}>
+    <div
+      className={classnames("PropertiesList", hideScrollFade && "hide-scroll-fade")}
+      ref={firstHeaderRef}
+    >
       <ReactTableFixedColumns
         data={addrs}
         minRows={10}
@@ -96,6 +107,10 @@ const PropertiesListWithoutI18n: React.FC<
         columns={[
           {
             fixed: "left",
+            headerStyle: {
+              height: `${HEADER_HEIGHT}px`,
+              top: `${headerTopSpacing}px`,
+            },
             columns: [
               {
                 Header: (
@@ -104,6 +119,9 @@ const PropertiesListWithoutI18n: React.FC<
                     <ArrowIcon />
                   </div>
                 ),
+                headerStyle: {
+                  top: `${headerTopSpacing + HEADER_HEIGHT}px`,
+                },
                 accessor: (d) => `${d.housenumber} ${d.streetname}`,
                 id: "address",
                 width: FIRST_COLUMN_WIDTH,

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -99,9 +99,14 @@ const PropertiesListWithoutI18n: React.FC<
   // - the table comes into view
   // - the page's locale changes
   // - the user resizes their viewport window
+  //
+  // For older browsers, let's not even bother setting the top spacing as
+  // we won't be able to detect when the table becomes visible. Luckily,
+  // the `react-table-hoc-fixed-columns` packages has fallback CSS for these browsers.
   useEffect(() => {
-    if (tableRef?.current?.offsetTop) setHeaderTopSpacing(tableRef.current.offsetTop);
-  }, [isTableVisible, locale, windowWidth, windowHeight]);
+    if (!isOlderBrowser && tableRef?.current?.offsetTop)
+      setHeaderTopSpacing(tableRef.current.offsetTop);
+  }, [isTableVisible, locale, windowWidth, windowHeight, isOlderBrowser]);
 
   return (
     <div

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -92,7 +92,7 @@ const PropertiesListWithoutI18n: React.FC<
   // Make sure to setHeaderTopSpacing whenever the user changes the page's locale:
   useEffect(() => {
     if (firstHeaderRef?.current?.offsetTop) setHeaderTopSpacing(firstHeaderRef.current.offsetTop);
-  }, [i18n.language, window.innerHeight]);
+  }, [i18n.language]);
 
   return (
     <div

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -110,7 +110,9 @@ const PropertiesListWithoutI18n: React.FC<
             fixed: "left",
             headerStyle: {
               height: `${HEADER_HEIGHT}px`,
-              top: `${headerTopSpacing}px`,
+              ...(headerTopSpacing > 0 && {
+                top: `${headerTopSpacing}px`,
+              }),
             },
             columns: [
               {
@@ -121,7 +123,9 @@ const PropertiesListWithoutI18n: React.FC<
                   </div>
                 ),
                 headerStyle: {
-                  top: `${headerTopSpacing + HEADER_HEIGHT}px`,
+                  ...(headerTopSpacing > 0 && {
+                    top: `${headerTopSpacing + HEADER_HEIGHT}px`,
+                  }),
                 },
                 accessor: (d) => `${d.housenumber} ${d.streetname}`,
                 id: "address",

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -96,7 +96,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.zip,
                 id: "zip",
-                width: 85,
+                width: i18n.language === "es" ? 125 : 85,
               },
               {
                 Header: (
@@ -132,7 +132,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.yearbuilt,
                 id: "yearbuilt",
-                maxWidth: 75,
+                maxWidth: i18n.language === "es" ? 100 : 75,
               },
               {
                 Header: (
@@ -143,7 +143,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.unitsres,
                 id: "unitsres",
-                maxWidth: 75,
+                maxWidth: i18n.language === "es" ? 85 : 75,
               },
             ],
           },
@@ -197,7 +197,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.totalcomplaints,
                 id: "totalcomplaints",
-                maxWidth: 75,
+                minWidth: i18n.language === "es" ? 90 : 75,
               },
               {
                 Header: (
@@ -208,7 +208,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.recentcomplaints,
                 id: "recentcomplaints",
-                minWidth: 115,
+                minWidth: i18n.language === "es" ? 130 : 115,
               },
               {
                 Header: (
@@ -290,7 +290,7 @@ const PropertiesListWithoutI18n: React.FC<
                   return owner ? owner.value : "";
                 },
                 id: "ownernames",
-                minWidth: 150,
+                minWidth: i18n.language === "es" ? 165 : 150,
               },
             ],
           },
@@ -341,6 +341,7 @@ const PropertiesListWithoutI18n: React.FC<
                     </a>
                   ) : null,
                 id: "lastsaleacrisid",
+                width: i18n.language === "es" ? 165 : 110,
               },
               {
                 Header: (
@@ -362,7 +363,7 @@ const PropertiesListWithoutI18n: React.FC<
                       : i18n._(t`No`)
                     : null,
                 id: "lastsaleisgroupsale",
-                minWidth: 110,
+                minWidth: i18n.language === "es" ? 145 : 110,
               },
             ],
           },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -64,6 +64,7 @@ const PropertiesListWithoutI18n: React.FC<
                 accessor: (d) => `${d.housenumber} ${d.streetname}`,
                 id: "address",
                 minWidth: 130,
+                fixed: "left",
                 style: {
                   textAlign: "left",
                   whiteSpace: "unset",

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -52,6 +52,12 @@ const getWidthFromLabel = (label: string, customDefaultWidth?: number) => {
   return Math.max(label.length * LETTER_WIDTH + ARROW_ICON_WIDTH + MARGIN_OFFSET, MIN_WIDTH);
 };
 
+const FIRST_COLUMN_WIDTH = 130;
+
+const secondColumnStyle = {
+  marginLeft: `${FIRST_COLUMN_WIDTH}px`,
+};
+
 const PropertiesListWithoutI18n: React.FC<
   withMachineInStateProps<"portfolioFound"> & {
     i18n: I18n;
@@ -93,15 +99,16 @@ const PropertiesListWithoutI18n: React.FC<
             columns: [
               {
                 Header: (
-                  <>
+                  <div>
                     <Trans>Address</Trans>
                     <ArrowIcon />
-                  </>
+                  </div>
                 ),
                 accessor: (d) => `${d.housenumber} ${d.streetname}`,
                 id: "address",
-                width: 130,
+                width: FIRST_COLUMN_WIDTH,
                 fixed: "left",
+                resizable: false,
                 style: {
                   textAlign: "left",
                   whiteSpace: "unset",
@@ -112,6 +119,8 @@ const PropertiesListWithoutI18n: React.FC<
           },
           {
             Header: i18n._(t`Location`),
+            headerStyle: secondColumnStyle,
+            style: secondColumnStyle,
             columns: [
               {
                 Header: (
@@ -123,6 +132,7 @@ const PropertiesListWithoutI18n: React.FC<
                 accessor: (d) => d.zip,
                 id: "zip",
                 width: getWidthFromLabel(i18n._(t`Zipcode`)),
+                headerStyle: secondColumnStyle,
               },
               {
                 Header: (

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -10,7 +10,7 @@ import "react-table-hoc-fixed-columns/lib/styles.css"; // important: this line m
 
 import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
-import { t } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import { Link } from "react-router-dom";
 import { SupportedLocale } from "../i18n-base";
 import Helpers, { longDateOptions } from "../util/helpers";
@@ -34,6 +34,12 @@ const findMostCommonType = (complaints: HpdComplaintCount[] | null) =>
 const ReactTableFixedColumns = withFixedColumns(ReactTable) as React.ComponentType<
   Partial<TablePropsColumnFixed<AddressRecord, AddressRecord>>
 >;
+
+const ArrowIcon = () => (
+  <span className="arrow-icon">
+    ↑<span>↓</span>
+  </span>
+);
 
 const PropertiesListWithoutI18n: React.FC<
   withMachineInStateProps<"portfolioFound"> & {
@@ -60,7 +66,12 @@ const PropertiesListWithoutI18n: React.FC<
             fixed: "left",
             columns: [
               {
-                Header: i18n._(t`Address`) + " ⇅",
+                Header: (
+                  <>
+                    <Trans>Address</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => `${d.housenumber} ${d.streetname}`,
                 id: "address",
                 minWidth: 130,
@@ -68,6 +79,7 @@ const PropertiesListWithoutI18n: React.FC<
                 style: {
                   textAlign: "left",
                   whiteSpace: "unset",
+                  paddingRight: "0.75rem",
                 },
               },
             ],
@@ -76,18 +88,33 @@ const PropertiesListWithoutI18n: React.FC<
             Header: i18n._(t`Location`),
             columns: [
               {
-                Header: i18n._(t`Zipcode`) + " ⇅",
+                Header: (
+                  <>
+                    <Trans>Zipcode</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.zip,
                 id: "zip",
                 width: 85,
               },
               {
-                Header: i18n._(t`Borough`) + " ⇅",
+                Header: (
+                  <>
+                    <Trans>Borough</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.boro,
                 id: "boro",
               },
               {
-                Header: "BBL ⇅",
+                Header: (
+                  <>
+                    BBL
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.bbl,
                 id: "bbl",
               },
@@ -97,13 +124,23 @@ const PropertiesListWithoutI18n: React.FC<
             Header: i18n._(t`Information`),
             columns: [
               {
-                Header: i18n._(t`Built`),
+                Header: (
+                  <>
+                    <Trans>Built</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.yearbuilt,
                 id: "yearbuilt",
                 maxWidth: 75,
               },
               {
-                Header: i18n._(t`Units`),
+                Header: (
+                  <>
+                    <Trans>Units</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.unitsres,
                 id: "unitsres",
                 maxWidth: 75,
@@ -114,13 +151,23 @@ const PropertiesListWithoutI18n: React.FC<
             Header: i18n._(t`RS Units`),
             columns: [
               {
-                Header: "2007",
+                Header: (
+                  <>
+                    2007
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.rsunits2007,
                 id: "rsunits2007",
                 maxWidth: 75,
               },
               {
-                Header: rsunitslatestyear,
+                Header: (
+                  <>
+                    {rsunitslatestyear}
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.rsunitslatest,
                 id: "rsunitslatest",
                 Cell: (row) => {
@@ -142,19 +189,34 @@ const PropertiesListWithoutI18n: React.FC<
             Header: i18n._(t`HPD Complaints`),
             columns: [
               {
-                Header: i18n._(t`Total`),
+                Header: (
+                  <>
+                    <Trans>Total</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.totalcomplaints,
                 id: "totalcomplaints",
                 maxWidth: 75,
               },
               {
-                Header: i18n._(t`Last 3 Years`),
+                Header: (
+                  <>
+                    <Trans>Last 3 Years</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.recentcomplaints,
                 id: "recentcomplaints",
                 maxWidth: 100,
               },
               {
-                Header: i18n._(t`Top Complaint`),
+                Header: (
+                  <>
+                    <Trans>Top Complaint</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => {
                   const mostCommonType = findMostCommonType(d.recentcomplaintsbytype);
                   return mostCommonType
@@ -170,13 +232,23 @@ const PropertiesListWithoutI18n: React.FC<
             Header: i18n._(t`HPD Violations`),
             columns: [
               {
-                Header: i18n._(t`Open`),
+                Header: (
+                  <>
+                    <Trans>Open</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.openviolations,
                 id: "openviolations",
                 maxWidth: 75,
               },
               {
-                Header: i18n._(t`Total`),
+                Header: (
+                  <>
+                    <Trans>Total</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.totalviolations,
                 id: "totalviolations",
                 maxWidth: 75,
@@ -187,7 +259,12 @@ const PropertiesListWithoutI18n: React.FC<
             Header: i18n._(t`Evictions`),
             columns: [
               {
-                Header: i18n._(t`Since 2017`),
+                Header: (
+                  <>
+                    <Trans>Since 2017</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.evictions || null,
                 id: "evictions",
                 maxWidth: 100,
@@ -198,7 +275,12 @@ const PropertiesListWithoutI18n: React.FC<
             Header: i18n._(t`Landlord`),
             columns: [
               {
-                Header: i18n._(t`Officer/Owner`),
+                Header: (
+                  <>
+                    <Trans>Officer/Owner</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => {
                   var owner =
                     d.ownernames &&
@@ -216,7 +298,12 @@ const PropertiesListWithoutI18n: React.FC<
             Header: i18n._(t`Last Sale`),
             columns: [
               {
-                Header: i18n._(t`Date`),
+                Header: (
+                  <>
+                    <Trans>Date</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.lastsaledate,
                 Cell: (row) =>
                   row.original.lastsaledate
@@ -225,7 +312,12 @@ const PropertiesListWithoutI18n: React.FC<
                 id: "lastsaledate",
               },
               {
-                Header: i18n._(t`Amount`),
+                Header: (
+                  <>
+                    <Trans>Amount</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => d.lastsaleamount || null,
                 Cell: (row) =>
                   row.original.lastsaleamount
@@ -251,7 +343,12 @@ const PropertiesListWithoutI18n: React.FC<
                 id: "lastsaleacrisid",
               },
               {
-                Header: i18n._(t`Group Sale?`),
+                Header: (
+                  <>
+                    <Trans>Group Sale?</Trans>
+                    <ArrowIcon />
+                  </>
+                ),
                 accessor: (d) => {
                   // Make id's that are part of group sales show up first when sorted:
                   const idPrefix =

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -60,12 +60,13 @@ const PropertiesListWithoutI18n: React.FC<
             fixed: "left",
             columns: [
               {
-                Header: i18n._(t`Address`),
+                Header: i18n._(t`Address`) + " ⇅",
                 accessor: (d) => `${d.housenumber} ${d.streetname}`,
                 id: "address",
                 minWidth: 130,
                 style: {
                   textAlign: "left",
+                  whiteSpace: "unset",
                 },
               },
             ],
@@ -74,18 +75,18 @@ const PropertiesListWithoutI18n: React.FC<
             Header: i18n._(t`Location`),
             columns: [
               {
-                Header: i18n._(t`Zipcode`),
+                Header: i18n._(t`Zipcode`) + " ⇅",
                 accessor: (d) => d.zip,
                 id: "zip",
-                width: 75,
+                width: 85,
               },
               {
-                Header: i18n._(t`Borough`),
+                Header: i18n._(t`Borough`) + " ⇅",
                 accessor: (d) => d.boro,
                 id: "boro",
               },
               {
-                Header: "BBL",
+                Header: "BBL" + " ⇅",
                 accessor: (d) => d.bbl,
                 id: "bbl",
               },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -87,7 +87,7 @@ const PropertiesListWithoutI18n: React.FC<
   const hideScrollFade = isOlderBrowser || isLastColumnVisible;
 
   const firstHeaderRef = useRef<HTMLDivElement>(null);
-  const [headerTopSpacing, setHeaderTopSpacing] = useState(0);
+  const [headerTopSpacing, setHeaderTopSpacing] = useState<number | undefined>();
 
   // Make sure to setHeaderTopSpacing whenever the user changes the page's locale:
   useEffect(() => {
@@ -110,7 +110,7 @@ const PropertiesListWithoutI18n: React.FC<
             fixed: "left",
             headerStyle: {
               height: `${HEADER_HEIGHT}px`,
-              ...(headerTopSpacing > 0 && {
+              ...(!!headerTopSpacing && {
                 top: `${headerTopSpacing}px`,
               }),
             },
@@ -123,7 +123,7 @@ const PropertiesListWithoutI18n: React.FC<
                   </div>
                 ),
                 headerStyle: {
-                  ...(headerTopSpacing > 0 && {
+                  ...(!!headerTopSpacing && {
                     top: `${headerTopSpacing + HEADER_HEIGHT}px`,
                   }),
                 },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -208,7 +208,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.recentcomplaints,
                 id: "recentcomplaints",
-                maxWidth: 100,
+                minWidth: 115,
               },
               {
                 Header: (
@@ -362,6 +362,7 @@ const PropertiesListWithoutI18n: React.FC<
                       : i18n._(t`No`)
                     : null,
                 id: "lastsaleisgroupsale",
+                minWidth: 110,
               },
             ],
           },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -268,7 +268,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.openviolations,
                 id: "openviolations",
-                width: getWidthFromLabel(i18n._(t`Open`)),
+                width: getWidthFromLabel(i18n._(t`Open`), 80),
               },
               {
                 Header: (
@@ -279,7 +279,7 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => d.totalviolations,
                 id: "totalviolations",
-                width: getWidthFromLabel(i18n._(t`Total`)),
+                width: getWidthFromLabel(i18n._(t`Total`), 80),
               },
             ],
           },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -89,9 +89,10 @@ const PropertiesListWithoutI18n: React.FC<
   const firstHeaderRef = useRef<HTMLDivElement>(null);
   const [headerTopSpacing, setHeaderTopSpacing] = useState(0);
 
+  // Make sure to setHeaderTopSpacing whenever the user changes the page's locale:
   useEffect(() => {
     if (firstHeaderRef?.current?.offsetTop) setHeaderTopSpacing(firstHeaderRef.current.offsetTop);
-  });
+  }, [i18n.language, window.innerHeight]);
 
   return (
     <div

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -4,6 +4,10 @@ import Browser from "../util/browser";
 
 import "react-table/react-table.css";
 import "styles/PropertiesList.css";
+
+import withFixedColumns, { TablePropsColumnFixed } from "react-table-hoc-fixed-columns";
+import "react-table-hoc-fixed-columns/lib/styles.css"; // important: this line must be placed after react-table css import
+
 import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
 import { t } from "@lingui/macro";
@@ -22,6 +26,15 @@ export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
 const findMostCommonType = (complaints: HpdComplaintCount[] | null) =>
   complaints && complaints.length > 0 && complaints[0].type;
 
+/**
+ * By default, the `withFixedColumns` hook retypes the Column components within the table
+ * as having data arrays of type `unknown`, so this recasting is necessary to make sure
+ * we are tyepchecking the raw data as `AddressRecords`
+ */
+const ReactTableFixedColumns = withFixedColumns(ReactTable) as React.ComponentType<
+  Partial<TablePropsColumnFixed<AddressRecord, AddressRecord>>
+>;
+
 const PropertiesListWithoutI18n: React.FC<
   withMachineInStateProps<"portfolioFound"> & {
     i18n: I18n;
@@ -34,26 +47,32 @@ const PropertiesListWithoutI18n: React.FC<
 
   const addrs = props.state.context.portfolioData.assocAddrs;
   const rsunitslatestyear = props.state.context.portfolioData.searchAddr.rsunitslatestyear;
+
   return (
     <div className="PropertiesList">
-      <ReactTable
+      <ReactTableFixedColumns
         data={addrs}
         minRows={Browser.isMobile() ? 5 : 10}
         defaultPageSize={addrs.length}
         showPagination={false}
         columns={[
           {
-            Header: i18n._(t`Location`),
+            fixed: "left",
             columns: [
               {
                 Header: i18n._(t`Address`),
                 accessor: (d) => `${d.housenumber} ${d.streetname}`,
                 id: "address",
-                minWidth: 150,
+                minWidth: 130,
                 style: {
                   textAlign: "left",
                 },
               },
+            ],
+          },
+          {
+            Header: i18n._(t`Location`),
+            columns: [
               {
                 Header: i18n._(t`Zipcode`),
                 accessor: (d) => d.zip,

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -86,18 +86,23 @@ const PropertiesListWithoutI18n: React.FC<
    */
   const hideScrollFade = isOlderBrowser || isLastColumnVisible;
 
-  const firstHeaderRef = useRef<HTMLDivElement>(null);
+  const tableRef = useRef<HTMLDivElement>(null);
+  const isTableVisible = Helpers.useOnScreen(tableRef);
+
   const [headerTopSpacing, setHeaderTopSpacing] = useState<number | undefined>();
 
-  // Make sure to setHeaderTopSpacing whenever the user changes the page's locale:
+  // Make sure to setHeaderTopSpacing whenever
+  // - the page's locale changes
+  // - the table comes into view
+  // - the user resizes their viewport window
   useEffect(() => {
-    if (firstHeaderRef?.current?.offsetTop) setHeaderTopSpacing(firstHeaderRef.current.offsetTop);
-  }, [i18n.language]);
+    if (tableRef?.current?.offsetTop) setHeaderTopSpacing(tableRef.current.offsetTop);
+  }, [i18n.language, isTableVisible, Helpers.useWindowSize()]);
 
   return (
     <div
       className={classnames("PropertiesList", hideScrollFade && "hide-scroll-fade")}
-      ref={firstHeaderRef}
+      ref={tableRef}
     >
       <ReactTableFixedColumns
         data={addrs}

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -79,8 +79,9 @@ const PropertiesListWithoutI18n: React.FC<
                 ),
                 accessor: (d) => `${d.housenumber} ${d.streetname}`,
                 id: "address",
-                minWidth: 130,
+                width: 130,
                 fixed: "left",
+                resizable: false,
                 style: {
                   textAlign: "left",
                   whiteSpace: "unset",

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -97,7 +97,12 @@ const PropertiesListWithoutI18n: React.FC<
   // - the user resizes their viewport window
   useEffect(() => {
     if (tableRef?.current?.offsetTop) setHeaderTopSpacing(tableRef.current.offsetTop);
-  }, [i18n.language, isTableVisible, Helpers.useWindowSize()]);
+  }, [
+    i18n.language,
+    isTableVisible,
+    Helpers.useWindowSize().height,
+    Helpers.useWindowSize().width,
+  ]);
 
   return (
     <div

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -67,9 +67,20 @@ const PropertiesListWithoutI18n: React.FC<
 
   const lastColumnRef = createRef<any>();
   const isLastColumnVisible = Helpers.useOnScreen(lastColumnRef);
+  /**
+   * For older browsers that do not support the `useOnScreen` hook,
+   * let's hide the dynamic scroll fade by default.
+   */
+  const isOlderBrowser = typeof IntersectionObserver === "undefined";
+  /**
+   * Let's hide the fade out on the right edge of the table if:
+   * - We've scrolled to the last column OR
+   * - We're using an older browser that cannot detect where we've scrolled
+   */
+  const hideScrollFade = isOlderBrowser || isLastColumnVisible;
 
   return (
-    <div className={classnames("PropertiesList", isLastColumnVisible && "last-column-visible")}>
+    <div className={classnames("PropertiesList", hideScrollFade && "hide-scroll-fade")}>
       <ReactTableFixedColumns
         data={addrs}
         minRows={10}

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -67,6 +67,7 @@ const PropertiesListWithoutI18n: React.FC<
   }
 > = (props) => {
   const { i18n } = props;
+  const { width: windowWidth, height: windowHeight } = Helpers.useWindowSize();
   const locale = (i18n.language as SupportedLocale) || "en";
 
   const addrs = props.state.context.portfolioData.assocAddrs;
@@ -92,17 +93,12 @@ const PropertiesListWithoutI18n: React.FC<
   const [headerTopSpacing, setHeaderTopSpacing] = useState<number | undefined>();
 
   // Make sure to setHeaderTopSpacing whenever
-  // - the page's locale changes
   // - the table comes into view
+  // - the page's locale changes
   // - the user resizes their viewport window
   useEffect(() => {
     if (tableRef?.current?.offsetTop) setHeaderTopSpacing(tableRef.current.offsetTop);
-  }, [
-    i18n.language,
-    isTableVisible,
-    Helpers.useWindowSize().height,
-    Helpers.useWindowSize().width,
-  ]);
+  }, [isTableVisible, locale, windowWidth, windowHeight]);
 
   return (
     <div

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -72,7 +72,7 @@ msgstr "According to available HPD data, this portfolio has received <0>{totalvi
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:42
+#: src/components/PropertiesList.tsx:49
 msgid "Address"
 msgstr "Address"
 
@@ -88,7 +88,8 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:247
+#: src/components/PropertiesList.tsx:256
+#: src/components/PropertiesList.tsx:264
 msgid "Amount"
 msgstr "Amount"
 
@@ -113,7 +114,8 @@ msgstr "BUILDING:"
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
-#: src/components/PropertiesList.tsx:72
+#: src/components/PropertiesList.tsx:78
+#: src/components/PropertiesList.tsx:83
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -141,7 +143,8 @@ msgstr "Building Permits Applied For"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:93
+#: src/components/PropertiesList.tsx:101
+#: src/components/PropertiesList.tsx:106
 msgid "Built"
 msgstr "Built"
 
@@ -233,7 +236,8 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PropertiesList.tsx:236
+#: src/components/PropertiesList.tsx:244
+#: src/components/PropertiesList.tsx:252
 msgid "Date"
 msgstr "Date"
 
@@ -279,7 +283,7 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:200
+#: src/components/PropertiesList.tsx:208
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -321,7 +325,8 @@ msgstr "GARBAGE/RECYCLING STORAGE"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:267
+#: src/components/PropertiesList.tsx:277
+#: src/components/PropertiesList.tsx:291
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -338,7 +343,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:140
+#: src/components/PropertiesList.tsx:148
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -347,7 +352,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:177
+#: src/components/PropertiesList.tsx:185
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -393,7 +398,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:89
+#: src/components/PropertiesList.tsx:97
 msgid "Information"
 msgstr "Information"
 
@@ -421,7 +426,7 @@ msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PropertiesList.tsx:214
+#: src/components/PropertiesList.tsx:222
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Landlord"
@@ -430,11 +435,12 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:153
+#: src/components/PropertiesList.tsx:161
+#: src/components/PropertiesList.tsx:166
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PropertiesList.tsx:232
+#: src/components/PropertiesList.tsx:240
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -462,8 +468,9 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PropertiesList.tsx:257
-#: src/components/PropertiesList.tsx:259
+#: src/components/PropertiesList.tsx:267
+#: src/components/PropertiesList.tsx:269
+#: src/components/PropertiesList.tsx:273
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -475,7 +482,7 @@ msgstr "Link to Deed"
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:59
+#: src/components/PropertiesList.tsx:65
 msgid "Location"
 msgstr "Location"
 
@@ -536,7 +543,7 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:278
+#: src/components/PropertiesList.tsx:288
 msgid "No"
 msgstr "No"
 
@@ -577,7 +584,8 @@ msgstr "OUTSIDE BUILDING"
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PropertiesList.tsx:218
+#: src/components/PropertiesList.tsx:226
+#: src/components/PropertiesList.tsx:235
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -591,7 +599,8 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:181
+#: src/components/PropertiesList.tsx:189
+#: src/components/PropertiesList.tsx:194
 msgid "Open"
 msgstr "Open"
 
@@ -650,7 +659,7 @@ msgid "Quarter"
 msgstr "Quarter"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:112
+#: src/components/PropertiesList.tsx:120
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -716,7 +725,8 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:204
+#: src/components/PropertiesList.tsx:212
+#: src/components/PropertiesList.tsx:217
 msgid "Since 2017"
 msgstr "Since 2017"
 
@@ -886,13 +896,16 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PropertiesList.tsx:162
+#: src/components/PropertiesList.tsx:170
+#: src/components/PropertiesList.tsx:180
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:144
-#: src/components/PropertiesList.tsx:190
+#: src/components/PropertiesList.tsx:152
+#: src/components/PropertiesList.tsx:157
+#: src/components/PropertiesList.tsx:198
+#: src/components/PropertiesList.tsx:203
 msgid "Total"
 msgstr "Total"
 
@@ -909,7 +922,8 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:102
+#: src/components/PropertiesList.tsx:110
+#: src/components/PropertiesList.tsx:115
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -936,8 +950,9 @@ msgstr "View by:"
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PropertiesList.tsx:287
-#: src/components/PropertiesList.tsx:293
+#: src/components/PropertiesList.tsx:297
+#: src/components/PropertiesList.tsx:303
+#: src/components/PropertiesList.tsx:307
 msgid "View detail"
 msgstr "View detail"
 
@@ -1030,7 +1045,7 @@ msgstr "Year"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:277
+#: src/components/PropertiesList.tsx:287
 msgid "Yes"
 msgstr "Yes"
 
@@ -1038,7 +1053,8 @@ msgstr "Yes"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:63
+#: src/components/PropertiesList.tsx:69
+#: src/components/PropertiesList.tsx:74
 msgid "Zipcode"
 msgstr "Zipcode"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -88,7 +88,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:246
+#: src/components/PropertiesList.tsx:247
 msgid "Amount"
 msgstr "Amount"
 
@@ -113,7 +113,7 @@ msgstr "BUILDING:"
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
-#: src/components/PropertiesList.tsx:71
+#: src/components/PropertiesList.tsx:72
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -141,7 +141,7 @@ msgstr "Building Permits Applied For"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:92
+#: src/components/PropertiesList.tsx:93
 msgid "Built"
 msgstr "Built"
 
@@ -233,7 +233,7 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PropertiesList.tsx:235
+#: src/components/PropertiesList.tsx:236
 msgid "Date"
 msgstr "Date"
 
@@ -279,7 +279,7 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:199
+#: src/components/PropertiesList.tsx:200
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -321,7 +321,7 @@ msgstr "GARBAGE/RECYCLING STORAGE"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:266
+#: src/components/PropertiesList.tsx:267
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -338,7 +338,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:139
+#: src/components/PropertiesList.tsx:140
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -347,7 +347,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:176
+#: src/components/PropertiesList.tsx:177
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -393,7 +393,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:88
+#: src/components/PropertiesList.tsx:89
 msgid "Information"
 msgstr "Information"
 
@@ -421,7 +421,7 @@ msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PropertiesList.tsx:213
+#: src/components/PropertiesList.tsx:214
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Landlord"
@@ -430,11 +430,11 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:152
+#: src/components/PropertiesList.tsx:153
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PropertiesList.tsx:231
+#: src/components/PropertiesList.tsx:232
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -462,8 +462,8 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PropertiesList.tsx:256
-#: src/components/PropertiesList.tsx:258
+#: src/components/PropertiesList.tsx:257
+#: src/components/PropertiesList.tsx:259
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -475,7 +475,7 @@ msgstr "Link to Deed"
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:58
+#: src/components/PropertiesList.tsx:59
 msgid "Location"
 msgstr "Location"
 
@@ -536,7 +536,7 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:277
+#: src/components/PropertiesList.tsx:278
 msgid "No"
 msgstr "No"
 
@@ -577,7 +577,7 @@ msgstr "OUTSIDE BUILDING"
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PropertiesList.tsx:217
+#: src/components/PropertiesList.tsx:218
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -591,7 +591,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:181
 msgid "Open"
 msgstr "Open"
 
@@ -650,7 +650,7 @@ msgid "Quarter"
 msgstr "Quarter"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:111
+#: src/components/PropertiesList.tsx:112
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -716,7 +716,7 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:203
+#: src/components/PropertiesList.tsx:204
 msgid "Since 2017"
 msgstr "Since 2017"
 
@@ -886,13 +886,13 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PropertiesList.tsx:161
+#: src/components/PropertiesList.tsx:162
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:143
-#: src/components/PropertiesList.tsx:189
+#: src/components/PropertiesList.tsx:144
+#: src/components/PropertiesList.tsx:190
 msgid "Total"
 msgstr "Total"
 
@@ -909,7 +909,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:101
+#: src/components/PropertiesList.tsx:102
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -936,8 +936,8 @@ msgstr "View by:"
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PropertiesList.tsx:286
-#: src/components/PropertiesList.tsx:292
+#: src/components/PropertiesList.tsx:287
+#: src/components/PropertiesList.tsx:293
 msgid "View detail"
 msgstr "View detail"
 
@@ -1030,7 +1030,7 @@ msgstr "Year"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:276
+#: src/components/PropertiesList.tsx:277
 msgid "Yes"
 msgstr "Yes"
 
@@ -1038,7 +1038,7 @@ msgstr "Yes"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:62
+#: src/components/PropertiesList.tsx:63
 msgid "Zipcode"
 msgstr "Zipcode"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -72,7 +72,7 @@ msgstr "According to available HPD data, this portfolio has received <0>{totalvi
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:26
+#: src/components/PropertiesList.tsx:38
 msgid "Address"
 msgstr "Address"
 
@@ -88,7 +88,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:174
+#: src/components/PropertiesList.tsx:242
 msgid "Amount"
 msgstr "Amount"
 
@@ -113,7 +113,7 @@ msgstr "BUILDING:"
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
-#: src/components/PropertiesList.tsx:41
+#: src/components/PropertiesList.tsx:67
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -141,7 +141,7 @@ msgstr "Building Permits Applied For"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:56
+#: src/components/PropertiesList.tsx:88
 msgid "Built"
 msgstr "Built"
 
@@ -233,7 +233,7 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesList.tsx:231
 msgid "Date"
 msgstr "Date"
 
@@ -279,7 +279,7 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:137
+#: src/components/PropertiesList.tsx:195
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -321,7 +321,7 @@ msgstr "GARBAGE/RECYCLING STORAGE"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:190
+#: src/components/PropertiesList.tsx:261
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -338,7 +338,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:92
+#: src/components/PropertiesList.tsx:135
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -347,7 +347,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:120
+#: src/components/PropertiesList.tsx:172
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -393,7 +393,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:53
+#: src/components/PropertiesList.tsx:84
 msgid "Information"
 msgstr "Information"
 
@@ -421,7 +421,7 @@ msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PropertiesList.tsx:148
+#: src/components/PropertiesList.tsx:209
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Landlord"
@@ -430,11 +430,11 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:101
+#: src/components/PropertiesList.tsx:148
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PropertiesList.tsx:163
+#: src/components/PropertiesList.tsx:227
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -462,8 +462,8 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PropertiesList.tsx:182
-#: src/components/PropertiesList.tsx:184
+#: src/components/PropertiesList.tsx:252
+#: src/components/PropertiesList.tsx:254
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -475,7 +475,7 @@ msgstr "Link to Deed"
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:23
+#: src/components/PropertiesList.tsx:54
 msgid "Location"
 msgstr "Location"
 
@@ -536,7 +536,7 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:199
+#: src/components/PropertiesList.tsx:272
 msgid "No"
 msgstr "No"
 
@@ -577,7 +577,7 @@ msgstr "OUTSIDE BUILDING"
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PropertiesList.tsx:151
+#: src/components/PropertiesList.tsx:213
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -591,7 +591,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:123
+#: src/components/PropertiesList.tsx:176
 msgid "Open"
 msgstr "Open"
 
@@ -650,7 +650,7 @@ msgid "Quarter"
 msgstr "Quarter"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:70
+#: src/components/PropertiesList.tsx:107
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -716,7 +716,7 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:140
+#: src/components/PropertiesList.tsx:199
 msgid "Since 2017"
 msgstr "Since 2017"
 
@@ -886,13 +886,13 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PropertiesList.tsx:107
+#: src/components/PropertiesList.tsx:157
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:95
-#: src/components/PropertiesList.tsx:129
+#: src/components/PropertiesList.tsx:139
+#: src/components/PropertiesList.tsx:185
 msgid "Total"
 msgstr "Total"
 
@@ -909,7 +909,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:62
+#: src/components/PropertiesList.tsx:97
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -936,8 +936,8 @@ msgstr "View by:"
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PropertiesList.tsx:206
-#: src/components/PropertiesList.tsx:211
+#: src/components/PropertiesList.tsx:279
+#: src/components/PropertiesList.tsx:284
 msgid "View detail"
 msgstr "View detail"
 
@@ -1030,7 +1030,7 @@ msgstr "Year"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:198
+#: src/components/PropertiesList.tsx:271
 msgid "Yes"
 msgstr "Yes"
 
@@ -1038,7 +1038,7 @@ msgstr "Yes"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:35
+#: src/components/PropertiesList.tsx:58
 msgid "Zipcode"
 msgstr "Zipcode"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/util/helpers.ts:241
+#: src/util/helpers.ts:242
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
@@ -55,7 +55,7 @@ msgstr "<0>While the legal owner of a building is often a company (usually calle
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
 
-#: src/util/helpers.ts:53
+#: src/util/helpers.ts:54
 msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
@@ -72,11 +72,11 @@ msgstr "According to available HPD data, this portfolio has received <0>{totalvi
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:38
+#: src/components/PropertiesList.tsx:42
 msgid "Address"
 msgstr "Address"
 
-#: src/util/helpers.ts:68
+#: src/util/helpers.ts:69
 msgid "Agent"
 msgstr "Agent"
 
@@ -88,7 +88,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:242
+#: src/components/PropertiesList.tsx:246
 msgid "Amount"
 msgstr "Amount"
 
@@ -100,7 +100,7 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/util/helpers.ts:33
+#: src/util/helpers.ts:34
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
@@ -113,7 +113,7 @@ msgstr "BUILDING:"
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
-#: src/components/PropertiesList.tsx:67
+#: src/components/PropertiesList.tsx:71
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -141,7 +141,7 @@ msgstr "Building Permits Applied For"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:88
+#: src/components/PropertiesList.tsx:92
 msgid "Built"
 msgstr "Built"
 
@@ -155,19 +155,19 @@ msgstr "Business Addresses"
 msgid "Business Entities"
 msgstr "Business Entities"
 
-#: src/util/helpers.ts:42
+#: src/util/helpers.ts:43
 msgid "CABINET"
 msgstr "CABINET"
 
-#: src/util/helpers.ts:55
+#: src/util/helpers.ts:56
 msgid "CERAMIC TILE"
 msgstr "CERAMIC TILE"
 
-#: src/util/helpers.ts:30
+#: src/util/helpers.ts:31
 msgid "CONSTRUCTION"
 msgstr "CONSTRUCTION"
 
-#: src/util/helpers.ts:56
+#: src/util/helpers.ts:57
 msgid "COOKING GAS"
 msgstr "COOKING GAS"
 
@@ -207,11 +207,11 @@ msgstr "Close legend"
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
-#: src/util/helpers.ts:64
+#: src/util/helpers.ts:65
 msgid "Corporate Owner"
 msgstr "Corporate Owner"
 
-#: src/util/helpers.ts:72
+#: src/util/helpers.ts:73
 msgid "Corporation"
 msgstr "Corporation"
 
@@ -225,15 +225,15 @@ msgstr "DOB Building Profile"
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
-#: src/util/helpers.ts:27
+#: src/util/helpers.ts:28
 msgid "DOOR/WINDOW"
 msgstr "DOOR/WINDOW"
 
-#: src/util/helpers.ts:59
+#: src/util/helpers.ts:60
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PropertiesList.tsx:231
+#: src/components/PropertiesList.tsx:235
 msgid "Date"
 msgstr "Date"
 
@@ -254,11 +254,11 @@ msgstr "Donate"
 msgid "Download"
 msgstr "Download"
 
-#: src/util/helpers.ts:50
+#: src/util/helpers.ts:51
 msgid "ELECTRIC"
 msgstr "ELECTRIC"
 
-#: src/util/helpers.ts:40
+#: src/util/helpers.ts:41
 msgid "ELEVATOR"
 msgstr "ELEVATOR"
 
@@ -279,7 +279,7 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:195
+#: src/components/PropertiesList.tsx:199
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -297,15 +297,15 @@ msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD 
 msgid "Export Data"
 msgstr "Export Data"
 
-#: src/util/helpers.ts:35
+#: src/util/helpers.ts:36
 msgid "FIRE ESCAPE"
 msgstr "FIRE ESCAPE"
 
-#: src/util/helpers.ts:45
+#: src/util/helpers.ts:46
 msgid "FLOOR"
 msgstr "FLOOR"
 
-#: src/util/helpers.ts:51
+#: src/util/helpers.ts:52
 msgid "FLOORING/STAIRS"
 msgstr "FLOORING/STAIRS"
 
@@ -313,7 +313,7 @@ msgstr "FLOORING/STAIRS"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/util/helpers.ts:41
+#: src/util/helpers.ts:42
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
@@ -321,15 +321,15 @@ msgstr "GARBAGE/RECYCLING STORAGE"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:261
+#: src/components/PropertiesList.tsx:266
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
-#: src/util/helpers.ts:58
+#: src/util/helpers.ts:59
 msgid "HEAT/HOT WATER"
 msgstr "HEAT/HOT WATER"
 
-#: src/util/helpers.ts:28
+#: src/util/helpers.ts:29
 msgid "HEATING"
 msgstr "HEATING"
 
@@ -338,7 +338,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:135
+#: src/components/PropertiesList.tsx:139
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -347,7 +347,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:172
+#: src/components/PropertiesList.tsx:176
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -359,7 +359,7 @@ msgstr "HPD Violations occur when an official City Inspector finds the condition
 msgid "HUD Complaint Form 958"
 msgstr "HUD Complaint Form 958"
 
-#: src/util/helpers.ts:63
+#: src/util/helpers.ts:64
 msgid "Head Officer"
 msgstr "Head Officer"
 
@@ -385,7 +385,7 @@ msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open viol
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
-#: src/util/helpers.ts:65
+#: src/util/helpers.ts:66
 msgid "Individual Owner"
 msgstr "Individual Owner"
 
@@ -393,7 +393,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:84
+#: src/components/PropertiesList.tsx:88
 msgid "Information"
 msgstr "Information"
 
@@ -401,7 +401,7 @@ msgstr "Information"
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "It doesn't seem like this property is required to register with HPD."
 
-#: src/util/helpers.ts:31
+#: src/util/helpers.ts:32
 msgid "JANITOR/SUPER"
 msgstr "JANITOR/SUPER"
 
@@ -409,7 +409,7 @@ msgstr "JANITOR/SUPER"
 msgid "Join the fight for tenant rights!"
 msgstr "Join the fight for tenant rights!"
 
-#: src/util/helpers.ts:66
+#: src/util/helpers.ts:67
 msgid "Joint Owner"
 msgstr "Joint Owner"
 
@@ -417,11 +417,11 @@ msgstr "Joint Owner"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
-#: src/util/helpers.ts:60
+#: src/util/helpers.ts:61
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PropertiesList.tsx:209
+#: src/components/PropertiesList.tsx:213
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Landlord"
@@ -430,11 +430,11 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:148
+#: src/components/PropertiesList.tsx:152
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PropertiesList.tsx:227
+#: src/components/PropertiesList.tsx:231
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -458,12 +458,12 @@ msgstr "Learn more"
 msgid "Legend"
 msgstr "Legend"
 
-#: src/util/helpers.ts:69
+#: src/util/helpers.ts:70
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PropertiesList.tsx:252
-#: src/components/PropertiesList.tsx:254
+#: src/components/PropertiesList.tsx:256
+#: src/components/PropertiesList.tsx:258
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -475,7 +475,7 @@ msgstr "Link to Deed"
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:54
+#: src/components/PropertiesList.tsx:58
 msgid "Location"
 msgstr "Location"
 
@@ -483,11 +483,11 @@ msgstr "Location"
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
-#: src/util/helpers.ts:38
+#: src/util/helpers.ts:39
 msgid "MAILBOX"
 msgstr "MAILBOX"
 
-#: src/util/helpers.ts:48
+#: src/util/helpers.ts:49
 msgid "MOLD"
 msgstr "MOLD"
 
@@ -520,7 +520,7 @@ msgstr "Most Common 311 Complaints, Last 3 Years"
 msgid "MyNYCHA App"
 msgstr "MyNYCHA App"
 
-#: src/util/helpers.ts:54
+#: src/util/helpers.ts:55
 msgid "NON-CONSTRUCTION"
 msgstr "NON-CONSTRUCTION"
 
@@ -536,7 +536,7 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:272
+#: src/components/PropertiesList.tsx:277
 msgid "No"
 msgstr "No"
 
@@ -569,15 +569,15 @@ msgstr "None"
 msgid "Not found"
 msgstr "Not found"
 
-#: src/util/helpers.ts:32
+#: src/util/helpers.ts:33
 msgid "OUTSIDE BUILDING"
 msgstr "OUTSIDE BUILDING"
 
-#: src/util/helpers.ts:70
+#: src/util/helpers.ts:71
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PropertiesList.tsx:213
+#: src/components/PropertiesList.tsx:217
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -591,7 +591,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:176
+#: src/components/PropertiesList.tsx:180
 msgid "Open"
 msgstr "Open"
 
@@ -607,15 +607,15 @@ msgstr "Overview"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 
-#: src/util/helpers.ts:52
+#: src/util/helpers.ts:53
 msgid "PAINT/PLASTER"
 msgstr "PAINT/PLASTER"
 
-#: src/util/helpers.ts:37
+#: src/util/helpers.ts:38
 msgid "PESTS"
 msgstr "PESTS"
 
-#: src/util/helpers.ts:46
+#: src/util/helpers.ts:47
 msgid "PLUMBING"
 msgstr "PLUMBING"
 
@@ -650,7 +650,7 @@ msgid "Quarter"
 msgstr "Quarter"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:107
+#: src/components/PropertiesList.tsx:111
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -658,19 +658,19 @@ msgstr "RS Units"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/util/helpers.ts:57
+#: src/util/helpers.ts:58
 msgid "SAFETY"
 msgstr "SAFETY"
 
-#: src/util/helpers.ts:34
+#: src/util/helpers.ts:35
 msgid "SEWAGE"
 msgstr "SEWAGE"
 
-#: src/util/helpers.ts:36
+#: src/util/helpers.ts:37
 msgid "SIGNAGE MISSING"
 msgstr "SIGNAGE MISSING"
 
-#: src/util/helpers.ts:29
+#: src/util/helpers.ts:30
 msgid "STAIRS"
 msgstr "STAIRS"
 
@@ -704,7 +704,7 @@ msgstr "Share"
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
 
-#: src/util/helpers.ts:71
+#: src/util/helpers.ts:72
 msgid "Shareholder"
 msgstr "Shareholder"
 
@@ -716,7 +716,7 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:199
+#: src/components/PropertiesList.tsx:203
 msgid "Since 2017"
 msgstr "Since 2017"
 
@@ -724,7 +724,7 @@ msgstr "Since 2017"
 msgid "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/util/helpers.ts:67
+#: src/util/helpers.ts:68
 msgid "Site Manager"
 msgstr "Site Manager"
 
@@ -748,7 +748,7 @@ msgstr "Source code"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/util/helpers.ts:43
+#: src/util/helpers.ts:44
 msgid "TENANT HARASSMENT"
 msgstr "TENANT HARASSMENT"
 
@@ -886,13 +886,13 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PropertiesList.tsx:157
+#: src/components/PropertiesList.tsx:161
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:139
-#: src/components/PropertiesList.tsx:185
+#: src/components/PropertiesList.tsx:143
+#: src/components/PropertiesList.tsx:189
 msgid "Total"
 msgstr "Total"
 
@@ -909,7 +909,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:97
+#: src/components/PropertiesList.tsx:101
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -924,7 +924,7 @@ msgstr "Use this free tool from JustFix.nyc to research your building and invest
 msgid "Useful links"
 msgstr "Useful links"
 
-#: src/util/helpers.ts:47
+#: src/util/helpers.ts:48
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
@@ -936,8 +936,8 @@ msgstr "View by:"
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PropertiesList.tsx:279
-#: src/components/PropertiesList.tsx:284
+#: src/components/PropertiesList.tsx:286
+#: src/components/PropertiesList.tsx:292
 msgid "View detail"
 msgstr "View detail"
 
@@ -971,15 +971,15 @@ msgstr "Violations Issued"
 msgid "Visit our website"
 msgstr "Visit our website"
 
-#: src/util/helpers.ts:49
+#: src/util/helpers.ts:50
 msgid "WATER LEAK"
 msgstr "WATER LEAK"
 
-#: src/util/helpers.ts:44
+#: src/util/helpers.ts:45
 msgid "WINDOW GUARDS"
 msgstr "WINDOW GUARDS"
 
-#: src/util/helpers.ts:39
+#: src/util/helpers.ts:40
 msgid "WINDOWS"
 msgstr "WINDOWS"
 
@@ -1030,7 +1030,7 @@ msgstr "Year"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:271
+#: src/components/PropertiesList.tsx:276
 msgid "Yes"
 msgstr "Yes"
 
@@ -1038,7 +1038,7 @@ msgstr "Yes"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:58
+#: src/components/PropertiesList.tsx:62
 msgid "Zipcode"
 msgstr "Zipcode"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -77,7 +77,7 @@ msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha re
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:42
+#: src/components/PropertiesList.tsx:49
 msgid "Address"
 msgstr "Dirección"
 
@@ -93,7 +93,8 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:247
+#: src/components/PropertiesList.tsx:256
+#: src/components/PropertiesList.tsx:264
 msgid "Amount"
 msgstr "Importe"
 
@@ -118,7 +119,8 @@ msgstr "EDIFICIO:"
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
-#: src/components/PropertiesList.tsx:72
+#: src/components/PropertiesList.tsx:78
+#: src/components/PropertiesList.tsx:83
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -146,7 +148,8 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:93
+#: src/components/PropertiesList.tsx:101
+#: src/components/PropertiesList.tsx:106
 msgid "Built"
 msgstr "Construido"
 
@@ -238,7 +241,8 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PropertiesList.tsx:236
+#: src/components/PropertiesList.tsx:244
+#: src/components/PropertiesList.tsx:252
 msgid "Date"
 msgstr "Fecha"
 
@@ -284,7 +288,7 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:200
+#: src/components/PropertiesList.tsx:208
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -326,7 +330,8 @@ msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:267
+#: src/components/PropertiesList.tsx:277
+#: src/components/PropertiesList.tsx:291
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -343,7 +348,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:140
+#: src/components/PropertiesList.tsx:148
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -352,7 +357,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:177
+#: src/components/PropertiesList.tsx:185
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
@@ -398,7 +403,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
-#: src/components/PropertiesList.tsx:89
+#: src/components/PropertiesList.tsx:97
 msgid "Information"
 msgstr "Información"
 
@@ -426,7 +431,7 @@ msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucr
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PropertiesList.tsx:214
+#: src/components/PropertiesList.tsx:222
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Dueño del edificio"
@@ -435,11 +440,12 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:153
+#: src/components/PropertiesList.tsx:161
+#: src/components/PropertiesList.tsx:166
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PropertiesList.tsx:232
+#: src/components/PropertiesList.tsx:240
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -467,8 +473,9 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PropertiesList.tsx:257
-#: src/components/PropertiesList.tsx:259
+#: src/components/PropertiesList.tsx:267
+#: src/components/PropertiesList.tsx:269
+#: src/components/PropertiesList.tsx:273
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -480,7 +487,7 @@ msgstr "Enlace a la Escritura"
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:59
+#: src/components/PropertiesList.tsx:65
 msgid "Location"
 msgstr "Ubicación"
 
@@ -541,7 +548,7 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:278
+#: src/components/PropertiesList.tsx:288
 msgid "No"
 msgstr "No"
 
@@ -582,7 +589,8 @@ msgstr "AFUERA DEL EDIFICIO"
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PropertiesList.tsx:218
+#: src/components/PropertiesList.tsx:226
+#: src/components/PropertiesList.tsx:235
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -596,7 +604,8 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:181
+#: src/components/PropertiesList.tsx:189
+#: src/components/PropertiesList.tsx:194
 msgid "Open"
 msgstr "Actuales"
 
@@ -655,7 +664,7 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:112
+#: src/components/PropertiesList.tsx:120
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
@@ -721,7 +730,8 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:204
+#: src/components/PropertiesList.tsx:212
+#: src/components/PropertiesList.tsx:217
 msgid "Since 2017"
 msgstr "Desde 2017"
 
@@ -891,13 +901,16 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PropertiesList.tsx:162
+#: src/components/PropertiesList.tsx:170
+#: src/components/PropertiesList.tsx:180
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:144
-#: src/components/PropertiesList.tsx:190
+#: src/components/PropertiesList.tsx:152
+#: src/components/PropertiesList.tsx:157
+#: src/components/PropertiesList.tsx:198
+#: src/components/PropertiesList.tsx:203
 msgid "Total"
 msgstr "Total"
 
@@ -914,7 +927,8 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:102
+#: src/components/PropertiesList.tsx:110
+#: src/components/PropertiesList.tsx:115
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades Residenciales"
@@ -941,8 +955,9 @@ msgstr "Visualizar por:"
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PropertiesList.tsx:287
-#: src/components/PropertiesList.tsx:293
+#: src/components/PropertiesList.tsx:297
+#: src/components/PropertiesList.tsx:303
+#: src/components/PropertiesList.tsx:307
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -1035,7 +1050,7 @@ msgstr "Año"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:277
+#: src/components/PropertiesList.tsx:287
 msgid "Yes"
 msgstr "Sí"
 
@@ -1043,7 +1058,8 @@ msgstr "Sí"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:63
+#: src/components/PropertiesList.tsx:69
+#: src/components/PropertiesList.tsx:74
 msgid "Zipcode"
 msgstr "Código postal"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -93,7 +93,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:246
+#: src/components/PropertiesList.tsx:247
 msgid "Amount"
 msgstr "Importe"
 
@@ -118,7 +118,7 @@ msgstr "EDIFICIO:"
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
-#: src/components/PropertiesList.tsx:71
+#: src/components/PropertiesList.tsx:72
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -146,7 +146,7 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:92
+#: src/components/PropertiesList.tsx:93
 msgid "Built"
 msgstr "Construido"
 
@@ -238,7 +238,7 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PropertiesList.tsx:235
+#: src/components/PropertiesList.tsx:236
 msgid "Date"
 msgstr "Fecha"
 
@@ -284,7 +284,7 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:199
+#: src/components/PropertiesList.tsx:200
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -326,7 +326,7 @@ msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:266
+#: src/components/PropertiesList.tsx:267
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -343,7 +343,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:139
+#: src/components/PropertiesList.tsx:140
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -352,7 +352,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:176
+#: src/components/PropertiesList.tsx:177
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
@@ -398,7 +398,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
-#: src/components/PropertiesList.tsx:88
+#: src/components/PropertiesList.tsx:89
 msgid "Information"
 msgstr "Información"
 
@@ -426,7 +426,7 @@ msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucr
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PropertiesList.tsx:213
+#: src/components/PropertiesList.tsx:214
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Dueño del edificio"
@@ -435,11 +435,11 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:152
+#: src/components/PropertiesList.tsx:153
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PropertiesList.tsx:231
+#: src/components/PropertiesList.tsx:232
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -467,8 +467,8 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PropertiesList.tsx:256
-#: src/components/PropertiesList.tsx:258
+#: src/components/PropertiesList.tsx:257
+#: src/components/PropertiesList.tsx:259
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -480,7 +480,7 @@ msgstr "Enlace a la Escritura"
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:58
+#: src/components/PropertiesList.tsx:59
 msgid "Location"
 msgstr "Ubicación"
 
@@ -541,7 +541,7 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:277
+#: src/components/PropertiesList.tsx:278
 msgid "No"
 msgstr "No"
 
@@ -582,7 +582,7 @@ msgstr "AFUERA DEL EDIFICIO"
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PropertiesList.tsx:217
+#: src/components/PropertiesList.tsx:218
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -596,7 +596,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:181
 msgid "Open"
 msgstr "Actuales"
 
@@ -655,7 +655,7 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:111
+#: src/components/PropertiesList.tsx:112
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
@@ -721,7 +721,7 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:203
+#: src/components/PropertiesList.tsx:204
 msgid "Since 2017"
 msgstr "Desde 2017"
 
@@ -891,13 +891,13 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PropertiesList.tsx:161
+#: src/components/PropertiesList.tsx:162
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:143
-#: src/components/PropertiesList.tsx:189
+#: src/components/PropertiesList.tsx:144
+#: src/components/PropertiesList.tsx:190
 msgid "Total"
 msgstr "Total"
 
@@ -914,7 +914,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:101
+#: src/components/PropertiesList.tsx:102
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades Residenciales"
@@ -941,8 +941,8 @@ msgstr "Visualizar por:"
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PropertiesList.tsx:286
-#: src/components/PropertiesList.tsx:292
+#: src/components/PropertiesList.tsx:287
+#: src/components/PropertiesList.tsx:293
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -1035,7 +1035,7 @@ msgstr "Año"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:276
+#: src/components/PropertiesList.tsx:277
 msgid "Yes"
 msgstr "Sí"
 
@@ -1043,7 +1043,7 @@ msgstr "Sí"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:62
+#: src/components/PropertiesList.tsx:63
 msgid "Zipcode"
 msgstr "Código postal"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -77,7 +77,7 @@ msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha re
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:26
+#: src/components/PropertiesList.tsx:38
 msgid "Address"
 msgstr "Dirección"
 
@@ -93,7 +93,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:174
+#: src/components/PropertiesList.tsx:242
 msgid "Amount"
 msgstr "Importe"
 
@@ -118,7 +118,7 @@ msgstr "EDIFICIO:"
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
-#: src/components/PropertiesList.tsx:41
+#: src/components/PropertiesList.tsx:67
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -146,7 +146,7 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:56
+#: src/components/PropertiesList.tsx:88
 msgid "Built"
 msgstr "Construido"
 
@@ -238,7 +238,7 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesList.tsx:231
 msgid "Date"
 msgstr "Fecha"
 
@@ -284,7 +284,7 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:137
+#: src/components/PropertiesList.tsx:195
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -326,7 +326,7 @@ msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:190
+#: src/components/PropertiesList.tsx:261
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -343,7 +343,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:92
+#: src/components/PropertiesList.tsx:135
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -352,7 +352,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:120
+#: src/components/PropertiesList.tsx:172
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
@@ -398,7 +398,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
-#: src/components/PropertiesList.tsx:53
+#: src/components/PropertiesList.tsx:84
 msgid "Information"
 msgstr "Información"
 
@@ -426,7 +426,7 @@ msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucr
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PropertiesList.tsx:148
+#: src/components/PropertiesList.tsx:209
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Dueño del edificio"
@@ -435,11 +435,11 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:101
+#: src/components/PropertiesList.tsx:148
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PropertiesList.tsx:163
+#: src/components/PropertiesList.tsx:227
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -467,8 +467,8 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PropertiesList.tsx:182
-#: src/components/PropertiesList.tsx:184
+#: src/components/PropertiesList.tsx:252
+#: src/components/PropertiesList.tsx:254
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -480,7 +480,7 @@ msgstr "Enlace a la Escritura"
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:23
+#: src/components/PropertiesList.tsx:54
 msgid "Location"
 msgstr "Ubicación"
 
@@ -541,7 +541,7 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:199
+#: src/components/PropertiesList.tsx:272
 msgid "No"
 msgstr "No"
 
@@ -582,7 +582,7 @@ msgstr "AFUERA DEL EDIFICIO"
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PropertiesList.tsx:151
+#: src/components/PropertiesList.tsx:213
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -596,7 +596,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:123
+#: src/components/PropertiesList.tsx:176
 msgid "Open"
 msgstr "Actuales"
 
@@ -655,7 +655,7 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:70
+#: src/components/PropertiesList.tsx:107
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
@@ -721,7 +721,7 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:140
+#: src/components/PropertiesList.tsx:199
 msgid "Since 2017"
 msgstr "Desde 2017"
 
@@ -891,13 +891,13 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PropertiesList.tsx:107
+#: src/components/PropertiesList.tsx:157
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:95
-#: src/components/PropertiesList.tsx:129
+#: src/components/PropertiesList.tsx:139
+#: src/components/PropertiesList.tsx:185
 msgid "Total"
 msgstr "Total"
 
@@ -914,7 +914,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:62
+#: src/components/PropertiesList.tsx:97
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades Residenciales"
@@ -941,8 +941,8 @@ msgstr "Visualizar por:"
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PropertiesList.tsx:206
-#: src/components/PropertiesList.tsx:211
+#: src/components/PropertiesList.tsx:279
+#: src/components/PropertiesList.tsx:284
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -1035,7 +1035,7 @@ msgstr "Año"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:198
+#: src/components/PropertiesList.tsx:271
 msgid "Yes"
 msgstr "Sí"
 
@@ -1043,7 +1043,7 @@ msgstr "Sí"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:35
+#: src/components/PropertiesList.tsx:58
 msgid "Zipcode"
 msgstr "Código postal"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
-#: src/util/helpers.ts:241
+#: src/util/helpers.ts:242
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
@@ -60,7 +60,7 @@ msgstr "<0>Mientras el dueño legal de un edificio es, con frecuencia, una compa
 msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
 
-#: src/util/helpers.ts:53
+#: src/util/helpers.ts:54
 msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
@@ -77,11 +77,11 @@ msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha re
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:38
+#: src/components/PropertiesList.tsx:42
 msgid "Address"
 msgstr "Dirección"
 
-#: src/util/helpers.ts:68
+#: src/util/helpers.ts:69
 msgid "Agent"
 msgstr "Agente"
 
@@ -93,7 +93,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:242
+#: src/components/PropertiesList.tsx:246
 msgid "Amount"
 msgstr "Importe"
 
@@ -105,7 +105,7 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
-#: src/util/helpers.ts:33
+#: src/util/helpers.ts:34
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
@@ -118,7 +118,7 @@ msgstr "EDIFICIO:"
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
-#: src/components/PropertiesList.tsx:67
+#: src/components/PropertiesList.tsx:71
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -146,7 +146,7 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:88
+#: src/components/PropertiesList.tsx:92
 msgid "Built"
 msgstr "Construido"
 
@@ -160,19 +160,19 @@ msgstr "Dirección Comercial"
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
-#: src/util/helpers.ts:42
+#: src/util/helpers.ts:43
 msgid "CABINET"
 msgstr "GABINETE"
 
-#: src/util/helpers.ts:55
+#: src/util/helpers.ts:56
 msgid "CERAMIC TILE"
 msgstr "AZULEJOS CERÁMICAS"
 
-#: src/util/helpers.ts:30
+#: src/util/helpers.ts:31
 msgid "CONSTRUCTION"
 msgstr "CONSTRUCCIÓN"
 
-#: src/util/helpers.ts:56
+#: src/util/helpers.ts:57
 msgid "COOKING GAS"
 msgstr "GAS DE COCINA"
 
@@ -212,11 +212,11 @@ msgstr "Cerrar leyenda"
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
-#: src/util/helpers.ts:64
+#: src/util/helpers.ts:65
 msgid "Corporate Owner"
 msgstr "Dueño Corporativo"
 
-#: src/util/helpers.ts:72
+#: src/util/helpers.ts:73
 msgid "Corporation"
 msgstr "Corporación"
 
@@ -230,15 +230,15 @@ msgstr "Perfil de edificio en DOB"
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
-#: src/util/helpers.ts:27
+#: src/util/helpers.ts:28
 msgid "DOOR/WINDOW"
 msgstr "PUERTA/VENTANA"
 
-#: src/util/helpers.ts:59
+#: src/util/helpers.ts:60
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PropertiesList.tsx:231
+#: src/components/PropertiesList.tsx:235
 msgid "Date"
 msgstr "Fecha"
 
@@ -259,11 +259,11 @@ msgstr "Donar"
 msgid "Download"
 msgstr "Descargar"
 
-#: src/util/helpers.ts:50
+#: src/util/helpers.ts:51
 msgid "ELECTRIC"
 msgstr "ELÉCTRICO"
 
-#: src/util/helpers.ts:40
+#: src/util/helpers.ts:41
 msgid "ELEVATOR"
 msgstr "ASCENSOR"
 
@@ -284,7 +284,7 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:195
+#: src/components/PropertiesList.tsx:199
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -302,15 +302,15 @@ msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 20
 msgid "Export Data"
 msgstr "Exportar datos"
 
-#: src/util/helpers.ts:35
+#: src/util/helpers.ts:36
 msgid "FIRE ESCAPE"
 msgstr "ESCALERA DE INCENDIO"
 
-#: src/util/helpers.ts:45
+#: src/util/helpers.ts:46
 msgid "FLOOR"
 msgstr "PISO"
 
-#: src/util/helpers.ts:51
+#: src/util/helpers.ts:52
 msgid "FLOORING/STAIRS"
 msgstr "PISO/ESCALERAS"
 
@@ -318,7 +318,7 @@ msgstr "PISO/ESCALERAS"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/util/helpers.ts:41
+#: src/util/helpers.ts:42
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
@@ -326,15 +326,15 @@ msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:261
+#: src/components/PropertiesList.tsx:266
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
-#: src/util/helpers.ts:58
+#: src/util/helpers.ts:59
 msgid "HEAT/HOT WATER"
 msgstr "CALEFACCIÓN/AGUA CALIENTE"
 
-#: src/util/helpers.ts:28
+#: src/util/helpers.ts:29
 msgid "HEATING"
 msgstr "CALEFACCIÓN"
 
@@ -343,7 +343,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:135
+#: src/components/PropertiesList.tsx:139
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -352,7 +352,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:172
+#: src/components/PropertiesList.tsx:176
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
@@ -364,7 +364,7 @@ msgstr "Infracciones del HPD se dan cuando un Inspector oficial de la Ciudad det
 msgid "HUD Complaint Form 958"
 msgstr "Formulario de queja HUD 958"
 
-#: src/util/helpers.ts:63
+#: src/util/helpers.ts:64
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
@@ -390,7 +390,7 @@ msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
-#: src/util/helpers.ts:65
+#: src/util/helpers.ts:66
 msgid "Individual Owner"
 msgstr "Dueño Individual"
 
@@ -398,7 +398,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
-#: src/components/PropertiesList.tsx:84
+#: src/components/PropertiesList.tsx:88
 msgid "Information"
 msgstr "Información"
 
@@ -406,7 +406,7 @@ msgstr "Información"
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "Parece que esta propiedad no necesita estar registrada con el HPD."
 
-#: src/util/helpers.ts:31
+#: src/util/helpers.ts:32
 msgid "JANITOR/SUPER"
 msgstr "CONSERJE/SÚPER"
 
@@ -414,7 +414,7 @@ msgstr "CONSERJE/SÚPER"
 msgid "Join the fight for tenant rights!"
 msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 
-#: src/util/helpers.ts:66
+#: src/util/helpers.ts:67
 msgid "Joint Owner"
 msgstr "Dueño Conjunto"
 
@@ -422,11 +422,11 @@ msgstr "Dueño Conjunto"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: src/util/helpers.ts:60
+#: src/util/helpers.ts:61
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PropertiesList.tsx:209
+#: src/components/PropertiesList.tsx:213
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Dueño del edificio"
@@ -435,11 +435,11 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:148
+#: src/components/PropertiesList.tsx:152
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PropertiesList.tsx:227
+#: src/components/PropertiesList.tsx:231
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -463,12 +463,12 @@ msgstr "Aprende más"
 msgid "Legend"
 msgstr "Leyenda"
 
-#: src/util/helpers.ts:69
+#: src/util/helpers.ts:70
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PropertiesList.tsx:252
-#: src/components/PropertiesList.tsx:254
+#: src/components/PropertiesList.tsx:256
+#: src/components/PropertiesList.tsx:258
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -480,7 +480,7 @@ msgstr "Enlace a la Escritura"
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:54
+#: src/components/PropertiesList.tsx:58
 msgid "Location"
 msgstr "Ubicación"
 
@@ -488,11 +488,11 @@ msgstr "Ubicación"
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
-#: src/util/helpers.ts:38
+#: src/util/helpers.ts:39
 msgid "MAILBOX"
 msgstr "BUZÓN"
 
-#: src/util/helpers.ts:48
+#: src/util/helpers.ts:49
 msgid "MOLD"
 msgstr "MOHO"
 
@@ -525,7 +525,7 @@ msgstr "Las quejas más comunes de 311, los últimos 3 años"
 msgid "MyNYCHA App"
 msgstr "App MyNYCHA"
 
-#: src/util/helpers.ts:54
+#: src/util/helpers.ts:55
 msgid "NON-CONSTRUCTION"
 msgstr "NO CONSTRUCCIÓN"
 
@@ -541,7 +541,7 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:272
+#: src/components/PropertiesList.tsx:277
 msgid "No"
 msgstr "No"
 
@@ -574,15 +574,15 @@ msgstr "Ninguna"
 msgid "Not found"
 msgstr "No encontrado"
 
-#: src/util/helpers.ts:32
+#: src/util/helpers.ts:33
 msgid "OUTSIDE BUILDING"
 msgstr "AFUERA DEL EDIFICIO"
 
-#: src/util/helpers.ts:70
+#: src/util/helpers.ts:71
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PropertiesList.tsx:213
+#: src/components/PropertiesList.tsx:217
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -596,7 +596,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:176
+#: src/components/PropertiesList.tsx:180
 msgid "Open"
 msgstr "Actuales"
 
@@ -612,15 +612,15 @@ msgstr "General"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/> Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
 
-#: src/util/helpers.ts:52
+#: src/util/helpers.ts:53
 msgid "PAINT/PLASTER"
 msgstr "PINTURA/YESO"
 
-#: src/util/helpers.ts:37
+#: src/util/helpers.ts:38
 msgid "PESTS"
 msgstr "PLAGAS"
 
-#: src/util/helpers.ts:46
+#: src/util/helpers.ts:47
 msgid "PLUMBING"
 msgstr "PLOMERÍA"
 
@@ -655,7 +655,7 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:107
+#: src/components/PropertiesList.tsx:111
 msgid "RS Units"
 msgstr "Unidades Residenciales RS"
 
@@ -663,19 +663,19 @@ msgstr "Unidades Residenciales RS"
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
-#: src/util/helpers.ts:57
+#: src/util/helpers.ts:58
 msgid "SAFETY"
 msgstr "SEGURIDAD"
 
-#: src/util/helpers.ts:34
+#: src/util/helpers.ts:35
 msgid "SEWAGE"
 msgstr "AGUAS NEGRAS"
 
-#: src/util/helpers.ts:36
+#: src/util/helpers.ts:37
 msgid "SIGNAGE MISSING"
 msgstr "FALTA DE SEÑALIZACIÓN"
 
-#: src/util/helpers.ts:29
+#: src/util/helpers.ts:30
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
@@ -709,7 +709,7 @@ msgstr "Compartir"
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
 
-#: src/util/helpers.ts:71
+#: src/util/helpers.ts:72
 msgid "Shareholder"
 msgstr "Accionista"
 
@@ -721,7 +721,7 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:199
+#: src/components/PropertiesList.tsx:203
 msgid "Since 2017"
 msgstr "Desde 2017"
 
@@ -729,7 +729,7 @@ msgstr "Desde 2017"
 msgid "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde el 2017, los Mariscales de NYC programaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en este portafolio de edificios."
 
-#: src/util/helpers.ts:67
+#: src/util/helpers.ts:68
 msgid "Site Manager"
 msgstr "Administrador del Sitio"
 
@@ -753,7 +753,7 @@ msgstr "Código fuente"
 msgid "Summary"
 msgstr "Resúmen"
 
-#: src/util/helpers.ts:43
+#: src/util/helpers.ts:44
 msgid "TENANT HARASSMENT"
 msgstr "ACOSO DE INQUILINO"
 
@@ -891,13 +891,13 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PropertiesList.tsx:157
+#: src/components/PropertiesList.tsx:161
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:139
-#: src/components/PropertiesList.tsx:185
+#: src/components/PropertiesList.tsx:143
+#: src/components/PropertiesList.tsx:189
 msgid "Total"
 msgstr "Total"
 
@@ -914,7 +914,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:97
+#: src/components/PropertiesList.tsx:101
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades Residenciales"
@@ -929,7 +929,7 @@ msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edif
 msgid "Useful links"
 msgstr "Enlaces útiles"
 
-#: src/util/helpers.ts:47
+#: src/util/helpers.ts:48
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
@@ -941,8 +941,8 @@ msgstr "Visualizar por:"
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PropertiesList.tsx:279
-#: src/components/PropertiesList.tsx:284
+#: src/components/PropertiesList.tsx:286
+#: src/components/PropertiesList.tsx:292
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -976,15 +976,15 @@ msgstr "Infracciones emitidas"
 msgid "Visit our website"
 msgstr "Visite nuestro sitio web"
 
-#: src/util/helpers.ts:49
+#: src/util/helpers.ts:50
 msgid "WATER LEAK"
 msgstr "CAJA DE AGUA"
 
-#: src/util/helpers.ts:44
+#: src/util/helpers.ts:45
 msgid "WINDOW GUARDS"
 msgstr "PROTECTORES DE VENTANA"
 
-#: src/util/helpers.ts:39
+#: src/util/helpers.ts:40
 msgid "WINDOWS"
 msgstr "VENTANAS"
 
@@ -1035,7 +1035,7 @@ msgstr "Año"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:271
+#: src/components/PropertiesList.tsx:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -1043,7 +1043,7 @@ msgstr "Sí"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:58
+#: src/components/PropertiesList.tsx:62
 msgid "Zipcode"
 msgstr "Código postal"
 

--- a/client/src/styles/AddressPage.scss
+++ b/client/src/styles/AddressPage.scss
@@ -81,10 +81,6 @@
     width: 100%;
   }
 
-  .AddressPage__table {
-    overflow-x: scroll;
-  }
-
   .AddressPage__summary {
     overflow-y: scroll;
     @include scrollbar();

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -38,7 +38,7 @@ $table-border-dark: 1px solid $dark;
         border-bottom: $table-border-light;
       }
 
-      &.-header .rthfc-th-fixed {
+      &.-header .rt-tr {
         border-bottom: $table-border-dark;
       }
 

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -24,18 +24,11 @@
     }
 
     .rt-thead {
+      .rt-tr {
+        border-bottom: 1px solid $gray-light;
+      }
       .rt-th {
         padding: 7px 5px;
-      }
-      .rthfc-th-fixed {
-        position: fixed;
-        display: list-item;
-      }
-      .rt-tr {
-        // This offsets the rest of the header against the fixed first column
-        // Hence, this value should match the defined width inside the
-        // PropertiesList.tsx component's first column
-        padding-left: 130px;
       }
     }
 
@@ -53,21 +46,6 @@
 
     .rt-td {
       text-align: center;
-    }
-
-    .-pagination {
-      box-shadow: none;
-      border-top: 1px solid $gray-dark;
-      padding: 5px;
-
-      .-btn {
-        @include button();
-        border-radius: 0;
-      }
-      .-btn[disabled] {
-        opacity: 0.3;
-        cursor: default;
-      }
     }
   }
 

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -27,6 +27,7 @@ $table-border-dark: 1px solid $dark;
     }
 
     .rt-thead {
+      max-height: 30px;
       .rthfc-th-fixed {
         position: fixed;
         display: list-item;

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -91,5 +91,14 @@
       rgba(255, 255, 255, 1) 100%
     ); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=1 ); /* IE6-9 */
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.5s linear;
+  }
+
+  &.last-column-visible::after {
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s 0.5s, opacity 0.5s linear;
   }
 }

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -24,7 +24,6 @@
     .rt-thead.-header {
       box-shadow: none;
       border-bottom: 1px solid $dark;
-      text-decoration: underline;
     }
 
     .rt-td {

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -21,10 +21,7 @@
         transform: translateY(0.5px);
       }
     }
-
-    .rthfc-td-fixed {
-      z-index: 1000;
-    }
+    
     .rt-thead .rt-th {
       padding: 7px 5px;
     }

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -2,6 +2,9 @@
 @import "_scrollbar.scss";
 @import "_button.scss";
 
+$table-border-light: 1px solid $gray-light;
+$table-border-dark: 1px solid $dark;
+
 .PropertiesList {
   height: 100%;
   width: 100%;
@@ -27,17 +30,20 @@
       .rthfc-th-fixed {
         position: fixed;
         display: list-item;
+        z-index: 5;
       }
 
       &.-headerGroups .rthfc-th-fixed {
-        border-bottom: 1px solid $gray-light;
+        border-bottom: $table-border-light;
       }
 
       &.-header .rthfc-th-fixed {
+        // This extra bottom padding makes sure the user doesn't
+        // see underneath the header column when trying to scroll up
         padding: 0 0 100px 0;
         > div {
           padding: 7px 5px;
-          border-bottom: 1px solid $dark;
+          border-bottom: $table-border-dark;
         }
       }
 
@@ -55,7 +61,7 @@
 
     .rt-thead.-header {
       box-shadow: none;
-      border-bottom: 1px solid $dark;
+      border-bottom: $table-border-dark;
     }
 
     .rt-td {
@@ -64,6 +70,13 @@
 
     .rt-tbody {
       z-index: 10;
+
+      .rt-tr-group {
+        border-bottom: $table-border-light;
+        .rt-td {
+          border-right: $table-border-light;
+        }
+      }
     }
   }
 

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -10,6 +10,7 @@
 
   .ReactTable {
     border-top: none;
+    border-left: none;
     border-color: $gray-dark;
 
     .arrow-icon {
@@ -22,8 +23,20 @@
       }
     }
 
-    .rt-thead .rt-th {
-      padding: 7px 5px;
+    .rt-thead {
+      .rt-th {
+        padding: 7px 5px;
+      }
+      .rthfc-th-fixed {
+        position: fixed;
+        display: list-item;
+      }
+      .rt-tr {
+        // This offsets the rest of the header against the fixed first column
+        // Hence, this value should match the defined width inside the
+        // PropertiesList.tsx component's first column
+        padding-left: 130px;
+      }
     }
 
     .rt-thead.-headerGroups {

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -80,7 +80,7 @@
     transition: opacity 0.5s linear;
   }
 
-  &.last-column-visible::after {
+  &.hide-scroll-fade::after {
     visibility: hidden;
     opacity: 0;
     transition: visibility 0s 0.5s, opacity 0.5s linear;

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -32,12 +32,10 @@ $table-border-dark: 1px solid $dark;
       max-height: 30px;
       .rt-tr .rthfc-th-fixed.rthfc-th-fixed-left {
         position: fixed;
-        z-index: 5;
         // This display prop makes sure that the fixed table cells
         // fill up their entire allotted spaces
         display: list-item;
-        // This fixes a spacing issue on Internet Explorer
-        transform: translate3d(0px, 0px, 0px);
+        z-index: 5;
       }
 
       &.-headerGroups .rthfc-th-fixed {

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -21,7 +21,7 @@
         transform: translateY(0.5px);
       }
     }
-    
+
     .rt-thead .rt-th {
       padding: 7px 5px;
     }

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -32,10 +32,12 @@ $table-border-dark: 1px solid $dark;
       max-height: 30px;
       .rt-tr .rthfc-th-fixed.rthfc-th-fixed-left {
         position: fixed;
+        z-index: 5;
         // This display prop makes sure that the fixed table cells
         // fill up their entire allotted spaces
         display: list-item;
-        z-index: 5;
+        // This fixes a spacing issue on Internet Explorer
+        transform: translate3d(0px, 0px, 0px);
       }
 
       &.-headerGroups .rthfc-th-fixed {

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -8,8 +8,9 @@ $table-border-dark: 1px solid $dark;
 .PropertiesList {
   height: 100%;
   width: 100%;
-  // This makes sure that the fade effect from the "::after" component
-  // doesn't overflow past the boundary of the PropertiesList container
+  // These next 2 items ensure that the fade effect from the "::after"
+  // component doesn't overflow past the edge of the full 
+  // PropertiesList container
   position: relative;
   overflow: auto;
 
@@ -33,7 +34,7 @@ $table-border-dark: 1px solid $dark;
       .rt-tr .rthfc-th-fixed.rthfc-th-fixed-left {
         position: fixed;
         // This display prop makes sure that the fixed table cells
-        // fill up their entire alloted spaces
+        // fill up their entire allotted spaces
         display: list-item;
         z-index: 5;
       }

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -45,10 +45,6 @@
       text-align: center;
     }
 
-    .rt-tbody {
-      overflow-y: overlay;
-    }
-
     .-pagination {
       box-shadow: none;
       border-top: 1px solid $gray-dark;

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -38,13 +38,7 @@ $table-border-dark: 1px solid $dark;
       }
 
       &.-header .rthfc-th-fixed {
-        // This extra bottom padding makes sure the user doesn't
-        // see underneath the header column when trying to scroll up
-        padding: 0 0 100px 0;
-        > div {
-          padding: 7px 5px;
-          border-bottom: $table-border-dark;
-        }
+        border-bottom: $table-border-dark;
       }
 
       .rt-th {
@@ -69,8 +63,6 @@ $table-border-dark: 1px solid $dark;
     }
 
     .rt-tbody {
-      z-index: 10;
-
       .rt-tr-group {
         border-bottom: $table-border-light;
         .rt-td {

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -77,6 +77,7 @@ $table-border-dark: 1px solid $dark;
     content: "";
     display: block;
     position: absolute;
+    pointer-events: none;
     top: 0;
     bottom: 0;
     right: 0;

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -28,15 +28,32 @@ $table-border-dark: 1px solid $dark;
       }
     }
 
+    // These three props fix our top left cells of the table in place.
+    // This area is within two nested sticky containers and
+    // therefore has laggin issues on mobile devices without these new css rules.
+    &.-sp .rt-thead .rt-tr .rthfc-th-fixed.rthfc-th-fixed-left {
+      position: fixed;
+      // This display prop makes sure that the fixed table cells
+      // fill up their entire allotted spaces
+      display: list-item;
+      z-index: 5;
+    }
+
+    // The "react-table-hoc-fixed-columns" package has a built-in fallback for fixing columns using the
+    // `transform` property for older browsers that don't support `position: sticky`. These following rules
+    // remove conflicts with some custom CSS when this fallback is present (when the "-se" class is attached).
+    &.-se {
+      .rt-thead .rt-tr .rthfc-th-fixed.rthfc-th-fixed-left {
+        position: static;
+      }
+      .rt-th {
+        // This property is set as an inline style in PropertiesList.tsx, so we need the `!important` flag to override it
+        margin-left: 0px !important;
+      }
+    }
+
     .rt-thead {
       max-height: 30px;
-      .rt-tr .rthfc-th-fixed.rthfc-th-fixed-left {
-        position: fixed;
-        // This display prop makes sure that the fixed table cells
-        // fill up their entire allotted spaces
-        display: list-item;
-        z-index: 5;
-      }
 
       &.-headerGroups .rthfc-th-fixed {
         border-bottom: $table-border-light;

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -12,6 +12,16 @@
     border-top: none;
     border-color: $gray-dark;
 
+    .arrow-icon {
+      display: inline-block;
+      margin-left: 0.5rem;
+      span {
+        // This small adjustment aligns second arrow in icon with first
+        display: inline-block;
+        transform: translateY(0.5px);
+      }
+    }
+
     .rthfc-td-fixed {
       z-index: 1000;
     }

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -8,6 +8,8 @@ $table-border-dark: 1px solid $dark;
 .PropertiesList {
   height: 100%;
   width: 100%;
+  // This makes sure that the fade effect from the "::after" component
+  // doesn't overflow past the boundary of the PropertiesList container
   position: relative;
   overflow: auto;
 
@@ -30,6 +32,8 @@ $table-border-dark: 1px solid $dark;
       max-height: 30px;
       .rthfc-th-fixed {
         position: fixed;
+        // This display prop makes sure that the fixed table cells
+        // fill up their entire alloted spaces
         display: list-item;
         z-index: 5;
       }

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -24,9 +24,23 @@
     }
 
     .rt-thead {
-      .rt-tr {
+      .rthfc-th-fixed {
+        position: fixed;
+        display: list-item;
+      }
+
+      &.-headerGroups .rthfc-th-fixed {
         border-bottom: 1px solid $gray-light;
       }
+
+      &.-header .rthfc-th-fixed {
+        padding: 0 0 100px 0;
+        > div {
+          padding: 7px 5px;
+          border-bottom: 1px solid $dark;
+        }
+      }
+
       .rt-th {
         padding: 7px 5px;
       }
@@ -46,6 +60,10 @@
 
     .rt-td {
       text-align: center;
+    }
+
+    .rt-tbody {
+      z-index: 10;
     }
   }
 

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -30,7 +30,7 @@ $table-border-dark: 1px solid $dark;
 
     .rt-thead {
       max-height: 30px;
-      .rthfc-th-fixed {
+      .rt-tr .rthfc-th-fixed.rthfc-th-fixed-left {
         position: fixed;
         // This display prop makes sure that the fixed table cells
         // fill up their entire alloted spaces

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -5,6 +5,8 @@
 .PropertiesList {
   height: 100%;
   width: 100%;
+  position: relative;
+  overflow: auto;
 
   .ReactTable {
     border-top: none;
@@ -50,7 +52,31 @@
     }
   }
 
-  .rt-table {
-    @include scrollbar();
+  // Add right-side fade out when list is scrollable:
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 50px;
+    z-index: 10;
+    background: -moz-linear-gradient(
+      left,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(255, 255, 255, 1) 100%
+    ); /* FF3.6-15 */
+    background: -webkit-linear-gradient(
+      left,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(255, 255, 255, 1) 100%
+    ); /* Chrome10-25,Safari5.1-6 */
+    background: linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(255, 255, 255, 1) 100%
+    ); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=1 ); /* IE6-9 */
   }
 }

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -9,8 +9,7 @@ $table-border-dark: 1px solid $dark;
   height: 100%;
   width: 100%;
   // These next 2 items ensure that the fade effect from the "::after"
-  // component doesn't overflow past the edge of the full 
-  // PropertiesList container
+  // component doesn't overflow past the edge of the PropertiesList container
   position: relative;
   overflow: auto;
 

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -12,6 +12,9 @@
     border-top: none;
     border-color: $gray-dark;
 
+    .rthfc-td-fixed {
+      z-index: 1000;
+    }
     .rt-thead .rt-th {
       padding: 7px 5px;
     }

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -359,10 +359,13 @@ export default {
 
   /**
    * Detects whether a user's viewport window has changed dimensions.
+   * The optional parameter `debounceTime` sets the number of milliseconds
+   * to wait between checks of the window size. If unset,
+   * the default value is used (defined below).
    *
    * Adapted from https://usehooks.com/useWindowSize/
    */
-  useWindowSize() {
+  useWindowSize(debounceTime?: number) {
     // Initialize state with undefined width/height so server and client renders match
     // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
     const [windowSize, setWindowSize] = useState<{
@@ -374,7 +377,7 @@ export default {
     });
 
     // How long we should wait before handling a window resize
-    const DEBOUNCE_TIME_IN_MS = 250;
+    const DEFAULT_DEBOUNCE_TIME_IN_MS = 250;
     useEffect(() => {
       // Handler to call on window resize
       function handleResize() {
@@ -385,7 +388,10 @@ export default {
         });
       }
       // Add event listener
-      window.addEventListener("resize", debounce(DEBOUNCE_TIME_IN_MS, handleResize));
+      window.addEventListener(
+        "resize",
+        debounce(debounceTime || DEFAULT_DEBOUNCE_TIME_IN_MS, handleResize)
+      );
       // Call handler right away so state gets updated with initial window size
       handleResize();
       // Remove event listener on cleanup

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -385,7 +385,7 @@ export default {
         });
       }
       // Add event listener
-      window.addEventListener("resize", debounce(250, handleResize));
+      window.addEventListener("resize", debounce(DEBOUNCE_TIME_IN_MS, handleResize));
       // Call handler right away so state gets updated with initial window size
       handleResize();
       // Remove event listener on cleanup

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -309,15 +309,22 @@ export default {
 
   /**
    * Detects whether a given DOM element is visible on screen.
+   *
+   * Note: for older browsers that do not support IntersectionObserver, this
+   * hook will always return FALSE by default.
+   *
    * Borrowed from https://stackoverflow.com/questions/45514676/react-check-if-element-is-visible-in-dom
    */
   useOnScreen(ref: React.RefObject<any>) {
-    const [isIntersecting, setIntersecting] = useState(false);
+    const isIntersectionObserverSupported = typeof IntersectionObserver !== "undefined";
 
-    const observer = new IntersectionObserver(([entry]) => setIntersecting(entry.isIntersecting));
+    const [isIntersecting, setIntersecting] = useState(false);
+    const observer =
+      isIntersectionObserverSupported &&
+      new IntersectionObserver(([entry]) => setIntersecting(entry.isIntersecting));
 
     useEffect(() => {
-      if (ref.current) {
+      if (observer && ref.current) {
         observer.observe(ref.current);
         // Remove the observer as soon as the component is unmounted
         return () => {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -359,13 +359,10 @@ export default {
 
   /**
    * Detects whether a user's viewport window has changed dimensions.
-   * The optional parameter `debounceTime` sets the number of milliseconds
-   * to wait between checks of the window size. If unset,
-   * the default value is used (defined below).
    *
    * Adapted from https://usehooks.com/useWindowSize/
    */
-  useWindowSize(debounceTime?: number) {
+  useWindowSize() {
     // Initialize state with undefined width/height so server and client renders match
     // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
     const [windowSize, setWindowSize] = useState<{
@@ -377,7 +374,7 @@ export default {
     });
 
     // How long we should wait before handling a window resize
-    const DEFAULT_DEBOUNCE_TIME_IN_MS = 250;
+    const DEBOUNCE_TIME_IN_MS = 250;
     useEffect(() => {
       // Handler to call on window resize
       function handleResize() {
@@ -388,10 +385,7 @@ export default {
         });
       }
       // Add event listener
-      window.addEventListener(
-        "resize",
-        debounce(debounceTime || DEFAULT_DEBOUNCE_TIME_IN_MS, handleResize)
-      );
+      window.addEventListener("resize", debounce(DEBOUNCE_TIME_IN_MS, handleResize));
       // Call handler right away so state gets updated with initial window size
       handleResize();
       // Remove event listener on cleanup

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -335,4 +335,38 @@ export default {
 
     return isIntersecting;
   },
+
+  /**
+   * Detects whether a user's viewport window has changed dimensions.
+   *
+   * Adapted from https://usehooks.com/useWindowSize/
+   */
+  useWindowSize() {
+    // Initialize state with undefined width/height so server and client renders match
+    // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
+    const [windowSize, setWindowSize] = useState<{
+      width: number | undefined;
+      height: number | undefined;
+    }>({
+      width: undefined,
+      height: undefined,
+    });
+    useEffect(() => {
+      // Handler to call on window resize
+      function handleResize() {
+        // Set window width/height to state
+        setWindowSize({
+          width: window.innerWidth,
+          height: window.innerHeight,
+        });
+      }
+      // Add event listener
+      window.addEventListener("resize", handleResize);
+      // Call handler right away so state gets updated with initial window size
+      handleResize();
+      // Remove event listener on cleanup
+      return () => window.removeEventListener("resize", handleResize);
+    }, []); // Empty array ensures that effect is only run on mount
+    return windowSize;
+  },
 };

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -83,6 +83,25 @@ export const longDateOptions = { year: "numeric", month: "short", day: "numeric"
 export const mediumDateOptions = { year: "numeric", month: "long" };
 export const shortDateOptions = { month: "short" };
 
+/**
+ * A React Hook that "debounces" the given value, ensuring that the value
+ * returned by the hook is one that hasn't changed in the given number of
+ * milliseconds.
+ *
+ * Originally copied from the tenants2 repo maintained by JustFix
+ * https://github.com/JustFixNYC/tenants2/blob/master/frontend/lib/util/use-debounced-value.tsx
+ */
+const useDebouncedValue = <T>(value: T, ms: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedValue(value), ms);
+    return () => clearTimeout(timeout);
+  }, [ms, value]);
+
+  return debouncedValue;
+};
+
 const createTranslationFunctionFromMap = (
   map: Map<string, MessageDescriptor>,
   description: string,
@@ -335,6 +354,7 @@ export default {
 
     return isIntersecting;
   },
+  useDebouncedValue,
 
   /**
    * Detects whether a user's viewport window has changed dimensions.
@@ -356,8 +376,8 @@ export default {
       function handleResize() {
         // Set window width/height to state
         setWindowSize({
-          width: window.innerWidth,
-          height: window.innerHeight,
+          width: useDebouncedValue(window.innerWidth, 250),
+          height: useDebouncedValue(window.innerHeight, 250),
         });
       }
       // Add event listener

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -8,6 +8,7 @@ import { HpdContactAddress, SearchAddressWithoutBbl } from "components/APIDataTy
 import { reportError } from "error-reporting";
 import { t } from "@lingui/macro";
 import { I18n, MessageDescriptor } from "@lingui/core";
+import React, { useEffect, useState } from "react";
 
 /**
  * An array consisting of Who Owns What's standard enumerations for street names,
@@ -304,5 +305,27 @@ export default {
       const translationSuffix = i18n._(t`("${textInEnglish}" in English)`);
       return translation + " " + translationSuffix;
     }
+  },
+
+  /**
+   * Detects whether a given DOM element is visible on screen.
+   * Borrowed from https://stackoverflow.com/questions/45514676/react-check-if-element-is-visible-in-dom
+   */
+  useOnScreen(ref: React.RefObject<any>) {
+    const [isIntersecting, setIntersecting] = useState(false);
+
+    const observer = new IntersectionObserver(([entry]) => setIntersecting(entry.isIntersecting));
+
+    useEffect(() => {
+      if (ref.current) {
+        observer.observe(ref.current);
+        // Remove the observer as soon as the component is unmounted
+        return () => {
+          observer.disconnect();
+        };
+      }
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return isIntersecting;
   },
 };

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -84,22 +84,24 @@ export const mediumDateOptions = { year: "numeric", month: "long" };
 export const shortDateOptions = { month: "short" };
 
 /**
- * A React Hook that "debounces" the given value, ensuring that the value
- * returned by the hook is one that hasn't changed in the given number of
- * milliseconds.
+ * Delay the action of a certian function by a set amount of time.
  *
- * Originally copied from the tenants2 repo maintained by JustFix
- * https://github.com/JustFixNYC/tenants2/blob/master/frontend/lib/util/use-debounced-value.tsx
+ * Originally copied from:
+ * https://gist.github.com/gragland/4e3d9b1c934a18dc76f585350f97e321#gistcomment-3073492
  */
-const useDebouncedValue = <T>(value: T, ms: number): T => {
-  const [debouncedValue, setDebouncedValue] = useState(value);
+const debounce = (delay: number, fn: any) => {
+  let timerId: any;
 
-  useEffect(() => {
-    const timeout = window.setTimeout(() => setDebouncedValue(value), ms);
-    return () => clearTimeout(timeout);
-  }, [ms, value]);
+  return function (...args: any[]) {
+    if (timerId) {
+      clearTimeout(timerId);
+    }
 
-  return debouncedValue;
+    timerId = setTimeout(() => {
+      fn(...args);
+      timerId = null;
+    }, delay);
+  };
 };
 
 const createTranslationFunctionFromMap = (
@@ -354,7 +356,6 @@ export default {
 
     return isIntersecting;
   },
-  useDebouncedValue,
 
   /**
    * Detects whether a user's viewport window has changed dimensions.
@@ -371,17 +372,20 @@ export default {
       width: undefined,
       height: undefined,
     });
+
+    // How long we should wait before handling a window resize
+    const DEBOUNCE_TIME_IN_MS = 250;
     useEffect(() => {
       // Handler to call on window resize
       function handleResize() {
         // Set window width/height to state
         setWindowSize({
-          width: useDebouncedValue(window.innerWidth, 250),
-          height: useDebouncedValue(window.innerHeight, 250),
+          width: window.innerWidth,
+          height: window.innerHeight,
         });
       }
       // Add event listener
-      window.addEventListener("resize", handleResize);
+      window.addEventListener("resize", debounce(250, handleResize));
       // Call handler right away so state gets updated with initial window size
       handleResize();
       // Remove event listener on cleanup

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4358,7 +4358,7 @@ classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
-classnames@^2.2.6:
+classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4358,6 +4358,11 @@ classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+classnames@^2.2.6:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
@@ -11617,6 +11622,14 @@ react-social@^1.10.0:
     create-react-class "^15.6.0"
     prop-types "^15.5.10"
 
+react-table-hoc-fixed-columns@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/react-table-hoc-fixed-columns/-/react-table-hoc-fixed-columns-2.3.3.tgz#77e903806216a62695f30935a8371ce46507f3bf"
+  integrity sha512-c6FyOAhPpIBxV5gPIbhNgDiZo/BPKyYcQzN3TUXAGYu4E6KG3yWwifiTY+M4SNPR2K2Bdv6US8wp1MkHAXRDNA==
+  dependencies:
+    classnames "^2.2.6"
+    uniqid "^5.0.3"
+
 react-table@^6.5.3:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.10.0.tgz#20444b19d8ca3c1a08e7544e5c3a93e4ba56690e"
@@ -13625,6 +13638,11 @@ uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
   integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
+
+uniqid@^5.0.3:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/uniqid/-/uniqid-5.3.0.tgz#4545f8e9c9a5830ef804e512cca6a9331e9761bf"
+  integrity sha512-Jq8EzvAT8/CcLu8tzoSiylnzPkNhJJKpnMT964Dj1jI4pG4sKYP9aFVByNTp8KzMvYlW1Um63PCDqtOoujNzrA==
 
 uniqs@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR makes various front-end improvements to the Portfolio Tab, with the main intention of improving our mobile experience. These include:
- Fix in place the first "Address" column
- Decrease width of Address column to ~90% (130px)
- Wrap text of Address entries onto 2+ lines
- Add Up down arrows in headers to indicate that data can be re-ordered
- Include fade out rectangle on viewport edge for horizontal scroll (and remove it when reaching end of scroll)
- Make all column headers fully shown 
- Make all columns only resizable on desktop

UPDATE: This PR now includes some tooling to set the height of the first column header as fixed to avoid some very distracting jank on mobile devices. 