### PR TITLE
Show full list of useful links on Not Registered pages

### DIFF
--- a/client/src/components/UsefulLinks.tsx
+++ b/client/src/components/UsefulLinks.tsx
@@ -4,8 +4,8 @@ import Helpers from "../util/helpers";
 import { AddressRecord } from "./APIDataTypes";
 
 type UsefulLinksProps = {
-  addrForLinks: AddressRecord;
-  location: "overview-tab" | "timeline-tab";
+  addrForLinks: Pick<AddressRecord, "bbl" | "housenumber" | "streetname">;
+  location: "overview-tab" | "timeline-tab" | "not-registered-page";
 };
 
 export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location }) => {
@@ -13,9 +13,7 @@ export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location
   const { boro, block, lot } = Helpers.splitBBL(bbl);
   return (
     <div className="card-body-links">
-      <b>
-        <Trans>Useful links</Trans>
-      </b>
+      <Trans render={location === "not-registered-page" ? "p" : "b"}>Useful links</Trans>
       <ul>
         <li>
           <Trans>

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -7,10 +7,11 @@ import { AddressPageUrlParams } from "../routes";
 import Modal from "../components/Modal";
 import LegalFooter from "../components/LegalFooter";
 import Helpers from "../util/helpers";
-import { SocialShareAddressPage } from "../components/SocialShare";
+import SocialShare, { SocialShareAddressPage } from "../components/SocialShare";
 import { Nobr } from "../components/Nobr";
 import { withMachineInStateProps } from "state-machine";
 import Page from "components/Page";
+import { UsefulLinks } from "components/UsefulLinks";
 
 type Props = withMachineInStateProps<"unregisteredFound">;
 
@@ -18,12 +19,12 @@ type State = {
   showModal: boolean;
 };
 
-export const SocialShareForNotRegisteredPage = (props: { addr?: AddressPageUrlParams | null }) => (
+export const SocialShareForNotRegisteredPage = () => (
   <div className="social-share">
     <p>
       <Trans>Share this page with your neighbors</Trans>
     </p>
-    <SocialShareAddressPage location="not-registered-page" />
+    <SocialShare location="not-registered-page" />
   </div>
 );
 
@@ -44,17 +45,17 @@ export default class NotRegisteredPage extends Component<Props, State> {
 
     const usersInputAddress = searchAddrParams
       ? {
-          boro: searchAddrParams.boro,
-          housenumber: searchAddrParams.housenumber || " ",
-          streetname: searchAddrParams.streetname,
-        }
+        bbl: searchAddrBbl,
+        housenumber: searchAddrParams.housenumber || " ",
+        streetname: searchAddrParams.streetname,
+      }
       : buildingInfo
-      ? {
-          boro: buildingInfo.boro,
+        ? {
+          bbl: searchAddrBbl,
           housenumber: buildingInfo.housenumber || " ",
           streetname: buildingInfo.streetname || " ",
         }
-      : null;
+        : null;
 
     const failedToRegisterLink = (
       <div className="text-center">
@@ -209,52 +210,11 @@ export default class NotRegisteredPage extends Component<Props, State> {
                   </span>
                 </div>
                 <br />
-                <div>
-                  <Trans render="p">Useful links</Trans>
-                  <div>
-                    <div className="btn-group btn-group-block">
-                      <a
-                        href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn"
-                      >
-                        <Trans>View documents on ACRIS</Trans> &#8599;
-                      </a>
-                      <a
-                        href={`http://webapps.nyc.gov:8084/CICS/fin1/find001i?FFUNC=C&FBORO=${boro}&FBLOCK=${block}&FLOT=${lot}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn"
-                      >
-                        <Trans>DOF Property Tax Bills</Trans> &#8599;
-                      </a>
-                    </div>
-                    <div className="btn-group btn-group-block">
-                      <a
-                        href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn"
-                      >
-                        <Trans>DOB Building Profile</Trans> &#8599;
-                      </a>
-                      <a
-                        href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn"
-                      >
-                        <Trans>ANHD DAP Portal</Trans> &#8599;
-                      </a>
-                    </div>
-                  </div>
-                </div>
-
-                <SocialShareForNotRegisteredPage addr={usersInputAddress} />
+                {usersInputAddress &&
+                  <UsefulLinks addrForLinks={usersInputAddress} location="not-registered-page" />}
+                <SocialShareForNotRegisteredPage />
                 <br />
                 <br />
-
                 <Link className="btn btn-primary btn-block" to="/">
                   &lt;-- <Trans>Search for a different address</Trans>
                 </Link>

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -42,6 +42,12 @@ export default class NotRegisteredPage extends Component<Props, State> {
 
     const { boro, block, lot } = Helpers.splitBBL(searchAddrBbl);
 
+    /**
+     * This is the address that will show up in the top header of the page.
+     * If the user didn't enter an address themselves (i.e. they are redirected to this page
+     * directly from a BBL-based url), we will fall back on the buildingInfo SQL query to grab
+     * a standard address for the property they are searching.
+     */
     const usersInputAddress = searchAddrBbl
       ? {
           bbl: searchAddrBbl,

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -42,19 +42,20 @@ export default class NotRegisteredPage extends Component<Props, State> {
 
     const { boro, block, lot } = Helpers.splitBBL(searchAddrBbl);
 
-    const usersInputAddress = searchAddrParams
-      ? {
-          bbl: searchAddrBbl,
-          housenumber: searchAddrParams.housenumber || " ",
-          streetname: searchAddrParams.streetname,
-        }
-      : buildingInfo
-      ? {
-          bbl: searchAddrBbl,
-          housenumber: buildingInfo.housenumber || " ",
-          streetname: buildingInfo.streetname || " ",
-        }
-      : null;
+    const usersInputAddress =
+      searchAddrParams && searchAddrBbl
+        ? {
+            bbl: searchAddrBbl,
+            housenumber: searchAddrParams.housenumber || " ",
+            streetname: searchAddrParams.streetname,
+          }
+        : buildingInfo
+        ? {
+            bbl: searchAddrBbl,
+            housenumber: buildingInfo.housenumber || " ",
+            streetname: buildingInfo.streetname || " ",
+          }
+        : null;
 
     const failedToRegisterLink = (
       <div className="text-center">

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -42,20 +42,13 @@ export default class NotRegisteredPage extends Component<Props, State> {
 
     const { boro, block, lot } = Helpers.splitBBL(searchAddrBbl);
 
-    const usersInputAddress =
-      searchAddrParams && searchAddrBbl
-        ? {
-            bbl: searchAddrBbl,
-            housenumber: searchAddrParams.housenumber || " ",
-            streetname: searchAddrParams.streetname,
-          }
-        : buildingInfo
-        ? {
-            bbl: searchAddrBbl,
-            housenumber: buildingInfo.housenumber || " ",
-            streetname: buildingInfo.streetname || " ",
-          }
-        : null;
+    const usersInputAddress = searchAddrBbl
+      ? {
+          bbl: searchAddrBbl,
+          housenumber: searchAddrParams?.housenumber || buildingInfo?.housenumber || " ",
+          streetname: searchAddrParams?.streetname || buildingInfo?.streetname || " ",
+        }
+      : null;
 
     const failedToRegisterLink = (
       <div className="text-center">

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -3,11 +3,10 @@ import { LocaleLink as Link } from "../i18n";
 
 import "styles/NotRegisteredPage.css";
 import { Trans } from "@lingui/macro";
-import { AddressPageUrlParams } from "../routes";
 import Modal from "../components/Modal";
 import LegalFooter from "../components/LegalFooter";
 import Helpers from "../util/helpers";
-import SocialShare, { SocialShareAddressPage } from "../components/SocialShare";
+import SocialShare from "../components/SocialShare";
 import { Nobr } from "../components/Nobr";
 import { withMachineInStateProps } from "state-machine";
 import Page from "components/Page";

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -45,17 +45,17 @@ export default class NotRegisteredPage extends Component<Props, State> {
 
     const usersInputAddress = searchAddrParams
       ? {
-        bbl: searchAddrBbl,
-        housenumber: searchAddrParams.housenumber || " ",
-        streetname: searchAddrParams.streetname,
-      }
+          bbl: searchAddrBbl,
+          housenumber: searchAddrParams.housenumber || " ",
+          streetname: searchAddrParams.streetname,
+        }
       : buildingInfo
-        ? {
+      ? {
           bbl: searchAddrBbl,
           housenumber: buildingInfo.housenumber || " ",
           streetname: buildingInfo.streetname || " ",
         }
-        : null;
+      : null;
 
     const failedToRegisterLink = (
       <div className="text-center">
@@ -210,8 +210,9 @@ export default class NotRegisteredPage extends Component<Props, State> {
                   </span>
                 </div>
                 <br />
-                {usersInputAddress &&
-                  <UsefulLinks addrForLinks={usersInputAddress} location="not-registered-page" />}
+                {usersInputAddress && (
+                  <UsefulLinks addrForLinks={usersInputAddress} location="not-registered-page" />
+                )}
                 <SocialShareForNotRegisteredPage />
                 <br />
                 <br />

--- a/client/src/containers/NychaPage.tsx
+++ b/client/src/containers/NychaPage.tsx
@@ -29,50 +29,50 @@ const NychaPageWithoutI18n: React.FC<NychaPageProps> = (props) => {
   const boroData =
     boro === "1"
       ? {
-          boroName: "Manhattan",
-          boroOfficeAddress1: "1980 Lexington Ave #1",
-          boroOfficeAddress2: "New York, NY 10035",
-          boroOfficePhone: "(917) 206-3500",
-        }
+        boroName: "Manhattan",
+        boroOfficeAddress1: "1980 Lexington Ave #1",
+        boroOfficeAddress2: "New York, NY 10035",
+        boroOfficePhone: "(917) 206-3500",
+      }
       : boro === "2"
-      ? {
+        ? {
           boroName: "Bronx",
           boroOfficeAddress1: "1200 Water Pl, Suite #200",
           boroOfficeAddress2: "Bronx, NY 10461",
           boroOfficePhone: "(718) 409-8626",
         }
-      : boro === "3"
-      ? {
-          boroName: "Brooklyn",
-          boroOfficeAddress1: "816 Ashford St",
-          boroOfficeAddress2: "Brooklyn, NY 11207",
-          boroOfficePhone: "(718) 491-6967",
-        }
-      : boro === "4" || boro === "5"
-      ? {
-          boroName: "Queens",
-          boroOfficeAddress1: "90-20 170th St, 1st Floor",
-          boroOfficeAddress2: "Jamaica, NY 11432",
-          boroOfficePhone: "(718) 553-4700",
-        }
-      : null;
+        : boro === "3"
+          ? {
+            boroName: "Brooklyn",
+            boroOfficeAddress1: "816 Ashford St",
+            boroOfficeAddress2: "Brooklyn, NY 11207",
+            boroOfficePhone: "(718) 491-6967",
+          }
+          : boro === "4" || boro === "5"
+            ? {
+              boroName: "Queens",
+              boroOfficeAddress1: "90-20 170th St, 1st Floor",
+              boroOfficeAddress2: "Jamaica, NY 11432",
+              boroOfficePhone: "(718) 553-4700",
+            }
+            : null;
 
   const usersInputAddress =
     searchAddrParams &&
-    searchAddrParams.boro &&
-    (searchAddrParams.housenumber || searchAddrParams.streetname)
+      searchAddrParams.boro &&
+      (searchAddrParams.housenumber || searchAddrParams.streetname)
       ? {
-          boro: searchAddrParams.boro,
-          housenumber: searchAddrParams.housenumber || " ",
-          streetname: searchAddrParams.streetname || " ",
-        }
+        boro: searchAddrParams.boro,
+        housenumber: searchAddrParams.housenumber || " ",
+        streetname: searchAddrParams.streetname || " ",
+      }
       : buildingInfo && buildingInfo.boro && (buildingInfo.housenumber || buildingInfo.streetname)
-      ? {
+        ? {
           boro: buildingInfo.boro,
           housenumber: buildingInfo.housenumber || " ",
           streetname: buildingInfo.streetname || " ",
         }
-      : null;
+        : null;
 
   const takeActionURL = Helpers.createTakeActionURL(usersInputAddress, "nycha_page");
 
@@ -264,7 +264,7 @@ const NychaPageWithoutI18n: React.FC<NychaPageProps> = (props) => {
                 </a>
               </div>
 
-              <SocialShareForNotRegisteredPage addr={usersInputAddress} />
+              <SocialShareForNotRegisteredPage />
 
               <br />
               {/* <div className="toast toast-error">

--- a/client/src/containers/NychaPage.tsx
+++ b/client/src/containers/NychaPage.tsx
@@ -29,50 +29,50 @@ const NychaPageWithoutI18n: React.FC<NychaPageProps> = (props) => {
   const boroData =
     boro === "1"
       ? {
-        boroName: "Manhattan",
-        boroOfficeAddress1: "1980 Lexington Ave #1",
-        boroOfficeAddress2: "New York, NY 10035",
-        boroOfficePhone: "(917) 206-3500",
-      }
+          boroName: "Manhattan",
+          boroOfficeAddress1: "1980 Lexington Ave #1",
+          boroOfficeAddress2: "New York, NY 10035",
+          boroOfficePhone: "(917) 206-3500",
+        }
       : boro === "2"
-        ? {
+      ? {
           boroName: "Bronx",
           boroOfficeAddress1: "1200 Water Pl, Suite #200",
           boroOfficeAddress2: "Bronx, NY 10461",
           boroOfficePhone: "(718) 409-8626",
         }
-        : boro === "3"
-          ? {
-            boroName: "Brooklyn",
-            boroOfficeAddress1: "816 Ashford St",
-            boroOfficeAddress2: "Brooklyn, NY 11207",
-            boroOfficePhone: "(718) 491-6967",
-          }
-          : boro === "4" || boro === "5"
-            ? {
-              boroName: "Queens",
-              boroOfficeAddress1: "90-20 170th St, 1st Floor",
-              boroOfficeAddress2: "Jamaica, NY 11432",
-              boroOfficePhone: "(718) 553-4700",
-            }
-            : null;
+      : boro === "3"
+      ? {
+          boroName: "Brooklyn",
+          boroOfficeAddress1: "816 Ashford St",
+          boroOfficeAddress2: "Brooklyn, NY 11207",
+          boroOfficePhone: "(718) 491-6967",
+        }
+      : boro === "4" || boro === "5"
+      ? {
+          boroName: "Queens",
+          boroOfficeAddress1: "90-20 170th St, 1st Floor",
+          boroOfficeAddress2: "Jamaica, NY 11432",
+          boroOfficePhone: "(718) 553-4700",
+        }
+      : null;
 
   const usersInputAddress =
     searchAddrParams &&
-      searchAddrParams.boro &&
-      (searchAddrParams.housenumber || searchAddrParams.streetname)
+    searchAddrParams.boro &&
+    (searchAddrParams.housenumber || searchAddrParams.streetname)
       ? {
-        boro: searchAddrParams.boro,
-        housenumber: searchAddrParams.housenumber || " ",
-        streetname: searchAddrParams.streetname || " ",
-      }
+          boro: searchAddrParams.boro,
+          housenumber: searchAddrParams.housenumber || " ",
+          streetname: searchAddrParams.streetname || " ",
+        }
       : buildingInfo && buildingInfo.boro && (buildingInfo.housenumber || buildingInfo.streetname)
-        ? {
+      ? {
           boro: buildingInfo.boro,
           housenumber: buildingInfo.housenumber || " ",
           streetname: buildingInfo.streetname || " ",
         }
-        : null;
+      : null;
 
   const takeActionURL = Helpers.createTakeActionURL(usersInputAddress, "nycha_page");
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -53,8 +53,7 @@ msgstr "<0>While the legal owner of a building is often a company (usually calle
 msgid "A DOB Violation is a notice that a property is not in compliance with applicable law, usually a building code. DOB violations typically relate to building-wide services (like elevators or boilers), the structural integrity of a property, or illegal construction. Owners must cure all DOB violations before they can file a new or amended Certificate of Occupancy (\"CO\").<0/><1/><2>Non-ECB</2> — typical violation, no court hearing needed<3/><4>ECB (Environment Control Board)</4> — a specific violation of New York City Construction Codes or Zoning Resolution. These violations come with additional penalties and require an owner to attend an <5>OATH hearing</5>. They fall into three classes: Class I (immediately hazardous), Class II (major), and Class III (lesser).<6/><7/>Read more about DOB Violations at the <8>official DOB page</8>."
 msgstr "A DOB Violation is a notice that a property is not in compliance with applicable law, usually a building code. DOB violations typically relate to building-wide services (like elevators or boilers), the structural integrity of a property, or illegal construction. Owners must cure all DOB violations before they can file a new or amended Certificate of Occupancy (\"CO\").<0/><1/><2>Non-ECB</2> — typical violation, no court hearing needed<3/><4>ECB (Environment Control Board)</4> — a specific violation of New York City Construction Codes or Zoning Resolution. These violations come with additional penalties and require an owner to attend an <5>OATH hearing</5>. They fall into three classes: Class I (immediately hazardous), Class II (major), and Class III (lesser).<6/><7/>Read more about DOB Violations at the <8>official DOB page</8>."
 
-#: src/components/UsefulLinks.tsx:47
-#: src/containers/NotRegisteredPage.tsx:158
+#: src/components/UsefulLinks.tsx:45
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
@@ -123,9 +122,9 @@ msgstr "Borough"
 msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
-#: src/containers/NotRegisteredPage.tsx:64
-#: src/containers/NotRegisteredPage.tsx:84
-#: src/containers/NotRegisteredPage.tsx:103
+#: src/containers/NotRegisteredPage.tsx:65
+#: src/containers/NotRegisteredPage.tsx:85
+#: src/containers/NotRegisteredPage.tsx:104
 msgid "Building Classification"
 msgstr "Building Classification"
 
@@ -134,11 +133,11 @@ msgid "Building Permit Applications"
 msgstr "Building Permit Applications"
 
 #: src/components/IndicatorsDatasets.tsx:69
-#: src/components/IndicatorsViz.tsx:174
+#: src/components/IndicatorsViz.tsx:175
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
-#: src/containers/NotRegisteredPage.tsx:174
+#: src/containers/NotRegisteredPage.tsx:153
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
@@ -177,23 +176,23 @@ msgstr "COOKING GAS"
 msgid "Check out the issues in this building"
 msgstr "Check out the issues in this building"
 
-#: src/containers/NotRegisteredPage.tsx:178
+#: src/containers/NotRegisteredPage.tsx:157
 msgid "Civil penalties of $250-$500"
 msgstr "Civil penalties of $250-$500"
 
-#: src/components/IndicatorsViz.tsx:145
+#: src/components/IndicatorsViz.tsx:146
 msgid "Class A"
 msgstr "Class A"
 
-#: src/components/IndicatorsViz.tsx:138
+#: src/components/IndicatorsViz.tsx:139
 msgid "Class B"
 msgstr "Class B"
 
-#: src/components/IndicatorsViz.tsx:131
+#: src/components/IndicatorsViz.tsx:132
 msgid "Class C"
 msgstr "Class C"
 
-#: src/containers/NotRegisteredPage.tsx:187
+#: src/containers/NotRegisteredPage.tsx:166
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
@@ -217,8 +216,7 @@ msgstr "Corporate Owner"
 msgid "Corporation"
 msgstr "Corporation"
 
-#: src/components/UsefulLinks.tsx:33
-#: src/containers/NotRegisteredPage.tsx:155
+#: src/components/UsefulLinks.tsx:31
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
@@ -226,8 +224,7 @@ msgstr "DOB Building Profile"
 msgid "DOB/ECB Violations"
 msgstr "DOB/ECB Violations"
 
-#: src/components/UsefulLinks.tsx:40
-#: src/containers/NotRegisteredPage.tsx:150
+#: src/components/UsefulLinks.tsx:38
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
@@ -266,7 +263,7 @@ msgstr "Donate"
 msgid "Download"
 msgstr "Download"
 
-#: src/components/IndicatorsViz.tsx:185
+#: src/components/IndicatorsViz.tsx:186
 msgid "ECB"
 msgstr "ECB"
 
@@ -282,7 +279,7 @@ msgstr "ELEVATOR"
 msgid "Email"
 msgstr "Email"
 
-#: src/components/IndicatorsViz.tsx:156
+#: src/components/IndicatorsViz.tsx:157
 msgid "Emergency"
 msgstr "Emergency"
 
@@ -325,7 +322,7 @@ msgstr "FLOOR"
 msgid "FLOORING/STAIRS"
 msgstr "FLOORING/STAIRS"
 
-#: src/containers/NotRegisteredPage.tsx:173
+#: src/containers/NotRegisteredPage.tsx:152
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
@@ -350,7 +347,7 @@ msgstr "HEAT/HOT WATER"
 msgid "HEATING"
 msgstr "HEATING"
 
-#: src/components/UsefulLinks.tsx:26
+#: src/components/UsefulLinks.tsx:24
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
@@ -406,7 +403,7 @@ msgstr "I was checking out this building on Who Owns What, a free landlord resea
 msgid "Individual Owner"
 msgstr "Individual Owner"
 
-#: src/containers/NotRegisteredPage.tsx:180
+#: src/containers/NotRegisteredPage.tsx:159
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
@@ -414,7 +411,7 @@ msgstr "Ineligible to certify violations"
 msgid "Information"
 msgstr "Information"
 
-#: src/containers/NotRegisteredPage.tsx:98
+#: src/containers/NotRegisteredPage.tsx:99
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "It doesn't seem like this property is required to register with HPD."
 
@@ -456,7 +453,7 @@ msgstr "Last 3 Years"
 msgid "Last Sale"
 msgstr "Last Sale"
 
-#: src/components/IndicatorsViz.tsx:366
+#: src/components/IndicatorsViz.tsx:368
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
@@ -518,7 +515,7 @@ msgstr "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgid "Maintenance code violations"
 msgstr "Maintenance code violations"
 
-#: src/containers/NotRegisteredPage.tsx:179
+#: src/containers/NotRegisteredPage.tsx:158
 msgid "May be issued official Orders"
 msgstr "May be issued official Orders"
 
@@ -572,23 +569,23 @@ msgstr "No"
 msgid "No address found"
 msgstr "No address found"
 
-#: src/components/IndicatorsViz.tsx:420
+#: src/components/IndicatorsViz.tsx:422
 msgid "No data available"
 msgstr "No data available"
 
-#: src/containers/NotRegisteredPage.tsx:122
+#: src/containers/NotRegisteredPage.tsx:123
 msgid "No registration found for {usersInputAddressFragment}!"
 msgstr "No registration found for {usersInputAddressFragment}!"
 
-#: src/containers/NotRegisteredPage.tsx:122
+#: src/containers/NotRegisteredPage.tsx:123
 msgid "No registration found!"
 msgstr "No registration found!"
 
-#: src/components/IndicatorsViz.tsx:192
+#: src/components/IndicatorsViz.tsx:193
 msgid "Non-ECB"
 msgstr "Non-ECB"
 
-#: src/components/IndicatorsViz.tsx:163
+#: src/components/IndicatorsViz.tsx:164
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
@@ -707,7 +704,7 @@ msgstr "STAIRS"
 msgid "Search"
 msgstr "Search"
 
-#: src/containers/NotRegisteredPage.tsx:169
+#: src/containers/NotRegisteredPage.tsx:148
 #: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
 msgstr "Search for a different address"
@@ -725,7 +722,7 @@ msgstr "Share"
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
 #: src/containers/App.tsx:124
-#: src/containers/NotRegisteredPage.tsx:13
+#: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
 
@@ -754,7 +751,7 @@ msgstr "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one evi
 msgid "Site Manager"
 msgstr "Site Manager"
 
-#: src/components/IndicatorsViz.tsx:365
+#: src/components/IndicatorsViz.tsx:367
 msgid "Sold to Current Owner"
 msgstr "Sold to Current Owner"
 
@@ -844,7 +841,7 @@ msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "This building is owned by the NYC Housing Authority (NYCHA)"
 
-#: src/containers/NotRegisteredPage.tsx:79
+#: src/containers/NotRegisteredPage.tsx:80
 msgid "This building seems like it should be registered with HPD!"
 msgstr "This building seems like it should be registered with HPD!"
 
@@ -896,7 +893,7 @@ msgstr "This represents <0>{rsProportion}%</0> of the total size of this portfol
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 
-#: src/containers/NotRegisteredPage.tsx:56
+#: src/containers/NotRegisteredPage.tsx:57
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 
@@ -917,7 +914,7 @@ msgstr "Timeline"
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
-#: src/components/IndicatorsViz.tsx:328
+#: src/components/IndicatorsViz.tsx:330
 #: src/components/PropertiesList.tsx:206
 #: src/components/PropertiesList.tsx:211
 #: src/components/PropertiesList.tsx:255
@@ -929,11 +926,11 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Total Violations"
 
-#: src/containers/NotRegisteredPage.tsx:182
+#: src/containers/NotRegisteredPage.tsx:161
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "Unable to initiate a court action for nonpayment of rent."
 
-#: src/containers/NotRegisteredPage.tsx:181
+#: src/containers/NotRegisteredPage.tsx:160
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
@@ -948,8 +945,7 @@ msgstr "Units"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 
-#: src/components/UsefulLinks.tsx:9
-#: src/containers/NotRegisteredPage.tsx:143
+#: src/components/UsefulLinks.tsx:8
 #: src/containers/NychaPage.tsx:153
 msgid "Useful links"
 msgstr "Useful links"
@@ -973,13 +969,9 @@ msgstr "View data over time ↗︎"
 msgid "View detail"
 msgstr "View detail"
 
-#: src/components/UsefulLinks.tsx:13
+#: src/components/UsefulLinks.tsx:11
 msgid "View documents on <0>ACRIS</0>"
 msgstr "View documents on <0>ACRIS</0>"
-
-#: src/containers/NotRegisteredPage.tsx:147
-msgid "View documents on ACRIS"
-msgstr "View documents on ACRIS"
 
 #: src/components/PropertiesMap.tsx:193
 msgid "View legend"
@@ -1028,7 +1020,7 @@ msgstr "We compare your search address with a database of over 200k buildings to
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
-#: src/containers/NotRegisteredPage.tsx:43
+#: src/containers/NotRegisteredPage.tsx:44
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -58,8 +58,7 @@ msgstr "<0>Mientras el dueño legal de un edificio es, con frecuencia, una compa
 msgid "A DOB Violation is a notice that a property is not in compliance with applicable law, usually a building code. DOB violations typically relate to building-wide services (like elevators or boilers), the structural integrity of a property, or illegal construction. Owners must cure all DOB violations before they can file a new or amended Certificate of Occupancy (\"CO\").<0/><1/><2>Non-ECB</2> — typical violation, no court hearing needed<3/><4>ECB (Environment Control Board)</4> — a specific violation of New York City Construction Codes or Zoning Resolution. These violations come with additional penalties and require an owner to attend an <5>OATH hearing</5>. They fall into three classes: Class I (immediately hazardous), Class II (major), and Class III (lesser).<6/><7/>Read more about DOB Violations at the <8>official DOB page</8>."
 msgstr "Una violación de DOB es un aviso de que una propiedad no cumple con la ley aplicable, generalmente un código de edificios. Las violaciones de DOB generalmente se relacionan con servicios en todo el edificio (como ascensores o calderas), la integridad estructural de una propiedad o la construcción ilegal. Los dueños deben arreglar todas las violaciones de DOB antes de poder presentar un Certificado de ocupación (\"CO\") nuevo o enmendado.<0/><1/><2>No ECB</2> — infracción típica, no se necesita audiencia judicial<3/><4>ECB (Junta de Control Medioambiental)</4> — una violación específica de los Códigos de Construcción de la Ciudad de Nueva York o la Resolución de Zonificación. Estas violaciones vienen con sanciones adicionales y requieren que el dueño asista a una <5>audiencia de OATH</5>. Se dividen en tres clases: Clase I (peligro inmediato), Clase II (mayor) y Clase III (menor).<6/><7/>Encontrarás más información sobre las Violaciones del DOB en la <8>página oficial del DOB</8>."
 
-#: src/components/UsefulLinks.tsx:47
-#: src/containers/NotRegisteredPage.tsx:158
+#: src/components/UsefulLinks.tsx:45
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
@@ -128,9 +127,9 @@ msgstr "Municipio"
 msgid "Borough Management Office:"
 msgstr "Oficina de Gestión Municipal:"
 
-#: src/containers/NotRegisteredPage.tsx:64
-#: src/containers/NotRegisteredPage.tsx:84
-#: src/containers/NotRegisteredPage.tsx:103
+#: src/containers/NotRegisteredPage.tsx:65
+#: src/containers/NotRegisteredPage.tsx:85
+#: src/containers/NotRegisteredPage.tsx:104
 msgid "Building Classification"
 msgstr "Clasificación del Edificio"
 
@@ -139,11 +138,11 @@ msgid "Building Permit Applications"
 msgstr "Solicitudes de Permisos de Construcción"
 
 #: src/components/IndicatorsDatasets.tsx:69
-#: src/components/IndicatorsViz.tsx:174
+#: src/components/IndicatorsViz.tsx:175
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
 
-#: src/containers/NotRegisteredPage.tsx:174
+#: src/containers/NotRegisteredPage.tsx:153
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
@@ -182,23 +181,23 @@ msgstr "GAS DE COCINA"
 msgid "Check out the issues in this building"
 msgstr "Mira los problemas en este edificio"
 
-#: src/containers/NotRegisteredPage.tsx:178
+#: src/containers/NotRegisteredPage.tsx:157
 msgid "Civil penalties of $250-$500"
 msgstr "Sanciones civiles de $250-$500"
 
-#: src/components/IndicatorsViz.tsx:145
+#: src/components/IndicatorsViz.tsx:146
 msgid "Class A"
 msgstr "Clase A"
 
-#: src/components/IndicatorsViz.tsx:138
+#: src/components/IndicatorsViz.tsx:139
 msgid "Class B"
 msgstr "Clase B"
 
-#: src/components/IndicatorsViz.tsx:131
+#: src/components/IndicatorsViz.tsx:132
 msgid "Class C"
 msgstr "Clase C"
 
-#: src/containers/NotRegisteredPage.tsx:187
+#: src/containers/NotRegisteredPage.tsx:166
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
@@ -222,8 +221,7 @@ msgstr "Dueño Corporativo"
 msgid "Corporation"
 msgstr "Corporación"
 
-#: src/components/UsefulLinks.tsx:33
-#: src/containers/NotRegisteredPage.tsx:155
+#: src/components/UsefulLinks.tsx:31
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
@@ -231,8 +229,7 @@ msgstr "Perfil de edificio en DOB"
 msgid "DOB/ECB Violations"
 msgstr "Violaciones del DOB/ECB"
 
-#: src/components/UsefulLinks.tsx:40
-#: src/containers/NotRegisteredPage.tsx:150
+#: src/components/UsefulLinks.tsx:38
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
@@ -271,7 +268,7 @@ msgstr "Donar"
 msgid "Download"
 msgstr "Descargar"
 
-#: src/components/IndicatorsViz.tsx:185
+#: src/components/IndicatorsViz.tsx:186
 msgid "ECB"
 msgstr "ECB"
 
@@ -287,7 +284,7 @@ msgstr "ASCENSOR"
 msgid "Email"
 msgstr "Email"
 
-#: src/components/IndicatorsViz.tsx:156
+#: src/components/IndicatorsViz.tsx:157
 msgid "Emergency"
 msgstr "Emergencia"
 
@@ -330,7 +327,7 @@ msgstr "PISO"
 msgid "FLOORING/STAIRS"
 msgstr "PISO/ESCALERAS"
 
-#: src/containers/NotRegisteredPage.tsx:173
+#: src/containers/NotRegisteredPage.tsx:152
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
@@ -355,7 +352,7 @@ msgstr "CALEFACCIÓN/AGUA CALIENTE"
 msgid "HEATING"
 msgstr "CALEFACCIÓN"
 
-#: src/components/UsefulLinks.tsx:26
+#: src/components/UsefulLinks.tsx:24
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
@@ -411,7 +408,7 @@ msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta g
 msgid "Individual Owner"
 msgstr "Dueño Individual"
 
-#: src/containers/NotRegisteredPage.tsx:180
+#: src/containers/NotRegisteredPage.tsx:159
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
@@ -419,7 +416,7 @@ msgstr "Inelegible para certificar violaciones"
 msgid "Information"
 msgstr "Información"
 
-#: src/containers/NotRegisteredPage.tsx:98
+#: src/containers/NotRegisteredPage.tsx:99
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "Parece que esta propiedad no necesita estar registrada con el HPD."
 
@@ -461,7 +458,7 @@ msgstr "Últimos 3 años"
 msgid "Last Sale"
 msgstr "Última venta"
 
-#: src/components/IndicatorsViz.tsx:366
+#: src/components/IndicatorsViz.tsx:368
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
@@ -523,7 +520,7 @@ msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.nyc</0>"
 msgid "Maintenance code violations"
 msgstr "Violaciones del código de mantenimiento"
 
-#: src/containers/NotRegisteredPage.tsx:179
+#: src/containers/NotRegisteredPage.tsx:158
 msgid "May be issued official Orders"
 msgstr "Pueden emitirse órdenes oficiales"
 
@@ -577,23 +574,23 @@ msgstr "No"
 msgid "No address found"
 msgstr "No se encontraron direcciones"
 
-#: src/components/IndicatorsViz.tsx:420
+#: src/components/IndicatorsViz.tsx:422
 msgid "No data available"
 msgstr "No hay datos disponibles"
 
-#: src/containers/NotRegisteredPage.tsx:122
+#: src/containers/NotRegisteredPage.tsx:123
 msgid "No registration found for {usersInputAddressFragment}!"
 msgstr "¡No se ha encontrado ningún registro para {usersInputAddressFragment}!"
 
-#: src/containers/NotRegisteredPage.tsx:122
+#: src/containers/NotRegisteredPage.tsx:123
 msgid "No registration found!"
 msgstr "¡No se ha encontrado nigún registro!"
 
-#: src/components/IndicatorsViz.tsx:192
+#: src/components/IndicatorsViz.tsx:193
 msgid "Non-ECB"
 msgstr "No ECB"
 
-#: src/components/IndicatorsViz.tsx:163
+#: src/components/IndicatorsViz.tsx:164
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
@@ -712,7 +709,7 @@ msgstr "ESCALERAS"
 msgid "Search"
 msgstr "Buscar"
 
-#: src/containers/NotRegisteredPage.tsx:169
+#: src/containers/NotRegisteredPage.tsx:148
 #: src/containers/NychaPage.tsx:190
 msgid "Search for a different address"
 msgstr "Buscar otra dirección"
@@ -730,7 +727,7 @@ msgstr "Compartir"
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:133
 #: src/containers/App.tsx:124
-#: src/containers/NotRegisteredPage.tsx:13
+#: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
 
@@ -759,7 +756,7 @@ msgstr "Desde el 2017, los Mariscales de NYC programaron {totalEvictions, plural
 msgid "Site Manager"
 msgstr "Administrador del Sitio"
 
-#: src/components/IndicatorsViz.tsx:365
+#: src/components/IndicatorsViz.tsx:367
 msgid "Sold to Current Owner"
 msgstr "Vendido al Propietario Actual"
 
@@ -849,7 +846,7 @@ msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edif
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "Este edificio es propiedad de la NYC Housing Authority (NYCHA)"
 
-#: src/containers/NotRegisteredPage.tsx:79
+#: src/containers/NotRegisteredPage.tsx:80
 msgid "This building seems like it should be registered with HPD!"
 msgstr "¡Parece que este edificio debería estar registrado con el HPD!"
 
@@ -901,7 +898,7 @@ msgstr "Esto representa el <0>{rsProportion}%</0> del tamaño total de este port
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr "Esto representa el número total de violaciones del HPD (tanto actuales como cerradas) registradas por la ciudad."
 
-#: src/containers/NotRegisteredPage.tsx:56
+#: src/containers/NotRegisteredPage.tsx:57
 msgid "This seems like a smaller residential building. If the landlord doesn't reside there, it should be registered with HPD."
 msgstr "Este parece ser un edificio residencial pequeño. Si el dueño no reside allí, el edificio debería estar registrado con el HPD."
 
@@ -922,7 +919,7 @@ msgstr "Cronología"
 msgid "Top Complaint"
 msgstr "Queja principal"
 
-#: src/components/IndicatorsViz.tsx:328
+#: src/components/IndicatorsViz.tsx:330
 #: src/components/PropertiesList.tsx:206
 #: src/components/PropertiesList.tsx:211
 #: src/components/PropertiesList.tsx:255
@@ -934,11 +931,11 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Violaciones Totales"
 
-#: src/containers/NotRegisteredPage.tsx:182
+#: src/containers/NotRegisteredPage.tsx:161
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "No es possible iniciar una acción judicial por falta de pago del alquiler."
 
-#: src/containers/NotRegisteredPage.tsx:181
+#: src/containers/NotRegisteredPage.tsx:160
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
@@ -953,8 +950,7 @@ msgstr "Unidades"
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edificio e investigar a los arrendadores de Nueva York! Utilizamos el mapeo de propiedad para identificar el portafolio de edificios de un arrendador y proporcionar datos para revelar posibles casos de hostigamiento y desplazamiento de inquilinos."
 
-#: src/components/UsefulLinks.tsx:9
-#: src/containers/NotRegisteredPage.tsx:143
+#: src/components/UsefulLinks.tsx:8
 #: src/containers/NychaPage.tsx:153
 msgid "Useful links"
 msgstr "Enlaces útiles"
@@ -978,13 +974,9 @@ msgstr "Ver datos a lo largo del tiempo ↗︎"
 msgid "View detail"
 msgstr "Ver detalles"
 
-#: src/components/UsefulLinks.tsx:13
+#: src/components/UsefulLinks.tsx:11
 msgid "View documents on <0>ACRIS</0>"
 msgstr "Ver documentos en <0>ACRIS</0>"
-
-#: src/containers/NotRegisteredPage.tsx:147
-msgid "View documents on ACRIS"
-msgstr "Ver documentos en ACRIS"
 
 #: src/components/PropertiesMap.tsx:193
 msgid "View legend"
@@ -1033,7 +1025,7 @@ msgstr "Comparamos la dirección que buscaste con una base de datos de más de 2
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
-#: src/containers/NotRegisteredPage.tsx:43
+#: src/containers/NotRegisteredPage.tsx:44
 msgid "What happens if the landlord has failed to register?"
 msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 
@@ -1124,4 +1116,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:35
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2010} other {# Violaciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/styles/NotRegisteredPage.scss
+++ b/client/src/styles/NotRegisteredPage.scss
@@ -94,6 +94,17 @@
       }
     }
 
+    .card-body-links 
+    { 
+      ul,ol {
+      margin: 1rem 0.5rem;
+
+      li {
+        margin-top: 0.5rem;
+        line-height: 1.8rem;
+      }
+    }
+  }
     .justfix-cta,
     .social-share {
       margin-top: 2rem;

--- a/client/src/styles/NotRegisteredPage.scss
+++ b/client/src/styles/NotRegisteredPage.scss
@@ -94,17 +94,17 @@
       }
     }
 
-    .card-body-links 
-    { 
-      ul,ol {
-      margin: 1rem 0.5rem;
+    .card-body-links {
+      ul,
+      ol {
+        margin: 1rem 0.5rem;
 
-      li {
-        margin-top: 0.5rem;
-        line-height: 1.8rem;
+        li {
+          margin-top: 0.5rem;
+          line-height: 1.8rem;
+        }
       }
     }
-  }
     .justfix-cta,
     .social-share {
       margin-top: 2rem;

--- a/client/src/styles/NotRegisteredPage.scss
+++ b/client/src/styles/NotRegisteredPage.scss
@@ -10,7 +10,7 @@
   width: 85vw;
 
   @include for-tablet-portrait-up() {
-    width: 65vw;
+    max-width: 700px;
     padding: 35px;
     margin: 4rem auto;
   }


### PR DESCRIPTION
This PR is a restructuring of the UI of our "Not Registered" page. Specifically, it replaces the buttons under the "Useful Links" header with our `<UsefulLinks>` component. This is a response to a request from the Program team about having the HPD Building Profile link available, even for non-registered properties.

Note that this PR also fixes a minor bug where we were not including a proper google event tag with these outbound useful links on the Not Registered pages.