### PR TITLE
Update statistic for "average violations per residential unit citywide" on Summary tab

### DIFF
--- a/client/src/components/ViolationsSummary.tsx
+++ b/client/src/components/ViolationsSummary.tsx
@@ -3,10 +3,10 @@ import * as _ from "lodash";
 import { Trans } from "@lingui/macro";
 import { SummaryStatsRecord } from "./APIDataTypes";
 
-const VIOLATIONS_AVG = 0.7; // By Unit
-// 1668635 open violations according to wow_bldgs
-// 2366392 total units in registered buildings, according to wow_bldgs
-// Last updated: 5/25/2020
+const VIOLATIONS_AVG = 0.8; // By Unit
+// 1917247 open violations according to wow_bldgs
+// 2414366 total units in registered buildings, according to wow_bldgs
+// Last updated: 9/20/2021
 
 type ViolationsSummaryData = Pick<
   SummaryStatsRecord,


### PR DESCRIPTION
This PR is a long overdue update of a variable on within the `<ViolationsSummary>` component that quantifies the average number of violations per residential unit across the entire city. The number is manually calculated by writing a super simple query to nycdb.

I've always wondered if we should. find a way to automate the process of updating this... the number has maybe changed once or twice over the last 3.5 years and only by 0.1 (which is what we round the metric to on the front-end). So, it always felt like too much overhead to make a network request, but maybe there is another option? 