### PR TITLE
Refactor Export Data feature so that it doesn't require an API call

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -64,6 +64,7 @@
     "react-leaflet": "^1.4.0",
     "react-mapbox-gl": "^4",
     "react-modal": "^3.0.0",
+    "react-papaparse": "^3.17.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
     "react-social": "^1.10.0",

--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,6 @@
     "cytoscape": "^3.19.1",
     "cytoscape-fcose": "^2.1.0",
     "downshift": "^3.2.2",
-    "file-saver": "^1.3.3",
     "focus-trap-react": "^8.6.0",
     "leaflet": "^1.1.0",
     "lodash": "^4.17.21",

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -117,10 +117,6 @@ async function getIndicatorHistory(bbl: string): Promise<IndicatorsDataFromAPI> 
   return structuredIndicatorData;
 }
 
-function getAddressExport(bbl: string) {
-  return friendlyFetch(apiURL(`/api/address/export?bbl=${bbl}`));
-}
-
 // OTHER API FUNCTIONS AND HELPERS:
 
 /**
@@ -172,7 +168,6 @@ const Client = {
   getAggregate,
   getBuildingInfo,
   getIndicatorHistory,
-  getAddressExport,
 };
 
 export default Client;

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -14,7 +14,7 @@ export type SearchAddressWithoutBbl = Omit<SearchAddress, "bbl">;
 
 // TYPES ASSOCIATED WITH ADDRESS SEARCH QUERY:
 
-type HpdOwnerContact = {
+export type HpdOwnerContact = {
   title: string;
   value: string;
 };

--- a/client/src/components/AddressToolbar.tsx
+++ b/client/src/components/AddressToolbar.tsx
@@ -7,18 +7,15 @@ import { Trans } from "@lingui/macro";
 import { SearchAddress } from "./AddressSearch";
 import { useState } from "react";
 import { ToggleButtonBetweenPortfolioMethods } from "./WowzaToggle";
+import { AddressRecord } from "./APIDataTypes";
+import ExportDataButton from "./ExportData";
 
 export type AddressToolbarProps = {
-  onExportClick: () => void;
-  numOfAssocAddrs: number;
   searchAddr: SearchAddress;
+  assocAddrs: AddressRecord[];
 };
 
-const AddressToolbar: React.FC<AddressToolbarProps> = ({
-  onExportClick,
-  numOfAssocAddrs,
-  searchAddr,
-}) => {
+const AddressToolbar: React.FC<AddressToolbarProps> = ({ searchAddr, assocAddrs }) => {
   const allowChangingPortfolioMethod =
     process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1";
   const [showExportModal, setExportModalVisibility] = useState(false);
@@ -44,7 +41,7 @@ const AddressToolbar: React.FC<AddressToolbarProps> = ({
       </div>
       <Modal showModal={showExportModal} onClose={() => setExportModalVisibility(false)}>
         <Trans render="p">
-          This will export <b>{numOfAssocAddrs}</b> addresses associated with the landlord at{" "}
+          This will export <b>{assocAddrs.length}</b> addresses associated with the landlord at{" "}
           <b>{userAddrStr}</b>!
         </Trans>
         <Trans render="p">
@@ -52,15 +49,7 @@ const AddressToolbar: React.FC<AddressToolbarProps> = ({
           or any other spreadsheet program.
         </Trans>
         <br />
-        <button
-          className="btn centered"
-          onClick={() => {
-            window.gtag("event", "export-data");
-            onExportClick();
-          }}
-        >
-          <Trans>Download</Trans>
-        </button>
+        <ExportDataButton data={assocAddrs} />
       </Modal>
     </div>
   );

--- a/client/src/components/ExportData.test.tsx
+++ b/client/src/components/ExportData.test.tsx
@@ -1,0 +1,66 @@
+import { HpdComplaintCount, HpdFullContact, HpdOwnerContact } from "./APIDataTypes";
+import { formatAllContacts, formatComplaintTypes, formatOwnerNames } from "./ExportData";
+
+describe("formatOwnerNames()", () => {
+  it("works when passed real data", () => {
+    const owners: HpdOwnerContact[] = [
+      { title: "HeadOfficer", value: "BOOP" },
+      { title: "Agent", value: "BLARG" },
+    ];
+    expect(formatOwnerNames(owners)).toBe("BOOP (HeadOfficer), BLARG (Agent)");
+  });
+  it("works when passed null", () => {
+    expect(formatOwnerNames(null)).toBe("");
+  });
+});
+
+describe("formatComplaintTypes()", () => {
+  it("works when passed real data", () => {
+    const complaintsByType: HpdComplaintCount[] = [
+      { type: "Roaches", count: 1000 },
+      { type: "Toilet", count: 505 },
+    ];
+    expect(formatComplaintTypes(complaintsByType)).toBe("Roaches (1000), Toilet (505)");
+  });
+  it("works when passed null", () => {
+    expect(formatComplaintTypes(null)).toBe("");
+  });
+});
+
+describe("formatAllContacts()", () => {
+  it("works when passed real data, including different kinds of addresses", () => {
+    const contacts: HpdFullContact[] = [
+      {
+        title: "HeadOfficer",
+        value: "BOOP",
+        address: {
+          zip: "11205",
+          city: "BROOKLYN",
+          state: "NY",
+          apartment: "4",
+          streetname: "SPENCER STREET",
+          housenumber: "12",
+        },
+      },
+      {
+        title: "Officer",
+        value: "JONES",
+        address: {
+          zip: null,
+          city: "HELL",
+          state: "NY",
+          apartment: null,
+          streetname: "HUDSON RIVER",
+          housenumber: null,
+        },
+      },
+      { title: "Agent", value: "BLARG", address: null },
+    ];
+    expect(formatAllContacts(contacts)).toBe(
+      "BOOP (HeadOfficer), 12 SPENCER STREET 4 BROOKLYN, NY 11205; JONES (Officer), HUDSON RIVER HELL, NY; BLARG (Agent)"
+    );
+  });
+  it("works when passed null", () => {
+    expect(formatAllContacts(null)).toBe("");
+  });
+});

--- a/client/src/components/ExportData.test.tsx
+++ b/client/src/components/ExportData.test.tsx
@@ -2,33 +2,33 @@ import { HpdComplaintCount, HpdFullContact, HpdOwnerContact } from "./APIDataTyp
 import { formatAllContacts, formatComplaintTypes, formatOwnerNames } from "./ExportData";
 
 describe("formatOwnerNames()", () => {
-  it("works when passed real data", () => {
+  it("formats owner names when passed data", () => {
     const owners: HpdOwnerContact[] = [
       { title: "HeadOfficer", value: "BOOP" },
       { title: "Agent", value: "BLARG" },
     ];
     expect(formatOwnerNames(owners)).toBe("BOOP (HeadOfficer), BLARG (Agent)");
   });
-  it("works when passed null", () => {
+  it("returns empty string when passed null", () => {
     expect(formatOwnerNames(null)).toBe("");
   });
 });
 
 describe("formatComplaintTypes()", () => {
-  it("works when passed real data", () => {
+  it("formats complaint types when passed data", () => {
     const complaintsByType: HpdComplaintCount[] = [
       { type: "Roaches", count: 1000 },
       { type: "Toilet", count: 505 },
     ];
     expect(formatComplaintTypes(complaintsByType)).toBe("Roaches (1000), Toilet (505)");
   });
-  it("works when passed null", () => {
+  it("returns empty string when passed null", () => {
     expect(formatComplaintTypes(null)).toBe("");
   });
 });
 
 describe("formatAllContacts()", () => {
-  it("works when passed real data, including different kinds of addresses", () => {
+  it("formats contacts when passed data, including different kinds of business addresses", () => {
     const contacts: HpdFullContact[] = [
       {
         title: "HeadOfficer",
@@ -60,7 +60,7 @@ describe("formatAllContacts()", () => {
       "BOOP (HeadOfficer), 12 SPENCER STREET 4 BROOKLYN, NY 11205; JONES (Officer), HUDSON RIVER HELL, NY; BLARG (Agent)"
     );
   });
-  it("works when passed null", () => {
+  it("returns empty string when passed null", () => {
     expect(formatAllContacts(null)).toBe("");
   });
 });

--- a/client/src/components/ExportData.tsx
+++ b/client/src/components/ExportData.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Trans } from "@lingui/macro";
+import { CSVDownloader } from "react-papaparse";
+import { AddressRecord } from "./APIDataTypes";
+
+const ExportDataButton: React.FC<{ data: AddressRecord[] }> = ({ data }) => {
+  // Remove fields we do not want to include in the data export:
+  const fieldsWeWant = data.map(({ mapType, ...fields }) => fields);
+  const formattedData = fieldsWeWant.map((addr) => {
+    return {
+      ...addr,
+    };
+  });
+
+  return (
+    <CSVDownloader data={formattedData} filename="who_owns_what_export.csv">
+      <button
+        className="btn centered"
+        onClick={() => {
+          window.gtag("event", "export-data");
+        }}
+      >
+        <Trans>Download</Trans>
+      </button>
+    </CSVDownloader>
+  );
+};
+
+export default ExportDataButton;

--- a/client/src/components/ExportData.tsx
+++ b/client/src/components/ExportData.tsx
@@ -4,11 +4,15 @@ import { CSVDownloader } from "react-papaparse";
 import { AddressRecord, HpdComplaintCount, HpdFullContact, HpdOwnerContact } from "./APIDataTypes";
 import helpers from "util/helpers";
 
-const formatOwnerNames = (names: HpdOwnerContact[] | null) => {
+export const formatOwnerNames = (names: HpdOwnerContact[] | null) => {
   return names ? names.map(({ title, value }) => `${value} (${title})`).join(", ") : "";
 };
 
-const formatAllContacts = (contacts: HpdFullContact[] | null) => {
+export const formatComplaintTypes = (complaints: HpdComplaintCount[] | null) => {
+  return complaints ? complaints.map(({ type, count }) => `${type} (${count})`).join(", ") : "";
+};
+
+export const formatAllContacts = (contacts: HpdFullContact[] | null) => {
   if (!contacts) return "";
   else
     return contacts
@@ -23,10 +27,6 @@ const formatAllContacts = (contacts: HpdFullContact[] | null) => {
       .join("; ");
 };
 
-const formatComplaintTypes = (complaints: HpdComplaintCount[] | null) => {
-  return complaints ? complaints.map(({ type, count }) => `${type} (${count})`).join(", ") : "";
-};
-
 const ExportDataButton: React.FC<{ data: AddressRecord[] }> = ({ data }) => {
   // Remove fields we do not want to include in the data export:
   const fieldsWeWant = data.map(({ mapType, ...fields }) => fields);
@@ -36,8 +36,8 @@ const ExportDataButton: React.FC<{ data: AddressRecord[] }> = ({ data }) => {
       corpnames: !!addr.corpnames ? addr.corpnames.join("; ") : "",
       businessaddrs: !!addr.businessaddrs ? addr.businessaddrs.join("; ") : "",
       ownernames: formatOwnerNames(addr.ownernames),
-      allcontacts: formatAllContacts(addr.allcontacts),
       recentcomplaintsbytype: formatComplaintTypes(addr.recentcomplaintsbytype),
+      allcontacts: formatAllContacts(addr.allcontacts),
     };
   });
 

--- a/client/src/components/ExportData.tsx
+++ b/client/src/components/ExportData.tsx
@@ -1,7 +1,31 @@
 import React from "react";
 import { Trans } from "@lingui/macro";
 import { CSVDownloader } from "react-papaparse";
-import { AddressRecord } from "./APIDataTypes";
+import { AddressRecord, HpdComplaintCount, HpdFullContact, HpdOwnerContact } from "./APIDataTypes";
+import helpers from "util/helpers";
+
+const formatOwnerNames = (names: HpdOwnerContact[] | null) => {
+  return names ? names.map(({ title, value }) => `${value} (${title})`).join(", ") : "";
+};
+
+const formatAllContacts = (contacts: HpdFullContact[] | null) => {
+  if (!contacts) return "";
+  else
+    return contacts
+      .map(({ title, value, address }) => {
+        const formattedAddress = address
+          ? `, ${helpers.formatHpdContactAddress(address).addressLine1} ${
+              helpers.formatHpdContactAddress(address).addressLine2
+            }`
+          : "";
+        return `${value} (${title})${formattedAddress}`;
+      })
+      .join("; ");
+};
+
+const formatComplaintTypes = (complaints: HpdComplaintCount[] | null) => {
+  return complaints ? complaints.map(({ type, count }) => `${type} (${count})`).join(", ") : "";
+};
 
 const ExportDataButton: React.FC<{ data: AddressRecord[] }> = ({ data }) => {
   // Remove fields we do not want to include in the data export:
@@ -9,6 +33,11 @@ const ExportDataButton: React.FC<{ data: AddressRecord[] }> = ({ data }) => {
   const formattedData = fieldsWeWant.map((addr) => {
     return {
       ...addr,
+      corpnames: !!addr.corpnames ? addr.corpnames.join("; ") : "",
+      businessaddrs: !!addr.businessaddrs ? addr.businessaddrs.join("; ") : "",
+      ownernames: formatOwnerNames(addr.ownernames),
+      allcontacts: formatAllContacts(addr.allcontacts),
+      recentcomplaintsbytype: formatComplaintTypes(addr.recentcomplaintsbytype),
     };
   });
 

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import FileSaver from "file-saver";
 
 import AddressToolbar from "../components/AddressToolbar";
 import PropertiesMap from "../components/PropertiesMap";
@@ -7,7 +6,6 @@ import PropertiesList from "../components/PropertiesList";
 import PropertiesSummary from "../components/PropertiesSummary";
 import Indicators from "../components/Indicators";
 import DetailView from "../components/DetailView";
-import APIClient from "../components/APIClient";
 import Loader from "../components/Loader";
 
 import "styles/AddressPage.css";
@@ -111,13 +109,6 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     this.handleOpenDetail();
   };
 
-  // should this properly live in AddressToolbar? you tell me
-  handleExportClick = (bbl: string) => {
-    APIClient.getAddressExport(bbl)
-      .then((response) => response.blob())
-      .then((blob) => FileSaver.saveAs(blob, "export.csv"));
-  };
-
   render() {
     const { state, send, useNewPortfolioMethod } = this.props;
 
@@ -144,11 +135,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
         >
           <div className="AddressPage">
             <div className="AddressPage__info">
-              <AddressToolbar
-                onExportClick={() => this.handleExportClick(searchAddr.bbl)}
-                searchAddr={searchAddr}
-                numOfAssocAddrs={assocAddrs.length}
-              />
+              <AddressToolbar searchAddr={searchAddr} assocAddrs={assocAddrs} />
               <div className="float-left">
                 <h1 className="primary">
                   <Trans>

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -209,7 +209,7 @@ msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
 #: src/components/DetailView.tsx:52
-#: src/components/FeatureCalloutWidget.tsx:69
+#: src/components/FeatureCalloutWidget.tsx:60
 msgid "Close"
 msgstr "Close"
 
@@ -272,7 +272,7 @@ msgstr "Display:"
 msgid "Donate"
 msgstr "Donate"
 
-#: src/components/AddressToolbar.tsx:38
+#: src/components/ExportData.tsx:48
 msgid "Download"
 msgstr "Download"
 
@@ -319,7 +319,7 @@ msgstr "Evictions executed by NYC Marshals since 2017. ANHD and the Housing Data
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
-#: src/components/AddressToolbar.tsx:21
+#: src/components/AddressToolbar.tsx:22
 msgid "Export Data"
 msgstr "Export Data"
 
@@ -503,7 +503,7 @@ msgstr "Link to Deed"
 #: src/components/Indicators.tsx:135
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:63
-#: src/containers/AddressPage.tsx:169
+#: src/containers/AddressPage.tsx:161
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
 msgstr "Loading"
@@ -577,7 +577,7 @@ msgstr "NYCHA Directory"
 msgid "New Method (WOWZA!)"
 msgstr "New Method (WOWZA!)"
 
-#: src/components/AddressToolbar.tsx:18
+#: src/components/AddressToolbar.tsx:19
 msgid "New Search"
 msgstr "New Search"
 
@@ -585,7 +585,7 @@ msgstr "New Search"
 msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
-#: src/components/FeatureCalloutWidget.tsx:89
+#: src/components/FeatureCalloutWidget.tsx:80
 msgid "Next"
 msgstr "Next"
 
@@ -662,7 +662,7 @@ msgstr "Open"
 msgid "Open Violations"
 msgstr "Open Violations"
 
-#: src/containers/AddressPage.tsx:118
+#: src/containers/AddressPage.tsx:110
 msgid "Overview"
 msgstr "Overview"
 
@@ -682,7 +682,7 @@ msgstr "PESTS"
 msgid "PLUMBING"
 msgstr "PLUMBING"
 
-#: src/containers/AddressPage.tsx:110
+#: src/containers/AddressPage.tsx:102
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
@@ -695,7 +695,7 @@ msgstr "People"
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/containers/AddressPage.tsx:132
+#: src/containers/AddressPage.tsx:124
 msgid "Portfolio"
 msgstr "Portfolio"
 
@@ -703,7 +703,7 @@ msgstr "Portfolio"
 msgid "Portfolio Table Redesign"
 msgstr "Portfolio Table Redesign"
 
-#: src/components/FeatureCalloutWidget.tsx:82
+#: src/components/FeatureCalloutWidget.tsx:73
 msgid "Previous"
 msgstr "Previous"
 
@@ -812,7 +812,7 @@ msgstr "Sorry, the page you are looking for doesn't seem to exist."
 msgid "Source code"
 msgstr "Source code"
 
-#: src/containers/AddressPage.tsx:139
+#: src/containers/AddressPage.tsx:131
 msgid "Summary"
 msgstr "Summary"
 
@@ -898,7 +898,7 @@ msgstr "This building is owned by the NYC Housing Authority (NYCHA)"
 msgid "This building seems like it should be registered with HPD!"
 msgstr "This building seems like it should be registered with HPD!"
 
-#: src/components/AddressToolbar.tsx:29
+#: src/components/AddressToolbar.tsx:30
 msgid "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 msgstr "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 
@@ -954,11 +954,11 @@ msgstr "This seems like a smaller residential building. If the landlord doesn't 
 msgid "This tracks how rent stabilized units in the building have changed (i.e. \"{delta}\") from 2007 to {0}. If the number for {1} is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
 msgstr "This tracks how rent stabilized units in the building have changed (i.e. \"{delta}\") from 2007 to {0}. If the number for {1} is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
 
-#: src/components/AddressToolbar.tsx:25
-msgid "This will export <0>{numOfAssocAddrs}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
-msgstr "This will export <0>{numOfAssocAddrs}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
+#: src/components/AddressToolbar.tsx:26
+msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
+msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:125
+#: src/containers/AddressPage.tsx:117
 msgid "Timeline"
 msgstr "Timeline"
 
@@ -1081,8 +1081,8 @@ msgstr "What are {0}?"
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 
-#: src/components/FeatureCalloutWidget.tsx:51
-#: src/components/FeatureCalloutWidget.tsx:67
+#: src/components/FeatureCalloutWidget.tsx:42
+#: src/components/FeatureCalloutWidget.tsx:58
 msgid "What's New"
 msgstr "What's New"
 
@@ -1154,7 +1154,7 @@ msgstr "search address"
 msgid "year"
 msgstr "year"
 
-#: src/components/FeatureCalloutWidget.tsx:34
+#: src/components/FeatureCalloutWidget.tsx:25
 msgid "{0} of {numberOfEntries}"
 msgstr "{0} of {numberOfEntries}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -214,7 +214,7 @@ msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
 #: src/components/DetailView.tsx:52
-#: src/components/FeatureCalloutWidget.tsx:69
+#: src/components/FeatureCalloutWidget.tsx:60
 msgid "Close"
 msgstr "Cerrar"
 
@@ -277,7 +277,7 @@ msgstr "Mostrar:"
 msgid "Donate"
 msgstr "Donar"
 
-#: src/components/AddressToolbar.tsx:38
+#: src/components/ExportData.tsx:48
 msgid "Download"
 msgstr "Descargar"
 
@@ -324,7 +324,7 @@ msgstr "Desalojos ejecutados en este edificio por el Mariscal de NYC desde el 20
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 2017. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes del DOI."
 
-#: src/components/AddressToolbar.tsx:21
+#: src/components/AddressToolbar.tsx:22
 msgid "Export Data"
 msgstr "Exportar datos"
 
@@ -508,7 +508,7 @@ msgstr "Enlace a la Escritura"
 #: src/components/Indicators.tsx:135
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:63
-#: src/containers/AddressPage.tsx:169
+#: src/containers/AddressPage.tsx:161
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
 msgstr "Cargando"
@@ -582,7 +582,7 @@ msgstr "Directorio de NYCHA"
 msgid "New Method (WOWZA!)"
 msgstr ""
 
-#: src/components/AddressToolbar.tsx:18
+#: src/components/AddressToolbar.tsx:19
 msgid "New Search"
 msgstr "Nueva búsqueda"
 
@@ -590,7 +590,7 @@ msgstr "Nueva búsqueda"
 msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
-#: src/components/FeatureCalloutWidget.tsx:89
+#: src/components/FeatureCalloutWidget.tsx:80
 msgid "Next"
 msgstr "Siguiente"
 
@@ -667,7 +667,7 @@ msgstr "Actuales"
 msgid "Open Violations"
 msgstr "Violaciones Actuales"
 
-#: src/containers/AddressPage.tsx:118
+#: src/containers/AddressPage.tsx:110
 msgid "Overview"
 msgstr "General"
 
@@ -687,7 +687,7 @@ msgstr "PLAGAS"
 msgid "PLUMBING"
 msgstr "PLOMERÍA"
 
-#: src/containers/AddressPage.tsx:110
+#: src/containers/AddressPage.tsx:102
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
@@ -700,7 +700,7 @@ msgstr "Personas"
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/containers/AddressPage.tsx:132
+#: src/containers/AddressPage.tsx:124
 msgid "Portfolio"
 msgstr "Portafolio"
 
@@ -708,7 +708,7 @@ msgstr "Portafolio"
 msgid "Portfolio Table Redesign"
 msgstr "Rediseño de la tabla del portafolio"
 
-#: src/components/FeatureCalloutWidget.tsx:82
+#: src/components/FeatureCalloutWidget.tsx:73
 msgid "Previous"
 msgstr "Anterior"
 
@@ -817,7 +817,7 @@ msgstr "Lo sentimos, la página que estás buscando no existe."
 msgid "Source code"
 msgstr "Código fuente"
 
-#: src/containers/AddressPage.tsx:139
+#: src/containers/AddressPage.tsx:131
 msgid "Summary"
 msgstr "Resúmen"
 
@@ -903,7 +903,7 @@ msgstr "Este edificio es propiedad de la NYC Housing Authority (NYCHA)"
 msgid "This building seems like it should be registered with HPD!"
 msgstr "¡Parece que este edificio debería estar registrado con el HPD!"
 
-#: src/components/AddressToolbar.tsx:29
+#: src/components/AddressToolbar.tsx:30
 msgid "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 msgstr "Estos datos están en <0>formato de archivo CSV</0>, que puede utilizarse fácilmente en Excel, Google Sheets o cualquier otro programa de hoja de cálculo."
 
@@ -959,11 +959,11 @@ msgstr "Este parece ser un edificio residencial pequeño. Si el dueño no reside
 msgid "This tracks how rent stabilized units in the building have changed (i.e. \"{delta}\") from 2007 to {0}. If the number for {1} is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
 msgstr "El cambio en apartamentos de renta estabilizada que hay en el edificio (es decir, \"{delta}\") del 2007 al {0}. Si el número en {1} está en rojo, ¡esto significa que ha habido una pérdida en las cantidad de apartamentos de renta estabilizada! Estos recuentos se calculan a partir de las facturas de impuestos del Departamento de Finanzas."
 
-#: src/components/AddressToolbar.tsx:25
-msgid "This will export <0>{numOfAssocAddrs}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
+#: src/components/AddressToolbar.tsx:26
+msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr ""
 
-#: src/containers/AddressPage.tsx:125
+#: src/containers/AddressPage.tsx:117
 msgid "Timeline"
 msgstr "Cronología"
 
@@ -1086,8 +1086,8 @@ msgstr "¿Qué son {0}?"
 msgid "What happens if the landlord has failed to register?"
 msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 
-#: src/components/FeatureCalloutWidget.tsx:51
-#: src/components/FeatureCalloutWidget.tsx:67
+#: src/components/FeatureCalloutWidget.tsx:42
+#: src/components/FeatureCalloutWidget.tsx:58
 msgid "What's New"
 msgstr "Qué hay de nuevo"
 
@@ -1159,7 +1159,7 @@ msgstr "dirección de búsqueda"
 msgid "year"
 msgstr "año"
 
-#: src/components/FeatureCalloutWidget.tsx:34
+#: src/components/FeatureCalloutWidget.tsx:25
 msgid "{0} of {numberOfEntries}"
 msgstr "{0} de {numberOfEntries}"
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6452,11 +6452,6 @@ file-loader@4.3.0:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
 
-file-saver@^1.3.3:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
-  integrity sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==
-
 filesize@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.0.1.tgz#f850b509909c7c86f7e450ea19006c31c2ed3d2f"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2737,6 +2737,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.12.tgz#4caaf874d5eaf26e5723d30c95f6d40cac2c49bb"
   integrity sha512-HMD9cEGP+k2Y1Lk8LL6Cux9UlxkWst1wJdoMHnvH3XlVecHdjffW829/YzWd/ptFkIWtcbqQDrTkz5PY6pN+0w==
 
+"@types/papaparse@^5.0.4":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-5.2.6.tgz#0bba18de4d15eff65883bc7c0794e0134de9e7c7"
+  integrity sha512-xGKSd0UTn58N1h0+zf8mW863Rv8BvXcGibEgKFtBIXZlcDXAmX/T4RdDO2mwmrmOypUDt5vRgo2v32a78JdqUA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -10092,6 +10099,11 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
+papaparse@^5.2.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.1.tgz#770b7a9124d821d4b2132132b7bd7dce7194b5b1"
+  integrity sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==
+
 parallel-transform@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06"
@@ -11584,6 +11596,14 @@ react-modal@^3.0.0:
     prop-types "^15.5.10"
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
+
+react-papaparse@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/react-papaparse/-/react-papaparse-3.17.1.tgz#f9cc8b0f383e1555acd61cc3bfc793139c15d433"
+  integrity sha512-Pe/eheSNMDJzJJWVtryp4A3GjzMzkop1G+a3xNPsBCkPN3YzgX3ed4Vfb4kbMjbYNqS3k2gevXjszHtyFZIWtg==
+  dependencies:
+    "@types/papaparse" "^5.0.4"
+    papaparse "^5.2.0"
 
 react-router-dom@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
Inspired by #526, this PR implements a similar refactoring of our Export Data feature such that it no longer re-submits a request to our database for portfolio data and instead takes the portfolio data cached in our client state and generates a CSV for download purely using javascript. One less network request our user's browsers now have to make, yay!

I ended up using the https://github.com/Bunlong/react-papaparse package to help with CSV export functionality—it is Typescript friendly and also seems to be frequently updated/well maintained.