### PR TITLE
Set up permanent redirects for alternate domains

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,3 +18,15 @@
   # in our package.json won't propagate. For more details on this, see
   # https://github.com/JustFixNYC/who-owns-what/pull/335.
   command = "rm -rf node_modules/.cache && yarn build"
+
+[[redirects]]
+  from = "https://whoownswhat.nyc/*"
+  to = "https://whoownswhat.justfix.nyc"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://wow-django.netlify.app/*"
+  to = "https://whoownswhat.justfix.nyc"
+  status = 301
+  force = true


### PR DESCRIPTION
Turns out we've owned the `whoownswhat.nyc` domain for a while but haven't properly configured its DNS to redirect to the main WOW domain. This PR updates our [Netlify configuration file ](https://docs.netlify.com/configure-builds/file-based-configuration/#redirects) to set up these redirects (along with another redirect from the standard netlify domain), just like we do [on the justfix website](https://github.com/JustFixNYC/justfix-website/blob/master/netlify.toml).

Hopefully fixes #51 