### PR TITLE
Add search address and detail address nodes to portfolio graph visualization

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -129,6 +129,10 @@ const LearnMoreAccordion = () => (
   </I18n>
 );
 
+const BldgAssociationHeader = () => (
+  <Trans>How is this building associated to this portfolio?</Trans>
+);
+
 class DetailViewWithoutI18n extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -211,17 +215,17 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                       {!Helpers.addrsAreEqual(detailAddr, searchAddr) &&
                         (useNewPortfolioMethod ? (
                           <Link to={this.props.addressPageRoutes.summary}>
-                            <Trans render="i">
-                              How is this building associated to this portfolio?
-                            </Trans>
+                            <i>
+                              <BldgAssociationHeader />
+                            </i>
                           </Link>
                         ) : (
                           <a // eslint-disable-line jsx-a11y/anchor-is-valid
                             onClick={() => this.setState({ showCompareModal: true })}
                           >
-                            <Trans render="i">
-                              How is this building associated to this portfolio?
-                            </Trans>
+                            <i>
+                              <BldgAssociationHeader />
+                            </i>
                           </a>
                         ))}
                     </div>
@@ -365,7 +369,9 @@ class DetailViewWithoutI18n extends Component<Props, State> {
               onClose={() => this.setState({ showCompareModal: false })}
             >
               <h6>
-                <Trans render="b">How is this building associated to this portfolio?</Trans>
+                <b>
+                  <BldgAssociationHeader />
+                </b>
               </h6>
               <Trans render="p">
                 We compare your search address with a database of over 200k buildings to identify a

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -152,7 +152,8 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const isMobile = Browser.isMobile();
     const { i18n } = this.props;
     const locale = (i18n.language as SupportedLocale) || "en";
-    const { assocAddrs, detailAddr, searchAddr } = this.props.state.context.portfolioData;
+    const { useNewPortfolioMethod, portfolioData } = this.props.state.context;
+    const { assocAddrs, detailAddr, searchAddr } = portfolioData;
 
     // Let's save some variables that will be helpful in rendering the front-end component
     let takeActionURL, formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
@@ -207,15 +208,22 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                         {Helpers.titleCase(detailAddr.streetname)},{" "}
                         {Helpers.titleCase(detailAddr.boro)}
                       </h4>
-                      {!Helpers.addrsAreEqual(detailAddr, searchAddr) && (
-                        <a // eslint-disable-line jsx-a11y/anchor-is-valid
-                          onClick={() => this.setState({ showCompareModal: true })}
-                        >
-                          <Trans render="i">
-                            How is this building associated to this portfolio?
-                          </Trans>
-                        </a>
-                      )}
+                      {!Helpers.addrsAreEqual(detailAddr, searchAddr) &&
+                        (useNewPortfolioMethod ? (
+                          <Link to={this.props.addressPageRoutes.summary}>
+                            <Trans render="i">
+                              How is this building associated to this portfolio?
+                            </Trans>
+                          </Link>
+                        ) : (
+                          <a // eslint-disable-line jsx-a11y/anchor-is-valid
+                            onClick={() => this.setState({ showCompareModal: true })}
+                          >
+                            <Trans render="i">
+                              How is this building associated to this portfolio?
+                            </Trans>
+                          </a>
+                        ))}
                     </div>
                     <div className="card-body">
                       <BuildingStatsTable addr={detailAddr} />

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -129,7 +129,7 @@ const LearnMoreAccordion = () => (
   </I18n>
 );
 
-const BldgAssociationHeader = () => (
+const HowIsBldgAssociatedHeader = () => (
   <Trans>How is this building associated to this portfolio?</Trans>
 );
 
@@ -216,7 +216,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                         (useNewPortfolioMethod ? (
                           <Link to={this.props.addressPageRoutes.summary}>
                             <i>
-                              <BldgAssociationHeader />
+                              <HowIsBldgAssociatedHeader />
                             </i>
                           </Link>
                         ) : (
@@ -224,7 +224,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                             onClick={() => this.setState({ showCompareModal: true })}
                           >
                             <i>
-                              <BldgAssociationHeader />
+                              <HowIsBldgAssociatedHeader />
                             </i>
                           </a>
                         ))}
@@ -370,7 +370,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
             >
               <h6>
                 <b>
-                  <BldgAssociationHeader />
+                  <HowIsBldgAssociatedHeader />
                 </b>
               </h6>
               <Trans render="p">

--- a/client/src/components/PortfolioGraph.test.tsx
+++ b/client/src/components/PortfolioGraph.test.tsx
@@ -1,0 +1,48 @@
+import { PortfolioGraphNode } from "./APIDataTypes";
+import { getLandlordNodeIDFromAddress } from "./PortfolioGraph";
+import { SAMPLE_ADDRESS_RECORDS } from "../state-machine-sample-data";
+
+const sampleNodes: PortfolioGraphNode[] = [
+  {
+    id: 1,
+    value: {
+      kind: "name",
+      value: "MOSES GUTMAN",
+    },
+  },
+  {
+    id: 2,
+    value: {
+      kind: "name",
+      value: "BOOP JONES",
+    },
+  },
+  {
+    id: 3,
+    value: {
+      kind: "bizaddr",
+      value: "101 MAIN ST QUEENS",
+    },
+  },
+];
+
+describe("getLandlordNodeIDFromAddress()", () => {
+  it("correctly identifies a node ID", () => {
+    expect(getLandlordNodeIDFromAddress(sampleNodes, SAMPLE_ADDRESS_RECORDS[0])).toEqual(["1"]);
+  });
+  it("returns an empty array if no matching nodes are found", () => {
+    expect(getLandlordNodeIDFromAddress(sampleNodes, SAMPLE_ADDRESS_RECORDS[1])).toEqual([]);
+  });
+  it("can find multiple node IDs if there are multiple matches ", () => {
+    expect(
+      getLandlordNodeIDFromAddress(sampleNodes, {
+        ...SAMPLE_ADDRESS_RECORDS[0],
+        ownernames: [
+          { title: "CorporateOwner", value: "MOSES GUTMAN" },
+          { title: "IndividualOwner", value: "BOOP JONES" },
+          { title: "Agent", value: "IRRELEVANT TOM" },
+        ],
+      })
+    ).toEqual(["1", "2"]);
+  });
+});

--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -3,29 +3,28 @@ import Cytoscape from "cytoscape";
 import CytoscapeComponent from "react-cytoscapejs";
 // @ts-ignore
 import fcose from "cytoscape-fcose";
-import { RawPortfolioGraphJson } from "./APIDataTypes";
+import { AddressRecord, RawPortfolioGraphJson } from "./APIDataTypes";
+import { withMachineInStateProps } from "state-machine";
+import helpers from "util/helpers";
 
 Cytoscape.use(fcose);
 
-const formatGraphJSON = (rawJSON: RawPortfolioGraphJson): cytoscape.ElementDefinition[] => {
-  const nodes: cytoscape.ElementDefinition[] = rawJSON.nodes.map((node) => ({
-    group: "nodes",
-    data: {
-      id: node.id.toString(),
-      type: node.value.kind,
-      value: node.value.value,
-    },
-  }));
+const formatGraphJSON = (
+  rawJSON: RawPortfolioGraphJson,
+  additionalNodes: Cytoscape.NodeDefinition[],
+  additionalEdges: Cytoscape.EdgeDefinition[]
+): cytoscape.ElementDefinition[] => {
+  let nodes: cytoscape.ElementDefinition[] = rawJSON.nodes.map((node) => createNode(
+    node.id.toString(),
+    node.value.kind,
+    node.value.value)
+  );
+  nodes = nodes.concat(additionalNodes);
 
-  const edges: cytoscape.ElementDefinition[] = rawJSON.edges.map((edge) => ({
-    group: "edges",
-    data: {
-      source: edge.from.toString(),
-      target: edge.to.toString(),
-      count_hpd_registrations: edge.reg_contacts,
-    },
-  }));
-
+  const edges: cytoscape.ElementDefinition[] = rawJSON.edges.map((edge) =>
+    createEdge(edge.from.toString(), edge.to.toString(), edge.reg_contacts)
+  );
+  nodes = edges.concat(additionalEdges);
   return nodes.concat(edges);
 };
 
@@ -38,20 +37,113 @@ const layout = {
   nodeSeparation: 300,
 };
 
-export const PortfolioGraph: React.FC<{ graphJSON: RawPortfolioGraphJson }> = ({ graphJSON }) => (
-  <CytoscapeComponent
-    elements={formatGraphJSON(graphJSON)}
-    style={{ width: "900px", height: "600px" }}
-    layout={layout}
-    stylesheet={[
-      {
-        selector: "node",
-        style: {
-          label: "data(value)",
-          backgroundColor: (ele) => (ele.data("type") === "name" ? "red" : "green"),
-          "min-zoomed-font-size": 16,
+type PortfolioGraphProps = withMachineInStateProps<"portfolioFound"> & {
+  graphJSON: RawPortfolioGraphJson;
+};
+
+function createNode(id: string, type: string, value: string): cytoscape.NodeDefinition {
+  return {
+    group: "nodes",
+    data: {
+      id,
+      type,
+      value,
+    },
+  };
+}
+
+function createEdge(
+  source: string,
+  target: string,
+  count_hpd_registrations: number=1
+): cytoscape.EdgeDefinition {
+  return {
+    group: "edges",
+    data: {
+      source,
+      target,
+      count_hpd_registrations,
+    },
+  };
+}
+
+/**
+ * Generates one node for the search BBL and one for the detail BBL to show on the portfolio graph.
+ * @param searchAddr 
+ * @param detailAddr 
+ * @returns 
+ */
+function generateAdditionalNodes(searchAddr: AddressRecord, detailAddr?: AddressRecord) {
+  var additionalNodes = [];
+  const searchBBLNode = createNode(
+    "searchaddr",
+    "searchaddr",
+    `${searchAddr.housenumber} ${searchAddr.streetname}, ${searchAddr.boro}`
+  );
+  additionalNodes.push(searchBBLNode);
+
+  if (detailAddr) {
+    const detailBBLNode = createNode(
+      "detailaddr",
+      "detailaddr",
+      `${detailAddr.housenumber} ${detailAddr.streetname}, ${detailAddr.boro}`
+    );
+    additionalNodes.push(detailAddr);
+  }
+  return additionalNodes;
+}
+
+function getLandlordNodeIDFromAddress(addr: AddressRecord, landlordNodes: RawPortfolioGraphJson) {
+  const ll_name = helpers.getLandlordNameFromAddress(addr);
+  // TODO: look through landlordNodes to find the one that matches LL_name, return that 
+}
+
+function generateAdditionalEdges(searchAddr: AddressRecord, detailAddr?: AddressRecord) {
+  var additionalEdges = [];
+  const searchBBLEdge = createEdge(
+    getLandlordNodeIDFromAddress(searchAddr),
+    'searchAddr'
+  );
+  additionalEdges.push(searchBBLEdge);
+  if (detailAddr) {
+    const detailBBLEdge = createEdge(
+      getLandlordNodeIDFromAddress(detailAddr),
+      'detailaddr' 
+    );
+    additionalEdges.push(detailBBLEdge);
+  }
+  return additionalEdges;
+}
+
+
+
+export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state }) => {
+  const { searchAddr, detailAddr } = state.context.portfolioData;
+  const additionalNodes = generateAdditionalNodes(searchAddr, detailAddr);
+  const additionalEdges = generateAdditionalEdges(searchAddr, detailAddr);
+
+  return (
+    <CytoscapeComponent
+      elements={formatGraphJSON(graphJSON, additionalNodes, additionalEdges)}
+      style={{ width: "900px", height: "600px" }}
+      layout={layout}
+      stylesheet={[
+        {
+          selector: "node",
+          style: {
+            label: "data(value)",
+            backgroundColor: (ele) => (NODE_TYPE_TO_COLOR[ele.data("type")]),
+            "min-zoomed-font-size": 16,
+          },
         },
-      },
-    ]}
-  />
-);
+      ]}
+    />
+  );
+};
+
+const NODE_TYPE_TO_COLOR:Record<string,string> = {
+  'name': 'red',
+  'bizaddr': 'green',
+  'searchaddr': 'orange',
+  'detailaddr': 'yellow',
+};

--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -72,7 +72,10 @@ function generateAdditionalNodes(searchAddr: AddressRecord, detailAddr?: Address
  * finds the `id` property of a node of type `name` that corresponds to the owner
  * (or owners) listed with the address.
  */
-function getLandlordNodeIDFromAddress(existingNodes: PortfolioGraphNode[], addr: AddressRecord) {
+export function getLandlordNodeIDFromAddress(
+  existingNodes: PortfolioGraphNode[],
+  addr: AddressRecord
+) {
   const landlordNames = helpers.getLandlordNameFromAddress(addr);
   const landlordMatches = existingNodes.filter(
     (node) => node.value.kind === "name" && landlordNames.includes(node.value.value)

--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -107,10 +107,10 @@ const formatGraphJSON = (
   );
   nodes = nodes.concat(additionalNodes);
 
-  const edges: cytoscape.ElementDefinition[] = rawJSON.edges.map((edge) =>
+  let edges: cytoscape.ElementDefinition[] = rawJSON.edges.map((edge) =>
     createEdge(edge.from.toString(), edge.to.toString(), edge.reg_contacts)
   );
-  nodes = edges.concat(additionalEdges);
+  edges = edges.concat(additionalEdges);
   return nodes.concat(edges);
 };
 
@@ -120,8 +120,11 @@ type PortfolioGraphProps = Pick<withMachineInStateProps<"portfolioFound">, "stat
 
 export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state }) => {
   const { searchAddr, detailAddr } = state.context.portfolioData;
-  const additionalNodes = generateAdditionalNodes(searchAddr, detailAddr);
-  const additionalEdges = generateAdditionalEdges(graphJSON.nodes, searchAddr, detailAddr);
+  const distinctDetailAddr = !helpers.addrsAreEqual(searchAddr, detailAddr)
+    ? detailAddr
+    : undefined;
+  const additionalNodes = generateAdditionalNodes(searchAddr, distinctDetailAddr);
+  const additionalEdges = generateAdditionalEdges(graphJSON.nodes, searchAddr, distinctDetailAddr);
 
   return (
     <CytoscapeComponent

--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -83,16 +83,16 @@ function generateAdditionalEdges(
   searchAddr: AddressRecord,
   detailAddr?: AddressRecord
 ) {
-  var additionalEdges: Cytoscape.EdgeDefinition[] = [];
+  let additionalEdges: Cytoscape.EdgeDefinition[] = [];
   const searchBBLEdges = getLandlordNodeIDFromAddress(existingNodes, searchAddr).map((id) =>
-    createEdge(id, "searchAddr")
+    createEdge(id, "searchaddr")
   );
-  additionalEdges.concat(searchBBLEdges);
+  additionalEdges = additionalEdges.concat(searchBBLEdges);
   if (detailAddr) {
     const detailBBLEdges = getLandlordNodeIDFromAddress(existingNodes, detailAddr).map((id) =>
-      createEdge(id, "detailAddr")
+      createEdge(id, "detailaddr")
     );
-    additionalEdges.concat(detailBBLEdges);
+    additionalEdges = additionalEdges.concat(detailBBLEdges);
   }
   return additionalEdges;
 }

--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -46,9 +46,6 @@ function createEdge(
 
 /**
  * Generates one node for the search BBL and one for the detail BBL to show on the portfolio graph.
- * @param searchAddr
- * @param detailAddr
- * @returns
  */
 function generateAdditionalNodes(searchAddr: AddressRecord, detailAddr?: AddressRecord) {
   var additionalNodes = [];
@@ -70,6 +67,11 @@ function generateAdditionalNodes(searchAddr: AddressRecord, detailAddr?: Address
   return additionalNodes;
 }
 
+/**
+ * Given an existing array of graph nodes and an Address Record, this function
+ * finds the `id` property of a node of type `name` that corresponds to the owner
+ * (or owners) listed with the address.
+ */
 function getLandlordNodeIDFromAddress(existingNodes: PortfolioGraphNode[], addr: AddressRecord) {
   const landlordNames = helpers.getLandlordNameFromAddress(addr);
   const landlordMatches = existingNodes.filter(
@@ -78,6 +80,13 @@ function getLandlordNodeIDFromAddress(existingNodes: PortfolioGraphNode[], addr:
   return landlordMatches.map((node) => node.id.toString());
 }
 
+/**
+ * Given the existing array of graph nodes, this function generates an edge from search BBL to its corresponding owner name,
+ * as well as an edge from the detail BBL to its corresponding owner name.
+ *
+ * Note: in rare edge cases, there may be more than one corresponding owner name for a given BBL.
+ * In these cases, multiple edges may be created here.
+ */
 function generateAdditionalEdges(
   existingNodes: PortfolioGraphNode[],
   searchAddr: AddressRecord,

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -99,7 +99,10 @@ export default class PropertiesSummary extends Component<Props, {}> {
         <div className="Page PropertiesSummary">
           <div className="PropertiesSummary__content Page__content">
             {state.context.useNewPortfolioMethod && state.context.portfolioData.portfolioGraph && (
-              <PortfolioGraph graphJSON={state.context.portfolioData.portfolioGraph} />
+              <PortfolioGraph
+                graphJSON={state.context.portfolioData.portfolioGraph}
+                state={state}
+              />
             )}
             <div>
               <Trans render="h6">General info</Trans>

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -17,19 +17,19 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/util/helpers.ts:274
+#: src/util/helpers.ts:269
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
-#: src/components/DetailView.tsx:209
+#: src/components/DetailView.tsx:215
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:191
+#: src/components/DetailView.tsx:197
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:194
+#: src/components/DetailView.tsx:200
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -66,12 +66,12 @@ msgstr "A new set of dropdown menus and design tweaks make it more comfortable t
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
 
-#: src/util/helpers.ts:55
+#: src/util/helpers.ts:50
 msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:71
+#: src/containers/App.tsx:72
 msgid "About"
 msgstr "About"
 
@@ -87,7 +87,7 @@ msgstr "Additional links"
 msgid "Address"
 msgstr "Address"
 
-#: src/util/helpers.ts:70
+#: src/util/helpers.ts:65
 msgid "Agent"
 msgstr "Agent"
 
@@ -104,7 +104,7 @@ msgstr "All the public info on your landlord"
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/DetailView.tsx:222
+#: src/components/DetailView.tsx:228
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -112,11 +112,11 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/util/helpers.ts:35
+#: src/util/helpers.ts:30
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:130
+#: src/components/DetailView.tsx:131
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -154,29 +154,29 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:286
-#: src/components/DetailView.tsx:295
+#: src/components/DetailView.tsx:292
+#: src/components/DetailView.tsx:301
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:266
-#: src/components/DetailView.tsx:275
+#: src/components/DetailView.tsx:272
+#: src/components/DetailView.tsx:281
 msgid "Business Entities"
 msgstr "Business Entities"
 
-#: src/util/helpers.ts:44
+#: src/util/helpers.ts:39
 msgid "CABINET"
 msgstr "CABINET"
 
-#: src/util/helpers.ts:57
+#: src/util/helpers.ts:52
 msgid "CERAMIC TILE"
 msgstr "CERAMIC TILE"
 
-#: src/util/helpers.ts:32
+#: src/util/helpers.ts:27
 msgid "CONSTRUCTION"
 msgstr "CONSTRUCTION"
 
-#: src/util/helpers.ts:58
+#: src/util/helpers.ts:53
 msgid "COOKING GAS"
 msgstr "COOKING GAS"
 
@@ -225,11 +225,11 @@ msgstr "Complaints Issued"
 msgid "Complaints to 311"
 msgstr "Complaints to 311"
 
-#: src/util/helpers.ts:66
+#: src/util/helpers.ts:61
 msgid "Corporate Owner"
 msgstr "Corporate Owner"
 
-#: src/util/helpers.ts:74
+#: src/util/helpers.ts:69
 msgid "Corporation"
 msgstr "Corporation"
 
@@ -245,11 +245,11 @@ msgstr "DOB/ECB Violations"
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
-#: src/util/helpers.ts:29
+#: src/util/helpers.ts:24
 msgid "DOOR/WINDOW"
 msgstr "DOOR/WINDOW"
 
-#: src/util/helpers.ts:61
+#: src/util/helpers.ts:56
 msgid "DOORS"
 msgstr "DOORS"
 
@@ -258,7 +258,7 @@ msgstr "DOORS"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:94
+#: src/containers/App.tsx:95
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -272,7 +272,7 @@ msgid "Display:"
 msgstr "Display:"
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:77
+#: src/containers/App.tsx:78
 msgid "Donate"
 msgstr "Donate"
 
@@ -284,11 +284,11 @@ msgstr "Download"
 msgid "ECB"
 msgstr "ECB"
 
-#: src/util/helpers.ts:52
+#: src/util/helpers.ts:47
 msgid "ELECTRIC"
 msgstr "ELECTRIC"
 
-#: src/util/helpers.ts:42
+#: src/util/helpers.ts:37
 msgid "ELEVATOR"
 msgstr "ELEVATOR"
 
@@ -327,15 +327,15 @@ msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD 
 msgid "Export Data"
 msgstr "Export Data"
 
-#: src/util/helpers.ts:37
+#: src/util/helpers.ts:32
 msgid "FIRE ESCAPE"
 msgstr "FIRE ESCAPE"
 
-#: src/util/helpers.ts:47
+#: src/util/helpers.ts:42
 msgid "FLOOR"
 msgstr "FLOOR"
 
-#: src/util/helpers.ts:53
+#: src/util/helpers.ts:48
 msgid "FLOORING/STAIRS"
 msgstr "FLOORING/STAIRS"
 
@@ -343,7 +343,7 @@ msgstr "FLOORING/STAIRS"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/util/helpers.ts:43
+#: src/util/helpers.ts:38
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
@@ -356,11 +356,11 @@ msgstr "General info"
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
-#: src/util/helpers.ts:60
+#: src/util/helpers.ts:55
 msgid "HEAT/HOT WATER"
 msgstr "HEAT/HOT WATER"
 
-#: src/util/helpers.ts:30
+#: src/util/helpers.ts:25
 msgid "HEATING"
 msgstr "HEATING"
 
@@ -390,7 +390,7 @@ msgstr "HPD Violations occur when an official City Inspector finds the condition
 msgid "HUD Complaint Form 958"
 msgstr "HUD Complaint Form 958"
 
-#: src/util/helpers.ts:65
+#: src/util/helpers.ts:60
 msgid "Head Officer"
 msgstr "Head Officer"
 
@@ -398,12 +398,13 @@ msgstr "Head Officer"
 msgid "How do you want to group landlord portfolios?"
 msgstr "How do you want to group landlord portfolios?"
 
-#: src/components/DetailView.tsx:136
-#: src/components/DetailView.tsx:241
+#: src/components/DetailView.tsx:137
+#: src/components/DetailView.tsx:142
+#: src/components/DetailView.tsx:247
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:74
+#: src/containers/App.tsx:75
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -420,7 +421,7 @@ msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open viol
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
-#: src/util/helpers.ts:67
+#: src/util/helpers.ts:62
 msgid "Individual Owner"
 msgstr "Individual Owner"
 
@@ -436,7 +437,7 @@ msgstr "Information"
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "It doesn't seem like this property is required to register with HPD."
 
-#: src/util/helpers.ts:33
+#: src/util/helpers.ts:28
 msgid "JANITOR/SUPER"
 msgstr "JANITOR/SUPER"
 
@@ -444,7 +445,7 @@ msgstr "JANITOR/SUPER"
 msgid "Join the fight for tenant rights!"
 msgstr "Join the fight for tenant rights!"
 
-#: src/util/helpers.ts:68
+#: src/util/helpers.ts:63
 msgid "Joint Owner"
 msgstr "Joint Owner"
 
@@ -452,7 +453,7 @@ msgstr "Joint Owner"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
-#: src/util/helpers.ts:62
+#: src/util/helpers.ts:57
 msgid "LOCKS"
 msgstr "LOCKS"
 
@@ -478,11 +479,11 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:186
+#: src/components/DetailView.tsx:192
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:199
+#: src/components/DetailView.tsx:205
 msgid "Last sold:"
 msgstr "Last sold:"
 
@@ -494,7 +495,7 @@ msgstr "Learn more"
 msgid "Legend"
 msgstr "Legend"
 
-#: src/util/helpers.ts:71
+#: src/util/helpers.ts:66
 msgid "Lessee"
 msgstr "Lessee"
 
@@ -520,11 +521,11 @@ msgstr "Location"
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
-#: src/util/helpers.ts:40
+#: src/util/helpers.ts:35
 msgid "MAILBOX"
 msgstr "MAILBOX"
 
-#: src/util/helpers.ts:50
+#: src/util/helpers.ts:45
 msgid "MOLD"
 msgstr "MOLD"
 
@@ -553,7 +554,7 @@ msgstr "Methodology"
 msgid "More Mobile Friendly"
 msgstr "More Mobile Friendly"
 
-#: src/components/DetailView.tsx:153
+#: src/components/DetailView.tsx:159
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -569,7 +570,7 @@ msgstr "Move chart data right."
 msgid "MyNYCHA App"
 msgstr "MyNYCHA App"
 
-#: src/util/helpers.ts:56
+#: src/util/helpers.ts:51
 msgid "NON-CONSTRUCTION"
 msgstr "NON-CONSTRUCTION"
 
@@ -622,7 +623,7 @@ msgstr "Non-ECB"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:161
+#: src/components/DetailView.tsx:167
 msgid "None"
 msgstr "None"
 
@@ -630,11 +631,11 @@ msgstr "None"
 msgid "Not found"
 msgstr "Not found"
 
-#: src/util/helpers.ts:34
+#: src/util/helpers.ts:29
 msgid "OUTSIDE BUILDING"
 msgstr "OUTSIDE BUILDING"
 
-#: src/util/helpers.ts:72
+#: src/util/helpers.ts:67
 msgid "Officer"
 msgstr "Officer"
 
@@ -674,15 +675,15 @@ msgstr "Overview"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 
-#: src/util/helpers.ts:54
+#: src/util/helpers.ts:49
 msgid "PAINT/PLASTER"
 msgstr "PAINT/PLASTER"
 
-#: src/util/helpers.ts:39
+#: src/util/helpers.ts:34
 msgid "PESTS"
 msgstr "PESTS"
 
-#: src/util/helpers.ts:48
+#: src/util/helpers.ts:43
 msgid "PLUMBING"
 msgstr "PLUMBING"
 
@@ -690,8 +691,8 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/DetailView.tsx:306
-#: src/components/DetailView.tsx:316
+#: src/components/DetailView.tsx:312
+#: src/components/DetailView.tsx:322
 msgid "People"
 msgstr "People"
 
@@ -729,23 +730,23 @@ msgstr "RS Units"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/util/helpers.ts:59
+#: src/util/helpers.ts:54
 msgid "SAFETY"
 msgstr "SAFETY"
 
-#: src/util/helpers.ts:36
+#: src/util/helpers.ts:31
 msgid "SEWAGE"
 msgstr "SEWAGE"
 
-#: src/util/helpers.ts:38
+#: src/util/helpers.ts:33
 msgid "SIGNAGE MISSING"
 msgstr "SIGNAGE MISSING"
 
-#: src/util/helpers.ts:31
+#: src/util/helpers.ts:26
 msgid "STAIRS"
 msgstr "STAIRS"
 
-#: src/containers/App.tsx:68
+#: src/containers/App.tsx:69
 msgid "Search"
 msgstr "Search"
 
@@ -762,20 +763,20 @@ msgstr "See the most common complaints reported by tenants to 311, now on the Ov
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:102
-#: src/containers/App.tsx:113
+#: src/containers/App.tsx:103
+#: src/containers/App.tsx:114
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:231
+#: src/components/DetailView.tsx:237
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:134
-#: src/containers/App.tsx:124
+#: src/containers/App.tsx:125
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
 
-#: src/util/helpers.ts:73
+#: src/util/helpers.ts:68
 msgid "Shareholder"
 msgstr "Shareholder"
 
@@ -796,7 +797,7 @@ msgstr "Since 2017"
 msgid "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/util/helpers.ts:69
+#: src/util/helpers.ts:64
 msgid "Site Manager"
 msgstr "Site Manager"
 
@@ -828,11 +829,11 @@ msgstr "Switch to New Version"
 msgid "Switch to Old Version"
 msgstr "Switch to Old Version"
 
-#: src/util/helpers.ts:45
+#: src/util/helpers.ts:40
 msgid "TENANT HARASSMENT"
 msgstr "TENANT HARASSMENT"
 
-#: src/components/DetailView.tsx:225
+#: src/components/DetailView.tsx:231
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
@@ -1015,7 +1016,7 @@ msgstr "Use this free tool from JustFix.nyc to research your building and invest
 msgid "Useful links"
 msgstr "Useful links"
 
-#: src/util/helpers.ts:49
+#: src/util/helpers.ts:44
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
@@ -1024,7 +1025,7 @@ msgstr "VENTILATION SYSTEM"
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:147
+#: src/components/DetailView.tsx:153
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
@@ -1048,7 +1049,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:122
+#: src/components/DetailView.tsx:123
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -1061,19 +1062,19 @@ msgstr "Violations Issued"
 msgid "Visit our website"
 msgstr "Visit our website"
 
-#: src/util/helpers.ts:51
+#: src/util/helpers.ts:46
 msgid "WATER LEAK"
 msgstr "WATER LEAK"
 
-#: src/util/helpers.ts:46
+#: src/util/helpers.ts:41
 msgid "WINDOW GUARDS"
 msgstr "WINDOW GUARDS"
 
-#: src/util/helpers.ts:41
+#: src/util/helpers.ts:36
 msgid "WINDOWS"
 msgstr "WINDOWS"
 
-#: src/components/DetailView.tsx:243
+#: src/components/DetailView.tsx:249
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -1117,7 +1118,7 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:168
+#: src/components/DetailView.tsx:174
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -1146,7 +1147,7 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:203
+#: src/components/DetailView.tsx:209
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -21,15 +21,15 @@ msgstr "#WhoOwnsWhat via @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
-#: src/components/DetailView.tsx:215
+#: src/components/DetailView.tsx:216
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:197
+#: src/components/DetailView.tsx:198
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:201
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -104,7 +104,7 @@ msgstr "All the public info on your landlord"
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/DetailView.tsx:228
+#: src/components/DetailView.tsx:229
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -116,7 +116,7 @@ msgstr "Are you having issues in this development?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:131
+#: src/components/DetailView.tsx:132
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -154,13 +154,13 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:292
-#: src/components/DetailView.tsx:301
+#: src/components/DetailView.tsx:295
+#: src/components/DetailView.tsx:304
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:272
-#: src/components/DetailView.tsx:281
+#: src/components/DetailView.tsx:275
+#: src/components/DetailView.tsx:284
 msgid "Business Entities"
 msgstr "Business Entities"
 
@@ -398,9 +398,7 @@ msgstr "Head Officer"
 msgid "How do you want to group landlord portfolios?"
 msgstr "How do you want to group landlord portfolios?"
 
-#: src/components/DetailView.tsx:137
-#: src/components/DetailView.tsx:142
-#: src/components/DetailView.tsx:247
+#: src/components/DetailView.tsx:77
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
@@ -479,11 +477,11 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:192
+#: src/components/DetailView.tsx:193
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:205
+#: src/components/DetailView.tsx:206
 msgid "Last sold:"
 msgstr "Last sold:"
 
@@ -554,7 +552,7 @@ msgstr "Methodology"
 msgid "More Mobile Friendly"
 msgstr "More Mobile Friendly"
 
-#: src/components/DetailView.tsx:159
+#: src/components/DetailView.tsx:160
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -623,7 +621,7 @@ msgstr "Non-ECB"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:167
+#: src/components/DetailView.tsx:168
 msgid "None"
 msgstr "None"
 
@@ -691,8 +689,8 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/DetailView.tsx:312
-#: src/components/DetailView.tsx:322
+#: src/components/DetailView.tsx:315
+#: src/components/DetailView.tsx:325
 msgid "People"
 msgstr "People"
 
@@ -768,7 +766,7 @@ msgstr "Send us a data request"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:237
+#: src/components/DetailView.tsx:238
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:134
 #: src/containers/App.tsx:125
@@ -833,7 +831,7 @@ msgstr "Switch to Old Version"
 msgid "TENANT HARASSMENT"
 msgstr "TENANT HARASSMENT"
 
-#: src/components/DetailView.tsx:231
+#: src/components/DetailView.tsx:232
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
@@ -1025,7 +1023,7 @@ msgstr "VENTILATION SYSTEM"
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:153
+#: src/components/DetailView.tsx:154
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
@@ -1049,7 +1047,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:123
+#: src/components/DetailView.tsx:124
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -1074,7 +1072,7 @@ msgstr "WINDOW GUARDS"
 msgid "WINDOWS"
 msgstr "WINDOWS"
 
-#: src/components/DetailView.tsx:249
+#: src/components/DetailView.tsx:252
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -1118,7 +1116,7 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:174
+#: src/components/DetailView.tsx:175
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -1147,7 +1145,7 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:209
+#: src/components/DetailView.tsx:210
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
-#: src/util/helpers.ts:274
+#: src/util/helpers.ts:269
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
-#: src/components/DetailView.tsx:209
+#: src/components/DetailView.tsx:215
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:191
+#: src/components/DetailView.tsx:197
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:194
+#: src/components/DetailView.tsx:200
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -71,12 +71,12 @@ msgstr "Un nuevo conjunto de menús desplegables y ajustes de diseño hacen que 
 msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
 
-#: src/util/helpers.ts:55
+#: src/util/helpers.ts:50
 msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:71
+#: src/containers/App.tsx:72
 msgid "About"
 msgstr "Acerca de"
 
@@ -92,7 +92,7 @@ msgstr "Enlaces adicionales"
 msgid "Address"
 msgstr "Dirección"
 
-#: src/util/helpers.ts:70
+#: src/util/helpers.ts:65
 msgid "Agent"
 msgstr "Agente"
 
@@ -109,7 +109,7 @@ msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 msgid "Amount"
 msgstr "Importe"
 
-#: src/components/DetailView.tsx:222
+#: src/components/DetailView.tsx:228
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -117,11 +117,11 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
-#: src/util/helpers.ts:35
+#: src/util/helpers.ts:30
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:130
+#: src/components/DetailView.tsx:131
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -159,29 +159,29 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:286
-#: src/components/DetailView.tsx:295
+#: src/components/DetailView.tsx:292
+#: src/components/DetailView.tsx:301
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:266
-#: src/components/DetailView.tsx:275
+#: src/components/DetailView.tsx:272
+#: src/components/DetailView.tsx:281
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
-#: src/util/helpers.ts:44
+#: src/util/helpers.ts:39
 msgid "CABINET"
 msgstr "GABINETE"
 
-#: src/util/helpers.ts:57
+#: src/util/helpers.ts:52
 msgid "CERAMIC TILE"
 msgstr "AZULEJOS CERÁMICAS"
 
-#: src/util/helpers.ts:32
+#: src/util/helpers.ts:27
 msgid "CONSTRUCTION"
 msgstr "CONSTRUCCIÓN"
 
-#: src/util/helpers.ts:58
+#: src/util/helpers.ts:53
 msgid "COOKING GAS"
 msgstr "GAS DE COCINA"
 
@@ -230,11 +230,11 @@ msgstr "Quejas Emitidas"
 msgid "Complaints to 311"
 msgstr "Quejas al 311"
 
-#: src/util/helpers.ts:66
+#: src/util/helpers.ts:61
 msgid "Corporate Owner"
 msgstr "Dueño Corporativo"
 
-#: src/util/helpers.ts:74
+#: src/util/helpers.ts:69
 msgid "Corporation"
 msgstr "Corporación"
 
@@ -250,11 +250,11 @@ msgstr "Violaciones del DOB/ECB"
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
-#: src/util/helpers.ts:29
+#: src/util/helpers.ts:24
 msgid "DOOR/WINDOW"
 msgstr "PUERTA/VENTANA"
 
-#: src/util/helpers.ts:61
+#: src/util/helpers.ts:56
 msgid "DOORS"
 msgstr "PUERTAS"
 
@@ -263,7 +263,7 @@ msgstr "PUERTAS"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:94
+#: src/containers/App.tsx:95
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -277,7 +277,7 @@ msgid "Display:"
 msgstr "Mostrar:"
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:77
+#: src/containers/App.tsx:78
 msgid "Donate"
 msgstr "Donar"
 
@@ -289,11 +289,11 @@ msgstr "Descargar"
 msgid "ECB"
 msgstr "ECB"
 
-#: src/util/helpers.ts:52
+#: src/util/helpers.ts:47
 msgid "ELECTRIC"
 msgstr "ELÉCTRICO"
 
-#: src/util/helpers.ts:42
+#: src/util/helpers.ts:37
 msgid "ELEVATOR"
 msgstr "ASCENSOR"
 
@@ -332,15 +332,15 @@ msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 20
 msgid "Export Data"
 msgstr "Exportar datos"
 
-#: src/util/helpers.ts:37
+#: src/util/helpers.ts:32
 msgid "FIRE ESCAPE"
 msgstr "ESCALERA DE INCENDIO"
 
-#: src/util/helpers.ts:47
+#: src/util/helpers.ts:42
 msgid "FLOOR"
 msgstr "PISO"
 
-#: src/util/helpers.ts:53
+#: src/util/helpers.ts:48
 msgid "FLOORING/STAIRS"
 msgstr "PISO/ESCALERAS"
 
@@ -348,7 +348,7 @@ msgstr "PISO/ESCALERAS"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/util/helpers.ts:43
+#: src/util/helpers.ts:38
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
@@ -361,11 +361,11 @@ msgstr "Información general"
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
-#: src/util/helpers.ts:60
+#: src/util/helpers.ts:55
 msgid "HEAT/HOT WATER"
 msgstr "CALEFACCIÓN/AGUA CALIENTE"
 
-#: src/util/helpers.ts:30
+#: src/util/helpers.ts:25
 msgid "HEATING"
 msgstr "CALEFACCIÓN"
 
@@ -395,7 +395,7 @@ msgstr "Violaciones del HPD se dan cuando un Inspector oficial de la Ciudad dete
 msgid "HUD Complaint Form 958"
 msgstr "Formulario de queja HUD 958"
 
-#: src/util/helpers.ts:65
+#: src/util/helpers.ts:60
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
@@ -403,12 +403,13 @@ msgstr "Oficial Principal"
 msgid "How do you want to group landlord portfolios?"
 msgstr "¿Cómo quieres agrupar a los portafolios de los dueños?"
 
-#: src/components/DetailView.tsx:136
-#: src/components/DetailView.tsx:241
+#: src/components/DetailView.tsx:137
+#: src/components/DetailView.tsx:142
+#: src/components/DetailView.tsx:247
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:74
+#: src/containers/App.tsx:75
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
@@ -425,7 +426,7 @@ msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
-#: src/util/helpers.ts:67
+#: src/util/helpers.ts:62
 msgid "Individual Owner"
 msgstr "Dueño Individual"
 
@@ -441,7 +442,7 @@ msgstr "Información"
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "Parece que esta propiedad no necesita estar registrada con el HPD."
 
-#: src/util/helpers.ts:33
+#: src/util/helpers.ts:28
 msgid "JANITOR/SUPER"
 msgstr "CONSERJE/SÚPER"
 
@@ -449,7 +450,7 @@ msgstr "CONSERJE/SÚPER"
 msgid "Join the fight for tenant rights!"
 msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 
-#: src/util/helpers.ts:68
+#: src/util/helpers.ts:63
 msgid "Joint Owner"
 msgstr "Dueño Conjunto"
 
@@ -457,7 +458,7 @@ msgstr "Dueño Conjunto"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: src/util/helpers.ts:62
+#: src/util/helpers.ts:57
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
@@ -483,11 +484,11 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:186
+#: src/components/DetailView.tsx:192
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:199
+#: src/components/DetailView.tsx:205
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
@@ -499,7 +500,7 @@ msgstr "Aprende más"
 msgid "Legend"
 msgstr "Leyenda"
 
-#: src/util/helpers.ts:71
+#: src/util/helpers.ts:66
 msgid "Lessee"
 msgstr "Arrendatario"
 
@@ -525,11 +526,11 @@ msgstr "Ubicación"
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
-#: src/util/helpers.ts:40
+#: src/util/helpers.ts:35
 msgid "MAILBOX"
 msgstr "BUZÓN"
 
-#: src/util/helpers.ts:50
+#: src/util/helpers.ts:45
 msgid "MOLD"
 msgstr "MOHO"
 
@@ -558,7 +559,7 @@ msgstr "Metodología"
 msgid "More Mobile Friendly"
 msgstr "Más útil para dispositivos móviles"
 
-#: src/components/DetailView.tsx:153
+#: src/components/DetailView.tsx:159
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -574,7 +575,7 @@ msgstr "Mover datos del gráfico a la derecha."
 msgid "MyNYCHA App"
 msgstr "App MyNYCHA"
 
-#: src/util/helpers.ts:56
+#: src/util/helpers.ts:51
 msgid "NON-CONSTRUCTION"
 msgstr "NO CONSTRUCCIÓN"
 
@@ -627,7 +628,7 @@ msgstr "No ECB"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:161
+#: src/components/DetailView.tsx:167
 msgid "None"
 msgstr "Ninguna"
 
@@ -635,11 +636,11 @@ msgstr "Ninguna"
 msgid "Not found"
 msgstr "No encontrado"
 
-#: src/util/helpers.ts:34
+#: src/util/helpers.ts:29
 msgid "OUTSIDE BUILDING"
 msgstr "AFUERA DEL EDIFICIO"
 
-#: src/util/helpers.ts:72
+#: src/util/helpers.ts:67
 msgid "Officer"
 msgstr "Oficial"
 
@@ -679,15 +680,15 @@ msgstr "General"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/> Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
 
-#: src/util/helpers.ts:54
+#: src/util/helpers.ts:49
 msgid "PAINT/PLASTER"
 msgstr "PINTURA/YESO"
 
-#: src/util/helpers.ts:39
+#: src/util/helpers.ts:34
 msgid "PESTS"
 msgstr "PLAGAS"
 
-#: src/util/helpers.ts:48
+#: src/util/helpers.ts:43
 msgid "PLUMBING"
 msgstr "PLOMERÍA"
 
@@ -695,8 +696,8 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/DetailView.tsx:306
-#: src/components/DetailView.tsx:316
+#: src/components/DetailView.tsx:312
+#: src/components/DetailView.tsx:322
 msgid "People"
 msgstr "Personas"
 
@@ -734,23 +735,23 @@ msgstr "Unidades RS"
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
-#: src/util/helpers.ts:59
+#: src/util/helpers.ts:54
 msgid "SAFETY"
 msgstr "SEGURIDAD"
 
-#: src/util/helpers.ts:36
+#: src/util/helpers.ts:31
 msgid "SEWAGE"
 msgstr "AGUAS NEGRAS"
 
-#: src/util/helpers.ts:38
+#: src/util/helpers.ts:33
 msgid "SIGNAGE MISSING"
 msgstr "FALTA DE SEÑALIZACIÓN"
 
-#: src/util/helpers.ts:31
+#: src/util/helpers.ts:26
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
-#: src/containers/App.tsx:68
+#: src/containers/App.tsx:69
 msgid "Search"
 msgstr "Buscar"
 
@@ -767,20 +768,20 @@ msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en l
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:102
-#: src/containers/App.tsx:113
+#: src/containers/App.tsx:103
+#: src/containers/App.tsx:114
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:231
+#: src/components/DetailView.tsx:237
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:134
-#: src/containers/App.tsx:124
+#: src/containers/App.tsx:125
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
 
-#: src/util/helpers.ts:73
+#: src/util/helpers.ts:68
 msgid "Shareholder"
 msgstr "Accionista"
 
@@ -801,7 +802,7 @@ msgstr "Desde 2017"
 msgid "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde el 2017, los Mariscales de NYC programaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en este portafolio de edificios."
 
-#: src/util/helpers.ts:69
+#: src/util/helpers.ts:64
 msgid "Site Manager"
 msgstr "Administrador del Sitio"
 
@@ -833,11 +834,11 @@ msgstr "Cambiar a la nueva versión"
 msgid "Switch to Old Version"
 msgstr "Cambiar a la versión anterior"
 
-#: src/util/helpers.ts:45
+#: src/util/helpers.ts:40
 msgid "TENANT HARASSMENT"
 msgstr "ACOSO DE INQUILINO"
 
-#: src/components/DetailView.tsx:225
+#: src/components/DetailView.tsx:231
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
@@ -1020,7 +1021,7 @@ msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edif
 msgid "Useful links"
 msgstr "Enlaces útiles"
 
-#: src/util/helpers.ts:49
+#: src/util/helpers.ts:44
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
@@ -1029,7 +1030,7 @@ msgstr "SISTEMA DE VENTILACIÓN"
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:147
+#: src/components/DetailView.tsx:153
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
@@ -1053,7 +1054,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:122
+#: src/components/DetailView.tsx:123
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
@@ -1066,19 +1067,19 @@ msgstr "Violaciones emitidas"
 msgid "Visit our website"
 msgstr "Visite nuestro sitio web"
 
-#: src/util/helpers.ts:51
+#: src/util/helpers.ts:46
 msgid "WATER LEAK"
 msgstr "CAJA DE AGUA"
 
-#: src/util/helpers.ts:46
+#: src/util/helpers.ts:41
 msgid "WINDOW GUARDS"
 msgstr "PROTECTORES DE VENTANA"
 
-#: src/util/helpers.ts:41
+#: src/util/helpers.ts:36
 msgid "WINDOWS"
 msgstr "VENTANAS"
 
-#: src/components/DetailView.tsx:243
+#: src/components/DetailView.tsx:249
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -1122,7 +1123,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:168
+#: src/components/DetailView.tsx:174
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
@@ -1151,7 +1152,7 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:203
+#: src/components/DetailView.tsx:209
 msgid "for ${0}"
 msgstr "por ${0}"
 
@@ -1194,4 +1195,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:35
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2010} other {# Violaciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -26,15 +26,15 @@ msgstr "#QuiénEsElDueño por @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
-#: src/components/DetailView.tsx:215
+#: src/components/DetailView.tsx:216
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:197
+#: src/components/DetailView.tsx:198
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:201
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -109,7 +109,7 @@ msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 msgid "Amount"
 msgstr "Importe"
 
-#: src/components/DetailView.tsx:228
+#: src/components/DetailView.tsx:229
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -121,7 +121,7 @@ msgstr "¿Tienes problemas en tu edificio?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:131
+#: src/components/DetailView.tsx:132
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -159,13 +159,13 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:292
-#: src/components/DetailView.tsx:301
+#: src/components/DetailView.tsx:295
+#: src/components/DetailView.tsx:304
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:272
-#: src/components/DetailView.tsx:281
+#: src/components/DetailView.tsx:275
+#: src/components/DetailView.tsx:284
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
@@ -403,9 +403,7 @@ msgstr "Oficial Principal"
 msgid "How do you want to group landlord portfolios?"
 msgstr "¿Cómo quieres agrupar a los portafolios de los dueños?"
 
-#: src/components/DetailView.tsx:137
-#: src/components/DetailView.tsx:142
-#: src/components/DetailView.tsx:247
+#: src/components/DetailView.tsx:77
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
@@ -484,11 +482,11 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:192
+#: src/components/DetailView.tsx:193
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:205
+#: src/components/DetailView.tsx:206
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
@@ -559,7 +557,7 @@ msgstr "Metodología"
 msgid "More Mobile Friendly"
 msgstr "Más útil para dispositivos móviles"
 
-#: src/components/DetailView.tsx:159
+#: src/components/DetailView.tsx:160
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -628,7 +626,7 @@ msgstr "No ECB"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:167
+#: src/components/DetailView.tsx:168
 msgid "None"
 msgstr "Ninguna"
 
@@ -696,8 +694,8 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/DetailView.tsx:312
-#: src/components/DetailView.tsx:322
+#: src/components/DetailView.tsx:315
+#: src/components/DetailView.tsx:325
 msgid "People"
 msgstr "Personas"
 
@@ -773,7 +771,7 @@ msgstr "Envíanos una solicitud de datos"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:237
+#: src/components/DetailView.tsx:238
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:134
 #: src/containers/App.tsx:125
@@ -838,7 +836,7 @@ msgstr "Cambiar a la versión anterior"
 msgid "TENANT HARASSMENT"
 msgstr "ACOSO DE INQUILINO"
 
-#: src/components/DetailView.tsx:231
+#: src/components/DetailView.tsx:232
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
@@ -1030,7 +1028,7 @@ msgstr "SISTEMA DE VENTILACIÓN"
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:153
+#: src/components/DetailView.tsx:154
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
@@ -1054,7 +1052,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:123
+#: src/components/DetailView.tsx:124
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
@@ -1079,7 +1077,7 @@ msgstr "PROTECTORES DE VENTANA"
 msgid "WINDOWS"
 msgstr "VENTANAS"
 
-#: src/components/DetailView.tsx:249
+#: src/components/DetailView.tsx:252
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -1123,7 +1121,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:174
+#: src/components/DetailView.tsx:175
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
@@ -1152,7 +1150,7 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:209
+#: src/components/DetailView.tsx:210
 msgid "for ${0}"
 msgstr "por ${0}"
 


### PR DESCRIPTION
This PR refactors our `<PortfolioGraph>` component to dynamically add on nodes to the graph visualization for the user's Search Address, as well as the Detail Address if it differs from the Search Address. The idea behind these additional nodes was to create some feature parity with the "How is this building associated..." feature on the old WOW:

![image](https://user-images.githubusercontent.com/12834575/135511122-218ee426-f993-47d1-a25b-5084de7ddba4.png)

Now, when users click on this link, they are redirected to the Portfolio Graph (currently on the Summary tab) to see how their search address is related to the address in focus on the Overview tab:

![image](https://user-images.githubusercontent.com/12834575/135511499-2efc7461-10e1-4a78-bff1-c3f9ae8359a0.png)

This is particularly important because in order to build trust with our users regarding this new portfolio method, we need to have some feature that illustrates how each building in the portfolio connects back to the original address they searched.

Potential further improvements/considerations:
- adding better labels to the two additional nodes on the graph (like `Search address: ...` and `Focus address: ...`) maybe?
- updating the colors/style to pop out a bit more
- making sure that the graph is fully "unfurled" with the 2 new nodes added (little to no overlapping edges) 
