### PR TITLE
Restructure how datasets are selected on the Timeline Tab

### DIFF
--- a/client/src/components/Dropdown.tsx
+++ b/client/src/components/Dropdown.tsx
@@ -1,16 +1,22 @@
-import FocusTrap from "focus-trap-react";
 import React, { useState } from "react";
+import classnames from "classnames";
+import FocusTrap from "focus-trap-react";
 
 import "styles/Dropdown.css";
 
-export const Dropdown: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+type DropdownProps = {
+  children: React.ReactNode;
+  style?: "hamburger" | "selector";
+};
+
+export const Dropdown: React.FC<DropdownProps> = ({ children, style = "hamburger" }) => {
   const [isDropdownVisible, setDropdownVisibility] = useState(false);
 
   const closeDropdown = () => setDropdownVisibility(false);
   const toggleDropdown = () => {
     isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
   };
-  console.log(isDropdownVisible);
+
   return (
     <div className="DropdownComponent">
       <FocusTrap
@@ -21,7 +27,7 @@ export const Dropdown: React.FC<{ children: React.ReactNode }> = ({ children }) 
           onDeactivate: closeDropdown,
         }}
       >
-        <div className="dropdown dropdown-right show-lg">
+        <div className={classnames("dropdown", style === "hamburger" && "dropdown-right show-lg")}>
           <button
             aria-label="menu"
             aria-expanded={isDropdownVisible}

--- a/client/src/components/Dropdown.tsx
+++ b/client/src/components/Dropdown.tsx
@@ -31,7 +31,13 @@ export const Dropdown: React.FC<DropdownProps> = ({ children, buttonLabel }) => 
           onDeactivate: closeDropdown,
         }}
       >
-        <div className={classnames("dropdown", isHamburgerMenu && "dropdown-right show-lg")}>
+        <div
+          className={classnames(
+            "dropdown",
+            isDropdownVisible && "is-open",
+            isHamburgerMenu && "dropdown-right show-lg"
+          )}
+        >
           <button
             aria-label="menu"
             aria-expanded={isDropdownVisible}

--- a/client/src/components/Dropdown.tsx
+++ b/client/src/components/Dropdown.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import classnames from "classnames";
 import FocusTrap from "focus-trap-react";
 
+import chevron from "../assets/img/accordionchevron.svg";
+
 import "styles/Dropdown.css";
 
 type DropdownProps = {
@@ -33,11 +35,23 @@ export const Dropdown: React.FC<DropdownProps> = ({ children, buttonLabel }) => 
           <button
             aria-label="menu"
             aria-expanded={isDropdownVisible}
-            className={"btn btn-link dropdown-toggle m-2" + (isDropdownVisible ? " active" : "")}
+            className={classnames(
+              "btn",
+              "btn-link",
+              "dropdown-toggle",
+              "m-2",
+              isDropdownVisible && "active",
+              buttonLabel && "dropdown-selector-panel"
+            )}
             onClick={() => toggleDropdown()}
           >
             {buttonLabel ? (
-              <span>{buttonLabel}</span>
+              <>
+                <div className="float-left">{buttonLabel}</div>
+                <div className="float-right">
+                  <img src={chevron} className="icon" alt="Open" />
+                </div>
+              </>
             ) : (
               <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
             )}

--- a/client/src/components/Dropdown.tsx
+++ b/client/src/components/Dropdown.tsx
@@ -20,71 +20,84 @@ type DropdownProps = withI18nProps & {
    * If undefined, the toggle button will default to a hamburger icon.
    */
   buttonLabel?: string;
+  /**
+   * The aria-label on the button that toggles the dropdown menu (announced by screen readers).
+   * If undefined, the toggle button will have an aria-label that says "Menu"
+   */
+  buttonAriaLabel?: string;
 };
 
-export const Dropdown = withI18n()(({ i18n, children, buttonLabel }: DropdownProps) => {
-  const [isDropdownVisible, setDropdownVisibility] = useState(false);
+export const Dropdown = withI18n()(
+  ({ i18n, children, buttonLabel, buttonAriaLabel }: DropdownProps) => {
+    const [isDropdownVisible, setDropdownVisibility] = useState(false);
 
-  const closeDropdown = () => setDropdownVisibility(false);
-  const toggleDropdown = () => {
-    isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
-  };
+    const closeDropdown = () => setDropdownVisibility(false);
+    const toggleDropdown = () => {
+      isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
+    };
 
-  const isHamburgerMenu = !buttonLabel;
+    const isHamburgerMenu = !buttonLabel;
 
-  return (
-    <div className="DropdownComponent">
-      <FocusTrap
-        active={isDropdownVisible}
-        focusTrapOptions={{
-          clickOutsideDeactivates: true,
-          returnFocusOnDeactivate: false,
-          onDeactivate: closeDropdown,
-        }}
-      >
-        <div
-          className={classnames(
-            "dropdown",
-            isDropdownVisible && "is-open",
-            isHamburgerMenu && "dropdown-right show-lg"
-          )}
+    return (
+      <div className="DropdownComponent">
+        <FocusTrap
+          active={isDropdownVisible}
+          focusTrapOptions={{
+            clickOutsideDeactivates: true,
+            returnFocusOnDeactivate: false,
+            onDeactivate: closeDropdown,
+          }}
         >
-          <button
-            aria-label={buttonLabel || i18n._(t`Menu`)}
-            aria-expanded={isDropdownVisible}
+          <div
             className={classnames(
-              "btn",
-              "btn-link",
-              "dropdown-toggle",
-              "m-2",
-              isDropdownVisible && "active",
-              buttonLabel && "dropdown-selector-panel"
+              "dropdown",
+              isDropdownVisible && "is-open",
+              isHamburgerMenu && "dropdown-right show-lg"
             )}
-            onClick={() => toggleDropdown()}
           >
-            {buttonLabel ? (
-              <>
-                <div className="float-left">{buttonLabel}</div>
-                <div className="float-right">
-                  <img src={chevron} className="icon" alt="Open" />
-                </div>
-              </>
-            ) : (
-              <i className={classnames("icon", isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
-            )}
-          </button>
-          <ul
-            onClick={closeDropdown}
-            className={classnames("menu", "menu-reverse", isDropdownVisible ? "d-block" : "d-none")}
-          >
-            {children}
-          </ul>
-        </div>
-      </FocusTrap>
-      <div
-        onClick={closeDropdown}
-        className={classnames("dropdown-overlay", !isDropdownVisible && "hidden")}
-      />
-    </div>
-  );
-});
+            <button
+              aria-label={buttonAriaLabel || i18n._(t`Menu`)}
+              aria-expanded={isDropdownVisible}
+              className={classnames(
+                "btn",
+                "btn-link",
+                "dropdown-toggle",
+                "m-2",
+                isDropdownVisible && "active",
+                buttonLabel && "dropdown-selector-panel"
+              )}
+              onClick={() => toggleDropdown()}
+            >
+              {buttonLabel ? (
+                <>
+                  <div className="float-left">{buttonLabel}</div>
+                  <div className="float-right">
+                    <img src={chevron} className="icon" alt="Open" />
+                  </div>
+                </>
+              ) : (
+                <i
+                  className={classnames("icon", isDropdownVisible ? "icon-cross" : "icon-menu")}
+                ></i>
+              )}
+            </button>
+            <ul
+              onClick={closeDropdown}
+              className={classnames(
+                "menu",
+                "menu-reverse",
+                isDropdownVisible ? "d-block" : "d-none"
+              )}
+            >
+              {children}
+            </ul>
+          </div>
+        </FocusTrap>
+        <div
+          onClick={closeDropdown}
+          className={classnames("dropdown-overlay", !isDropdownVisible && "hidden")}
+        />
+      </div>
+    );
+  }
+);

--- a/client/src/components/Dropdown.tsx
+++ b/client/src/components/Dropdown.tsx
@@ -8,6 +8,10 @@ import "styles/Dropdown.css";
 
 type DropdownProps = {
   children: React.ReactNode;
+  /**
+   * The text label on the button that toggles the dropdown menu.
+   * If undefined, the toggle button will default to a hamburger icon.
+   */
   buttonLabel?: string;
 };
 

--- a/client/src/components/Dropdown.tsx
+++ b/client/src/components/Dropdown.tsx
@@ -1,0 +1,47 @@
+import FocusTrap from "focus-trap-react";
+import React, { useState } from "react";
+
+import "styles/Dropdown.css";
+
+export const Dropdown: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isDropdownVisible, setDropdownVisibility] = useState(false);
+
+  const closeDropdown = () => setDropdownVisibility(false);
+  const toggleDropdown = () => {
+    isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
+  };
+  console.log(isDropdownVisible);
+  return (
+    <div className="DropdownComponent">
+      <FocusTrap
+        active={isDropdownVisible}
+        focusTrapOptions={{
+          clickOutsideDeactivates: true,
+          returnFocusOnDeactivate: false,
+          onDeactivate: closeDropdown,
+        }}
+      >
+        <div className="dropdown dropdown-right show-lg">
+          <button
+            aria-label="menu"
+            aria-expanded={isDropdownVisible}
+            className={"btn btn-link dropdown-toggle m-2" + (isDropdownVisible ? " active" : "")}
+            onClick={() => toggleDropdown()}
+          >
+            <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
+          </button>
+          <ul
+            onClick={closeDropdown}
+            className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
+          >
+            {children}
+          </ul>
+        </div>
+      </FocusTrap>
+      <div
+        onClick={closeDropdown}
+        className={"dropdown-overlay" + (isDropdownVisible ? "" : " hidden")}
+      />
+    </div>
+  );
+};

--- a/client/src/components/Dropdown.tsx
+++ b/client/src/components/Dropdown.tsx
@@ -5,8 +5,15 @@ import FocusTrap from "focus-trap-react";
 import chevron from "../assets/img/accordionchevron.svg";
 
 import "styles/Dropdown.css";
+import { withI18n, withI18nProps } from "@lingui/react";
+import { t } from "@lingui/macro";
 
-type DropdownProps = {
+type DropdownProps = withI18nProps & {
+  /**
+   * The items that go inside the expandable menu. Since these are
+   * nested inside a `<ul>` element, they should consist of `<li>`'s,
+   * otherwise you may face some DOM nesting errors.
+   */
   children: React.ReactNode;
   /**
    * The text label on the button that toggles the dropdown menu.
@@ -15,7 +22,7 @@ type DropdownProps = {
   buttonLabel?: string;
 };
 
-export const Dropdown: React.FC<DropdownProps> = ({ children, buttonLabel }) => {
+export const Dropdown = withI18n()(({ i18n, children, buttonLabel }: DropdownProps) => {
   const [isDropdownVisible, setDropdownVisibility] = useState(false);
 
   const closeDropdown = () => setDropdownVisibility(false);
@@ -43,7 +50,7 @@ export const Dropdown: React.FC<DropdownProps> = ({ children, buttonLabel }) => 
           )}
         >
           <button
-            aria-label="menu"
+            aria-label={buttonLabel || i18n._(t`Menu`)}
             aria-expanded={isDropdownVisible}
             className={classnames(
               "btn",
@@ -63,12 +70,12 @@ export const Dropdown: React.FC<DropdownProps> = ({ children, buttonLabel }) => 
                 </div>
               </>
             ) : (
-              <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
+              <i className={classnames("icon", isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
             )}
           </button>
           <ul
             onClick={closeDropdown}
-            className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
+            className={classnames("menu", "menu-reverse", isDropdownVisible ? "d-block" : "d-none")}
           >
             {children}
           </ul>
@@ -76,8 +83,8 @@ export const Dropdown: React.FC<DropdownProps> = ({ children, buttonLabel }) => 
       </FocusTrap>
       <div
         onClick={closeDropdown}
-        className={"dropdown-overlay" + (isDropdownVisible ? "" : " hidden")}
+        className={classnames("dropdown-overlay", !isDropdownVisible && "hidden")}
       />
     </div>
   );
-};
+});

--- a/client/src/components/Dropdown.tsx
+++ b/client/src/components/Dropdown.tsx
@@ -6,16 +6,18 @@ import "styles/Dropdown.css";
 
 type DropdownProps = {
   children: React.ReactNode;
-  style?: "hamburger" | "selector";
+  buttonLabel?: string;
 };
 
-export const Dropdown: React.FC<DropdownProps> = ({ children, style = "hamburger" }) => {
+export const Dropdown: React.FC<DropdownProps> = ({ children, buttonLabel }) => {
   const [isDropdownVisible, setDropdownVisibility] = useState(false);
 
   const closeDropdown = () => setDropdownVisibility(false);
   const toggleDropdown = () => {
     isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
   };
+
+  const isHamburgerMenu = !buttonLabel;
 
   return (
     <div className="DropdownComponent">
@@ -27,14 +29,18 @@ export const Dropdown: React.FC<DropdownProps> = ({ children, style = "hamburger
           onDeactivate: closeDropdown,
         }}
       >
-        <div className={classnames("dropdown", style === "hamburger" && "dropdown-right show-lg")}>
+        <div className={classnames("dropdown", isHamburgerMenu && "dropdown-right show-lg")}>
           <button
             aria-label="menu"
             aria-expanded={isDropdownVisible}
             className={"btn btn-link dropdown-toggle m-2" + (isDropdownVisible ? " active" : "")}
             onClick={() => toggleDropdown()}
           >
-            <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
+            {buttonLabel ? (
+              <span>{buttonLabel}</span>
+            ) : (
+              <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
+            )}
           </button>
           <ul
             onClick={closeDropdown}

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -215,9 +215,9 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
 
                 <div className="Indicators__links">
                   <div className="Indicators__linksContainer">
-                    <em className="Indicators__linksTitle">
-                      <Trans>Select a Dataset:</Trans>
-                    </em>{" "}
+                    <span className="Indicators__linksTitle text-uppercase">
+                      <Trans>Display:</Trans>
+                    </span>{" "}
                     <br />
                     <Dropdown buttonLabel={INDICATORS_DATASETS[activeVis].name(i18n)}>
                       <IndicatorsDatasetRadio

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -24,6 +24,7 @@ import {
   IndicatorsTimeSpan,
 } from "./IndicatorsTypes";
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
+import { Dropdown } from "./Dropdown";
 
 class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> {
   constructor(props: IndicatorsProps) {
@@ -218,21 +219,23 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                       <Trans>Select a Dataset:</Trans>
                     </em>{" "}
                     <br />
-                    <IndicatorsDatasetRadio
-                      id="complaints"
-                      activeId={activeVis}
-                      onChange={this.handleVisChange}
-                    />
-                    <IndicatorsDatasetRadio
-                      id="viols"
-                      activeId={activeVis}
-                      onChange={this.handleVisChange}
-                    />
-                    <IndicatorsDatasetRadio
-                      id="permits"
-                      activeId={activeVis}
-                      onChange={this.handleVisChange}
-                    />
+                    <Dropdown>
+                      <IndicatorsDatasetRadio
+                        id="complaints"
+                        activeId={activeVis}
+                        onChange={this.handleVisChange}
+                      />
+                      <IndicatorsDatasetRadio
+                        id="viols"
+                        activeId={activeVis}
+                        onChange={this.handleVisChange}
+                      />
+                      <IndicatorsDatasetRadio
+                        id="permits"
+                        activeId={activeVis}
+                        onChange={this.handleVisChange}
+                      />
+                    </Dropdown>
                   </div>
                   <div className="Indicators__linksContainer">
                     <em className="Indicators__linksTitle">

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -15,7 +15,6 @@ import {
   INDICATORS_DATASETS,
   IndicatorsDatasetId,
 } from "./IndicatorsDatasets";
-import { Link } from "react-router-dom";
 import {
   indicatorsInitialState,
   IndicatorsProps,
@@ -171,7 +170,6 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
       const { state, send } = this.props;
 
       const { detailAddr } = state.context.portfolioData;
-      const { bbl } = detailAddr;
 
       const { activeVis } = this.state;
       const activeData = state.context.timelineData[activeVis];

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -23,7 +23,7 @@ import {
   IndicatorsState,
   IndicatorChartShift,
   IndicatorsTimeSpan,
-  IndicatorsTimeSpans,
+  indicatorsTimeSpans,
 } from "./IndicatorsTypes";
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
 import { Dropdown } from "./Dropdown";
@@ -36,6 +36,19 @@ const timeSpanTranslations: TimeSpanTranslationsMap = {
   month: (i18n) => i18n._(t`month`),
   quarter: (i18n) => i18n._(t`quarter`),
   year: (i18n) => i18n._(t`year`),
+};
+
+/**
+ * Generates an appropriate width for a dropdown selection menu
+ * that's scaled according to the longest text selection.
+ */
+const getDropdownWidthFromLongestSelection = (selections: string[]) => {
+  const LETTER_WIDTH = 10;
+  const MENU_BUFFER = 70;
+  const MAX_WIDTH = 350;
+
+  const lengthOfLongestSelection = Math.max(...selections.map((selection) => selection.length));
+  return Math.min(lengthOfLongestSelection * LETTER_WIDTH + MENU_BUFFER, MAX_WIDTH);
 };
 
 class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> {
@@ -196,6 +209,13 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
 
       const i18n = this.props.i18n;
 
+      const datasetSelectionNames = indicatorsDatasetIds.map((datasetId) =>
+        INDICATORS_DATASETS[datasetId].name(i18n)
+      );
+      const timeSpanSelectionNames = indicatorsTimeSpans.map((timeSpan) =>
+        timeSpanTranslations[timeSpan](i18n)
+      );
+
       const detailAddrStr = `${detailAddr.housenumber} ${Helpers.titleCase(
         detailAddr.streetname
       )}, ${Helpers.titleCase(detailAddr.boro)}`;
@@ -214,9 +234,13 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     </h4>
                   </div>
                 )}
-
                 <div className="Indicators__links">
-                  <div className="Indicators__linksContainer">
+                  <div
+                    className="Indicators__linksContainer"
+                    style={{
+                      width: `${getDropdownWidthFromLongestSelection(datasetSelectionNames)}px`,
+                    }}
+                  >
                     <span className="Indicators__linksTitle text-uppercase">
                       <Trans>Display:</Trans>
                     </span>{" "}
@@ -237,7 +261,12 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                       ))}
                     </Dropdown>
                   </div>
