### PR TITLE
Fix tabbing issues with homepage search bars

### DIFF
--- a/client/src/components/AddressSearch.tsx
+++ b/client/src/components/AddressSearch.tsx
@@ -137,28 +137,31 @@ export default class AddressSearch extends React.Component<AddressSearchProps, S
     ds: ControllerStateAndHelpers<SearchAddress>,
     event: React.KeyboardEvent
   ) {
+    const { results } = this.state;
     if (event.keyCode === KEY_ENTER) {
       if (this.selectFirstResult(ds)) {
         event.preventDefault();
       }
     }
-    // Allow tab key to navigate to next item in autocomplete list
-    if (event.keyCode === KEY_TAB && !event.shiftKey) {
-      ds.setHighlightedIndex(
-        ds.highlightedIndex === this.state.results.length - 1 || ds.highlightedIndex === null
-          ? 0
-          : ds.highlightedIndex + 1
-      );
-      event.preventDefault();
-    }
-    // Allow tab key + shift key to navigate to previous item in autocomplete list
-    if (event.keyCode === KEY_TAB && event.shiftKey) {
-      ds.setHighlightedIndex(
-        ds.highlightedIndex === 0 || ds.highlightedIndex === null
-          ? this.state.results.length - 1
-          : ds.highlightedIndex - 1
-      );
-      event.preventDefault();
+    if (results.length > 0) {
+      // Allow tab key to navigate to next item in autocomplete list
+      if (event.keyCode === KEY_TAB && !event.shiftKey) {
+        ds.setHighlightedIndex(
+          ds.highlightedIndex === results.length - 1 || ds.highlightedIndex === null
+            ? 0
+            : ds.highlightedIndex + 1
+        );
+        event.preventDefault();
+      }
+      // Allow tab key + shift key to navigate to previous item in autocomplete list
+      if (event.keyCode === KEY_TAB && event.shiftKey) {
+        ds.setHighlightedIndex(
+          ds.highlightedIndex === 0 || ds.highlightedIndex === null
+            ? results.length - 1
+            : ds.highlightedIndex - 1
+        );
+        event.preventDefault();
+      }
     }
     // Allow esc key to clear the results
     // Note: we do not call `event.preventDefault()` here as we also want to allow the event of

--- a/client/src/components/LandlordSearch.tsx
+++ b/client/src/components/LandlordSearch.tsx
@@ -152,7 +152,6 @@ const LandlordSearch = () => {
       active={userIsCurrentlySearching}
       focusTrapOptions={{
         clickOutsideDeactivates: true,
-        returnFocusOnDeactivate: false,
         onDeactivate: () => setSearchFocus(false),
       }}
     >


### PR DESCRIPTION
This PR fixes two issues that occur when trying to use the tab key to navigate around the search bars on the homepage:
- Once focusing on the Address searchbar, users would be trapped in focus on the search bar even with no results showing up. Now, we only enable a focus trap when there is at least 1 search result in the list to tab through
- When closing the Landlord searchbar, focus now returns to the element it previously was on and doesn't get completely lost as it did before.