### PR TITLE
Add 311 complaints section to summary page

### DIFF
--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -139,6 +139,9 @@ export type SummaryStatsRecord = {
   topbusinessaddr: string | null;
   topcorp: string | null;
   topowners: string[];
+  totalcomplaints: number;
+  totalrecentcomplaints: number;
+  recentcomplaintsbytype: HpdComplaintCount[] | null;
   totalevictions: number | null;
   totalopenviolations: number;
   totalrsdiff: number | null;

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -141,7 +141,7 @@ export type SummaryStatsRecord = {
   topowners: string[];
   totalcomplaints: number;
   totalrecentcomplaints: number;
-  recentcomplaintsbytype: HpdComplaintCount[] | null;
+  recentcomplaintsbytype: HpdComplaintCount[];
   totalevictions: number | null;
   totalopenviolations: number;
   totalrsdiff: number | null;

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -139,9 +139,9 @@ export type SummaryStatsRecord = {
   topbusinessaddr: string | null;
   topcorp: string | null;
   topowners: string[];
-  totalcomplaints: number;
-  totalrecentcomplaints: number;
-  recentcomplaintsbytype: HpdComplaintCount[];
+  totalhpdcomplaints: number;
+  totalrecenthpdcomplaints: number;
+  recenthpdcomplaintsbytype: HpdComplaintCount[];
   totalevictions: number | null;
   totalopenviolations: number;
   totalrsdiff: number | null;

--- a/client/src/components/ComplaintsSummary.tsx
+++ b/client/src/components/ComplaintsSummary.tsx
@@ -7,11 +7,16 @@ import { StringifyListWithConjunction } from "./StringifyList";
 
 type ComplaintsSummaryData = Pick<
   SummaryStatsRecord,
-  "totalcomplaints" | "totalrecentcomplaints" | "recentcomplaintsbytype"
+  "totalhpdcomplaints" | "totalrecenthpdcomplaints" | "recenthpdcomplaintsbytype"
 >;
 
 export const ComplaintsSummary = withI18n()((props: ComplaintsSummaryData & withI18nProps) => {
-  const { totalcomplaints, totalrecentcomplaints, recentcomplaintsbytype, i18n } = props;
+  const {
+    totalhpdcomplaints: totalcomplaints,
+    totalrecenthpdcomplaints: totalrecentcomplaints,
+    recenthpdcomplaintsbytype: recentcomplaintsbytype,
+    i18n,
+  } = props;
 
   return (
     <>

--- a/client/src/components/ComplaintsSummary.tsx
+++ b/client/src/components/ComplaintsSummary.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Plural, Trans } from "@lingui/macro";
+import { Trans, Plural } from "@lingui/macro";
 import { SummaryStatsRecord } from "./APIDataTypes";
 import helpers from "util/helpers";
 import { withI18n, withI18nProps } from "@lingui/react";

--- a/client/src/components/ComplaintsSummary.tsx
+++ b/client/src/components/ComplaintsSummary.tsx
@@ -3,13 +3,12 @@ import { Plural, Trans } from "@lingui/macro";
 import { SummaryStatsRecord } from "./APIDataTypes";
 import helpers from "util/helpers";
 import { withI18n, withI18nProps } from "@lingui/react";
+import { StringifyListWithConjunction } from "./StringifyList";
 
 type ComplaintsSummaryData = Pick<
   SummaryStatsRecord,
   "totalcomplaints" | "totalrecentcomplaints" | "recentcomplaintsbytype"
 >;
-
-const NUM_COMPLAINT_TYPES_TO_SHOW = 3;
 
 export const ComplaintsSummary = withI18n()((props: ComplaintsSummaryData & withI18nProps) => {
   const { totalcomplaints, totalrecentcomplaints, recentcomplaintsbytype, i18n } = props;
@@ -22,22 +21,22 @@ export const ComplaintsSummary = withI18n()((props: ComplaintsSummaryData & with
           Tenants in this portfolio have reported a total of <b>{totalcomplaints}</b>{" "}
           <Plural value={totalcomplaints} one="complaint" other="complaints" /> to 311,{" "}
           <b>{totalrecentcomplaints}</b> of which{" "}
-          <Plural value={totalrecentcomplaints} one="was" other="were" /> reported in the last 3
+          <Plural value={totalrecentcomplaints} one="was" other="were" /> reported in the last three
           years.
-        </Trans>
+        </Trans>{" "}
         {recentcomplaintsbytype && recentcomplaintsbytype.length > 0 && (
           <Trans>
             The most common{" "}
             <Plural value={recentcomplaintsbytype.length} one="issue" other="issues" /> reported in
-            this portfolio over the last 3 years{" "}
+            this portfolio over the last three years{" "}
             <Plural value={recentcomplaintsbytype.length} one="is" other="are" />{" "}
-            {recentcomplaintsbytype
-              .slice(0, NUM_COMPLAINT_TYPES_TO_SHOW)
-              .map(
+            <StringifyListWithConjunction
+              values={recentcomplaintsbytype.map(
                 (complaint) =>
                   `${helpers.translateComplaintType(complaint.type, i18n)} (${complaint.count})`
-              )
-              .join(", ")}
+              )}
+            />
+            .
           </Trans>
         )}
       </p>

--- a/client/src/components/ComplaintsSummary.tsx
+++ b/client/src/components/ComplaintsSummary.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Plural, Trans } from "@lingui/macro";
+import { SummaryStatsRecord } from "./APIDataTypes";
+import helpers from "util/helpers";
+import { withI18n, withI18nProps } from "@lingui/react";
+
+type ComplaintsSummaryData = Pick<
+  SummaryStatsRecord,
+  "totalcomplaints" | "totalrecentcomplaints" | "recentcomplaintsbytype"
+>;
+
+const NUM_COMPLAINT_TYPES_TO_SHOW = 3;
+
+export const ComplaintsSummary = withI18n()((props: ComplaintsSummaryData & withI18nProps) => {
+  const { totalcomplaints, totalrecentcomplaints, recentcomplaintsbytype, i18n } = props;
+
+  return (
+    <>
+      <Trans render="h6">Complaints called in to 311</Trans>
+      <p>
+        <Trans>
+          Tenants in this portfolio have reported a total of <b>{totalcomplaints}</b>{" "}
+          <Plural value={totalcomplaints} one="complaint" other="complaints" /> to 311,{" "}
+          <b>{totalrecentcomplaints}</b> of which{" "}
+          <Plural value={totalrecentcomplaints} one="was" other="were" /> reported in the last 3
+          years.
+        </Trans>
+        {recentcomplaintsbytype && recentcomplaintsbytype.length > 0 && (
+          <Trans>
+            The most common{" "}
+            <Plural value={recentcomplaintsbytype.length} one="issue" other="issues" /> reported in
+            this portfolio over the last 3 years{" "}
+            <Plural value={recentcomplaintsbytype.length} one="is" other="are" />{" "}
+            {recentcomplaintsbytype
+              .slice(0, NUM_COMPLAINT_TYPES_TO_SHOW)
+              .map(
+                (complaint) =>
+                  `${helpers.translateComplaintType(complaint.type, i18n)} (${complaint.count})`
+              )
+              .join(", ")}
+          </Trans>
+        )}
+      </p>
+    </>
+  );
+});

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -16,6 +16,7 @@ import { defaultLocale, isSupportedLocale } from "i18n-base";
 import { I18n } from "@lingui/core/i18n";
 import { I18n as I18nComponent } from "@lingui/react";
 import { PortfolioGraph } from "./PortfolioGraph";
+import { ComplaintsSummary } from "./ComplaintsSummary";
 
 type Props = withMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
@@ -176,6 +177,7 @@ export default class PropertiesSummary extends Component<Props, {}> {
                   </Trans>
                 )}
               </p>
+              <ComplaintsSummary {...agg} />
               <ViolationsSummary {...agg} />
               <Trans render="h6">Evictions</Trans>
               <EvictionsSummary {...agg} />

--- a/client/src/components/SummaryCalculation.ts
+++ b/client/src/components/SummaryCalculation.ts
@@ -18,7 +18,7 @@ export const getTopFiveContactsInPortfolio = (addrs: AddressRecord[]) => {
 export const NUM_COMPLAINT_TYPES_TO_SHOW = 3;
 
 export const getTopComplaintTypesInPortfolio = (addrs: AddressRecord[]) => {
-  // Generate array of alll HpdComplaintCount objects across entire portfolio
+  // Generate array of all HpdComplaintCount objects across entire portfolio
   const allComplaintTypes = helpers.flattenArray(
     addrs.map((addr) => addr.recentcomplaintsbytype || [])
   ) as HpdComplaintCount[];
@@ -104,9 +104,9 @@ export const calculateAggDataFromAddressList = (addrs: AddressRecord[]): Summary
     topowners: getTopFiveContactsInPortfolio(addrs),
     topcorp: helpers.getMostCommonElementsInArray(allCorpNames, 1)[0] || null,
     topbusinessaddr: helpers.getMostCommonElementsInArray(allBusinessAddrs, 1)[0] || null,
-    totalcomplaints,
-    totalrecentcomplaints,
-    recentcomplaintsbytype: getTopComplaintTypesInPortfolio(addrs),
+    totalhpdcomplaints: totalcomplaints,
+    totalrecenthpdcomplaints: totalrecentcomplaints,
+    recenthpdcomplaintsbytype: getTopComplaintTypesInPortfolio(addrs),
     totalopenviolations,
     totalviolations,
     openviolationsperbldg: totalopenviolations / bldgs,

--- a/client/src/components/SummaryCalculation.ts
+++ b/client/src/components/SummaryCalculation.ts
@@ -15,9 +15,9 @@ export const getTopFiveContactsInPortfolio = (addrs: AddressRecord[]) => {
   return helpers.getMostCommonElementsInArray(allContactNames, 5);
 };
 
-const NUM_COMPLAINT_TYPES_TO_SHOW = 3;
+export const NUM_COMPLAINT_TYPES_TO_SHOW = 3;
 
-const getTopComplaintTypesInPortfolio = (addrs: AddressRecord[]) => {
+export const getTopComplaintTypesInPortfolio = (addrs: AddressRecord[]) => {
   // Generate array of alll HpdComplaintCount objects across entire portfolio
   const allComplaintTypes = helpers.flattenArray(
     addrs.map((addr) => addr.recentcomplaintsbytype || [])

--- a/client/src/components/SummaryCalculation.ts
+++ b/client/src/components/SummaryCalculation.ts
@@ -29,6 +29,11 @@ export const calculateAggDataFromAddressList = (addrs: AddressRecord[]): Summary
   const totalopenviolations = _.sumBy(addrs, (a) => a.openviolations);
   const totalviolations = _.sumBy(addrs, (a) => a.totalviolations);
 
+  const totalcomplaints = _.sumBy(addrs, (a) => a.totalcomplaints);
+  const totalrecentcomplaints = _.sumBy(addrs, (a) => a.recentcomplaints);
+
+  const recentcomplaintsbytype = null;
+
   const totalevictions = _.sumBy(addrs, (a) => a.evictions || 0);
 
   /**
@@ -68,6 +73,9 @@ export const calculateAggDataFromAddressList = (addrs: AddressRecord[]): Summary
     topowners: getTopFiveContactsInPortfolio(addrs),
     topcorp: helpers.getMostCommonElementsInArray(allCorpNames, 1)[0] || null,
     topbusinessaddr: helpers.getMostCommonElementsInArray(allBusinessAddrs, 1)[0] || null,
+    totalcomplaints,
+    totalrecentcomplaints,
+    recentcomplaintsbytype,
     totalopenviolations,
     totalviolations,
     openviolationsperbldg: totalopenviolations / bldgs,

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -838,8 +838,8 @@ msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
 
 #: src/components/ComplaintsSummary.tsx:11
-msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311,<1>{totalrecentcomplaints}</1> of which reported in the last 3 years."
-msgstr "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311,<1>{totalrecentcomplaints}</1> of which reported in the last 3 years."
+msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311, <1>{totalrecentcomplaints}</1> of which reported in the last three years."
+msgstr "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311, <1>{totalrecentcomplaints}</1> of which reported in the last three years."
 
 #: src/components/LegalFooter.tsx:36
 #: src/containers/TermsOfUsePage.tsx:8
@@ -871,8 +871,8 @@ msgid "The most common corporate entity is <0>{0}</0> and the most common busine
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
 #: src/components/ComplaintsSummary.tsx:18
-msgid "The most common reported in this portfolio over the last 3 years {0}"
-msgstr "The most common reported in this portfolio over the last 3 years {0}"
+msgid "The most common reported in this portfolio over the last three years <0/>."
+msgstr "The most common reported in this portfolio over the last three years <0/>."
 
 #: src/components/PropertiesSummary.tsx:103
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -838,8 +838,8 @@ msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
 
 #: src/components/ComplaintsSummary.tsx:11
-msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311, <1>{totalrecentcomplaints}</1> of which reported in the last three years."
-msgstr "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311, <1>{totalrecentcomplaints}</1> of which reported in the last three years."
+msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> {totalcomplaints, plural, one {complaint} other {complaints}} to 311, <1>{totalrecentcomplaints}</1> of which {totalrecentcomplaints, plural, one {was} other {were}} reported in the last three years."
+msgstr "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> {totalcomplaints, plural, one {complaint} other {complaints}} to 311, <1>{totalrecentcomplaints}</1> of which {totalrecentcomplaints, plural, one {was} other {were}} reported in the last three years."
 
 #: src/components/LegalFooter.tsx:36
 #: src/containers/TermsOfUsePage.tsx:8
@@ -871,8 +871,8 @@ msgid "The most common corporate entity is <0>{0}</0> and the most common busine
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
 #: src/components/ComplaintsSummary.tsx:18
-msgid "The most common reported in this portfolio over the last three years <0/>."
-msgstr "The most common reported in this portfolio over the last three years <0/>."
+msgid "The most common {0, plural, one {issue} other {issues}} reported in this portfolio over the last three years {1, plural, one {is} other {are}} <0/>."
+msgstr "The most common {0, plural, one {issue} other {issues}} reported in this portfolio over the last three years {1, plural, one {is} other {are}} <0/>."
 
 #: src/components/PropertiesSummary.tsx:103
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/PropertiesSummary.tsx:136
+#: src/components/PropertiesSummary.tsx:138
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/util/helpers.ts:267
+#: src/util/helpers.ts:274
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
@@ -79,7 +79,7 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 
-#: src/components/PropertiesSummary.tsx:122
+#: src/components/PropertiesSummary.tsx:124
 msgid "Additional links"
 msgstr "Additional links"
 
@@ -221,6 +221,10 @@ msgstr "Close legend"
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
+#: src/components/ComplaintsSummary.tsx:9
+msgid "Complaints called in to 311"
+msgstr "Complaints called in to 311"
+
 #: src/util/helpers.ts:66
 msgid "Corporate Owner"
 msgstr "Corporate Owner"
@@ -306,7 +310,7 @@ msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
 #: src/components/PropertiesList.tsx:265
-#: src/components/PropertiesSummary.tsx:115
+#: src/components/PropertiesSummary.tsx:117
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
 msgstr "Evictions"
@@ -343,7 +347,7 @@ msgstr "Failure to register a building with HPD"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
-#: src/components/PropertiesSummary.tsx:68
+#: src/components/PropertiesSummary.tsx:69
 msgid "General info"
 msgstr "General info"
 
@@ -412,7 +416,7 @@ msgstr "I just looked up this building on Who Owns What, a free tool built by Ju
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
-#: src/components/PropertiesSummary.tsx:138
+#: src/components/PropertiesSummary.tsx:140
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
@@ -453,7 +457,7 @@ msgid "LOCKS"
 msgstr "LOCKS"
 
 #: src/components/PropertiesList.tsx:279
-#: src/components/PropertiesSummary.tsx:100
+#: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -502,7 +506,7 @@ msgstr "Link to Deed"
 
 #: src/components/Indicators.tsx:135
 #: src/components/PropertiesMap.tsx:156
-#: src/components/PropertiesSummary.tsx:60
+#: src/components/PropertiesSummary.tsx:61
 #: src/containers/AddressPage.tsx:161
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
@@ -512,7 +516,7 @@ msgstr "Loading"
 msgid "Location"
 msgstr "Location"
 
-#: src/components/PropertiesSummary.tsx:126
+#: src/components/PropertiesSummary.tsx:128
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
@@ -721,7 +725,7 @@ msgstr "Public Housing Development"
 msgid "RS Units"
 msgstr "RS Units"
 
-#: src/components/PropertiesSummary.tsx:117
+#: src/components/PropertiesSummary.tsx:119
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
@@ -754,7 +758,7 @@ msgstr "Search for a different address"
 msgid "See the most common complaints reported by tenants to 311, now on the Overview and Portfolio tabs."
 msgstr "See the most common complaints reported by tenants to 311, now on the Overview and Portfolio tabs."
 
-#: src/components/PropertiesSummary.tsx:36
+#: src/components/PropertiesSummary.tsx:37
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
@@ -765,7 +769,7 @@ msgstr "Share"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:132
+#: src/components/PropertiesSummary.tsx:134
 #: src/containers/App.tsx:124
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
@@ -833,6 +837,10 @@ msgstr "TENANT HARASSMENT"
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
 
+#: src/components/ComplaintsSummary.tsx:11
+msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311,<1>{totalrecentcomplaints}</1> of which reported in the last 3 years."
+msgstr "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311,<1>{totalrecentcomplaints}</1> of which reported in the last 3 years."
+
 #: src/components/LegalFooter.tsx:36
 #: src/containers/TermsOfUsePage.tsx:8
 msgid "Terms of use"
@@ -858,11 +866,15 @@ msgstr "The city borough where your search address is located"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
-#: src/components/PropertiesSummary.tsx:108
+#: src/components/PropertiesSummary.tsx:109
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:102
+#: src/components/ComplaintsSummary.tsx:18
+msgid "The most common reported in this portfolio over the last 3 years {0}"
+msgstr "The most common reported in this portfolio over the last 3 years {0}"
+
+#: src/components/PropertiesSummary.tsx:103
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
@@ -882,11 +894,11 @@ msgstr "The number of residential units in this building, according to the Dept.
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "The year that this building was originally constructed, according to the Dept. of City Planning."
 
-#: src/components/PropertiesSummary.tsx:81
+#: src/components/PropertiesSummary.tsx:82
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 
-#: src/components/PropertiesSummary.tsx:70
+#: src/components/PropertiesSummary.tsx:71
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
@@ -918,11 +930,11 @@ msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per r
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
-#: src/components/PropertiesSummary.tsx:135
+#: src/components/PropertiesSummary.tsx:137
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 
-#: src/components/PropertiesSummary.tsx:137
+#: src/components/PropertiesSummary.tsx:139
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "This landlord’s buildings average {0} open HPD violations per apartment"
 
@@ -1158,7 +1170,7 @@ msgstr "year"
 msgid "{0} of {numberOfEntries}"
 msgstr "{0} of {numberOfEntries}"
 
-#: src/components/PropertiesSummary.tsx:91
+#: src/components/PropertiesSummary.tsx:92
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -843,7 +843,7 @@ msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
 
 #: src/components/ComplaintsSummary.tsx:11
-msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311, <1>{totalrecentcomplaints}</1> of which reported in the last three years."
+msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> {totalcomplaints, plural, one {complaint} other {complaints}} to 311, <1>{totalrecentcomplaints}</1> of which {totalrecentcomplaints, plural, one {was} other {were}} reported in the last three years."
 msgstr ""
 
 #: src/components/LegalFooter.tsx:36
@@ -876,7 +876,7 @@ msgid "The most common corporate entity is <0>{0}</0> and the most common busine
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
 #: src/components/ComplaintsSummary.tsx:18
-msgid "The most common reported in this portfolio over the last three years <0/>."
+msgid "The most common {0, plural, one {issue} other {issues}} reported in this portfolio over the last three years {1, plural, one {is} other {are}} <0/>."
 msgstr ""
 
 #: src/components/PropertiesSummary.tsx:103

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -843,7 +843,7 @@ msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
 
 #: src/components/ComplaintsSummary.tsx:11
-msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311,<1>{totalrecentcomplaints}</1> of which reported in the last 3 years."
+msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311, <1>{totalrecentcomplaints}</1> of which reported in the last three years."
 msgstr ""
 
 #: src/components/LegalFooter.tsx:36
@@ -876,7 +876,7 @@ msgid "The most common corporate entity is <0>{0}</0> and the most common busine
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
 #: src/components/ComplaintsSummary.tsx:18
-msgid "The most common reported in this portfolio over the last 3 years {0}"
+msgid "The most common reported in this portfolio over the last three years <0/>."
 msgstr ""
 
 #: src/components/PropertiesSummary.tsx:103

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 31\n"
 
-#: src/components/PropertiesSummary.tsx:136
+#: src/components/PropertiesSummary.tsx:138
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
-#: src/util/helpers.ts:267
+#: src/util/helpers.ts:274
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
@@ -84,7 +84,7 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha recibido un total de <0>{totalviolations}</0> violaciones."
 
-#: src/components/PropertiesSummary.tsx:122
+#: src/components/PropertiesSummary.tsx:124
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
@@ -226,6 +226,10 @@ msgstr "Cerrar leyenda"
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
+#: src/components/ComplaintsSummary.tsx:9
+msgid "Complaints called in to 311"
+msgstr ""
+
 #: src/util/helpers.ts:66
 msgid "Corporate Owner"
 msgstr "Dueño Corporativo"
@@ -311,7 +315,7 @@ msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
 #: src/components/PropertiesList.tsx:265
-#: src/components/PropertiesSummary.tsx:115
+#: src/components/PropertiesSummary.tsx:117
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
 msgstr "Desalojos"
@@ -348,7 +352,7 @@ msgstr "Si no se registra un edificio con el HPD"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
-#: src/components/PropertiesSummary.tsx:68
+#: src/components/PropertiesSummary.tsx:69
 msgid "General info"
 msgstr "Información general"
 
@@ -417,7 +421,7 @@ msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta grat
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
-#: src/components/PropertiesSummary.tsx:138
+#: src/components/PropertiesSummary.tsx:140
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
@@ -458,7 +462,7 @@ msgid "LOCKS"
 msgstr "CERRADURAS"
 
 #: src/components/PropertiesList.tsx:279
-#: src/components/PropertiesSummary.tsx:100
+#: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -507,7 +511,7 @@ msgstr "Enlace a la Escritura"
 
 #: src/components/Indicators.tsx:135
 #: src/components/PropertiesMap.tsx:156
-#: src/components/PropertiesSummary.tsx:60
+#: src/components/PropertiesSummary.tsx:61
 #: src/containers/AddressPage.tsx:161
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
@@ -517,7 +521,7 @@ msgstr "Cargando"
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/PropertiesSummary.tsx:126
+#: src/components/PropertiesSummary.tsx:128
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
@@ -726,7 +730,7 @@ msgstr "Complejo de Vivienda Pública"
 msgid "RS Units"
 msgstr "Unidades RS"
 
-#: src/components/PropertiesSummary.tsx:117
+#: src/components/PropertiesSummary.tsx:119
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
@@ -759,7 +763,7 @@ msgstr "Buscar otra dirección"
 msgid "See the most common complaints reported by tenants to 311, now on the Overview and Portfolio tabs."
 msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en las pestañas General y Portafolio."
 
-#: src/components/PropertiesSummary.tsx:36
+#: src/components/PropertiesSummary.tsx:37
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
@@ -770,7 +774,7 @@ msgstr "Compartir"
 
 #: src/components/DetailView.tsx:231
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:132
+#: src/components/PropertiesSummary.tsx:134
 #: src/containers/App.tsx:124
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
@@ -838,6 +842,10 @@ msgstr "ACOSO DE INQUILINO"
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
 
+#: src/components/ComplaintsSummary.tsx:11
+msgid "Tenants in this portfolio have reported a total of <0>{totalcomplaints}</0> to 311,<1>{totalrecentcomplaints}</1> of which reported in the last 3 years."
+msgstr ""
+
 #: src/components/LegalFooter.tsx:36
 #: src/containers/TermsOfUsePage.tsx:8
 msgid "Terms of use"
@@ -863,11 +871,15 @@ msgstr "El municipio donde se encuentra la dirección que has buscado"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
-#: src/components/PropertiesSummary.tsx:108
+#: src/components/PropertiesSummary.tsx:109
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
-#: src/components/PropertiesSummary.tsx:102
+#: src/components/ComplaintsSummary.tsx:18
+msgid "The most common reported in this portfolio over the last 3 years {0}"
+msgstr ""
+
+#: src/components/PropertiesSummary.tsx:103
 msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "{0, plural, one {El nombre más común que aparece en este portafolio de edificios es} other {Los nombres más comunes que aparecen en este portafolio de edificios son}} <0/>."
 
@@ -887,11 +899,11 @@ msgstr "El número de unidades residenciales en este edificio, según el Departa
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "El año en que este edificio fue construido, según el Departamento de Planificación de la Ciudad."
 
-#: src/components/PropertiesSummary.tsx:81
+#: src/components/PropertiesSummary.tsx:82
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
-#: src/components/PropertiesSummary.tsx:70
+#: src/components/PropertiesSummary.tsx:71
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
@@ -923,11 +935,11 @@ msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "El identificador oficial del edificio según los registros del Departamento de Finanzas."
 
-#: src/components/PropertiesSummary.tsx:135
+#: src/components/PropertiesSummary.tsx:137
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "Este dueño de edificio posee {0} edificios, y según @NYCHousing, ha recibido un total de {1} violaciones del código de vivienda. ¿Puedes adivinar como se llama el dueño? Encuentra su nombre y ve más estadísticas aquí:"
 
-#: src/components/PropertiesSummary.tsx:137
+#: src/components/PropertiesSummary.tsx:139
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "Los edificios de este dueño tienen un promedio de {0} violaciones abiertas de HPD por cada apartamento"
 
@@ -1163,7 +1175,7 @@ msgstr "año"
 msgid "{0} of {numberOfEntries}"
 msgstr "{0} de {numberOfEntries}"
 
-#: src/components/PropertiesSummary.tsx:91
+#: src/components/PropertiesSummary.tsx:92
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una violación del HPD actual} other {# violaciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 
@@ -1182,4 +1194,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:35
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2010} other {# Violaciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/state-machine-sample-data.ts
+++ b/client/src/state-machine-sample-data.ts
@@ -98,7 +98,7 @@ export const SAMPLE_ADDRESS_RECORDS: AddressRecord[] = [
     openviolations: 0,
     recentcomplaints: 1,
     totalcomplaints: 2,
-    recentcomplaintsbytype: [{ type: "HEAT/HOT WATER", count: 1 }],
+    recentcomplaintsbytype: [{ type: "HEAT/HOT WATER", count: 3 }],
     unitsres: 13,
     yearbuilt: 1931,
     lat: 40.6737974139504,


### PR DESCRIPTION
This PR adds a new section to the Summary tab called "Complaints called in to 311" on Who Owns What that shows users a sum of 311 complaints across the portfolio, as well as a list of the most common complaint types. 