### PR TITLE
Add Facebook Pixel whitelisting code snippet

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -100,6 +100,27 @@
     // End Rollbar Snippet
     </script>
 
+    <!-- Facebook Pixel Code -->
+    <script>
+      !function (f, b, e, v, n, t, s) {
+        if (f.fbq) return; n = f.fbq = function () {
+          n.callMethod ?
+            n.callMethod.apply(n, arguments) : n.queue.push(arguments)
+        }; if (!f._fbq) f._fbq = n;
+        n.push = n; n.loaded = !0; n.version = '2.0'; n.queue = []; t = b.createElement(e); t.async = !0;
+        t.src = v; s = b.getElementsByTagName(e)[0]; s.parentNode.insertBefore(t, s)
+      }(window,
+        document, 'script', 'https://connect.facebook.net/en_US/fbevents.js');
+
+      fbq('init', '2758942167460891');
+      fbq('set', 'agent', 'tmgoogletagmanager', '2758942167460891');
+      fbq('track', "PageView");
+      fbq('trackCustom', "WoWAddressSearch");
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+        src="https://www.facebook.com/tr?id=2758942167460891&ev=PageView&noscript=1" /></noscript>
+    <!-- End Facebook Pixel Code -->
+
     <link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet">
 
     <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_STREETVIEW_API_KEY%&libraries=places,geometry"></script>


### PR DESCRIPTION
This PR addresses a request from WholeWhale: 

> would it be possible for you to whitelist the Facebook pixel on WoW domain? we identified this as the source of the issue for why we couldn't use the conversion we set up in our test run. 