### PR TITLE
Describe evictions as "executed" instead of "scheduled" on Summary tab

### DIFF
--- a/client/src/components/EvictionsSummary.tsx
+++ b/client/src/components/EvictionsSummary.tsx
@@ -12,7 +12,7 @@ export const EvictionsSummary: React.FC<EvictionsSummaryData> = (props) => {
   return (
     <p>
       <Trans>
-        Since 2017, NYC Marshals scheduled{" "}
+        Since 2017, NYC Marshals executed{" "}
         <Plural value={totalEvictions} one="one eviction" other="# evictions" /> across this
         portfolio.
       </Trans>{" "}

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -17,19 +17,19 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/util/helpers.ts:269
+#: src/util/helpers.ts:270
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
-#: src/components/DetailView.tsx:223
+#: src/components/DetailView.tsx:224
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:205
+#: src/components/DetailView.tsx:206
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:208
+#: src/components/DetailView.tsx:209
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -37,7 +37,7 @@ msgstr "(expires {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
-#: src/components/PropertiesList.tsx:90
+#: src/components/PropertiesList.tsx:91
 msgid "(this may take a while)"
 msgstr "(this may take a while)"
 
@@ -53,7 +53,7 @@ msgstr "... or view some sample portfolios:"
 msgid "311 Complaints Data"
 msgstr "311 Complaints Data"
 
-#: src/components/DetailView.tsx:54
+#: src/components/DetailView.tsx:55
 msgid "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 msgstr "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 
@@ -70,7 +70,7 @@ msgstr "A new set of dropdown menus and design tweaks make it more comfortable t
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
 
-#: src/util/helpers.ts:50
+#: src/util/helpers.ts:51
 msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
@@ -87,11 +87,11 @@ msgstr "According to available HPD data, this portfolio has received <0>{totalvi
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:110
+#: src/components/PropertiesList.tsx:111
 msgid "Address"
 msgstr "Address"
 
-#: src/util/helpers.ts:65
+#: src/util/helpers.ts:66
 msgid "Agent"
 msgstr "Agent"
 
@@ -103,12 +103,12 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:357
-#: src/components/PropertiesList.tsx:365
+#: src/components/PropertiesList.tsx:358
+#: src/components/PropertiesList.tsx:366
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/DetailView.tsx:236
+#: src/components/DetailView.tsx:237
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -116,16 +116,16 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/util/helpers.ts:30
+#: src/util/helpers.ts:31
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:132
+#: src/components/DetailView.tsx:133
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/PropertiesList.tsx:146
-#: src/components/PropertiesList.tsx:151
+#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:152
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -145,7 +145,7 @@ msgid "Building Permit Applications"
 msgstr "Building Permit Applications"
 
 #: src/components/IndicatorsDatasets.tsx:72
-#: src/components/IndicatorsViz.tsx:182
+#: src/components/IndicatorsViz.tsx:183
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
@@ -153,38 +153,38 @@ msgstr "Building Permits Applied For"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:169
-#: src/components/PropertiesList.tsx:174
+#: src/components/PropertiesList.tsx:170
+#: src/components/PropertiesList.tsx:175
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:302
-#: src/components/DetailView.tsx:311
+#: src/components/DetailView.tsx:303
+#: src/components/DetailView.tsx:312
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:282
-#: src/components/DetailView.tsx:291
+#: src/components/DetailView.tsx:283
+#: src/components/DetailView.tsx:292
 msgid "Business Entities"
 msgstr "Business Entities"
 
-#: src/util/helpers.ts:39
+#: src/util/helpers.ts:40
 msgid "CABINET"
 msgstr "CABINET"
 
-#: src/util/helpers.ts:52
+#: src/util/helpers.ts:53
 msgid "CERAMIC TILE"
 msgstr "CERAMIC TILE"
 
-#: src/util/helpers.ts:27
+#: src/util/helpers.ts:28
 msgid "CONSTRUCTION"
 msgstr "CONSTRUCTION"
 
-#: src/util/helpers.ts:53
+#: src/util/helpers.ts:54
 msgid "COOKING GAS"
 msgstr "COOKING GAS"
 
-#: src/components/DetailView.tsx:24
+#: src/components/DetailView.tsx:25
 msgid "Check out the issues in this building"
 msgstr "Check out the issues in this building"
 
@@ -192,19 +192,19 @@ msgstr "Check out the issues in this building"
 msgid "Civil penalties of $250-$500"
 msgstr "Civil penalties of $250-$500"
 
-#: src/components/IndicatorsViz.tsx:153
+#: src/components/IndicatorsViz.tsx:154
 msgid "Class A"
 msgstr "Class A"
 
-#: src/components/IndicatorsViz.tsx:146
+#: src/components/IndicatorsViz.tsx:147
 msgid "Class B"
 msgstr "Class B"
 
-#: src/components/IndicatorsViz.tsx:139
+#: src/components/IndicatorsViz.tsx:140
 msgid "Class C"
 msgstr "Class C"
 
-#: src/components/IndicatorsViz.tsx:132
+#: src/components/IndicatorsViz.tsx:133
 msgid "Class I"
 msgstr "Class I"
 
@@ -216,7 +216,7 @@ msgstr "Clearer Landlord Contact Info"
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
-#: src/components/DetailView.tsx:52
+#: src/components/DetailView.tsx:53
 #: src/components/FeatureCalloutWidget.tsx:60
 msgid "Close"
 msgstr "Close"
@@ -233,11 +233,11 @@ msgstr "Complaints Issued"
 msgid "Complaints to 311"
 msgstr "Complaints to 311"
 
-#: src/util/helpers.ts:61
+#: src/util/helpers.ts:62
 msgid "Corporate Owner"
 msgstr "Corporate Owner"
 
-#: src/util/helpers.ts:69
+#: src/util/helpers.ts:70
 msgid "Corporation"
 msgstr "Corporation"
 
@@ -253,16 +253,16 @@ msgstr "DOB/ECB Violations"
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
-#: src/util/helpers.ts:24
+#: src/util/helpers.ts:25
 msgid "DOOR/WINDOW"
 msgstr "DOOR/WINDOW"
 
-#: src/util/helpers.ts:56
+#: src/util/helpers.ts:57
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PropertiesList.tsx:345
-#: src/components/PropertiesList.tsx:353
+#: src/components/PropertiesList.tsx:346
+#: src/components/PropertiesList.tsx:354
 msgid "Date"
 msgstr "Date"
 
@@ -288,15 +288,15 @@ msgstr "Donate"
 msgid "Download"
 msgstr "Download"
 
-#: src/components/IndicatorsViz.tsx:193
+#: src/components/IndicatorsViz.tsx:194
 msgid "ECB"
 msgstr "ECB"
 
-#: src/util/helpers.ts:47
+#: src/util/helpers.ts:48
 msgid "ELECTRIC"
 msgstr "ELECTRIC"
 
-#: src/util/helpers.ts:37
+#: src/util/helpers.ts:38
 msgid "ELEVATOR"
 msgstr "ELEVATOR"
 
@@ -304,7 +304,7 @@ msgstr "ELEVATOR"
 msgid "Email"
 msgstr "Email"
 
-#: src/components/IndicatorsViz.tsx:164
+#: src/components/IndicatorsViz.tsx:165
 msgid "Emergency"
 msgstr "Emergency"
 
@@ -317,7 +317,7 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:279
+#: src/components/PropertiesList.tsx:280
 #: src/components/PropertiesSummary.tsx:117
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -335,15 +335,15 @@ msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD 
 msgid "Export Data"
 msgstr "Export Data"
 
-#: src/util/helpers.ts:32
+#: src/util/helpers.ts:33
 msgid "FIRE ESCAPE"
 msgstr "FIRE ESCAPE"
 
-#: src/util/helpers.ts:42
+#: src/util/helpers.ts:43
 msgid "FLOOR"
 msgstr "FLOOR"
 
-#: src/util/helpers.ts:48
+#: src/util/helpers.ts:49
 msgid "FLOORING/STAIRS"
 msgstr "FLOORING/STAIRS"
 
@@ -351,7 +351,7 @@ msgstr "FLOORING/STAIRS"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/util/helpers.ts:38
+#: src/util/helpers.ts:39
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
@@ -359,16 +359,16 @@ msgstr "GARBAGE/RECYCLING STORAGE"
 msgid "General info"
 msgstr "General info"
 
-#: src/components/PropertiesList.tsx:378
-#: src/components/PropertiesList.tsx:392
+#: src/components/PropertiesList.tsx:379
+#: src/components/PropertiesList.tsx:393
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
-#: src/util/helpers.ts:55
+#: src/util/helpers.ts:56
 msgid "HEAT/HOT WATER"
 msgstr "HEAT/HOT WATER"
 
-#: src/util/helpers.ts:25
+#: src/util/helpers.ts:26
 msgid "HEATING"
 msgstr "HEATING"
 
@@ -377,7 +377,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:216
+#: src/components/PropertiesList.tsx:217
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -386,7 +386,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:33
-#: src/components/PropertiesList.tsx:256
+#: src/components/PropertiesList.tsx:257
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -398,7 +398,7 @@ msgstr "HPD Violations occur when an official City Inspector finds the condition
 msgid "HUD Complaint Form 958"
 msgstr "HUD Complaint Form 958"
 
-#: src/util/helpers.ts:60
+#: src/util/helpers.ts:61
 msgid "Head Officer"
 msgstr "Head Officer"
 
@@ -406,7 +406,7 @@ msgstr "Head Officer"
 msgid "How do you want to group landlord portfolios?"
 msgstr "How do you want to group landlord portfolios?"
 
-#: src/components/DetailView.tsx:77
+#: src/components/DetailView.tsx:78
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
@@ -415,11 +415,11 @@ msgstr "How is this building associated to this portfolio?"
 msgid "How to use"
 msgstr "How to use"
 
-#: src/components/DetailView.tsx:25
+#: src/components/DetailView.tsx:26
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 
-#: src/components/DetailView.tsx:23
+#: src/components/DetailView.tsx:24
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
@@ -427,7 +427,7 @@ msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open viol
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
-#: src/util/helpers.ts:62
+#: src/util/helpers.ts:63
 msgid "Individual Owner"
 msgstr "Individual Owner"
 
@@ -435,7 +435,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:165
+#: src/components/PropertiesList.tsx:166
 msgid "Information"
 msgstr "Information"
 
@@ -443,7 +443,7 @@ msgstr "Information"
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "It doesn't seem like this property is required to register with HPD."
 
-#: src/util/helpers.ts:28
+#: src/util/helpers.ts:29
 msgid "JANITOR/SUPER"
 msgstr "JANITOR/SUPER"
 
@@ -451,7 +451,7 @@ msgstr "JANITOR/SUPER"
 msgid "Join the fight for tenant rights!"
 msgstr "Join the fight for tenant rights!"
 
-#: src/util/helpers.ts:63
+#: src/util/helpers.ts:64
 msgid "Joint Owner"
 msgstr "Joint Owner"
 
@@ -459,11 +459,11 @@ msgstr "Joint Owner"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
-#: src/util/helpers.ts:57
+#: src/util/helpers.ts:58
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PropertiesList.tsx:293
+#: src/components/PropertiesList.tsx:294
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Landlord"
@@ -472,28 +472,28 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:229
-#: src/components/PropertiesList.tsx:234
+#: src/components/PropertiesList.tsx:230
+#: src/components/PropertiesList.tsx:235
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PropertiesList.tsx:341
+#: src/components/PropertiesList.tsx:342
 msgid "Last Sale"
 msgstr "Last Sale"
 
-#: src/components/IndicatorsViz.tsx:375
+#: src/components/IndicatorsViz.tsx:376
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:201
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:213
+#: src/components/DetailView.tsx:214
 msgid "Last sold:"
 msgstr "Last sold:"
 
-#: src/components/DetailView.tsx:52
+#: src/components/DetailView.tsx:53
 msgid "Learn more"
 msgstr "Learn more"
 
@@ -501,18 +501,18 @@ msgstr "Learn more"
 msgid "Legend"
 msgstr "Legend"
 
-#: src/util/helpers.ts:66
+#: src/util/helpers.ts:67
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PropertiesList.tsx:368
-#: src/components/PropertiesList.tsx:370
-#: src/components/PropertiesList.tsx:374
+#: src/components/PropertiesList.tsx:369
+#: src/components/PropertiesList.tsx:371
+#: src/components/PropertiesList.tsx:375
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
 #: src/components/Indicators.tsx:135
-#: src/components/PropertiesList.tsx:91
+#: src/components/PropertiesList.tsx:92
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:61
 #: src/containers/AddressPage.tsx:161
@@ -520,11 +520,11 @@ msgstr "Link to Deed"
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:88
+#: src/components/PropertiesList.tsx:89
 msgid "Loading {0} rows"
 msgstr "Loading {0} rows"
 
-#: src/components/PropertiesList.tsx:130
+#: src/components/PropertiesList.tsx:131
 msgid "Location"
 msgstr "Location"
 
@@ -532,11 +532,11 @@ msgstr "Location"
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
-#: src/util/helpers.ts:35
+#: src/util/helpers.ts:36
 msgid "MAILBOX"
 msgstr "MAILBOX"
 
-#: src/util/helpers.ts:45
+#: src/util/helpers.ts:46
 msgid "MOLD"
 msgstr "MOLD"
 
@@ -565,7 +565,7 @@ msgstr "Methodology"
 msgid "More Mobile Friendly"
 msgstr "More Mobile Friendly"
 
-#: src/components/DetailView.tsx:160
+#: src/components/DetailView.tsx:161
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -581,7 +581,7 @@ msgstr "Move chart data right."
 msgid "MyNYCHA App"
 msgstr "MyNYCHA App"
 
-#: src/util/helpers.ts:51
+#: src/util/helpers.ts:52
 msgid "NON-CONSTRUCTION"
 msgstr "NON-CONSTRUCTION"
 
@@ -605,7 +605,7 @@ msgstr "New York Regional Office:"
 msgid "Next"
 msgstr "Next"
 
-#: src/components/PropertiesList.tsx:389
+#: src/components/PropertiesList.tsx:390
 msgid "No"
 msgstr "No"
 
@@ -614,7 +614,7 @@ msgstr "No"
 msgid "No address found"
 msgstr "No address found"
 
-#: src/components/IndicatorsViz.tsx:429
+#: src/components/IndicatorsViz.tsx:430
 msgid "No data available"
 msgstr "No data available"
 
@@ -626,15 +626,15 @@ msgstr "No registration found for {usersInputAddressFragment}!"
 msgid "No registration found!"
 msgstr "No registration found!"
 
-#: src/components/IndicatorsViz.tsx:200
+#: src/components/IndicatorsViz.tsx:201
 msgid "Non-ECB"
 msgstr "Non-ECB"
 
-#: src/components/IndicatorsViz.tsx:171
+#: src/components/IndicatorsViz.tsx:172
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:168
+#: src/components/DetailView.tsx:169
 msgid "None"
 msgstr "None"
 
@@ -642,16 +642,16 @@ msgstr "None"
 msgid "Not found"
 msgstr "Not found"
 
-#: src/util/helpers.ts:29
+#: src/util/helpers.ts:30
 msgid "OUTSIDE BUILDING"
 msgstr "OUTSIDE BUILDING"
 
-#: src/util/helpers.ts:67
+#: src/util/helpers.ts:68
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PropertiesList.tsx:297
-#: src/components/PropertiesList.tsx:306
+#: src/components/PropertiesList.tsx:298
+#: src/components/PropertiesList.tsx:307
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -669,8 +669,8 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:260
-#: src/components/PropertiesList.tsx:265
+#: src/components/PropertiesList.tsx:261
+#: src/components/PropertiesList.tsx:266
 msgid "Open"
 msgstr "Open"
 
@@ -686,15 +686,15 @@ msgstr "Overview"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 
-#: src/util/helpers.ts:49
+#: src/util/helpers.ts:50
 msgid "PAINT/PLASTER"
 msgstr "PAINT/PLASTER"
 
-#: src/util/helpers.ts:34
+#: src/util/helpers.ts:35
 msgid "PESTS"
 msgstr "PESTS"
 
-#: src/util/helpers.ts:43
+#: src/util/helpers.ts:44
 msgid "PLUMBING"
 msgstr "PLUMBING"
 
@@ -702,8 +702,8 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/DetailView.tsx:322
-#: src/components/DetailView.tsx:332
+#: src/components/DetailView.tsx:323
+#: src/components/DetailView.tsx:333
 msgid "People"
 msgstr "People"
 
@@ -733,7 +733,7 @@ msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:188
+#: src/components/PropertiesList.tsx:189
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -741,19 +741,19 @@ msgstr "RS Units"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/util/helpers.ts:54
+#: src/util/helpers.ts:55
 msgid "SAFETY"
 msgstr "SAFETY"
 
-#: src/util/helpers.ts:31
+#: src/util/helpers.ts:32
 msgid "SEWAGE"
 msgstr "SEWAGE"
 
-#: src/util/helpers.ts:33
+#: src/util/helpers.ts:34
 msgid "SIGNAGE MISSING"
 msgstr "SIGNAGE MISSING"
 
-#: src/util/helpers.ts:26
+#: src/util/helpers.ts:27
 msgid "STAIRS"
 msgstr "STAIRS"
 
@@ -779,7 +779,7 @@ msgstr "Send us a data request"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:245
+#: src/components/DetailView.tsx:246
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:134
 #: src/containers/App.tsx:125
@@ -787,7 +787,7 @@ msgstr "Share"
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
 
-#: src/util/helpers.ts:68
+#: src/util/helpers.ts:69
 msgid "Shareholder"
 msgstr "Shareholder"
 
@@ -799,24 +799,24 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:283
-#: src/components/PropertiesList.tsx:288
+#: src/components/PropertiesList.tsx:284
+#: src/components/PropertiesList.tsx:289
 msgid "Since 2017"
 msgstr "Since 2017"
 
 #: src/components/EvictionsSummary.tsx:8
-msgid "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
-msgstr "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
+msgid "Since 2017, NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
+msgstr "Since 2017, NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/components/PropertiesList.tsx:22
+#: src/components/PropertiesList.tsx:23
 msgid "Since {year}"
 msgstr "Since {year}"
 
-#: src/util/helpers.ts:64
+#: src/util/helpers.ts:65
 msgid "Site Manager"
 msgstr "Site Manager"
 
-#: src/components/IndicatorsViz.tsx:374
+#: src/components/IndicatorsViz.tsx:375
 msgid "Sold to Current Owner"
 msgstr "Sold to Current Owner"
 
@@ -832,7 +832,7 @@ msgstr "Sorry, the page you are looking for doesn't seem to exist."
 msgid "Source code"
 msgstr "Source code"
 
-#: src/components/PropertiesList.tsx:22
+#: src/components/PropertiesList.tsx:23
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
@@ -848,16 +848,16 @@ msgstr "Switch to New Version"
 msgid "Switch to Old Version"
 msgstr "Switch to Old Version"
 
-#: src/util/helpers.ts:40
+#: src/util/helpers.ts:41
 msgid "TENANT HARASSMENT"
 msgstr "TENANT HARASSMENT"
 
-#: src/components/DetailView.tsx:239
+#: src/components/DetailView.tsx:240
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
 
-#: src/components/PropertiesList.tsx:314
+#: src/components/PropertiesList.tsx:315
 msgid "Tax Exemptions"
 msgstr "Tax Exemptions"
 
@@ -998,16 +998,16 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PropertiesList.tsx:238
-#: src/components/PropertiesList.tsx:248
+#: src/components/PropertiesList.tsx:239
+#: src/components/PropertiesList.tsx:249
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
-#: src/components/IndicatorsViz.tsx:337
-#: src/components/PropertiesList.tsx:220
-#: src/components/PropertiesList.tsx:225
-#: src/components/PropertiesList.tsx:269
-#: src/components/PropertiesList.tsx:274
+#: src/components/IndicatorsViz.tsx:338
+#: src/components/PropertiesList.tsx:221
+#: src/components/PropertiesList.tsx:226
+#: src/components/PropertiesList.tsx:270
+#: src/components/PropertiesList.tsx:275
 msgid "Total"
 msgstr "Total"
 
@@ -1024,8 +1024,8 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:178
-#: src/components/PropertiesList.tsx:183
+#: src/components/PropertiesList.tsx:179
+#: src/components/PropertiesList.tsx:184
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -1039,7 +1039,7 @@ msgstr "Use this free tool from JustFix.nyc to research your building and invest
 msgid "Useful links"
 msgstr "Useful links"
 
-#: src/util/helpers.ts:44
+#: src/util/helpers.ts:45
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
@@ -1048,13 +1048,13 @@ msgstr "VENTILATION SYSTEM"
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:154
+#: src/components/DetailView.tsx:155
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PropertiesList.tsx:398
-#: src/components/PropertiesList.tsx:404
-#: src/components/PropertiesList.tsx:408
+#: src/components/PropertiesList.tsx:399
+#: src/components/PropertiesList.tsx:405
+#: src/components/PropertiesList.tsx:409
 msgid "View detail"
 msgstr "View detail"
 
@@ -1072,7 +1072,7 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:124
+#: src/components/DetailView.tsx:125
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -1085,23 +1085,23 @@ msgstr "Violations Issued"
 msgid "Visit our website"
 msgstr "Visit our website"
 
-#: src/util/helpers.ts:46
+#: src/util/helpers.ts:47
 msgid "WATER LEAK"
 msgstr "WATER LEAK"
 
-#: src/util/helpers.ts:41
+#: src/util/helpers.ts:42
 msgid "WINDOW GUARDS"
 msgstr "WINDOW GUARDS"
 
-#: src/util/helpers.ts:36
+#: src/util/helpers.ts:37
 msgid "WINDOWS"
 msgstr "WINDOWS"
 
-#: src/components/DetailView.tsx:192
+#: src/components/DetailView.tsx:193
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 
-#: src/components/DetailView.tsx:259
+#: src/components/DetailView.tsx:260
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -1145,7 +1145,7 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:175
+#: src/components/DetailView.tsx:176
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -1153,7 +1153,7 @@ msgstr "Who’s the landlord of this building?"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:388
+#: src/components/PropertiesList.tsx:389
 msgid "Yes"
 msgstr "Yes"
 
@@ -1161,8 +1161,8 @@ msgstr "Yes"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:136
-#: src/components/PropertiesList.tsx:141
+#: src/components/PropertiesList.tsx:137
+#: src/components/PropertiesList.tsx:142
 msgid "Zipcode"
 msgstr "Zipcode"
 
@@ -1174,7 +1174,7 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:217
+#: src/components/DetailView.tsx:218
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
-#: src/util/helpers.ts:269
+#: src/util/helpers.ts:270
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
-#: src/components/DetailView.tsx:223
+#: src/components/DetailView.tsx:224
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:205
+#: src/components/DetailView.tsx:206
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:208
+#: src/components/DetailView.tsx:209
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -42,7 +42,7 @@ msgstr "(caduca {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
-#: src/components/PropertiesList.tsx:90
+#: src/components/PropertiesList.tsx:91
 msgid "(this may take a while)"
 msgstr "(esto puede tardar un rato)"
 
@@ -58,7 +58,7 @@ msgstr "... o descubre ejemplos de portafolios de edificios:"
 msgid "311 Complaints Data"
 msgstr "Datos de quejas al 311"
 
-#: src/components/DetailView.tsx:54
+#: src/components/DetailView.tsx:55
 msgid "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 msgstr "<0>Mientras el dueño legal de un edificio es, con frecuencia, una compañía (se llama muchas veces un “LLC”), estos nombres y direcciones de negocio registrado con HPD se ofrecen una idea más clara de quién controla el edificio.</0><1>Las personas enumeradas aquí como “Oficial Principal” o “Dueño” normalmente tienen una conexión con la propiedad del edificio, mientras que los \"Administradores del Sitio\" formen parte de la gerencia. Dicho eso, estos nombres son autoinformados por el dueño, y entonces pueden ser engañosos.</1><2>Aprende más acerca de registros de HPD y cómo esta información impulsa la herramienta en la <3>página “Acerca de”</3>.</2>"
 
@@ -75,7 +75,7 @@ msgstr "Un nuevo conjunto de menús desplegables y ajustes de diseño hacen que 
 msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
 
-#: src/util/helpers.ts:50
+#: src/util/helpers.ts:51
 msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
@@ -92,11 +92,11 @@ msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha re
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:110
+#: src/components/PropertiesList.tsx:111
 msgid "Address"
 msgstr "Dirección"
 
-#: src/util/helpers.ts:65
+#: src/util/helpers.ts:66
 msgid "Agent"
 msgstr "Agente"
 
@@ -108,12 +108,12 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:357
-#: src/components/PropertiesList.tsx:365
+#: src/components/PropertiesList.tsx:358
+#: src/components/PropertiesList.tsx:366
 msgid "Amount"
 msgstr "Importe"
 
-#: src/components/DetailView.tsx:236
+#: src/components/DetailView.tsx:237
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -121,16 +121,16 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
-#: src/util/helpers.ts:30
+#: src/util/helpers.ts:31
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:132
+#: src/components/DetailView.tsx:133
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/PropertiesList.tsx:146
-#: src/components/PropertiesList.tsx:151
+#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:152
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -150,7 +150,7 @@ msgid "Building Permit Applications"
 msgstr "Solicitudes de Permisos de Construcción"
 
 #: src/components/IndicatorsDatasets.tsx:72
-#: src/components/IndicatorsViz.tsx:182
+#: src/components/IndicatorsViz.tsx:183
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
 
@@ -158,38 +158,38 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:169
-#: src/components/PropertiesList.tsx:174
+#: src/components/PropertiesList.tsx:170
+#: src/components/PropertiesList.tsx:175
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:302
-#: src/components/DetailView.tsx:311
+#: src/components/DetailView.tsx:303
+#: src/components/DetailView.tsx:312
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:282
-#: src/components/DetailView.tsx:291
+#: src/components/DetailView.tsx:283
+#: src/components/DetailView.tsx:292
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
-#: src/util/helpers.ts:39
+#: src/util/helpers.ts:40
 msgid "CABINET"
 msgstr "GABINETE"
 
-#: src/util/helpers.ts:52
+#: src/util/helpers.ts:53
 msgid "CERAMIC TILE"
 msgstr "AZULEJOS CERÁMICAS"
 
-#: src/util/helpers.ts:27
+#: src/util/helpers.ts:28
 msgid "CONSTRUCTION"
 msgstr "CONSTRUCCIÓN"
 
-#: src/util/helpers.ts:53
+#: src/util/helpers.ts:54
 msgid "COOKING GAS"
 msgstr "GAS DE COCINA"
 
-#: src/components/DetailView.tsx:24
+#: src/components/DetailView.tsx:25
 msgid "Check out the issues in this building"
 msgstr "Mira los problemas en este edificio"
 
@@ -197,19 +197,19 @@ msgstr "Mira los problemas en este edificio"
 msgid "Civil penalties of $250-$500"
 msgstr "Sanciones civiles de $250-$500"
 
-#: src/components/IndicatorsViz.tsx:153
+#: src/components/IndicatorsViz.tsx:154
 msgid "Class A"
 msgstr "Clase A"
 
-#: src/components/IndicatorsViz.tsx:146
+#: src/components/IndicatorsViz.tsx:147
 msgid "Class B"
 msgstr "Clase B"
 
-#: src/components/IndicatorsViz.tsx:139
+#: src/components/IndicatorsViz.tsx:140
 msgid "Class C"
 msgstr "Clase C"
 
-#: src/components/IndicatorsViz.tsx:132
+#: src/components/IndicatorsViz.tsx:133
 msgid "Class I"
 msgstr "Clase I"
 
@@ -221,7 +221,7 @@ msgstr "Información de contacto del dueño más clara"
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
-#: src/components/DetailView.tsx:52
+#: src/components/DetailView.tsx:53
 #: src/components/FeatureCalloutWidget.tsx:60
 msgid "Close"
 msgstr "Cerrar"
@@ -238,11 +238,11 @@ msgstr "Quejas Emitidas"
 msgid "Complaints to 311"
 msgstr "Quejas al 311"
 
-#: src/util/helpers.ts:61
+#: src/util/helpers.ts:62
 msgid "Corporate Owner"
 msgstr "Dueño Corporativo"
 
-#: src/util/helpers.ts:69
+#: src/util/helpers.ts:70
 msgid "Corporation"
 msgstr "Corporación"
 
@@ -258,16 +258,16 @@ msgstr "Violaciones del DOB/ECB"
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
-#: src/util/helpers.ts:24
+#: src/util/helpers.ts:25
 msgid "DOOR/WINDOW"
 msgstr "PUERTA/VENTANA"
 
-#: src/util/helpers.ts:56
+#: src/util/helpers.ts:57
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PropertiesList.tsx:345
-#: src/components/PropertiesList.tsx:353
+#: src/components/PropertiesList.tsx:346
+#: src/components/PropertiesList.tsx:354
 msgid "Date"
 msgstr "Fecha"
 
@@ -293,15 +293,15 @@ msgstr "Donar"
 msgid "Download"
 msgstr "Descargar"
 
-#: src/components/IndicatorsViz.tsx:193
+#: src/components/IndicatorsViz.tsx:194
 msgid "ECB"
 msgstr "ECB"
 
-#: src/util/helpers.ts:47
+#: src/util/helpers.ts:48
 msgid "ELECTRIC"
 msgstr "ELÉCTRICO"
 
-#: src/util/helpers.ts:37
+#: src/util/helpers.ts:38
 msgid "ELEVATOR"
 msgstr "ASCENSOR"
 
@@ -309,7 +309,7 @@ msgstr "ASCENSOR"
 msgid "Email"
 msgstr "Email"
 
-#: src/components/IndicatorsViz.tsx:164
+#: src/components/IndicatorsViz.tsx:165
 msgid "Emergency"
 msgstr "Emergencia"
 
@@ -322,7 +322,7 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:279
+#: src/components/PropertiesList.tsx:280
 #: src/components/PropertiesSummary.tsx:117
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -340,15 +340,15 @@ msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 20
 msgid "Export Data"
 msgstr "Exportar datos"
 
-#: src/util/helpers.ts:32
+#: src/util/helpers.ts:33
 msgid "FIRE ESCAPE"
 msgstr "ESCALERA DE INCENDIO"
 
-#: src/util/helpers.ts:42
+#: src/util/helpers.ts:43
 msgid "FLOOR"
 msgstr "PISO"
 
-#: src/util/helpers.ts:48
+#: src/util/helpers.ts:49
 msgid "FLOORING/STAIRS"
 msgstr "PISO/ESCALERAS"
 
@@ -356,7 +356,7 @@ msgstr "PISO/ESCALERAS"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/util/helpers.ts:38
+#: src/util/helpers.ts:39
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
@@ -364,16 +364,16 @@ msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 msgid "General info"
 msgstr "Información general"
 
-#: src/components/PropertiesList.tsx:378
-#: src/components/PropertiesList.tsx:392
+#: src/components/PropertiesList.tsx:379
+#: src/components/PropertiesList.tsx:393
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
-#: src/util/helpers.ts:55
+#: src/util/helpers.ts:56
 msgid "HEAT/HOT WATER"
 msgstr "CALEFACCIÓN/AGUA CALIENTE"
 
-#: src/util/helpers.ts:25
+#: src/util/helpers.ts:26
 msgid "HEATING"
 msgstr "CALEFACCIÓN"
 
@@ -382,7 +382,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:216
+#: src/components/PropertiesList.tsx:217
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -391,7 +391,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontrarás más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:33
-#: src/components/PropertiesList.tsx:256
+#: src/components/PropertiesList.tsx:257
 msgid "HPD Violations"
 msgstr "Violaciones del HPD"
 
@@ -403,7 +403,7 @@ msgstr "Infracciones del HPD se dan cuando un Inspector oficial de la Ciudad det
 msgid "HUD Complaint Form 958"
 msgstr "Formulario de queja HUD 958"
 
-#: src/util/helpers.ts:60
+#: src/util/helpers.ts:61
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
@@ -411,7 +411,7 @@ msgstr "Oficial Principal"
 msgid "How do you want to group landlord portfolios?"
 msgstr "¿Cómo quieres agrupar a los portafolios de los dueños?"
 
-#: src/components/DetailView.tsx:77
+#: src/components/DetailView.tsx:78
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
@@ -420,11 +420,11 @@ msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 msgid "How to use"
 msgstr "Cómo se usa"
 
-#: src/components/DetailView.tsx:25
+#: src/components/DetailView.tsx:26
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc que hace que la información sobre los dueños de edificios sea más transparente para los inquilinos. Sería bueno si buscaras tu edificio también. Míralo aquí: {url}"
 
-#: src/components/DetailView.tsx:23
+#: src/components/DetailView.tsx:24
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
@@ -432,7 +432,7 @@ msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
-#: src/util/helpers.ts:62
+#: src/util/helpers.ts:63
 msgid "Individual Owner"
 msgstr "Dueño Individual"
 
@@ -440,7 +440,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
-#: src/components/PropertiesList.tsx:165
+#: src/components/PropertiesList.tsx:166
 msgid "Information"
 msgstr "Información"
 
@@ -448,7 +448,7 @@ msgstr "Información"
 msgid "It doesn't seem like this property is required to register with HPD."
 msgstr "Parece que esta propiedad no necesita estar registrada con el HPD."
 
-#: src/util/helpers.ts:28
+#: src/util/helpers.ts:29
 msgid "JANITOR/SUPER"
 msgstr "CONSERJE/SÚPER"
 
@@ -456,7 +456,7 @@ msgstr "CONSERJE/SÚPER"
 msgid "Join the fight for tenant rights!"
 msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 
-#: src/util/helpers.ts:63
+#: src/util/helpers.ts:64
 msgid "Joint Owner"
 msgstr "Dueño Conjunto"
 
@@ -464,11 +464,11 @@ msgstr "Dueño Conjunto"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: src/util/helpers.ts:57
+#: src/util/helpers.ts:58
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PropertiesList.tsx:293
+#: src/components/PropertiesList.tsx:294
 #: src/components/PropertiesSummary.tsx:101
 msgid "Landlord"
 msgstr "Dueño del edificio"
@@ -477,28 +477,28 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:229
-#: src/components/PropertiesList.tsx:234
+#: src/components/PropertiesList.tsx:230
+#: src/components/PropertiesList.tsx:235
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PropertiesList.tsx:341
+#: src/components/PropertiesList.tsx:342
 msgid "Last Sale"
 msgstr "Última venta"
 
-#: src/components/IndicatorsViz.tsx:375
+#: src/components/IndicatorsViz.tsx:376
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:201
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:213
+#: src/components/DetailView.tsx:214
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
-#: src/components/DetailView.tsx:52
+#: src/components/DetailView.tsx:53
 msgid "Learn more"
 msgstr "Aprende más"
 
@@ -506,18 +506,18 @@ msgstr "Aprende más"
 msgid "Legend"
 msgstr "Leyenda"
 
-#: src/util/helpers.ts:66
+#: src/util/helpers.ts:67
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PropertiesList.tsx:368
-#: src/components/PropertiesList.tsx:370
-#: src/components/PropertiesList.tsx:374
+#: src/components/PropertiesList.tsx:369
+#: src/components/PropertiesList.tsx:371
+#: src/components/PropertiesList.tsx:375
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
 #: src/components/Indicators.tsx:135
-#: src/components/PropertiesList.tsx:91
+#: src/components/PropertiesList.tsx:92
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:61
 #: src/containers/AddressPage.tsx:161
@@ -525,11 +525,11 @@ msgstr "Enlace a la Escritura"
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:88
+#: src/components/PropertiesList.tsx:89
 msgid "Loading {0} rows"
 msgstr "Cargando {0} filas"
 
-#: src/components/PropertiesList.tsx:130
+#: src/components/PropertiesList.tsx:131
 msgid "Location"
 msgstr "Ubicación"
 
@@ -537,11 +537,11 @@ msgstr "Ubicación"
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
-#: src/util/helpers.ts:35
+#: src/util/helpers.ts:36
 msgid "MAILBOX"
 msgstr "BUZÓN"
 
-#: src/util/helpers.ts:45
+#: src/util/helpers.ts:46
 msgid "MOLD"
 msgstr "MOHO"
 
@@ -570,7 +570,7 @@ msgstr "Metodología"
 msgid "More Mobile Friendly"
 msgstr "Más útil para dispositivos móviles"
 
-#: src/components/DetailView.tsx:160
+#: src/components/DetailView.tsx:161
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -586,7 +586,7 @@ msgstr "Mover datos del gráfico a la derecha."
 msgid "MyNYCHA App"
 msgstr "App MyNYCHA"
 
-#: src/util/helpers.ts:51
+#: src/util/helpers.ts:52
 msgid "NON-CONSTRUCTION"
 msgstr "NO CONSTRUCCIÓN"
 
@@ -610,7 +610,7 @@ msgstr "Oficina Regional de Nueva York:"
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/components/PropertiesList.tsx:389
+#: src/components/PropertiesList.tsx:390
 msgid "No"
 msgstr "No"
 
@@ -619,7 +619,7 @@ msgstr "No"
 msgid "No address found"
 msgstr "No se encontraron direcciones"
 
-#: src/components/IndicatorsViz.tsx:429
+#: src/components/IndicatorsViz.tsx:430
 msgid "No data available"
 msgstr "No hay datos disponibles"
 
@@ -631,15 +631,15 @@ msgstr "¡No se ha encontrado ningún registro para {usersInputAddressFragment}!
 msgid "No registration found!"
 msgstr "¡No se ha encontrado nigún registro!"
 
-#: src/components/IndicatorsViz.tsx:200
+#: src/components/IndicatorsViz.tsx:201
 msgid "Non-ECB"
 msgstr "No ECB"
 
-#: src/components/IndicatorsViz.tsx:171
+#: src/components/IndicatorsViz.tsx:172
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:168
+#: src/components/DetailView.tsx:169
 msgid "None"
 msgstr "Ninguna"
 
@@ -647,16 +647,16 @@ msgstr "Ninguna"
 msgid "Not found"
 msgstr "No encontrado"
 
-#: src/util/helpers.ts:29
+#: src/util/helpers.ts:30
 msgid "OUTSIDE BUILDING"
 msgstr "AFUERA DEL EDIFICIO"
 
-#: src/util/helpers.ts:67
+#: src/util/helpers.ts:68
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PropertiesList.tsx:297
-#: src/components/PropertiesList.tsx:306
+#: src/components/PropertiesList.tsx:298
+#: src/components/PropertiesList.tsx:307
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -674,8 +674,8 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:260
-#: src/components/PropertiesList.tsx:265
+#: src/components/PropertiesList.tsx:261
+#: src/components/PropertiesList.tsx:266
 msgid "Open"
 msgstr "Actuales"
 
@@ -691,15 +691,15 @@ msgstr "General"
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/> Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
 
-#: src/util/helpers.ts:49
+#: src/util/helpers.ts:50
 msgid "PAINT/PLASTER"
 msgstr "PINTURA/YESO"
 
-#: src/util/helpers.ts:34
+#: src/util/helpers.ts:35
 msgid "PESTS"
 msgstr "PLAGAS"
 
-#: src/util/helpers.ts:43
+#: src/util/helpers.ts:44
 msgid "PLUMBING"
 msgstr "PLOMERÍA"
 
@@ -707,8 +707,8 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/DetailView.tsx:322
-#: src/components/DetailView.tsx:332
+#: src/components/DetailView.tsx:323
+#: src/components/DetailView.tsx:333
 msgid "People"
 msgstr "Personas"
 
@@ -738,7 +738,7 @@ msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:188
+#: src/components/PropertiesList.tsx:189
 msgid "RS Units"
 msgstr "Unidades RS"
 
@@ -746,19 +746,19 @@ msgstr "Unidades RS"
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
-#: src/util/helpers.ts:54
+#: src/util/helpers.ts:55
 msgid "SAFETY"
 msgstr "SEGURIDAD"
 
-#: src/util/helpers.ts:31
+#: src/util/helpers.ts:32
 msgid "SEWAGE"
 msgstr "AGUAS NEGRAS"
 
-#: src/util/helpers.ts:33
+#: src/util/helpers.ts:34
 msgid "SIGNAGE MISSING"
 msgstr "FALTA DE SEÑALIZACIÓN"
 
-#: src/util/helpers.ts:26
+#: src/util/helpers.ts:27
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
@@ -784,7 +784,7 @@ msgstr "Envíanos una solicitud de datos"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:245
+#: src/components/DetailView.tsx:246
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:134
 #: src/containers/App.tsx:125
@@ -792,7 +792,7 @@ msgstr "Compartir"
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
 
-#: src/util/helpers.ts:68
+#: src/util/helpers.ts:69
 msgid "Shareholder"
 msgstr "Accionista"
 
@@ -804,24 +804,24 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:283
-#: src/components/PropertiesList.tsx:288
+#: src/components/PropertiesList.tsx:284
+#: src/components/PropertiesList.tsx:289
 msgid "Since 2017"
 msgstr "Desde 2017"
 
 #: src/components/EvictionsSummary.tsx:8
-msgid "Since 2017, NYC Marshals scheduled {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
-msgstr "Desde el 2017, los Mariscales de NYC programaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en este portafolio de edificios."
+msgid "Since 2017, NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
+msgstr ""
 
-#: src/components/PropertiesList.tsx:22
+#: src/components/PropertiesList.tsx:23
 msgid "Since {year}"
 msgstr "Desde {year}"
 
-#: src/util/helpers.ts:64
+#: src/util/helpers.ts:65
 msgid "Site Manager"
 msgstr "Administrador del Sitio"
 
-#: src/components/IndicatorsViz.tsx:374
+#: src/components/IndicatorsViz.tsx:375
 msgid "Sold to Current Owner"
 msgstr "Vendido al Propietario Actual"
 
@@ -837,7 +837,7 @@ msgstr "Lo sentimos, la página que estás buscando no existe."
 msgid "Source code"
 msgstr "Código fuente"
 
-#: src/components/PropertiesList.tsx:22
+#: src/components/PropertiesList.tsx:23
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
@@ -853,16 +853,16 @@ msgstr "Cambiar a la nueva versión"
 msgid "Switch to Old Version"
 msgstr "Cambiar a la versión anterior"
 
-#: src/util/helpers.ts:40
+#: src/util/helpers.ts:41
 msgid "TENANT HARASSMENT"
 msgstr "ACOSO DE INQUILINO"
 
-#: src/components/DetailView.tsx:239
+#: src/components/DetailView.tsx:240
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
 
-#: src/components/PropertiesList.tsx:314
+#: src/components/PropertiesList.tsx:315
 msgid "Tax Exemptions"
 msgstr "Exenciones de impuestos"
 
@@ -1003,16 +1003,16 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PropertiesList.tsx:238
-#: src/components/PropertiesList.tsx:248
+#: src/components/PropertiesList.tsx:239
+#: src/components/PropertiesList.tsx:249
 msgid "Top Complaint"
 msgstr "Queja principal"
 
-#: src/components/IndicatorsViz.tsx:337
-#: src/components/PropertiesList.tsx:220
-#: src/components/PropertiesList.tsx:225
-#: src/components/PropertiesList.tsx:269
-#: src/components/PropertiesList.tsx:274
+#: src/components/IndicatorsViz.tsx:338
+#: src/components/PropertiesList.tsx:221
+#: src/components/PropertiesList.tsx:226
+#: src/components/PropertiesList.tsx:270
+#: src/components/PropertiesList.tsx:275
 msgid "Total"
 msgstr "Total"
 
@@ -1029,8 +1029,8 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:178
-#: src/components/PropertiesList.tsx:183
+#: src/components/PropertiesList.tsx:179
+#: src/components/PropertiesList.tsx:184
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades"
@@ -1044,7 +1044,7 @@ msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edif
 msgid "Useful links"
 msgstr "Enlaces útiles"
 
-#: src/util/helpers.ts:44
+#: src/util/helpers.ts:45
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
@@ -1053,13 +1053,13 @@ msgstr "SISTEMA DE VENTILACIÓN"
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:154
+#: src/components/DetailView.tsx:155
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PropertiesList.tsx:398
-#: src/components/PropertiesList.tsx:404
-#: src/components/PropertiesList.tsx:408
+#: src/components/PropertiesList.tsx:399
+#: src/components/PropertiesList.tsx:405
+#: src/components/PropertiesList.tsx:409
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -1077,7 +1077,7 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:124
+#: src/components/DetailView.tsx:125
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
@@ -1090,23 +1090,23 @@ msgstr "Violaciones emitidas"
 msgid "Visit our website"
 msgstr "Visite nuestro sitio web"
 
-#: src/util/helpers.ts:46
+#: src/util/helpers.ts:47
 msgid "WATER LEAK"
 msgstr "CAJA DE AGUA"
 
-#: src/util/helpers.ts:41
+#: src/util/helpers.ts:42
 msgid "WINDOW GUARDS"
 msgstr "PROTECTORES DE VENTANA"
 
-#: src/util/helpers.ts:36
+#: src/util/helpers.ts:37
 msgid "WINDOWS"
 msgstr "VENTANAS"
 
-#: src/components/DetailView.tsx:192
+#: src/components/DetailView.tsx:193
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Aviso: Este edificio tiene un registro vencido y se vendió después del vencimiento del registro. La información del dueño que se incluye aquí puede estar desactualizada."
 
-#: src/components/DetailView.tsx:259
+#: src/components/DetailView.tsx:260
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -1150,7 +1150,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:175
+#: src/components/DetailView.tsx:176
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
@@ -1158,7 +1158,7 @@ msgstr "¿Quién es el dueño de este edificio?"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:388
+#: src/components/PropertiesList.tsx:389
 msgid "Yes"
 msgstr "Sí"
 
@@ -1166,8 +1166,8 @@ msgstr "Sí"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:136
-#: src/components/PropertiesList.tsx:141
+#: src/components/PropertiesList.tsx:137
+#: src/components/PropertiesList.tsx:142
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -1179,7 +1179,7 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:217
+#: src/components/DetailView.tsx:218
 msgid "for ${0}"
 msgstr "por ${0}"
 


### PR DESCRIPTION
This PR changes a single word on our Summary tab, to describe our evictions data more clearly as "executed" evictions rather than ones that have just been "scheduled" by the courts. 