### PR TITLE
Attempt to memoize the portfolio table.

### DIFF
--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -112,7 +112,7 @@ const PropertiesListWithoutI18n: React.FC<
       className={classnames("PropertiesList", hideScrollFade && "hide-scroll-fade")}
       ref={tableRef}
     >
-      <TheTable
+      <TableOfData
         addrs={addrs}
         headerTopSpacing={headerTopSpacing}
         i18n={i18n}
@@ -136,11 +136,15 @@ type TheTableProps = {
   addressPageRoutes: AddressPageRoutes;
 };
 
-const TheTable = React.memo(
+/**
+ * This component memoizes the portfolio table via React.memo
+ * in an attempt to improve performance, particularly on IE11.
+ */
+const TableOfData = React.memo(
   React.forwardRef<HTMLDivElement, TheTableProps>((props, lastColumnRef) => {
     const { addrs, headerTopSpacing, i18n, locale, rsunitslatestyear } = props;
 
-    console.log("Rendering <TheTable>", headerTopSpacing);
+    console.log("Rendering <TableOfData>", headerTopSpacing);
 
     return (
       <ReactTableFixedColumns

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -126,7 +126,7 @@ const PropertiesListWithoutI18n: React.FC<
   );
 };
 
-type TheTableProps = {
+type TableOfDataProps = {
   addrs: AddressRecord[];
   headerTopSpacing: number | undefined;
   i18n: I18n;
@@ -141,10 +141,8 @@ type TheTableProps = {
  * in an attempt to improve performance, particularly on IE11.
  */
 const TableOfData = React.memo(
-  React.forwardRef<HTMLDivElement, TheTableProps>((props, lastColumnRef) => {
+  React.forwardRef<HTMLDivElement, TableOfDataProps>((props, lastColumnRef) => {
     const { addrs, headerTopSpacing, i18n, locale, rsunitslatestyear } = props;
-
-    console.log("Rendering <TableOfData>", headerTopSpacing);
 
     return (
       <ReactTableFixedColumns

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -17,7 +17,6 @@ import Helpers, { longDateOptions } from "../util/helpers";
 import { AddressRecord, HpdComplaintCount } from "./APIDataTypes";
 import { withMachineInStateProps } from "state-machine";
 import { AddressPageRoutes } from "routes";
-import { createRef } from "react";
 import classnames from "classnames";
 
 export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
@@ -73,7 +72,7 @@ const PropertiesListWithoutI18n: React.FC<
   const addrs = props.state.context.portfolioData.assocAddrs;
   const rsunitslatestyear = props.state.context.portfolioData.searchAddr.rsunitslatestyear;
 
-  const lastColumnRef = createRef<any>();
+  const lastColumnRef = useRef<HTMLDivElement>(null);
   const isLastColumnVisible = Helpers.useOnScreen(lastColumnRef);
   /**
    * For older browsers that do not support the `useOnScreen` hook,
@@ -113,6 +112,37 @@ const PropertiesListWithoutI18n: React.FC<
       className={classnames("PropertiesList", hideScrollFade && "hide-scroll-fade")}
       ref={tableRef}
     >
+      <TheTable
+        addrs={addrs}
+        headerTopSpacing={headerTopSpacing}
+        i18n={i18n}
+        locale={locale}
+        rsunitslatestyear={rsunitslatestyear}
+        onOpenDetail={props.onOpenDetail}
+        addressPageRoutes={props.addressPageRoutes}
+        ref={lastColumnRef}
+      />
+    </div>
+  );
+};
+
+type TheTableProps = {
+  addrs: AddressRecord[];
+  headerTopSpacing: number | undefined;
+  i18n: I18n;
+  locale: SupportedLocale;
+  rsunitslatestyear: number;
+  onOpenDetail: (bbl: string) => void;
+  addressPageRoutes: AddressPageRoutes;
+};
+
+const TheTable = React.memo(
+  React.forwardRef<HTMLDivElement, TheTableProps>((props, lastColumnRef) => {
+    const { addrs, headerTopSpacing, i18n, locale, rsunitslatestyear } = props;
+
+    console.log("Rendering <TheTable>", headerTopSpacing);
+
+    return (
       <ReactTableFixedColumns
         data={addrs}
         minRows={10}
@@ -481,9 +511,9 @@ const PropertiesListWithoutI18n: React.FC<
         }}
         className="-striped -highlight"
       />
-    </div>
-  );
-};
+    );
+  })
+);
 
 const PropertiesList = withI18n()(PropertiesListWithoutI18n);
 


### PR DESCRIPTION
This memoizes the portfolio table via [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) in an attempt to improve performance, particularly on IE11.

As far as I can tell via IE11's profiler, the majority of delay is now caused by layout:

> ![image](https://user-images.githubusercontent.com/124687/125527910-f82b8d5f-9cf3-4858-a9ae-81900839ff88.png)

I'm honestly not even sure how much it helps to make the table a pure component, though I guess it can't really hurt.  I suppose it does make the code a bit more complex, though.