### PR TITLE
Remove bottom margin from paragraph within homepage banner

### DIFF
--- a/client/src/styles/HomePage.scss
+++ b/client/src/styles/HomePage.scss
@@ -19,6 +19,11 @@
       padding-right: 24px;
       text-align: center;
 
+      // Override default <p> styling:
+      p {
+        margin-bottom: 0;
+      }
+
       a {
         color: $dark;
         text-decoration: underline;


### PR DESCRIPTION
This quick styling change removes some awkward spacing on the homepage warning banner introduced by #482. 