### PR TITLE
Make Address and BBL clickable on Portfolio Tab

### DIFF
--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -202,6 +202,16 @@ const TableOfData = React.memo(
                 width: FIRST_COLUMN_WIDTH,
                 fixed: "left",
                 resizable: false,
+                Cell: (row) => {
+                  return (
+                    <Link
+                      to={props.addressPageRoutes.overview}
+                      onClick={() => props.onOpenDetail(row.original.bbl)}
+                    >
+                      {row.original.housenumber} {row.original.streetname}
+                    </Link>
+                  );
+                },
                 style: {
                   textAlign: "left",
                   whiteSpace: "unset",
@@ -248,6 +258,16 @@ const TableOfData = React.memo(
                 accessor: (d) => d.bbl,
                 id: "bbl",
                 width: getWidthFromLabel("BBL", 100),
+                Cell: (row) => {
+                  return (
+                    <Link
+                      to={props.addressPageRoutes.overview}
+                      onClick={() => props.onOpenDetail(row.original.bbl)}
+                    >
+                      {row.original.bbl}
+                    </Link>
+                  );
+                },
               },
             ],
           },


### PR DESCRIPTION
This PR makes both the  BBLs & addresses clickable on the Portfolio tab, linking them back to the detail view just like the "View Detail" arrow button already does. 