### PR TITLE
Remove old helper functions we no longer use

### DIFF
--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -162,17 +162,6 @@ test("addrsAreEqual() works", () => {
   expect(helpers.addrsAreEqual({ bbl: "yes" }, { bbl: "no" })).toBe(false);
 });
 
-describe("jsonEqual()", () => {
-  it("returns true when objects are equal", () => {
-    expect(helpers.jsonEqual({ a: 1 }, { a: 1 })).toBe(true);
-    expect(helpers.jsonEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
-  });
-
-  it("returns false when objects are not equal", () => {
-    expect(helpers.jsonEqual({ a: 1 }, { b: 2 })).toBe(false);
-  });
-});
-
 describe("formatPrice()", () => {
   it("works with no locale provided", () => {
     expect(helpers.formatPrice(1000000)).toBe("1,000,000");
@@ -188,12 +177,6 @@ test("createTakeActionURL() works", () => {
   ).toBe(
     "https://app.justfix.nyc/ddo?address=1%20BOOP%20RD&borough=QUEENS&utm_source=whoownswhat&utm_content=take_action&utm_medium=boop"
   );
-});
-
-test("intersectAddrObjects() works", () => {
-  expect(helpers.intersectAddrObjects({ a: 1, b: 2, c: 3, d: 9 }, { a: 5, b: 2, c: 9 })).toEqual({
-    b: 2,
-  });
 });
 
 test("capitalize() works", () => {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -214,15 +214,6 @@ export default {
     return a.bbl === b.bbl;
   },
 
-  jsonEqual(a: any, b: any): boolean {
-    try {
-      assertDeepEqual(a, b);
-      return true;
-    } catch (e) {
-      return false;
-    }
-  },
-
   formatPrice(amount: number, locale?: SupportedLocale): string {
     const formatPrice = new Intl.NumberFormat(locale || "en");
     return formatPrice.format(amount);
@@ -251,12 +242,6 @@ export default {
       reportError(`Address improperly formatted for DDO: ${addr || "<falsy value>"}`);
       return `https://${subdomain}.justfix.nyc/?utm_source=whoownswhat&utm_content=take_action_failed_attempt&utm_medium=${utm_medium}`;
     }
-  },
-
-  intersectAddrObjects(a: any, b: any) {
-    return _pickBy(a, function (v, k) {
-      return b[k] === v;
-    });
   },
 
   capitalize(string: string): string {

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -1,8 +1,3 @@
-// import _clone from 'lodash/clone';
-// import _xor from 'lodash/xor';
-// import _keys from 'lodash/keys';
-import _pickBy from "lodash/pickBy";
-import { deepEqual as assertDeepEqual } from "assert";
 import { SupportedLocale } from "../i18n-base";
 import { AddressRecord, HpdContactAddress, SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { reportError } from "error-reporting";


### PR DESCRIPTION
I noticed two helper functions within `helpers.ts` that are not used anywhere in the codebase and also don't seem particularly novel or helpful. Removing them to reduce code bloat!