### PR TITLE
Allow "wowza" prefix within bbl-based URLs

### DIFF
--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -102,7 +102,7 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
           <AddressPage currentTab={3} {...machineProps} {...props} useNewPortfolioMethod />
         )}
       />
-      <Route path={paths.oldBbl} component={BBLPage} />
+      <Route path={paths.bblSeparatedIntoParts} component={BBLPage} />
       <Route path={paths.bbl} component={BBLPage} />
       <Route
         path={paths.wowzaBbl}

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -102,8 +102,12 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
           <AddressPage currentTab={3} {...machineProps} {...props} useNewPortfolioMethod />
         )}
       />
+      <Route path={paths.oldBbl} component={BBLPage} />
       <Route path={paths.bbl} component={BBLPage} />
-      <Route path={paths.bblWithFullBblInUrl} component={BBLPage} />
+      <Route
+        path={paths.wowzaBbl}
+        render={(props) => <BBLPage {...props} useNewPortfolioMethod />}
+      />
       <Route path={paths.about} component={AboutPage} />
       <Route path={paths.howToUse} component={HowToUsePage} />
       <Route path={paths.methodology} component={MethodologyPage} />

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -18,7 +18,9 @@ export type BBLPageParams = {
   lot?: string;
 };
 
-type BBLPageProps = RouteComponentProps<BBLPageParams>;
+type BBLPageProps = RouteComponentProps<BBLPageParams> & {
+  useNewPortfolioMethod?: boolean;
+};
 
 export const getFullBblFromPageParams = (params: BBLPageParams) => {
   var fullBBL: string;
@@ -57,10 +59,13 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
             setIsNotFound(true);
             return;
           }
-          const addressPage = createRouteForAddressPage({
-            ...results.result[0],
-            locale,
-          });
+          const addressPage = createRouteForAddressPage(
+            {
+              ...results.result[0],
+              locale,
+            },
+            props.useNewPortfolioMethod
+          );
           history.replace(addressPage);
         })
         .catch(reportError);
@@ -69,7 +74,7 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
         isMounted = false;
       };
     }
-  }, [fullBBL, history, locale]);
+  }, [fullBBL, history, locale, props.useNewPortfolioMethod]);
 
   return isNotFound ? (
     <AddrNotFoundPage />

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -58,16 +58,20 @@ export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
     ),
     /** Note: this path doesn't correspond to a stable page on the site. It simply provides an entry point that
      * immediately redirects to an addressPageOverview. This path is helpful for folks who, say, have a list of
-     * boro, block, lot values in a spreadsheet and want to easily generate direct links to WhoOwnsWhat.
+     * bbl values in a spreadsheet and want to easily generate direct links to WhoOwnsWhat.
      * See `BBLPage.tsx` for more details.
      */
-    bbl: `${pathPrefix}/bbl/:boro/:block/:lot`,
+    bbl: `${pathPrefix}/bbl/:bbl`,
     /** Note: this path doesn't correspond to a stable page on the site. It simply provides an entry point that
      * immediately redirects to an addressPageOverview. This path is helpful for folks who, say, have a list of
      * bbl values in a spreadsheet and want to easily generate direct links to WhoOwnsWhat.
      * See `BBLPage.tsx` for more details.
      */
-    bblWithFullBblInUrl: `${pathPrefix}/bbl/:bbl`,
+    wowzaBbl: `${pathPrefix}/wowza/bbl/:bbl`,
+    /** This route path corresponds to a page identical to the `bbl` route above, but with an older url
+     * pattern that we want to support so as not to break any old links that exist out in the web.
+     */
+    oldBbl: `${pathPrefix}/bbl/:boro/:block/:lot`,
     about: `${pathPrefix}/about`,
     howToUse: `${pathPrefix}/how-to-use`,
     methodology: `${pathPrefix}/how-it-works`,

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -69,7 +69,7 @@ export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
     /** This route path corresponds to a page identical to the `bbl` route above, but with an older url
      * pattern that we want to support so as not to break any old links that exist out in the web.
      */
-    oldBbl: `${pathPrefix}/bbl/:boro/:block/:lot`,
+    bblSeparatedIntoParts: `${pathPrefix}/bbl/:boro/:block/:lot`,
     about: `${pathPrefix}/about`,
     howToUse: `${pathPrefix}/how-to-use`,
     methodology: `${pathPrefix}/how-it-works`,

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -62,10 +62,8 @@ export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
      * See `BBLPage.tsx` for more details.
      */
     bbl: `${pathPrefix}/bbl/:bbl`,
-    /** Note: this path doesn't correspond to a stable page on the site. It simply provides an entry point that
-     * immediately redirects to an addressPageOverview. This path is helpful for folks who, say, have a list of
-     * bbl values in a spreadsheet and want to easily generate direct links to WhoOwnsWhat.
-     * See `BBLPage.tsx` for more details.
+    /** This route path corresponds to a page identical to the `bbl` path above, just specifying that the user
+     * requests to use the new "WOWZA" portfolio method.
      */
     wowzaBbl: `${pathPrefix}/wowza/bbl/:bbl`,
     /** This route path corresponds to a page identical to the `bbl` route above, but with an older url


### PR DESCRIPTION
This PR builds out the "bbl-based" url entrypoint into WOW by allowing users to specify in this URL scheme whether they want to use the new 'wowza' portfolio mapping algorithm or not. 

Basically, we have an existing feature where users can access WOW via a url like `/en/bbl/4015640058` and get redirected to the stable address page on WOW, which in this case is `/en/address/QUEENS/41-25/CASE%20STREET`. This is particularly helpful when you have a whole list of bbls (say, in a spreadsheet), and you want to quickly generate a list of direct links to WOW from it. 

So, this PR is essentially just adding an extra feature to these bbl-based urls where you can now ALSO define whether you want to access a new wowza page or a regular page.

NOTE: since we are introducing another route path, I changed some of our naming conventions around for these bbl-based urls just for clarity.