### PR TITLE
Specify exact python version to use for CircleCI container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     working_directory: ~/who-owns-what
     docker:
-      - image: circleci/python:3.6-node
+      - image: circleci/python:3.6.13-node
         environment:
           DATABASE_URL: postgres://wow:wow@localhost/wow
       - image: circleci/postgres:9.6


### PR DESCRIPTION
Soooo... upon trying to create a PR on who owns what this morning, we detected that our CircleCI build pipeline was failing, precisely when it was trying to download packages using Node 14 vs. the specified Node version 12 that we define within the Dockerfile as well as our engines list in `package.json`.  The problem seemed to stem from the use of the CircleCi docker image called `python:3.6-node`, which according to the [CircleCI docs](https://circleci.com/developer/images/image/cimg/python) pulls in Node 14 to accompany python 3.6. 

Our working theory was that there was a python patch (Specifically 3.6.13 --> 3.6.14) that triggered CircleCI to update their image in a way that changed the associated Node version to 14. While we aren't 100% sure, specifying python version 3.6.13 in the reference to the CircleCI image in the `config.yml` file seemed to fix the issue entirely. 