### PR TITLE
Add `getLandlordNameFromAddress` helper function

### DIFF
--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -1,5 +1,6 @@
 import helpers, { searchAddrsAreEqual } from "./helpers";
 import { SearchAddressWithoutBbl } from "components/APIDataTypes";
+import { SAMPLE_ADDRESS_RECORDS } from "state-machine-sample-data";
 
 describe("searchAddrsAreEqual()", () => {
   const searchAddr1: SearchAddressWithoutBbl = {
@@ -86,6 +87,52 @@ describe("getMostCommonElementsInArray()", () => {
 
   it("works with empty arrays", () => {
     expect(helpers.getMostCommonElementsInArray([], 1)).toEqual([]);
+  });
+});
+
+describe("getLandlordNameFromAddress()", () => {
+  it("returns an empty array when there are no ownernames", () => {
+    expect(
+      helpers.getLandlordNameFromAddress({
+        ...SAMPLE_ADDRESS_RECORDS[0],
+        ownernames: null,
+      })
+    ).toEqual([]);
+  });
+
+  it("returns an array with 1 landlord's name for addresses with one landlord", () => {
+    expect(
+      helpers.getLandlordNameFromAddress({
+        ...SAMPLE_ADDRESS_RECORDS[0],
+      })
+    ).toEqual(["MOSES GUTMAN"]);
+  });
+
+  it("returns an array with multiple landlord's name for addresses with more than one landlord", () => {
+    expect(
+      helpers.getLandlordNameFromAddress({
+        ...SAMPLE_ADDRESS_RECORDS[0],
+        ownernames: [
+          { title: "HeadOfficer", value: "MOSES GUTMAN" },
+          { title: "HeadOfficer", value: "BOOP GUTMAN" },
+          { title: "IndividualOwner", value: "BOOP JONES" },
+          { title: "Agent", value: "NATHAN SCHWARCZ" },
+        ],
+      })
+    ).toEqual(["MOSES GUTMAN", "BOOP GUTMAN", "BOOP JONES"]);
+  });
+
+  it("filters out duplicate landlord names", () => {
+    expect(
+      helpers.getLandlordNameFromAddress({
+        ...SAMPLE_ADDRESS_RECORDS[0],
+        ownernames: [
+          { title: "HeadOfficer", value: "MOSES GUTMAN" },
+          { title: "CorporateOwner", value: "MOSES GUTMAN" },
+          { title: "Agent", value: "NATHAN SCHWARCZ" },
+        ],
+      })
+    ).toEqual(["MOSES GUTMAN"]);
   });
 });
 

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -122,6 +122,19 @@ describe("getLandlordNameFromAddress()", () => {
     ).toEqual(["MOSES GUTMAN", "BOOP GUTMAN", "BOOP JONES"]);
   });
 
+  it("can detect all three types of landlord contact records", () => {
+    expect(
+      helpers.getLandlordNameFromAddress({
+        ...SAMPLE_ADDRESS_RECORDS[0],
+        ownernames: [
+          { title: "HeadOfficer", value: "SAM" },
+          { title: "CorporateOwner", value: "SAMARA" },
+          { title: "IndividualOwner", value: "TAHNEE" },
+        ],
+      })
+    ).toEqual(["SAM", "SAMARA", "TAHNEE"]);
+  });
+
   it("filters out duplicate landlord names", () => {
     expect(
       helpers.getLandlordNameFromAddress({

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -195,7 +195,7 @@ export default {
     const { ownernames } = addr;
     if (!ownernames) return [];
     const landlords = ownernames.filter((owner) =>
-      ["HeadOfficer", "IndividualOwner", "CorporateOwnerowner"].includes(owner.title)
+      ["HeadOfficer", "IndividualOwner", "CorporateOwner"].includes(owner.title)
     );
     const landlordNames = landlords.map((landlord) => landlord.value);
     // Remove duplicate names:

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -186,6 +186,11 @@ export default {
     return sortedElementsByFrequency.slice(0, numberOfResults).map((a) => a[0]);
   },
 
+  /**
+   * Note: while almost all address records will just have one landlord listed, there is a rare
+   * edge case where more than one distinct landlord name might be listed, so we return an array
+   * of names here to accommodate that edge case.
+   */
   getLandlordNameFromAddress(addr: AddressRecord): string[] {
     const { ownernames } = addr;
     if (!ownernames) return [];

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -192,7 +192,9 @@ export default {
     const landlords = ownernames.filter((owner) =>
       ["HeadOfficer", "IndividualOwner", "CorporateOwnerowner"].includes(owner.title)
     );
-    return landlords.map((landlord) => landlord.value);
+    const landlordNames = landlords.map((landlord) => landlord.value);
+    // Remove duplicate names:
+    return Array.from(new Set(landlordNames));
   },
 
   splitBBL(bbl: string) {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -4,7 +4,7 @@
 import _pickBy from "lodash/pickBy";
 import { deepEqual as assertDeepEqual } from "assert";
 import { SupportedLocale } from "../i18n-base";
-import { HpdContactAddress, SearchAddressWithoutBbl } from "components/APIDataTypes";
+import { AddressRecord, HpdContactAddress, SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { reportError } from "error-reporting";
 import { t } from "@lingui/macro";
 import { I18n, MessageDescriptor } from "@lingui/core";
@@ -184,6 +184,15 @@ export default {
     );
     // Let's discard the frequency number and just return a simple array of strings, in order:
     return sortedElementsByFrequency.slice(0, numberOfResults).map((a) => a[0]);
+  },
+
+  getLandlordNameFromAddress(addr: AddressRecord): string[] {
+    const { ownernames } = addr;
+    if (!ownernames) return [];
+    const landlords = ownernames.filter((owner) =>
+      ["HeadOfficer", "IndividualOwner", "CorporateOwnerowner"].includes(owner.title)
+    );
+    return landlords.map((landlord) => landlord.value);
   },
 
   splitBBL(bbl: string) {


### PR DESCRIPTION
This PR adds a new helper function called `getLandlordNameFromAddress` which takes in an AddressRecord object and finds the name of the landlord (or names, if there is a rare edge case where there is more than one) and returns a string array with the name(s) inside.