-                  <div className="Indicators__linksContainer">
+                  <div
+                    className="Indicators__linksContainer"
+                    style={{
+                      width: `${getDropdownWidthFromLongestSelection(timeSpanSelectionNames)}px`,
+                    }}
+                  >
                     <span className="Indicators__linksTitle text-uppercase">
                       <Trans>View by:</Trans>
                     </span>
@@ -248,7 +277,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                         this.state.activeTimeSpan
                       ](i18n)}`}
                     >
-                      {IndicatorsTimeSpans.map((timespan, i) => (
+                      {indicatorsTimeSpans.map((timespan, i) => (
                         <li className="menu-item" key={i}>
                           <label
                             className={
@@ -272,13 +301,11 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     </Dropdown>
                   </div>
                 </div>
-
                 <span className="title viz-title">
                   {datasetDescription &&
                     indicatorDataTotal !== null &&
                     datasetDescription.quantity(i18n, indicatorDataTotal)}
                 </span>
-
                 <div className="Indicators__viz">
                   <button
                     aria-label={i18n._(t`Move chart data left.`)}

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -221,7 +221,12 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                       <Trans>Display:</Trans>
                     </span>{" "}
                     <br />
-                    <Dropdown buttonLabel={INDICATORS_DATASETS[activeVis].name(i18n)}>
+                    <Dropdown
+                      buttonLabel={INDICATORS_DATASETS[activeVis].name(i18n)}
+                      buttonAriaLabel={`${i18n._(t`Display:`)} ${INDICATORS_DATASETS[
+                        activeVis
+                      ].name(i18n)}`}
+                    >
                       {indicatorsDatasetIds.map((datasetKey, i) => (
                         <IndicatorsDatasetRadio
                           key={i}
@@ -237,7 +242,12 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                       <Trans>View by:</Trans>
                     </span>
                     <br />
-                    <Dropdown buttonLabel={this.state.activeTimeSpan}>
+                    <Dropdown
+                      buttonLabel={timeSpanTranslations[this.state.activeTimeSpan](i18n)}
+                      buttonAriaLabel={`${i18n._(t`View by:`)} ${timeSpanTranslations[
+                        this.state.activeTimeSpan
+                      ](i18n)}`}
+                    >
                       {IndicatorsTimeSpans.map((timespan, i) => (
                         <li className="menu-item" key={i}>
                           <label
@@ -271,7 +281,11 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
 
                 <div className="Indicators__viz">
                   <button
+                    aria-label={i18n._(t`Move chart data left.`)}
                     aria-hidden={
+                      this.state.xAxisStart === 0 || this.state.activeTimeSpan === "year"
+                    }
+                    aria-disabled={
                       this.state.xAxisStart === 0 || this.state.activeTimeSpan === "year"
                     }
                     className={
@@ -288,7 +302,12 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                   </button>
                   <IndicatorsViz state={state} send={send} {...this.state} />
                   <button
+                    aria-label={i18n._(t`Move chart data right.`)}
                     aria-hidden={
+                      this.state.xAxisStart + this.state.xAxisViewableColumns >= xAxisLength ||
+                      this.state.activeTimeSpan === "year"
+                    }
+                    aria-disabled={
                       this.state.xAxisStart + this.state.xAxisViewableColumns >= xAxisLength ||
                       this.state.activeTimeSpan === "year"
                     }

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -219,7 +219,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                       <Trans>Select a Dataset:</Trans>
                     </em>{" "}
                     <br />
-                    <Dropdown>
+                    <Dropdown buttonLabel={INDICATORS_DATASETS[activeVis].name(i18n)}>
                       <IndicatorsDatasetRadio
                         id="complaints"
                         activeId={activeVis}

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -199,17 +199,8 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                 {detailAddr && (
                   <div className="title-card">
                     <h4 className="title">
-                      <span>
-                        <Trans>BUILDING:</Trans> <b>{detailAddrStr}</b>
-                      </span>
+                      <b>{detailAddrStr}</b>
                     </h4>
-                    <br />
-                    <Link
-                      to={this.props.addressPageRoutes.overview}
-                      onClick={() => this.props.onBackToOverview(bbl)}
-                    >
-                      <Trans>Back to Overview</Trans>
-                    </Link>
                   </div>
                 )}
 
@@ -238,64 +229,67 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     </Dropdown>
                   </div>
                   <div className="Indicators__linksContainer">
-                    <em className="Indicators__linksTitle">
+                    <span className="Indicators__linksTitle text-uppercase">
                       <Trans>View by:</Trans>
-                    </em>
+                    </span>
                     <br />
-                    <li className="menu-item">
-                      <label
-                        className={
-                          "form-radio" + (this.state.activeTimeSpan === "month" ? " active" : "")
-                        }
-                        onClick={() => {
-                          window.gtag("event", "month-timeline-tab");
-                        }}
-                      >
-                        <input
-                          type="radio"
-                          name="month"
-                          checked={this.state.activeTimeSpan === "month" ? true : false}
-                          onChange={() => this.handleTimeSpanChange("month")}
-                        />
-                        <i className="form-icon" /> <Trans>Month</Trans>
-                      </label>
-                    </li>
-                    <li className="menu-item">
-                      <label
-                        className={
-                          "form-radio" + (this.state.activeTimeSpan === "quarter" ? " active" : "")
-                        }
-                        onClick={() => {
-                          window.gtag("event", "quarter-timeline-tab");
-                        }}
-                      >
-                        <input
-                          type="radio"
-                          name="quarter"
-                          checked={this.state.activeTimeSpan === "quarter" ? true : false}
-                          onChange={() => this.handleTimeSpanChange("quarter")}
-                        />
-                        <i className="form-icon" /> <Trans>Quarter</Trans>
-                      </label>
-                    </li>
-                    <li className="menu-item">
-                      <label
-                        className={
-                          "form-radio" + (this.state.activeTimeSpan === "year" ? " active" : "")
-                        }
-                        onClick={() => {
-                          window.gtag("event", "year-timeline-tab");
-                        }}
-                      >
-                        <input
-                          type="radio"
-                          name="year"
-                          checked={this.state.activeTimeSpan === "year" ? true : false}
-                          onChange={() => this.handleTimeSpanChange("year")}
-                        />
-                        <i className="form-icon" /> <Trans>Year</Trans>
-                      </label>
-                    </li>
+                    <Dropdown buttonLabel={this.state.activeTimeSpan}>
+                      <li className="menu-item">
+                        <label
+                          className={
+                            "form-radio" + (this.state.activeTimeSpan === "month" ? " active" : "")
+                          }
+                          onClick={() => {
+                            window.gtag("event", "month-timeline-tab");
+                          }}
+                        >
+                          <input
+                            type="radio"
+                            name="month"
+                            checked={this.state.activeTimeSpan === "month" ? true : false}
+                            onChange={() => this.handleTimeSpanChange("month")}
+                          />
+                          <i className="form-icon" /> <Trans>month</Trans>
+                        </label>
+                      </li>
+                      <li className="menu-item">
+                        <label
+                          className={
+                            "form-radio" +
+                            (this.state.activeTimeSpan === "quarter" ? " active" : "")
+                          }
+                          onClick={() => {
+                            window.gtag("event", "quarter-timeline-tab");
+                          }}
+                        >
+                          <input
+                            type="radio"
+                            name="quarter"
+                            checked={this.state.activeTimeSpan === "quarter" ? true : false}
+                            onChange={() => this.handleTimeSpanChange("quarter")}
+                          />
+                          <i className="form-icon" /> <Trans>quarter</Trans>
+                        </label>
+                      </li>
+                      <li className="menu-item">
+                        <label
+                          className={
+                            "form-radio" + (this.state.activeTimeSpan === "year" ? " active" : "")
+                          }
+                          onClick={() => {
+                            window.gtag("event", "year-timeline-tab");
+                          }}
+                        >
+                          <input
+                            type="radio"
+                            name="year"
+                            checked={this.state.activeTimeSpan === "year" ? true : false}
+                            onChange={() => this.handleTimeSpanChange("year")}
+                          />
+                          <i className="form-icon" /> <Trans>year</Trans>
+                        </label>
+                      </li>
+                    </Dropdown>
                   </div>
                 </div>
 

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -7,13 +7,15 @@ import Loader from "../components/Loader";
 import LegalFooter from "../components/LegalFooter";
 import { UsefulLinks } from "./UsefulLinks";
 import { withI18n } from "@lingui/react";
-import { Trans } from "@lingui/macro";
+import { I18n } from "@lingui/core";
+import { t, Trans } from "@lingui/macro";
 
 import "styles/Indicators.css";
 import {
   IndicatorsDatasetRadio,
   INDICATORS_DATASETS,
   IndicatorsDatasetId,
+  indicatorsDatasetIds,
 } from "./IndicatorsDatasets";
 import {
   indicatorsInitialState,
@@ -21,9 +23,20 @@ import {
   IndicatorsState,
   IndicatorChartShift,
   IndicatorsTimeSpan,
+  IndicatorsTimeSpans,
 } from "./IndicatorsTypes";
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
 import { Dropdown } from "./Dropdown";
+
+type TimeSpanTranslationsMap = {
+  [K in IndicatorsTimeSpan]: (i18n: I18n) => string;
+};
+
+const timeSpanTranslations: TimeSpanTranslationsMap = {
+  month: (i18n) => i18n._(t`month`),
+  quarter: (i18n) => i18n._(t`quarter`),
+  year: (i18n) => i18n._(t`year`),
+};
 
 class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> {
   constructor(props: IndicatorsProps) {
@@ -209,21 +222,14 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     </span>{" "}
                     <br />
                     <Dropdown buttonLabel={INDICATORS_DATASETS[activeVis].name(i18n)}>
-                      <IndicatorsDatasetRadio
-                        id="complaints"
-                        activeId={activeVis}
-                        onChange={this.handleVisChange}
-                      />
-                      <IndicatorsDatasetRadio
-                        id="viols"
-                        activeId={activeVis}
-                        onChange={this.handleVisChange}
-                      />
-                      <IndicatorsDatasetRadio
-                        id="permits"
-                        activeId={activeVis}
-                        onChange={this.handleVisChange}
-                      />
+                      {indicatorsDatasetIds.map((datasetKey, i) => (
+                        <IndicatorsDatasetRadio
+                          key={i}
+                          id={datasetKey}
+                          activeId={activeVis}
+                          onChange={this.handleVisChange}
+                        />
+                      ))}
                     </Dropdown>
                   </div>
                   <div className="Indicators__linksContainer">
@@ -232,61 +238,27 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                     </span>
                     <br />
                     <Dropdown buttonLabel={this.state.activeTimeSpan}>
-                      <li className="menu-item">
-                        <label
-                          className={
-                            "form-radio" + (this.state.activeTimeSpan === "month" ? " active" : "")
-                          }
-                          onClick={() => {
-                            window.gtag("event", "month-timeline-tab");
-                          }}
-                        >
-                          <input
-                            type="radio"
-                            name="month"
-                            checked={this.state.activeTimeSpan === "month" ? true : false}
-                            onChange={() => this.handleTimeSpanChange("month")}
-                          />
-                          <i className="form-icon" /> <Trans>month</Trans>
-                        </label>
-                      </li>
-                      <li className="menu-item">
-                        <label
-                          className={
-                            "form-radio" +
-                            (this.state.activeTimeSpan === "quarter" ? " active" : "")
-                          }
-                          onClick={() => {
-                            window.gtag("event", "quarter-timeline-tab");
-                          }}
-                        >
-                          <input
-                            type="radio"
-                            name="quarter"
-                            checked={this.state.activeTimeSpan === "quarter" ? true : false}
-                            onChange={() => this.handleTimeSpanChange("quarter")}
-                          />
-                          <i className="form-icon" /> <Trans>quarter</Trans>
-                        </label>
-                      </li>
-                      <li className="menu-item">
-                        <label
-                          className={
-                            "form-radio" + (this.state.activeTimeSpan === "year" ? " active" : "")
-                          }
-                          onClick={() => {
-                            window.gtag("event", "year-timeline-tab");
-                          }}
-                        >
-                          <input
-                            type="radio"
-                            name="year"
-                            checked={this.state.activeTimeSpan === "year" ? true : false}
-                            onChange={() => this.handleTimeSpanChange("year")}
-                          />
-                          <i className="form-icon" /> <Trans>year</Trans>
-                        </label>
-                      </li>
+                      {IndicatorsTimeSpans.map((timespan, i) => (
+                        <li className="menu-item" key={i}>
+                          <label
+                            className={
+                              "form-radio" +
+                              (this.state.activeTimeSpan === timespan ? " active" : "")
+                            }
+                            onClick={() => {
+                              window.gtag("event", "month-timeline-tab");
+                            }}
+                          >
+                            <input
+                              type="radio"
+                              name={timespan}
+                              checked={this.state.activeTimeSpan === timespan ? true : false}
+                              onChange={() => this.handleTimeSpanChange(timespan)}
+                            />
+                            <i className="form-icon" /> {timeSpanTranslations[timespan](i18n)}
+                          </label>
+                        </li>
+                      ))}
                     </Dropdown>
                   </div>
                 </div>

--- a/client/src/components/IndicatorsDatasets.tsx
+++ b/client/src/components/IndicatorsDatasets.tsx
@@ -3,7 +3,14 @@ import { I18n } from "@lingui/core";
 import { t, Trans, plural } from "@lingui/macro";
 import { withI18n } from "@lingui/react";
 
-export type IndicatorsDatasetId = "complaints" | "viols" | "permits";
+/**
+ * The ids for all datasets shown on the Timeline Tab, _in the order they will appear on the select menu_.
+ *
+ * Note: This separation of array and type definition allows us to more easily iterate over all dataset ids.
+ * See https://stackoverflow.com/a/64174790 for more details on this approach.
+ */
+export const indicatorsDatasetIds = ["complaints", "viols", "permits"] as const;
+export type IndicatorsDatasetId = typeof indicatorsDatasetIds[number];
 
 /**
  * This interface encapsulates metadata about an Indicators dataset.

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -9,8 +9,8 @@ import { AddressPageRoutes } from "routes";
  * Note: This separation of array and type definition allows us to more easily iterate over all dataset ids.
  * See https://stackoverflow.com/a/64174790 for more details on this approach.
  */
-export const IndicatorsTimeSpans = ["month", "quarter", "year"] as const;
-export type IndicatorsTimeSpan = typeof IndicatorsTimeSpans[number];
+export const indicatorsTimeSpans = ["month", "quarter", "year"] as const;
+export type IndicatorsTimeSpan = typeof indicatorsTimeSpans[number];
 
 // Types Relating to the State Machine Data for the Indicators Component:
 

--- a/client/src/components/IndicatorsTypes.tsx
+++ b/client/src/components/IndicatorsTypes.tsx
@@ -3,7 +3,14 @@ import { withI18nProps } from "@lingui/react";
 import { withMachineInStateProps } from "state-machine";
 import { AddressPageRoutes } from "routes";
 
-export type IndicatorsTimeSpan = "month" | "quarter" | "year";
+/**
+ * All the time spans you can view data by on the Timeline Tab, _in the order they will appear on the select menu_.
+ *
+ * Note: This separation of array and type definition allows us to more easily iterate over all dataset ids.
+ * See https://stackoverflow.com/a/64174790 for more details on this approach.
+ */
+export const IndicatorsTimeSpans = ["month", "quarter", "year"] as const;
+export type IndicatorsTimeSpan = typeof IndicatorsTimeSpans[number];
 
 // Types Relating to the State Machine Data for the Indicators Component:
 

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { Trans, t } from "@lingui/macro";
-import FocusTrap from "focus-trap-react";
 
 import "styles/App.css";
 
@@ -33,6 +32,7 @@ import { DevPage } from "./DevPage";
 import { wowMachine } from "state-machine";
 import { NotFoundPage } from "./NotFoundPage";
 import widont from "widont";
+import { Dropdown } from "components/Dropdown";
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -108,12 +108,6 @@ const getMainNavLinks = () => {
 
 const App = () => {
   const [isEngageModalVisible, setEngageModalVisibility] = useState(false);
-  const [isDropdownVisible, setDropdownVisibility] = useState(false);
-
-  const closeDropdown = () => setDropdownVisibility(false);
-  const toggleDropdown = () => {
-    isDropdownVisible ? setDropdownVisibility(false) : setDropdownVisibility(true);
-  };
 
   const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
   const version = process.env.REACT_APP_VERSION;
@@ -131,10 +125,6 @@ const App = () => {
             />
           )}
           <div className="App">
-            <div
-              onClick={closeDropdown}
-              className={"dropdown-overlay" + (isDropdownVisible ? "" : " hidden")}
-            />
             {warnAboutOldBrowser && (
               <div className="App__warning old_safari_only">
                 <Trans render="h3">
@@ -159,46 +149,22 @@ const App = () => {
                   </a>
                   <LocaleSwitcher />
                 </span>
-                <FocusTrap
-                  active={isDropdownVisible}
-                  focusTrapOptions={{
-                    clickOutsideDeactivates: true,
-                    returnFocusOnDeactivate: false,
-                    onDeactivate: closeDropdown,
-                  }}
-                >
-                  <div className="dropdown dropdown-right show-lg">
-                    <button
-                      aria-label="menu"
-                      aria-expanded={isDropdownVisible}
-                      className={
-                        "btn btn-link dropdown-toggle m-2" + (isDropdownVisible ? " active" : "")
-                      }
-                      onClick={() => toggleDropdown()}
-                    >
-                      <i className={"icon " + (isDropdownVisible ? "icon-cross" : "icon-menu")}></i>
-                    </button>
-                    <ul
-                      onClick={closeDropdown}
-                      className={"menu menu-reverse " + (isDropdownVisible ? "d-block" : "d-none")}
-                    >
-                      {getMainNavLinks().map((link, i) => (
-                        <li className="menu-item" key={i}>
-                          {link}
-                        </li>
-                      ))}
-                      <li className="menu-item">
-                        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                        <a href="#" onClick={() => setEngageModalVisibility(true)}>
-                          <Trans>Share</Trans>
-                        </a>
-                      </li>
-                      <li className="menu-item">
-                        <LocaleSwitcherWithFullLanguageName />
-                      </li>
-                    </ul>
-                  </div>
-                </FocusTrap>
+                <Dropdown>
+                  {getMainNavLinks().map((link, i) => (
+                    <li className="menu-item" key={i}>
+                      {link}
+                    </li>
+                  ))}
+                  <li className="menu-item">
+                    {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                    <a href="#" onClick={() => setEngageModalVisibility(true)}>
+                      <Trans>Share</Trans>
+                    </a>
+                  </li>
+                  <li className="menu-item">
+                    <LocaleSwitcherWithFullLanguageName />
+                  </li>
+                </Dropdown>
               </nav>
 
               <Modal

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -245,6 +245,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
 #: src/components/Indicators.tsx:154
+#: src/components/Indicators.tsx:157
 msgid "Display:"
 msgstr "Display:"
 
@@ -521,6 +522,14 @@ msgstr "Methodology"
 #: src/components/DetailView.tsx:153
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
+
+#: src/components/Indicators.tsx:187
+msgid "Move chart data left."
+msgstr "Move chart data left."
+
+#: src/components/Indicators.tsx:196
+msgid "Move chart data right."
+msgstr "Move chart data right."
 
 #: src/containers/NychaPage.tsx:165
 msgid "MyNYCHA App"
@@ -934,6 +943,7 @@ msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
 #: src/components/Indicators.tsx:163
+#: src/components/Indicators.tsx:166
 msgid "View by:"
 msgstr "View by:"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -509,6 +509,10 @@ msgstr "Maintenance code violations"
 msgid "May be issued official Orders"
 msgstr "May be issued official Orders"
 
+#: src/components/Dropdown.tsx:22
+msgid "Menu"
+msgstr "Menu"
+
 #: src/components/LegalFooter.tsx:43
 #: src/containers/Methodology.tsx:14
 msgid "Methodology"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -125,7 +125,7 @@ msgstr "Borough Management Office:"
 msgid "Building Classification"
 msgstr "Building Classification"
 
-#: src/components/IndicatorsDatasets.tsx:61
+#: src/components/IndicatorsDatasets.tsx:68
 msgid "Building Permit Applications"
 msgstr "Building Permit Applications"
 
@@ -244,7 +244,7 @@ msgstr "Demo Site"
 msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
-#: src/components/Indicators.tsx:149
+#: src/components/Indicators.tsx:154
 msgid "Display:"
 msgstr "Display:"
 
@@ -341,21 +341,21 @@ msgstr "HEATING"
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
-#: src/components/IndicatorsDatasets.tsx:6
+#: src/components/IndicatorsDatasets.tsx:13
 #: src/components/PropertiesList.tsx:194
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
-#: src/components/IndicatorsDatasets.tsx:12
+#: src/components/IndicatorsDatasets.tsx:19
 msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
-#: src/components/IndicatorsDatasets.tsx:32
+#: src/components/IndicatorsDatasets.tsx:39
 #: src/components/PropertiesList.tsx:234
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
-#: src/components/IndicatorsDatasets.tsx:39
+#: src/components/IndicatorsDatasets.tsx:46
 msgid "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner— however, HPD violations are notoriously unenforced by the City. These Violations fall into three categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8/>Read more about HPD Violations at the <9>official HPD page</9>."
 msgstr "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner— however, HPD violations are notoriously unenforced by the City. These Violations fall into three categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8/>Read more about HPD Violations at the <9>official HPD page</9>."
 
@@ -473,7 +473,7 @@ msgstr "Lessee"
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
-#: src/components/Indicators.tsx:119
+#: src/components/Indicators.tsx:124
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:62
 #: src/containers/AddressPage.tsx:165
@@ -607,7 +607,7 @@ msgstr "Open Violations"
 msgid "Overview"
 msgstr "Overview"
 
-#: src/components/IndicatorsDatasets.tsx:67
+#: src/components/IndicatorsDatasets.tsx:74
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 
@@ -929,7 +929,7 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
-#: src/components/Indicators.tsx:160
+#: src/components/Indicators.tsx:163
 msgid "View by:"
 msgstr "View by:"
 
@@ -993,7 +993,7 @@ msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
-#: src/components/Indicators.tsx:222
+#: src/components/Indicators.tsx:209
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
@@ -1053,11 +1053,11 @@ msgstr "associated building"
 msgid "for ${0}"
 msgstr "for ${0}"
 
-#: src/components/Indicators.tsx:169
+#: src/components/Indicators.tsx:15
 msgid "month"
 msgstr "month"
 
-#: src/components/Indicators.tsx:178
+#: src/components/Indicators.tsx:16
 msgid "quarter"
 msgstr "quarter"
 
@@ -1065,7 +1065,7 @@ msgstr "quarter"
 msgid "search address"
 msgstr "search address"
 
-#: src/components/Indicators.tsx:186
+#: src/components/Indicators.tsx:17
 msgid "year"
 msgstr "year"
 
@@ -1073,14 +1073,14 @@ msgstr "year"
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 
-#: src/components/IndicatorsDatasets.tsx:62
+#: src/components/IndicatorsDatasets.tsx:69
 msgid "{value, plural, one {One Building Permit Application since 2010} other {# Building Permit Applications since 2010}}"
 msgstr "{value, plural, one {One Building Permit Application since 2010} other {# Building Permit Applications since 2010}}"
 
-#: src/components/IndicatorsDatasets.tsx:7
+#: src/components/IndicatorsDatasets.tsx:14
 msgid "{value, plural, one {One HPD Complaint Issued since 2014} other {# HPD Complaints Issued since 2014}}"
 msgstr "{value, plural, one {One HPD Complaint Issued since 2014} other {# HPD Complaints Issued since 2014}}"
 
-#: src/components/IndicatorsDatasets.tsx:34
+#: src/components/IndicatorsDatasets.tsx:41
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -72,7 +72,6 @@ msgstr "According to available HPD data, this portfolio has received <0>{totalvi
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:88
 #: src/components/PropertiesList.tsx:96
 msgid "Address"
 msgstr "Address"
@@ -89,8 +88,6 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:308
-#: src/components/PropertiesList.tsx:316
 #: src/components/PropertiesList.tsx:316
 #: src/components/PropertiesList.tsx:324
 msgid "Amount"
@@ -111,12 +108,6 @@ msgstr "BELL/BUZZER/INTERCOM"
 #: src/components/DetailView.tsx:130
 msgid "BUILDING:"
 msgstr "BUILDING:"
-
-#: src/components/PropertiesList.tsx:124
-#: src/components/PropertiesList.tsx:129
-#: src/components/Indicators.tsx:149
-msgid "Back to Overview"
-msgstr "Back to Overview"
 
 #: src/components/PropertiesList.tsx:132
 #: src/components/PropertiesList.tsx:137
@@ -147,8 +138,6 @@ msgstr "Building Permits Applied For"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:147
-#: src/components/PropertiesList.tsx:152
 #: src/components/PropertiesList.tsx:155
 #: src/components/PropertiesList.tsx:160
 msgid "Built"
@@ -242,8 +231,6 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PropertiesList.tsx:296
-#: src/components/PropertiesList.tsx:304
 #: src/components/PropertiesList.tsx:304
 #: src/components/PropertiesList.tsx:312
 msgid "Date"
@@ -296,7 +283,6 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:257
 #: src/components/PropertiesList.tsx:265
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
@@ -339,8 +325,6 @@ msgstr "GARBAGE/RECYCLING STORAGE"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:329
-#: src/components/PropertiesList.tsx:343
 #: src/components/PropertiesList.tsx:337
 #: src/components/PropertiesList.tsx:351
 msgid "Group Sale?"
@@ -359,8 +343,6 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:13
-#: src/components/PropertiesList.tsx:194
-#: src/components/IndicatorsDatasets.tsx:6
 #: src/components/PropertiesList.tsx:202
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
@@ -370,8 +352,6 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:39
-#: src/components/PropertiesList.tsx:234
-#: src/components/IndicatorsDatasets.tsx:32
 #: src/components/PropertiesList.tsx:242
 msgid "HPD Violations"
 msgstr "HPD Violations"
@@ -418,7 +398,6 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:143
 #: src/components/PropertiesList.tsx:151
 msgid "Information"
 msgstr "Information"
@@ -447,7 +426,6 @@ msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PropertiesList.tsx:271
 #: src/components/PropertiesList.tsx:279
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
@@ -457,12 +435,6 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:207
-#: src/components/PropertiesList.tsx:212
-msgid "Last 3 Years"
-msgstr "Last 3 Years"
-
-#: src/components/PropertiesList.tsx:292
 #: src/components/PropertiesList.tsx:215
 #: src/components/PropertiesList.tsx:220
 msgid "Last 3 Years"
@@ -496,9 +468,6 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PropertiesList.tsx:319
-#: src/components/PropertiesList.tsx:321
-#: src/components/PropertiesList.tsx:325
 #: src/components/PropertiesList.tsx:327
 #: src/components/PropertiesList.tsx:329
 #: src/components/PropertiesList.tsx:333
@@ -513,7 +482,6 @@ msgstr "Link to Deed"
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:108
 #: src/components/PropertiesList.tsx:116
 msgid "Location"
 msgstr "Location"
@@ -583,7 +551,6 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:340
 #: src/components/PropertiesList.tsx:348
 msgid "No"
 msgstr "No"
@@ -625,8 +592,6 @@ msgstr "OUTSIDE BUILDING"
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PropertiesList.tsx:275
-#: src/components/PropertiesList.tsx:284
 #: src/components/PropertiesList.tsx:283
 #: src/components/PropertiesList.tsx:292
 msgid "Officer/Owner"
@@ -642,8 +607,6 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:238
-#: src/components/PropertiesList.tsx:243
 #: src/components/PropertiesList.tsx:246
 #: src/components/PropertiesList.tsx:251
 msgid "Open"
@@ -700,7 +663,6 @@ msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:166
 #: src/components/PropertiesList.tsx:174
 msgid "RS Units"
 msgstr "RS Units"
@@ -763,8 +725,6 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:261
-#: src/components/PropertiesList.tsx:266
 #: src/components/PropertiesList.tsx:269
 #: src/components/PropertiesList.tsx:274
 msgid "Since 2017"
@@ -936,18 +896,12 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PropertiesList.tsx:216
-#: src/components/PropertiesList.tsx:226
 #: src/components/PropertiesList.tsx:224
 #: src/components/PropertiesList.tsx:234
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:198
-#: src/components/PropertiesList.tsx:203
-#: src/components/PropertiesList.tsx:247
-#: src/components/PropertiesList.tsx:252
 #: src/components/PropertiesList.tsx:206
 #: src/components/PropertiesList.tsx:211
 #: src/components/PropertiesList.tsx:255
@@ -968,8 +922,6 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:156
-#: src/components/PropertiesList.tsx:161
 #: src/components/PropertiesList.tsx:164
 #: src/components/PropertiesList.tsx:169
 #: src/containers/NychaPage.tsx:83
@@ -999,9 +951,6 @@ msgstr "View by:"
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PropertiesList.tsx:349
-#: src/components/PropertiesList.tsx:355
-#: src/components/PropertiesList.tsx:359
 #: src/components/PropertiesList.tsx:357
 #: src/components/PropertiesList.tsx:363
 #: src/components/PropertiesList.tsx:367
@@ -1058,7 +1007,7 @@ msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
-#: src/components/Indicators.tsx:209
+#: src/components/Indicators.tsx:210
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
@@ -1093,7 +1042,6 @@ msgstr "Who’s the landlord of this building?"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:339
 #: src/components/PropertiesList.tsx:347
 msgid "Yes"
 msgstr "Yes"
@@ -1102,8 +1050,6 @@ msgstr "Yes"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:114
-#: src/components/PropertiesList.tsx:119
 #: src/components/PropertiesList.tsx:122
 #: src/components/PropertiesList.tsx:127
 msgid "Zipcode"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/util/helpers.ts:242
+#: src/util/helpers.ts:260
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
@@ -41,7 +41,7 @@ msgstr "(hover over a box to learn more)"
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 
-#: src/containers/HomePage.tsx:79
+#: src/containers/HomePage.tsx:90
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
@@ -72,7 +72,7 @@ msgstr "According to available HPD data, this portfolio has received <0>{totalvi
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:49
+#: src/components/PropertiesList.tsx:88
 msgid "Address"
 msgstr "Address"
 
@@ -88,8 +88,8 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:256
-#: src/components/PropertiesList.tsx:264
+#: src/components/PropertiesList.tsx:308
+#: src/components/PropertiesList.tsx:316
 msgid "Amount"
 msgstr "Amount"
 
@@ -106,16 +106,11 @@ msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
 #: src/components/DetailView.tsx:130
-#: src/components/Indicators.tsx:144
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/Indicators.tsx:149
-msgid "Back to Overview"
-msgstr "Back to Overview"
-
-#: src/components/PropertiesList.tsx:78
-#: src/components/PropertiesList.tsx:83
+#: src/components/PropertiesList.tsx:124
+#: src/components/PropertiesList.tsx:129
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -143,8 +138,8 @@ msgstr "Building Permits Applied For"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:101
-#: src/components/PropertiesList.tsx:106
+#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:152
 msgid "Built"
 msgstr "Built"
 
@@ -236,18 +231,22 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PropertiesList.tsx:244
-#: src/components/PropertiesList.tsx:252
+#: src/components/PropertiesList.tsx:296
+#: src/components/PropertiesList.tsx:304
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:101
+#: src/containers/App.tsx:95
 msgid "Demo Site"
 msgstr "Demo Site"
 
 #: src/components/LegalFooter.tsx:13
 msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
+
+#: src/components/Indicators.tsx:149
+msgid "Display:"
+msgstr "Display:"
 
 #: src/components/LegalFooter.tsx:33
 #: src/containers/App.tsx:72
@@ -274,7 +273,7 @@ msgstr "Email"
 msgid "Emergency"
 msgstr "Emergency"
 
-#: src/containers/HomePage.tsx:66
+#: src/containers/HomePage.tsx:77
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Enter an NYC address and find other buildings your landlord might own:"
 
@@ -283,7 +282,7 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:208
+#: src/components/PropertiesList.tsx:257
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -325,8 +324,8 @@ msgstr "GARBAGE/RECYCLING STORAGE"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:277
-#: src/components/PropertiesList.tsx:291
+#: src/components/PropertiesList.tsx:329
+#: src/components/PropertiesList.tsx:343
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -343,7 +342,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:148
+#: src/components/PropertiesList.tsx:194
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -352,7 +351,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:185
+#: src/components/PropertiesList.tsx:234
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -398,7 +397,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:97
+#: src/components/PropertiesList.tsx:143
 msgid "Information"
 msgstr "Information"
 
@@ -426,7 +425,7 @@ msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PropertiesList.tsx:222
+#: src/components/PropertiesList.tsx:271
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Landlord"
@@ -435,12 +434,12 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:161
-#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesList.tsx:207
+#: src/components/PropertiesList.tsx:212
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PropertiesList.tsx:240
+#: src/components/PropertiesList.tsx:292
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -468,9 +467,9 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PropertiesList.tsx:267
-#: src/components/PropertiesList.tsx:269
-#: src/components/PropertiesList.tsx:273
+#: src/components/PropertiesList.tsx:319
+#: src/components/PropertiesList.tsx:321
+#: src/components/PropertiesList.tsx:325
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -482,7 +481,7 @@ msgstr "Link to Deed"
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:65
+#: src/components/PropertiesList.tsx:108
 msgid "Location"
 msgstr "Location"
 
@@ -515,10 +514,6 @@ msgstr "May be issued official Orders"
 msgid "Methodology"
 msgstr "Methodology"
 
-#: src/components/Indicators.tsx:173
-msgid "Month"
-msgstr "Month"
-
 #: src/components/DetailView.tsx:153
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
@@ -543,7 +538,7 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/PropertiesList.tsx:288
+#: src/components/PropertiesList.tsx:340
 msgid "No"
 msgstr "No"
 
@@ -584,8 +579,8 @@ msgstr "OUTSIDE BUILDING"
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PropertiesList.tsx:226
-#: src/components/PropertiesList.tsx:235
+#: src/components/PropertiesList.tsx:275
+#: src/components/PropertiesList.tsx:284
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -599,8 +594,8 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:189
-#: src/components/PropertiesList.tsx:194
+#: src/components/PropertiesList.tsx:238
+#: src/components/PropertiesList.tsx:243
 msgid "Open"
 msgstr "Open"
 
@@ -654,12 +649,8 @@ msgstr "Privacy policy"
 msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
-#: src/components/Indicators.tsx:181
-msgid "Quarter"
-msgstr "Quarter"
-
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:120
+#: src/components/PropertiesList.tsx:166
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -692,23 +683,19 @@ msgstr "Search"
 msgid "Search for a different address"
 msgstr "Search for a different address"
 
-#: src/components/Indicators.tsx:156
-msgid "Select a Dataset:"
-msgstr "Select a Dataset:"
-
 #: src/components/PropertiesSummary.tsx:36
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:108
-#: src/containers/App.tsx:128
+#: src/containers/App.tsx:102
+#: src/containers/App.tsx:113
 msgid "Share"
 msgstr "Share"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:141
+#: src/containers/App.tsx:124
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -725,8 +712,8 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:212
-#: src/components/PropertiesList.tsx:217
+#: src/components/PropertiesList.tsx:261
+#: src/components/PropertiesList.tsx:266
 msgid "Since 2017"
 msgstr "Since 2017"
 
@@ -788,7 +775,7 @@ msgstr "The building with the most evictions is <0>{0} {1}, {2}</0> with {buildi
 msgid "The city borough where your search address is located"
 msgstr "The city borough where your search address is located"
 
-#: src/containers/HomePage.tsx:132
+#: src/containers/HomePage.tsx:143
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
@@ -868,7 +855,7 @@ msgstr "This portfolio also had an estimated <0>net {changeType, select, gain {g
 msgid "This portfolio has an average of <0>{openviolationsperresunit}</0> open HPD violations per residential unit."
 msgstr "This portfolio has an average of <0>{openviolationsperresunit}</0> open HPD violations per residential unit."
 
-#: src/containers/HomePage.tsx:98
+#: src/containers/HomePage.tsx:109
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 
@@ -896,16 +883,16 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PropertiesList.tsx:170
-#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:216
+#: src/components/PropertiesList.tsx:226
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:152
-#: src/components/PropertiesList.tsx:157
 #: src/components/PropertiesList.tsx:198
 #: src/components/PropertiesList.tsx:203
+#: src/components/PropertiesList.tsx:247
+#: src/components/PropertiesList.tsx:252
 msgid "Total"
 msgstr "Total"
 
@@ -922,8 +909,8 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:110
-#: src/components/PropertiesList.tsx:115
+#: src/components/PropertiesList.tsx:156
+#: src/components/PropertiesList.tsx:161
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -942,7 +929,7 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
-#: src/components/Indicators.tsx:165
+#: src/components/Indicators.tsx:160
 msgid "View by:"
 msgstr "View by:"
 
@@ -950,9 +937,9 @@ msgstr "View by:"
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PropertiesList.tsx:297
-#: src/components/PropertiesList.tsx:303
-#: src/components/PropertiesList.tsx:307
+#: src/components/PropertiesList.tsx:349
+#: src/components/PropertiesList.tsx:355
+#: src/components/PropertiesList.tsx:359
 msgid "View detail"
 msgstr "View detail"
 
@@ -968,9 +955,9 @@ msgstr "View documents on ACRIS"
 msgid "View legend"
 msgstr "View legend"
 
-#: src/containers/HomePage.tsx:113
-#: src/containers/HomePage.tsx:155
-#: src/containers/HomePage.tsx:185
+#: src/containers/HomePage.tsx:124
+#: src/containers/HomePage.tsx:166
+#: src/containers/HomePage.tsx:196
 msgid "View portfolio"
 msgstr "View portfolio"
 
@@ -998,7 +985,7 @@ msgstr "WINDOW GUARDS"
 msgid "WINDOWS"
 msgstr "WINDOWS"
 
-#: src/containers/App.tsx:93
+#: src/containers/App.tsx:87
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 
@@ -1006,7 +993,7 @@ msgstr "Warning! This site doesn't fully work on older versions of Safari. Try a
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
-#: src/components/Indicators.tsx:224
+#: src/components/Indicators.tsx:222
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
@@ -1037,24 +1024,20 @@ msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWha
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
-#: src/components/Indicators.tsx:189
-msgid "Year"
-msgstr "Year"
-
 #: src/components/BuildingStatsTable.tsx:35
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:287
+#: src/components/PropertiesList.tsx:339
 msgid "Yes"
 msgstr "Yes"
 
-#: src/containers/HomePage.tsx:174
+#: src/containers/HomePage.tsx:185
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:69
-#: src/components/PropertiesList.tsx:74
+#: src/components/PropertiesList.tsx:114
+#: src/components/PropertiesList.tsx:119
 msgid "Zipcode"
 msgstr "Zipcode"
 
@@ -1070,9 +1053,21 @@ msgstr "associated building"
 msgid "for ${0}"
 msgstr "for ${0}"
 
+#: src/components/Indicators.tsx:169
+msgid "month"
+msgstr "month"
+
+#: src/components/Indicators.tsx:178
+msgid "quarter"
+msgstr "quarter"
+
 #: src/components/PropertiesMap.tsx:199
 msgid "search address"
 msgstr "search address"
+
+#: src/components/Indicators.tsx:186
+msgid "year"
+msgstr "year"
 
 #: src/components/PropertiesSummary.tsx:92
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -514,6 +514,10 @@ msgstr "Infracciones del código de mantenimiento"
 msgid "May be issued official Orders"
 msgstr "Pueden emitirse órdenes oficiales"
 
+#: src/components/Dropdown.tsx:22
+msgid "Menu"
+msgstr ""
+
 #: src/components/LegalFooter.tsx:43
 #: src/containers/Methodology.tsx:14
 msgid "Methodology"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
-#: src/util/helpers.ts:242
+#: src/util/helpers.ts:260
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
@@ -46,7 +46,7 @@ msgstr "(pase el cursor sobre una casilla para aprender más)"
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {pulsa} other {haz clic}} para ver detalles)"
 
-#: src/containers/HomePage.tsx:79
+#: src/containers/HomePage.tsx:90
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de portafolios de edificios:"
 
@@ -77,7 +77,7 @@ msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha re
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:49
+#: src/components/PropertiesList.tsx:88
 msgid "Address"
 msgstr "Dirección"
 
@@ -93,8 +93,8 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:256
-#: src/components/PropertiesList.tsx:264
+#: src/components/PropertiesList.tsx:308
+#: src/components/PropertiesList.tsx:316
 msgid "Amount"
 msgstr "Importe"
 
@@ -111,16 +111,11 @@ msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
 #: src/components/DetailView.tsx:130
-#: src/components/Indicators.tsx:144
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/Indicators.tsx:149
-msgid "Back to Overview"
-msgstr "Volver a la Vista General"
-
-#: src/components/PropertiesList.tsx:78
-#: src/components/PropertiesList.tsx:83
+#: src/components/PropertiesList.tsx:124
+#: src/components/PropertiesList.tsx:129
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -148,8 +143,8 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:101
-#: src/components/PropertiesList.tsx:106
+#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:152
 msgid "Built"
 msgstr "Construido"
 
@@ -241,18 +236,22 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PropertiesList.tsx:244
-#: src/components/PropertiesList.tsx:252
+#: src/components/PropertiesList.tsx:296
+#: src/components/PropertiesList.tsx:304
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:101
+#: src/containers/App.tsx:95
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
 #: src/components/LegalFooter.tsx:13
 msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
+
+#: src/components/Indicators.tsx:149
+msgid "Display:"
+msgstr ""
 
 #: src/components/LegalFooter.tsx:33
 #: src/containers/App.tsx:72
@@ -279,7 +278,7 @@ msgstr "Email"
 msgid "Emergency"
 msgstr "Emergencia"
 
-#: src/containers/HomePage.tsx:66
+#: src/containers/HomePage.tsx:77
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
 
@@ -288,7 +287,7 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:208
+#: src/components/PropertiesList.tsx:257
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -330,8 +329,8 @@ msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:277
-#: src/components/PropertiesList.tsx:291
+#: src/components/PropertiesList.tsx:329
+#: src/components/PropertiesList.tsx:343
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -348,7 +347,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:148
+#: src/components/PropertiesList.tsx:194
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -357,7 +356,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:32
-#: src/components/PropertiesList.tsx:185
+#: src/components/PropertiesList.tsx:234
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
@@ -403,7 +402,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
-#: src/components/PropertiesList.tsx:97
+#: src/components/PropertiesList.tsx:143
 msgid "Information"
 msgstr "Información"
 
@@ -431,7 +430,7 @@ msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucr
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PropertiesList.tsx:222
+#: src/components/PropertiesList.tsx:271
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Dueño del edificio"
@@ -440,12 +439,12 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:161
-#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesList.tsx:207
+#: src/components/PropertiesList.tsx:212
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PropertiesList.tsx:240
+#: src/components/PropertiesList.tsx:292
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -473,9 +472,9 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PropertiesList.tsx:267
-#: src/components/PropertiesList.tsx:269
-#: src/components/PropertiesList.tsx:273
+#: src/components/PropertiesList.tsx:319
+#: src/components/PropertiesList.tsx:321
+#: src/components/PropertiesList.tsx:325
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -487,7 +486,7 @@ msgstr "Enlace a la Escritura"
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:65
+#: src/components/PropertiesList.tsx:108
 msgid "Location"
 msgstr "Ubicación"
 
@@ -520,10 +519,6 @@ msgstr "Pueden emitirse órdenes oficiales"
 msgid "Methodology"
 msgstr "Metodología"
 
-#: src/components/Indicators.tsx:173
-msgid "Month"
-msgstr "Mes"
-
 #: src/components/DetailView.tsx:153
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
@@ -548,7 +543,7 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:288
+#: src/components/PropertiesList.tsx:340
 msgid "No"
 msgstr "No"
 
@@ -589,8 +584,8 @@ msgstr "AFUERA DEL EDIFICIO"
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PropertiesList.tsx:226
-#: src/components/PropertiesList.tsx:235
+#: src/components/PropertiesList.tsx:275
+#: src/components/PropertiesList.tsx:284
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -604,8 +599,8 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:189
-#: src/components/PropertiesList.tsx:194
+#: src/components/PropertiesList.tsx:238
+#: src/components/PropertiesList.tsx:243
 msgid "Open"
 msgstr "Actuales"
 
@@ -659,12 +654,8 @@ msgstr "Política de privacidad"
 msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
-#: src/components/Indicators.tsx:181
-msgid "Quarter"
-msgstr "Trimestre"
-
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:120
+#: src/components/PropertiesList.tsx:166
 msgid "RS Units"
 msgstr "Unidades RS"
 
@@ -697,23 +688,19 @@ msgstr "Buscar"
 msgid "Search for a different address"
 msgstr "Buscar otra dirección"
 
-#: src/components/Indicators.tsx:156
-msgid "Select a Dataset:"
-msgstr "Seleccione un conjunto de datos:"
-
 #: src/components/PropertiesSummary.tsx:36
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:108
-#: src/containers/App.tsx:128
+#: src/containers/App.tsx:102
+#: src/containers/App.tsx:113
 msgid "Share"
 msgstr "Compartir"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
-#: src/containers/App.tsx:141
+#: src/containers/App.tsx:124
 #: src/containers/NotRegisteredPage.tsx:13
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -730,8 +717,8 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:212
-#: src/components/PropertiesList.tsx:217
+#: src/components/PropertiesList.tsx:261
+#: src/components/PropertiesList.tsx:266
 msgid "Since 2017"
 msgstr "Desde 2017"
 
@@ -793,7 +780,7 @@ msgstr "El edificio con la major cantidad de desalojos es <0>{0} {1}, {2}</0> co
 msgid "The city borough where your search address is located"
 msgstr "El municipio donde se encuentra la dirección que has buscado"
 
-#: src/containers/HomePage.tsx:132
+#: src/containers/HomePage.tsx:143
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
@@ -873,7 +860,7 @@ msgstr "Este portafolio de edificios tuvo una <0>{changeType, select, gain {gana
 msgid "This portfolio has an average of <0>{openviolationsperresunit}</0> open HPD violations per residential unit."
 msgstr "Este portafolio de edificios tiene un promedio de <0>{openviolationsperresunit}</0> infracciones del HPD Actuales por cada unidad residencial."
 
-#: src/containers/HomePage.tsx:98
+#: src/containers/HomePage.tsx:109
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "Esta empresa de gestión inmobiliaria es propiedad de la familia Kushner y es notoria por <0>violar las normas de vivienda</0> y por <1>comportamientos abusivos</1>. La participación financiera actualmente sostenida por Jared Kushner e Ivanka Trump asciende a 761 millones de dólares."
 
@@ -901,16 +888,16 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PropertiesList.tsx:170
-#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:216
+#: src/components/PropertiesList.tsx:226
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:152
-#: src/components/PropertiesList.tsx:157
 #: src/components/PropertiesList.tsx:198
 #: src/components/PropertiesList.tsx:203
+#: src/components/PropertiesList.tsx:247
+#: src/components/PropertiesList.tsx:252
 msgid "Total"
 msgstr "Total"
 
@@ -927,8 +914,8 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:110
-#: src/components/PropertiesList.tsx:115
+#: src/components/PropertiesList.tsx:156
+#: src/components/PropertiesList.tsx:161
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades"
@@ -947,7 +934,7 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
-#: src/components/Indicators.tsx:165
+#: src/components/Indicators.tsx:160
 msgid "View by:"
 msgstr "Visualizar por:"
 
@@ -955,9 +942,9 @@ msgstr "Visualizar por:"
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PropertiesList.tsx:297
-#: src/components/PropertiesList.tsx:303
-#: src/components/PropertiesList.tsx:307
+#: src/components/PropertiesList.tsx:349
+#: src/components/PropertiesList.tsx:355
+#: src/components/PropertiesList.tsx:359
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -973,9 +960,9 @@ msgstr "Ver documentos en ACRIS"
 msgid "View legend"
 msgstr "Ver leyenda"
 
-#: src/containers/HomePage.tsx:113
-#: src/containers/HomePage.tsx:155
-#: src/containers/HomePage.tsx:185
+#: src/containers/HomePage.tsx:124
+#: src/containers/HomePage.tsx:166
+#: src/containers/HomePage.tsx:196
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
@@ -1003,7 +990,7 @@ msgstr "PROTECTORES DE VENTANA"
 msgid "WINDOWS"
 msgstr "VENTANAS"
 
-#: src/containers/App.tsx:93
+#: src/containers/App.tsx:87
 msgid "Warning! This site doesn't fully work on older versions of Safari. Try a <0>modern browser</0>."
 msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas de Safari. Prueba un <0>navegador moderno</0>."
 
@@ -1011,7 +998,7 @@ msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas 
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
-#: src/components/Indicators.tsx:224
+#: src/components/Indicators.tsx:222
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
@@ -1042,24 +1029,20 @@ msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? 
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
-#: src/components/Indicators.tsx:189
-msgid "Year"
-msgstr "Año"
-
 #: src/components/BuildingStatsTable.tsx:35
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:287
+#: src/components/PropertiesList.tsx:339
 msgid "Yes"
 msgstr "Sí"
 
-#: src/containers/HomePage.tsx:174
+#: src/containers/HomePage.tsx:185
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:69
-#: src/components/PropertiesList.tsx:74
+#: src/components/PropertiesList.tsx:114
+#: src/components/PropertiesList.tsx:119
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -1075,9 +1058,21 @@ msgstr "edificio asociado"
 msgid "for ${0}"
 msgstr "por ${0}"
 
+#: src/components/Indicators.tsx:169
+msgid "month"
+msgstr ""
+
+#: src/components/Indicators.tsx:178
+msgid "quarter"
+msgstr ""
+
 #: src/components/PropertiesMap.tsx:199
 msgid "search address"
 msgstr "dirección de búsqueda"
+
+#: src/components/Indicators.tsx:186
+msgid "year"
+msgstr ""
 
 #: src/components/PropertiesSummary.tsx:92
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
@@ -1094,4 +1089,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:34
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Infracción del HPD emitida desde el 2010} other {# Infracciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -77,7 +77,6 @@ msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha re
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:88
 #: src/components/PropertiesList.tsx:96
 msgid "Address"
 msgstr "Dirección"
@@ -94,8 +93,6 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:308
-#: src/components/PropertiesList.tsx:316
 #: src/components/PropertiesList.tsx:316
 #: src/components/PropertiesList.tsx:324
 msgid "Amount"
@@ -116,12 +113,6 @@ msgstr "TIMBRE/INTERCOMUNICADOR"
 #: src/components/DetailView.tsx:130
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
-
-#: src/components/PropertiesList.tsx:124
-#: src/components/PropertiesList.tsx:129
-#: src/components/Indicators.tsx:149
-msgid "Back to Overview"
-msgstr "Volver a la Vista General"
 
 #: src/components/PropertiesList.tsx:132
 #: src/components/PropertiesList.tsx:137
@@ -152,8 +143,6 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:147
-#: src/components/PropertiesList.tsx:152
 #: src/components/PropertiesList.tsx:155
 #: src/components/PropertiesList.tsx:160
 msgid "Built"
@@ -247,8 +236,6 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PropertiesList.tsx:296
-#: src/components/PropertiesList.tsx:304
 #: src/components/PropertiesList.tsx:304
 #: src/components/PropertiesList.tsx:312
 msgid "Date"
@@ -301,7 +288,6 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:257
 #: src/components/PropertiesList.tsx:265
 #: src/components/PropertiesSummary.tsx:116
 #: src/containers/NychaPage.tsx:87
@@ -344,8 +330,6 @@ msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:329
-#: src/components/PropertiesList.tsx:343
 #: src/components/PropertiesList.tsx:337
 #: src/components/PropertiesList.tsx:351
 msgid "Group Sale?"
@@ -364,8 +348,6 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:13
-#: src/components/PropertiesList.tsx:194
-#: src/components/IndicatorsDatasets.tsx:6
 #: src/components/PropertiesList.tsx:202
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
@@ -375,8 +357,6 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:39
-#: src/components/PropertiesList.tsx:234
-#: src/components/IndicatorsDatasets.tsx:32
 #: src/components/PropertiesList.tsx:242
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
@@ -423,7 +403,6 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar infracciones"
 
-#: src/components/PropertiesList.tsx:143
 #: src/components/PropertiesList.tsx:151
 msgid "Information"
 msgstr "Información"
@@ -452,7 +431,6 @@ msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucr
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PropertiesList.tsx:271
 #: src/components/PropertiesList.tsx:279
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
@@ -462,12 +440,6 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:207
-#: src/components/PropertiesList.tsx:212
-msgid "Last 3 Years"
-msgstr "Últimos 3 años"
-
-#: src/components/PropertiesList.tsx:292
 #: src/components/PropertiesList.tsx:215
 #: src/components/PropertiesList.tsx:220
 msgid "Last 3 Years"
@@ -501,9 +473,6 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PropertiesList.tsx:319
-#: src/components/PropertiesList.tsx:321
-#: src/components/PropertiesList.tsx:325
 #: src/components/PropertiesList.tsx:327
 #: src/components/PropertiesList.tsx:329
 #: src/components/PropertiesList.tsx:333
@@ -518,7 +487,6 @@ msgstr "Enlace a la Escritura"
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:108
 #: src/components/PropertiesList.tsx:116
 msgid "Location"
 msgstr "Ubicación"
@@ -588,7 +556,6 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/PropertiesList.tsx:340
 #: src/components/PropertiesList.tsx:348
 msgid "No"
 msgstr "No"
@@ -630,8 +597,6 @@ msgstr "AFUERA DEL EDIFICIO"
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PropertiesList.tsx:275
-#: src/components/PropertiesList.tsx:284
 #: src/components/PropertiesList.tsx:283
 #: src/components/PropertiesList.tsx:292
 msgid "Officer/Owner"
@@ -647,8 +612,6 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:238
-#: src/components/PropertiesList.tsx:243
 #: src/components/PropertiesList.tsx:246
 #: src/components/PropertiesList.tsx:251
 msgid "Open"
@@ -705,7 +668,6 @@ msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:166
 #: src/components/PropertiesList.tsx:174
 msgid "RS Units"
 msgstr "Unidades RS"
@@ -768,8 +730,6 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:261
-#: src/components/PropertiesList.tsx:266
 #: src/components/PropertiesList.tsx:269
 #: src/components/PropertiesList.tsx:274
 msgid "Since 2017"
@@ -941,18 +901,12 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PropertiesList.tsx:216
-#: src/components/PropertiesList.tsx:226
 #: src/components/PropertiesList.tsx:224
 #: src/components/PropertiesList.tsx:234
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:313
-#: src/components/PropertiesList.tsx:198
-#: src/components/PropertiesList.tsx:203
-#: src/components/PropertiesList.tsx:247
-#: src/components/PropertiesList.tsx:252
 #: src/components/PropertiesList.tsx:206
 #: src/components/PropertiesList.tsx:211
 #: src/components/PropertiesList.tsx:255
@@ -973,8 +927,6 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:156
-#: src/components/PropertiesList.tsx:161
 #: src/components/PropertiesList.tsx:164
 #: src/components/PropertiesList.tsx:169
 #: src/containers/NychaPage.tsx:83
@@ -1004,9 +956,6 @@ msgstr "Visualizar por:"
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PropertiesList.tsx:349
-#: src/components/PropertiesList.tsx:355
-#: src/components/PropertiesList.tsx:359
 #: src/components/PropertiesList.tsx:357
 #: src/components/PropertiesList.tsx:363
 #: src/components/PropertiesList.tsx:367
@@ -1063,7 +1012,7 @@ msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas 
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
-#: src/components/Indicators.tsx:209
+#: src/components/Indicators.tsx:210
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
@@ -1098,7 +1047,6 @@ msgstr "¿Quién es el dueño de este edificio?"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:339
 #: src/components/PropertiesList.tsx:347
 msgid "Yes"
 msgstr "Sí"
@@ -1107,8 +1055,6 @@ msgstr "Sí"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:114
-#: src/components/PropertiesList.tsx:119
 #: src/components/PropertiesList.tsx:122
 #: src/components/PropertiesList.tsx:127
 msgid "Zipcode"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -250,6 +250,7 @@ msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advi
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
 
 #: src/components/Indicators.tsx:154
+#: src/components/Indicators.tsx:157
 msgid "Display:"
 msgstr ""
 
@@ -526,6 +527,14 @@ msgstr "Metodología"
 #: src/components/DetailView.tsx:153
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
+
+#: src/components/Indicators.tsx:187
+msgid "Move chart data left."
+msgstr ""
+
+#: src/components/Indicators.tsx:196
+msgid "Move chart data right."
+msgstr ""
 
 #: src/containers/NychaPage.tsx:165
 msgid "MyNYCHA App"
@@ -939,6 +948,7 @@ msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
 #: src/components/Indicators.tsx:163
+#: src/components/Indicators.tsx:166
 msgid "View by:"
 msgstr "Visualizar por:"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -130,7 +130,7 @@ msgstr "Oficina de Gestión Municipal:"
 msgid "Building Classification"
 msgstr "Clasificación del Edificio"
 
-#: src/components/IndicatorsDatasets.tsx:61
+#: src/components/IndicatorsDatasets.tsx:68
 msgid "Building Permit Applications"
 msgstr "Solicitudes de Permisos de Construcción"
 
@@ -249,7 +249,7 @@ msgstr "Sitio Demo"
 msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
 
-#: src/components/Indicators.tsx:149
+#: src/components/Indicators.tsx:154
 msgid "Display:"
 msgstr ""
 
@@ -346,21 +346,21 @@ msgstr "CALEFACCIÓN"
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
-#: src/components/IndicatorsDatasets.tsx:6
+#: src/components/IndicatorsDatasets.tsx:13
 #: src/components/PropertiesList.tsx:194
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
-#: src/components/IndicatorsDatasets.tsx:12
+#: src/components/IndicatorsDatasets.tsx:19
 msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontraras más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
-#: src/components/IndicatorsDatasets.tsx:32
+#: src/components/IndicatorsDatasets.tsx:39
 #: src/components/PropertiesList.tsx:234
 msgid "HPD Violations"
 msgstr "Infracciones del HPD"
 
-#: src/components/IndicatorsDatasets.tsx:39
+#: src/components/IndicatorsDatasets.tsx:46
 msgid "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner— however, HPD violations are notoriously unenforced by the City. These Violations fall into three categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8/>Read more about HPD Violations at the <9>official HPD page</9>."
 msgstr "Infracciones del HPD se dan cuando un Inspector oficial de la Ciudad determina que las condiciones de un hogar están en violación de la ley. Si no se corrigen, estas infraccines incurren multas para el propietario, sin embargo, las infracciones del HPD son notoriamente incumplidas por la Ciudad. Existen tres categorías de Infracciones:<0/><1/><2>Clase A</2> — no-peligrosa<3/><4>Clase B</4> — peligrosa<5/><6>Clase C</6> — de peligro inmediato<7/><8/>Encontraras más información sobre las Infracciones del HPD en la <9>página oficial del HPD</9>."
 
@@ -478,7 +478,7 @@ msgstr "Arrendatario"
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
-#: src/components/Indicators.tsx:119
+#: src/components/Indicators.tsx:124
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:62
 #: src/containers/AddressPage.tsx:165
@@ -612,7 +612,7 @@ msgstr "Infracciones Actuales"
 msgid "Overview"
 msgstr "General"
 
-#: src/components/IndicatorsDatasets.tsx:67
+#: src/components/IndicatorsDatasets.tsx:74
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/> Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
 
@@ -934,7 +934,7 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
-#: src/components/Indicators.tsx:160
+#: src/components/Indicators.tsx:163
 msgid "View by:"
 msgstr "Visualizar por:"
 
@@ -998,7 +998,7 @@ msgstr "¡Atención! Este sitio no funciona completamente en versiones antiguas 
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
-#: src/components/Indicators.tsx:222
+#: src/components/Indicators.tsx:209
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
@@ -1058,11 +1058,11 @@ msgstr "edificio asociado"
 msgid "for ${0}"
 msgstr "por ${0}"
 
-#: src/components/Indicators.tsx:169
+#: src/components/Indicators.tsx:15
 msgid "month"
 msgstr ""
 
-#: src/components/Indicators.tsx:178
+#: src/components/Indicators.tsx:16
 msgid "quarter"
 msgstr ""
 
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "search address"
 msgstr "dirección de búsqueda"
 
-#: src/components/Indicators.tsx:186
+#: src/components/Indicators.tsx:17
 msgid "year"
 msgstr ""
 
@@ -1078,14 +1078,14 @@ msgstr ""
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una infracción del HPD actual} other {# infracciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 
-#: src/components/IndicatorsDatasets.tsx:62
+#: src/components/IndicatorsDatasets.tsx:69
 msgid "{value, plural, one {One Building Permit Application since 2010} other {# Building Permit Applications since 2010}}"
 msgstr "{value, plural, one {Una Solicitud de Permiso de Construcción desde el 2010} other {# Solicitudes de Permiso de Construcción desde el 2010}}"
 
-#: src/components/IndicatorsDatasets.tsx:7
+#: src/components/IndicatorsDatasets.tsx:14
 msgid "{value, plural, one {One HPD Complaint Issued since 2014} other {# HPD Complaints Issued since 2014}}"
 msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Quejas del HPD emitidas desde el 2014}}"
 
-#: src/components/IndicatorsDatasets.tsx:34
+#: src/components/IndicatorsDatasets.tsx:41
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Infracción del HPD emitida desde el 2010} other {# Infracciones del HPD emitidas desde el 2010}}"

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -5,18 +5,6 @@
   display: flex;
   flex-direction: column;
 
-  .dropdown-overlay {
-    &.hidden {
-      display: none;
-    }
-    position: fixed;
-    width: 100%;
-    height: 100%;
-    background-color: $dark;
-    opacity: 0.6;
-    z-index: 100;
-  }
-
   & > div {
     box-sizing: border-box;
   }
@@ -55,34 +43,6 @@
 
   @include for-phone-only {
     padding: 10px 8px 8px;
-  }
-  .dropdown.dropdown-right {
-    z-index: 110;
-    // Remove default border on focus:
-    button.dropdown-toggle:focus {
-      border: none;
-    }
-    .menu {
-      padding: 0.25rem 0.5rem;
-      font-size: 1.6rem;
-
-      .menu-item a {
-        &:focus {
-          outline-offset: 0px;
-        }
-        &:active,
-        &.active {
-          background: $gray-light;
-        }
-      }
-
-      &.d-block {
-        display: block;
-      }
-      &.d-none {
-        display: none;
-      }
-    }
   }
 
   .label.label-warning {

--- a/client/src/styles/Dropdown.scss
+++ b/client/src/styles/Dropdown.scss
@@ -4,7 +4,8 @@
 // some of these custom rules. This class nesting was designed to prioritize these custom
 // rules without bloating our CSS with many new custom class names.
 .App .DropdownComponent {
-  max-width: 350px;
+  // Don't let dropdown extend beyond viewport on mobile:
+  max-width: 100%;
 
   .dropdown-overlay {
     &.hidden {
@@ -21,8 +22,8 @@
   }
 
   .dropdown {
-    // Don't let dropdown menu extend beyond container:
-    max-width: 100%;
+    // Fill parent container:
+    width: 100%;
     &.is-open {
       z-index: 110;
     }
@@ -41,7 +42,8 @@
         padding: 0px;
 
         display: flex;
-        max-width: 100%;
+        // Fill parent container:
+        width: 100%;
 
         .float-left,
         .float-right {
@@ -50,6 +52,7 @@
         }
 
         .float-left {
+          flex-grow: 1;
           text-align: start;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/client/src/styles/Dropdown.scss
+++ b/client/src/styles/Dropdown.scss
@@ -4,6 +4,8 @@
 // some of these custom rules. This class nesting was designed to prioritize these custom
 // rules without bloating our CSS with many new custom class names.
 .App .DropdownComponent {
+  max-width: 350px;
+  
   .dropdown-overlay {
     &.hidden {
       display: none;

--- a/client/src/styles/Dropdown.scss
+++ b/client/src/styles/Dropdown.scss
@@ -20,7 +20,6 @@
 
   .dropdown {
     // Allow the dropdown toggle button child to have variable width (see below)
-    display: flex;
     max-width: 300px;
     button.dropdown-toggle {
       // Remove default border on focus:
@@ -36,11 +35,8 @@
         height: 4.4rem;
         padding: 0px;
 
-        // Allow the dropdown toggle button to fill space when it includes a text label
-        flex-grow: 1;
-        max-width: 100%;
-
         display: flex;
+        max-width: 100%;
 
         .float-left,
         .float-right {
@@ -49,7 +45,6 @@
         }
 
         .float-left {
-          flex-grow: 1;
           text-align: start;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/client/src/styles/Dropdown.scss
+++ b/client/src/styles/Dropdown.scss
@@ -20,10 +20,53 @@
 
   .dropdown {
     z-index: 110;
-    // Remove default border on focus:
-    button.dropdown-toggle:focus {
-      border: none;
+    // Allow the dropdown toggle button child to have variable width (see below)
+    display: flex;
+    max-width: 300px;
+    button.dropdown-toggle {
+      &.dropdown-selector-panel {
+        font-size: 2rem;
+        border: 0.5px solid $dark;
+        background-color: $gray-light;
+        height: 4.4rem;
+        padding: 0px;
+
+        // Allow the dropdown toggle button to fill space when it includes a text label
+        flex-grow: 1;
+        max-width: 100%;
+
+        display: flex;
+
+        .float-left,
+        .float-right {
+          height: 100%;
+          padding: 1.2rem;
+        }
+
+        .float-left {
+          flex-grow: 1;
+          text-align: start;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .float-right {
+          border-left: 0.5px solid $dark;
+        }
+        .icon {
+          padding: 1px;
+        }
+        &.active .icon {
+          transition: transform 0.2s linear;
+          transform: scaleY(-1) translateY(-3px);
+        }
+      }
+
+      // Remove default border on focus:
+      &:focus {
+        border: none;
+      }
     }
+
     .menu {
       padding: 0.25rem 0.5rem;
       font-size: 1.6rem;
@@ -44,6 +87,15 @@
       &.d-block {
         display: block;
       }
+    }
+  }
+
+  .dropdown-selector-panel + .menu {
+    padding: 1.25rem 0.5rem;
+    font-size: 2rem;
+    .menu-item {
+      display: inline-block;
+      margin: 1rem 0;
     }
   }
 }

--- a/client/src/styles/Dropdown.scss
+++ b/client/src/styles/Dropdown.scss
@@ -19,8 +19,11 @@
   }
 
   .dropdown {
-    // Allow the dropdown toggle button child to have variable width (see below)
-    max-width: 300px;
+    // Don't let dropdown menu extend beyond container:
+    max-width: 100%;
+    &.is-open {
+      z-index: 110;
+    }
     button.dropdown-toggle {
       // Remove default border on focus:
       &:focus {

--- a/client/src/styles/Dropdown.scss
+++ b/client/src/styles/Dropdown.scss
@@ -1,6 +1,9 @@
 @import "_vars.scss";
 
-.DropdownComponent {
+// NOTE: Spectre includes a lot of intricate ".dropdown" class rules that can override
+// some of these custom rules. This class nesting was designed to prioritize these custom
+// rules without bloating our CSS with many new custom class names.
+.App .DropdownComponent {
   .dropdown-overlay {
     &.hidden {
       display: none;
@@ -15,7 +18,7 @@
     z-index: 100;
   }
 
-  .dropdown.dropdown-right {
+  .dropdown {
     z-index: 110;
     // Remove default border on focus:
     button.dropdown-toggle:focus {

--- a/client/src/styles/Dropdown.scss
+++ b/client/src/styles/Dropdown.scss
@@ -1,0 +1,46 @@
+@import "_vars.scss";
+
+.DropdownComponent {
+  .dropdown-overlay {
+    &.hidden {
+      display: none;
+    }
+    position: fixed;
+    top: 0px;
+    right: 0px;
+    width: 100%;
+    height: 100%;
+    background-color: $dark;
+    opacity: 0.6;
+    z-index: 100;
+  }
+
+  .dropdown.dropdown-right {
+    z-index: 110;
+    // Remove default border on focus:
+    button.dropdown-toggle:focus {
+      border: none;
+    }
+    .menu {
+      padding: 0.25rem 0.5rem;
+      font-size: 1.6rem;
+
+      .menu-item a {
+        &:focus {
+          outline-offset: 0px;
+        }
+        &:active,
+        &.active {
+          background: $gray-light;
+        }
+      }
+
+      &.d-none {
+        display: none;
+      }
+      &.d-block {
+        display: block;
+      }
+    }
+  }
+}

--- a/client/src/styles/Dropdown.scss
+++ b/client/src/styles/Dropdown.scss
@@ -5,7 +5,7 @@
 // rules without bloating our CSS with many new custom class names.
 .App .DropdownComponent {
   max-width: 350px;
-  
+
   .dropdown-overlay {
     &.hidden {
       display: none;

--- a/client/src/styles/Dropdown.scss
+++ b/client/src/styles/Dropdown.scss
@@ -19,14 +19,19 @@
   }
 
   .dropdown {
-    z-index: 110;
     // Allow the dropdown toggle button child to have variable width (see below)
     display: flex;
     max-width: 300px;
     button.dropdown-toggle {
+      // Remove default border on focus:
+      &:focus {
+        border: none;
+      }
+
       &.dropdown-selector-panel {
         font-size: 2rem;
-        border: 0.5px solid $dark;
+        outline: 1px solid $dark;
+        border: none;
         background-color: $gray-light;
         height: 4.4rem;
         padding: 0px;
@@ -55,19 +60,19 @@
         .icon {
           padding: 1px;
         }
-        &.active .icon {
-          transition: transform 0.2s linear;
-          transform: scaleY(-1) translateY(-3px);
+        &.active {
+          // Keep toggle button above overlay when active:
+          z-index: 110;
+          .icon {
+            transition: transform 0.2s linear;
+            transform: scaleY(-1) translateY(-3px);
+          }
         }
-      }
-
-      // Remove default border on focus:
-      &:focus {
-        border: none;
       }
     }
 
     .menu {
+      z-index: 110;
       padding: 0.25rem 0.5rem;
       font-size: 1.6rem;
 
@@ -93,6 +98,9 @@
   .dropdown-selector-panel + .menu {
     padding: 1.25rem 0.5rem;
     font-size: 2rem;
+    box-shadow: none;
+    // Override default translation so it lies flush with toggle button outline:
+    transform: translateY(1px);
     .menu-item {
       display: inline-block;
       margin: 1rem 0;

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -120,6 +120,8 @@
     }
 
     .Indicators__linksContainer {
+      // Make sure links container doesn't extend beyond viewport
+      max-width: 100%;
       &:first-child {
         padding-bottom: 1rem;
       }

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -117,16 +117,6 @@
         font-size: 1.5rem;
         margin-right: 2rem;
       }
-
-      li {
-        list-style: none;
-        display: inline;
-
-        label.active {
-          font-weight: bold;
-          color: #000;
-        }
-      }
     }
   }
 

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -8,10 +8,14 @@
   // };
 
   .Indicators__content {
-    padding: 16px;
+    padding: 1.6rem;
 
     @include for-tablet-portrait-up() {
-      padding: 26px;
+      padding: 2.6rem;
+      .title-card,
+      .Indicators__links {
+        padding-left: 2.6rem;
+      }
     }
 
     & > div > h6 {
@@ -107,8 +111,14 @@
     padding: 0rem 1.5rem 2.5rem 0rem;
     position: relative;
 
+    @include for-tablet-portrait-up() {
+      display: flex;
+    }
+
     .Indicators__linksContainer {
       &:first-child {
+        flex: 1 0 auto;
+        max-width: 350px;
         padding-bottom: 1rem;
       }
 

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -141,7 +141,10 @@
     margin-bottom: 0.5rem;
 
     .Indicators__chart {
-      width: 100%;
+      width: 95%;
+      @include for-phone-only {
+        width: 85%;
+      }
     }
 
     .btn-axis-shift {

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -3,10 +3,6 @@
 @import "_button.scss";
 
 .Indicators {
-  // @include for-phone-only() {
-  //   padding-right: 30px;
-  // };
-
   .Indicators__content {
     padding: 1.6rem;
 
@@ -51,16 +47,6 @@
 
     .title-card {
       padding-bottom: 1.4rem;
-
-      a {
-        color: #454d5d;
-        margin-left: 1.5rem;
-        text-decoration: underline;
-
-        &:hover {
-          text-decoration: none;
-        }
-      }
     }
 
     .card {
@@ -79,22 +65,6 @@
           line-height: 1.8rem;
         }
       }
-    }
-
-    .control-panel {
-      justify-content: space-evenly;
-      padding-top: 15px;
-    }
-
-    .btn-data-select {
-      flex: 1 1 0;
-    }
-
-    .btn-data-select.selected,
-    .btn-data-select.selected:hover {
-      color: #fff;
-      background-color: #727e96;
-      box-shadow: inset 1px 1px 0px 0px #4f596c;
     }
 
     aside {

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -8,10 +8,10 @@
   // };
 
   .Indicators__content {
-    padding: 30px 30px 30px 30px;
+    padding: 16px;
 
     @include for-tablet-portrait-up() {
-      padding: 45px 45px 45px 45px;
+      padding: 26px;
     }
 
     & > div > h6 {
@@ -37,7 +37,6 @@
     .title {
       font-size: 2rem;
       text-decoration: none;
-      padding-left: 1.5rem;
       margin-bottom: 0px;
 
       &.viz-title {
@@ -47,7 +46,7 @@
     }
 
     .title-card {
-      padding-bottom: 2.5rem;
+      padding-bottom: 1.4rem;
 
       a {
         color: #454d5d;
@@ -105,7 +104,7 @@
   }
 
   .Indicators__links {
-    padding: 0rem 1.5rem 2.5rem 1.5rem;
+    padding: 0rem 1.5rem 2.5rem 0rem;
     position: relative;
 
     .Indicators__linksContainer {

--- a/client/src/styles/Indicators.scss
+++ b/client/src/styles/Indicators.scss
@@ -113,18 +113,21 @@
 
     @include for-tablet-portrait-up() {
       display: flex;
+
+      .Indicators__linksContainer:first-child {
+        padding-right: 3rem;
+      }
     }
 
     .Indicators__linksContainer {
       &:first-child {
-        flex: 1 0 auto;
-        max-width: 350px;
         padding-bottom: 1rem;
       }
 
       .Indicators__linksTitle {
+        display: inline-block;
         font-size: 1.5rem;
-        margin-right: 2rem;
+        margin: 0 2rem 0.4rem 0;
       }
     }
   }


### PR DESCRIPTION
This PR condenses the whole UI navigation of selecting a dataset to view on the Timeline Tab. Using Tahnee's designs, I implemented two accessible dropdown menus that allow the user to select a dataset and a "time span" from lists that can be arbitrarily long. 

My implementation involved factoring out a new component called `<Dropdown>` which is shared between the header hamburger menu and this new feature. The new component has accompanying styles in `Dropdown.scss` as well.

Note: you'll notice I actually built on some minor refactoring in #500, specifically my work making the list of datasets and timespans to choose from more DRY. This PR will likely merge sooner than #500 so I felt that work needed to be reflected here first. I will take responsibility and work through any merge conflicts! 

TODO:
- [x] A11y audit (specifically screen reader)
- [x] Tahnee approve the implementation