### PR TITLE
Use `defaultLocale` global variable wherever possible

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -15,7 +15,7 @@ import { Link } from "react-router-dom";
 import { LocaleLink } from "../i18n";
 import BuildingStatsTable from "./BuildingStatsTable";
 import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
-import { SupportedLocale } from "../i18n-base";
+import { defaultLocale, SupportedLocale } from "../i18n-base";
 import { withMachineInStateProps } from "state-machine";
 import { Accordion } from "./Accordion";
 import { UsefulLinks } from "./UsefulLinks";
@@ -155,7 +155,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
   render() {
     const isMobile = Browser.isMobile();
     const { i18n } = this.props;
-    const locale = (i18n.language as SupportedLocale) || "en";
+    const locale = (i18n.language as SupportedLocale) || defaultLocale;
     const { useNewPortfolioMethod, portfolioData } = this.props.state.context;
     const { assocAddrs, detailAddr, searchAddr } = portfolioData;
 

--- a/client/src/components/IndicatorsViz.tsx
+++ b/client/src/components/IndicatorsViz.tsx
@@ -14,7 +14,7 @@ import Helpers, { mediumDateOptions, shortDateOptions } from "../util/helpers";
 
 import "styles/Indicators.css";
 import { indicatorsDatasetIds, IndicatorsState } from "./IndicatorsTypes";
-import { SupportedLocale } from "../i18n-base";
+import { defaultLocale, SupportedLocale } from "../i18n-base";
 import { ChartOptions } from "chart.js";
 import { withMachineInStateProps } from "state-machine";
 import { INDICATORS_DATASETS } from "./IndicatorsDatasets";
@@ -182,7 +182,7 @@ class IndicatorsVizImplementation extends Component<IndicatorVizImplementationPr
     var { timelineData } = this.props.state.context;
 
     const { i18n } = this.props;
-    const locale = (i18n.language || "en") as SupportedLocale;
+    const locale = (i18n.language || defaultLocale) as SupportedLocale;
 
     switch (this.props.activeVis) {
       case "hpdviolations":

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -13,7 +13,7 @@ import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
 import { t, Trans } from "@lingui/macro";
 import { Link } from "react-router-dom";
-import { SupportedLocale } from "../i18n-base";
+import { defaultLocale, SupportedLocale } from "../i18n-base";
 import Helpers, { longDateOptions } from "../util/helpers";
 import { AddressRecord, HpdComplaintCount } from "./APIDataTypes";
 import { withMachineInStateProps } from "state-machine";
@@ -76,7 +76,7 @@ const PropertiesListWithoutI18n: React.FC<
 > = (props) => {
   const { i18n } = props;
   const { width: windowWidth, height: windowHeight } = Helpers.useWindowSize();
-  const locale = (i18n.language as SupportedLocale) || "en";
+  const locale = (i18n.language as SupportedLocale) || defaultLocale;
 
   const addrs = props.state.context.portfolioData.assocAddrs;
   const rsunitslatestyear = props.state.context.portfolioData.searchAddr.rsunitslatestyear;

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -1,4 +1,4 @@
-import { SupportedLocale } from "../i18n-base";
+import { defaultLocale, SupportedLocale } from "../i18n-base";
 import { AddressRecord, HpdContactAddress, SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { reportError } from "error-reporting";
 import { t } from "@lingui/macro";
@@ -210,7 +210,7 @@ export default {
   },
 
   formatPrice(amount: number, locale?: SupportedLocale): string {
-    const formatPrice = new Intl.NumberFormat(locale || "en");
+    const formatPrice = new Intl.NumberFormat(locale || defaultLocale);
     return formatPrice.format(amount);
   },
 
@@ -255,7 +255,7 @@ export default {
 
   formatDate(dateString: string, options: object, locale?: SupportedLocale): string {
     var date = new Date(dateString);
-    return this.capitalize(date.toLocaleDateString(locale || "en", options));
+    return this.capitalize(date.toLocaleDateString(locale || defaultLocale, options));
   },
 
   /** The quarter number written out as it's range of months (ex: "1" becomes "Jan - Mar")  */


### PR DESCRIPTION
So, turns out that we have a global variable called `defaultLocale` that we aren't using everywhere. This PR makes sure we are referencing this variable (instead of the string "en") in all functions and components that need the default locale. For functions/components that are explicitly fetching the "English" translation of something, I left the string "en" as is. 

Fixes #360.