### PR TITLE
Remove ENABLE_OLD_BROWSER_WARNING feature flag

### DIFF
--- a/client/.env.local.sample
+++ b/client/.env.local.sample
@@ -88,16 +88,6 @@ REACT_APP_TENANT_PLATFORM_SITE_ORIGIN=
 REACT_APP_API_BASE_URL=
 
 # =========================
-# ENABLE OLD BROWSER WARNING (OPTIONAL)
-# =========================
-#
-# This feature flag determines whether to enable a warning banner
-# for old versions of the Safari broswer that some functionality may not work properly.
-# The content for this banner is defined in `App.tsx`
-
-# REACT_APP_ENABLE_OLD_BROWSER_WARNING=
-
-# =========================
 # ENABLE FEATURE CALLOUT WIDGET (OPTIONAL)
 # =========================
 #

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -139,7 +139,6 @@ const App = () => {
   const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
   const addFeatureCalloutWidget = process.env.REACT_APP_ENABLE_FEATURE_CALLOUT_WIDGET === "1";
   const version = process.env.REACT_APP_VERSION;
-  const warnAboutOldBrowser = process.env.REACT_APP_ENABLE_OLD_BROWSER_WARNING;
 
   return (
     <Router>
@@ -153,14 +152,6 @@ const App = () => {
             />
           )}
           <div className="App">
-            {warnAboutOldBrowser && (
-              <div className="App__warning old_safari_only">
-                <Trans render="h3">
-                  Warning! This site doesn't fully work on older versions of Safari. Try a{" "}
-                  <a href="http://outdatedbrowser.com/en">modern browser</a>.
-                </Trans>
-              </div>
-            )}
             <div className="App__header navbar">
               <HomeLink />
               {isDemoSite && (


### PR DESCRIPTION
This PR removes an old env variable that we no longer use because of changes to Chrome and other browsers.