### PR TITLE
Only use most recent HPD registration for each registrationid when building wow_portfolios

### DIFF
--- a/portfoliograph/hpd_regs.py
+++ b/portfoliograph/hpd_regs.py
@@ -6,6 +6,9 @@ RegBblMap = Dict[int, Set[str]]
 
 def build_reg_bbl_map(dict_cursor) -> RegBblMap:
     reg_bbl_map: RegBblMap = {}
+    # For each BBL, we grab the most recent registrationid we have on file.
+    # We define 'most recent' to mean a registration with the most recent
+    # expiration date and, if there is a tie, most recent non-null registration date
     dict_cursor.execute(
         f"""
         SELECT FIRST(registrationid) registrationid, bbl


### PR DESCRIPTION
This PR updates the SQL that helps generate our wow_portfolios table—specifically the SQL code that creates a mapping between `registrationids` and their associated bbls. Now, we ensure that all `bbls` in the mapping are distinct from one another, so now a bbl cannot belong to two different portfolios. Before, there were several duplicate `registrationids` and `bbls` in the table. We fixed this by sorting by the registration expiration date and only keeping the most recent registrations when grouping by `bbl`.