### PR TITLE
Add warning for when a building's hpd registration expired before its last sale

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -293,8 +293,8 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                         detailAddr.lastsaledate > detailAddr.registrationenddate && (
                           <p className="text-danger text-italic">
                             <Trans>
-                              Warning: a new owner bought this building after its registration
-                              expired. The landlord details here may be outdated.
+                              Warning: this building has been sold since its registration expired.
+                              The landlord details here may be outdated.
                             </Trans>
                           </p>
                         )}

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -1094,8 +1094,8 @@ msgid "WINDOWS"
 msgstr "WINDOWS"
 
 #: src/components/DetailView.tsx:192
-msgid "Warning: a new owner bought this building after its registration expired. The landlord details here may be outdated."
-msgstr "Warning: a new owner bought this building after its registration expired. The landlord details here may be outdated."
+msgid "Warning: this building has been sold since its registration expired. The landlord details here may be outdated."
+msgstr "Warning: this building has been sold since its registration expired. The landlord details here may be outdated."
 
 #: src/components/DetailView.tsx:259
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -1099,7 +1099,7 @@ msgid "WINDOWS"
 msgstr "VENTANAS"
 
 #: src/components/DetailView.tsx:192
-msgid "Warning: a new owner bought this building after its registration expired. The landlord details here may be outdated."
+msgid "Warning: this building has been sold since its registration expired. The landlord details here may be outdated."
 msgstr ""
 
 #: src/components/DetailView.tsx:259


### PR DESCRIPTION
This PR adds a special warning to the Detail View on the overview tab for any building that:
1. has an HPD registration that is expired 
2. was sold to a new owner _after_ the registration expired

Members of our program team made it clear that is important to include expired registrations as it often is just a symptoms of the current landlord being negligent. That being said, there are roughly 6000 buildings with an expired registration that were sold _after_ the registration expired, which would imply there may be a new owner that is not reflected in the hpd contact details. 

So, this PR adds a small flag underneath the "Landlord Contact Details" section for this particular case. I think of this as an "MVP" of a warning system like this that we can build out later. 