### PR TITLE
Make new WOWZA demo site easier to navigate for beta testers

### DIFF
--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -139,41 +139,59 @@ export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state
   const additionalEdges = generateAdditionalEdges(graphJSON.nodes, searchAddr, distinctDetailAddr);
 
   return (
-    <CytoscapeComponent
-      elements={formatGraphJSON(graphJSON, additionalNodes, additionalEdges)}
-      style={{ width: "100%", height: "60vh" }}
-      layout={layout}
-      stylesheet={[
-        {
-          selector: "node",
-          style: {
-            label: "data(value)",
-            width: (ele: Cytoscape.NodeSingular) => (ele.data("type") === "bizaddr" ? 20 : 30),
-            height: (ele: Cytoscape.NodeSingular) => (ele.data("type") === "bizaddr" ? 20 : 30),
-            "text-wrap": "wrap",
-            "text-max-width": "200px",
-            "font-size": (ele: Cytoscape.NodeSingular) =>
-              ele.data("type") === "bizaddr" ? "12px" : "15px",
-            "font-weight": (ele: Cytoscape.NodeSingular) =>
-              ["searchaddr", "detailaddr"].includes(ele.data("type")) ? 700 : 400,
-            "font-family": "Inconsolata, monospace",
-            backgroundColor: (ele) => NODE_TYPE_TO_COLOR[ele.data("type")],
-            "min-zoomed-font-size": 16,
+    <>
+      <div className="float-left">
+        <span
+          style={{
+            color: "red",
+          }}
+        >
+          ● Landlords
+        </span>{" "}
+        <span
+          style={{
+            color: "gray",
+          }}
+        >
+          ● Business Addresses
+        </span>
+      </div>
+      <CytoscapeComponent
+        elements={formatGraphJSON(graphJSON, additionalNodes, additionalEdges)}
+        style={{ width: "100%", height: "60vh" }}
+        layout={layout}
+        stylesheet={[
+          {
+            selector: "node",
+            style: {
+              label: "data(value)",
+              width: (ele: Cytoscape.NodeSingular) => (ele.data("type") === "bizaddr" ? 20 : 30),
+              height: (ele: Cytoscape.NodeSingular) => (ele.data("type") === "bizaddr" ? 20 : 30),
+              "text-wrap": "wrap",
+              "text-max-width": "200px",
+              "font-size": (ele: Cytoscape.NodeSingular) =>
+                ele.data("type") === "bizaddr" ? "12px" : "15px",
+              "font-weight": (ele: Cytoscape.NodeSingular) =>
+                ["searchaddr", "detailaddr"].includes(ele.data("type")) ? 700 : 400,
+              "font-family": "Inconsolata, monospace",
+              backgroundColor: (ele) => NODE_TYPE_TO_COLOR[ele.data("type")],
+              "min-zoomed-font-size": 16,
+            },
           },
-        },
-        {
-          selector: "edge",
-          style: {
-            "line-color": (ele: Cytoscape.EdgeSingular) =>
-              ele.data("target") === "searchaddr"
-                ? "orange"
-                : ele.data("target") === "detailaddr"
-                ? "yellow"
-                : "default",
+          {
+            selector: "edge",
+            style: {
+              "line-color": (ele: Cytoscape.EdgeSingular) =>
+                ele.data("target") === "searchaddr"
+                  ? "orange"
+                  : ele.data("target") === "detailaddr"
+                  ? "yellow"
+                  : "default",
+            },
           },
-        },
-      ]}
-    />
+        ]}
+      />
+    </>
   );
 };
 

--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -14,7 +14,7 @@ const layout = {
   nodeDimensionsIncludeLabels: true,
   animate: false,
   quality: "proof",
-  idealEdgeLength: 200,
+  idealEdgeLength: 100,
   nodeSeparation: 300,
 };
 
@@ -52,7 +52,7 @@ function generateAdditionalNodes(searchAddr: AddressRecord, detailAddr?: Address
   const searchBBLNode = createNode(
     "searchaddr",
     "searchaddr",
-    `${searchAddr.housenumber} ${searchAddr.streetname}, ${searchAddr.boro}`
+    `SEARCH ADDRESS: ${searchAddr.housenumber} ${searchAddr.streetname}`
   );
   additionalNodes.push(searchBBLNode);
 
@@ -60,7 +60,7 @@ function generateAdditionalNodes(searchAddr: AddressRecord, detailAddr?: Address
     const detailBBLNode = createNode(
       "detailaddr",
       "detailaddr",
-      `${detailAddr.housenumber} ${detailAddr.streetname}, ${detailAddr.boro}`
+      `SELECTED ADDRESS: ${detailAddr.housenumber} ${detailAddr.streetname}`
     );
     additionalNodes.push(detailBBLNode);
   }
@@ -141,15 +141,35 @@ export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state
   return (
     <CytoscapeComponent
       elements={formatGraphJSON(graphJSON, additionalNodes, additionalEdges)}
-      style={{ width: "900px", height: "600px" }}
+      style={{ width: "100%", height: "60vh" }}
       layout={layout}
       stylesheet={[
         {
           selector: "node",
           style: {
             label: "data(value)",
+            width: (ele: Cytoscape.NodeSingular) => (ele.data("type") === "bizaddr" ? 20 : 30),
+            height: (ele: Cytoscape.NodeSingular) => (ele.data("type") === "bizaddr" ? 20 : 30),
+            "text-wrap": "wrap",
+            "text-max-width": "200px",
+            "font-size": (ele: Cytoscape.NodeSingular) =>
+              ele.data("type") === "bizaddr" ? "12px" : "15px",
+            "font-weight": (ele: Cytoscape.NodeSingular) =>
+              ["searchaddr", "detailaddr"].includes(ele.data("type")) ? 700 : 400,
+            "font-family": "Inconsolata, monospace",
             backgroundColor: (ele) => NODE_TYPE_TO_COLOR[ele.data("type")],
             "min-zoomed-font-size": 16,
+          },
+        },
+        {
+          selector: "edge",
+          style: {
+            "line-color": (ele: Cytoscape.EdgeSingular) =>
+              ele.data("target") === "searchaddr"
+                ? "orange"
+                : ele.data("target") === "detailaddr"
+                ? "yellow"
+                : "default",
           },
         },
       ]}
@@ -159,7 +179,7 @@ export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state
 
 const NODE_TYPE_TO_COLOR: Record<string, string> = {
   name: "red",
-  bizaddr: "green",
+  bizaddr: "gray",
   searchaddr: "orange",
   detailaddr: "yellow",
 };

--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -191,6 +191,7 @@ export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state
           },
         ]}
       />
+      <br />
     </>
   );
 };

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
+import { BrowserRouter as Router, Switch, Route, useHistory, useLocation } from "react-router-dom";
 import { Trans, t } from "@lingui/macro";
 
 import "styles/App.css";
@@ -35,10 +35,14 @@ import { wowMachine } from "state-machine";
 import { NotFoundPage } from "./NotFoundPage";
 import widont from "widont";
 import { Dropdown } from "components/Dropdown";
+import { isWowzaPath } from "components/WowzaToggle";
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const title = i18n._(t`Who owns what in nyc?`);
+
+  const { pathname } = useLocation();
+
   return (
     <Link
       // We need to spell out each letter of "nyc" here for screenreaders to pronounce:
@@ -46,7 +50,7 @@ const HomeLink = withI18n()((props: withI18nProps) => {
       onClick={() => {
         window.gtag("event", "site-title");
       }}
-      to="/"
+      to={isWowzaPath(pathname) ? "/wowza" : "/"}
     >
       <h4>{widont(title)}</h4>
     </Link>
@@ -124,12 +128,22 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
   );
 };
 
+const SearchLink = () => {
+  const { pathname } = useLocation();
+  const { home, wowzaHome } = createWhoOwnsWhatRoutePaths();
+  const searchRoute = isWowzaPath(pathname) ? wowzaHome : home;
+
+  return (
+    <LocaleNavLink exact to={searchRoute} key={1}>
+      <Trans>Search</Trans>
+    </LocaleNavLink>
+  );
+};
+
 const getMainNavLinks = () => {
   const paths = createWhoOwnsWhatRoutePaths();
   return [
-    <LocaleNavLink exact to={paths.home} key={1}>
-      <Trans>Search</Trans>
-    </LocaleNavLink>,
+    <SearchLink />,
     <LocaleNavLink to={paths.about} key={2}>
       <Trans>About</Trans>
     </LocaleNavLink>,

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -61,6 +61,11 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
     <Switch>
       <Route exact path={paths.home} component={HomePage} />
       <Route
+        exact
+        path={paths.wowzaHome}
+        render={(props) => <HomePage useNewPortfolioMethod {...machineProps} {...props} />}
+      />
+      <Route
         path={paths.addressPage.overview}
         render={(props) => <AddressPage currentTab={0} {...machineProps} {...props} />}
         exact

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { BrowserRouter as Router, Switch, Route, useHistory, useLocation } from "react-router-dom";
+import { BrowserRouter as Router, Switch, Route, useLocation } from "react-router-dom";
 import { Trans, t } from "@lingui/macro";
 
 import "styles/App.css";

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -22,6 +22,7 @@ import { ContentfulCommonStrings } from "@justfixnyc/contentful-common-strings";
 import _commonStrings from "../data/common-strings.json";
 import { useState } from "react";
 import LandlordSearch, { algoliaAppId, algoliaSearchKey } from "components/LandlordSearch";
+import { ToggleButtonBetweenPortfolioMethods } from "components/WowzaToggle";
 
 const commonStrings = new ContentfulCommonStrings(_commonStrings as any);
 
@@ -69,8 +70,11 @@ class MoratoriumBannerWithoutI18n extends Component<withI18nProps, BannerState> 
 
 const MoratoriumBanner = withI18n()(MoratoriumBannerWithoutI18n);
 
-const HomePage: React.FC<withMachineProps> = (props) => {
-  const [useNewPortfolioMethod, setPortfolioMethod] = useState(false);
+type HomePageProps = {
+  useNewPortfolioMethod?: boolean;
+} & withMachineProps;
+
+const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
   const allowChangingPortfolioMethod =
     process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1";
 
@@ -137,36 +141,11 @@ const HomePage: React.FC<withMachineProps> = (props) => {
                     <Trans>Or search by your landlord's name:</Trans>
                   </h1>
                   <LandlordSearch />
+                  <br />
                 </>
               )}
-            </div>{" "}
-            {allowChangingPortfolioMethod && (
-              <div>
-                <em>
-                  <Trans>How do you want to group landlord portfolios?</Trans>
-                </em>
-                <br />
-                <label className={"form-radio" + (!useNewPortfolioMethod ? " active" : "")}>
-                  <input
-                    type="radio"
-                    name="Old Version"
-                    checked={!useNewPortfolioMethod}
-                    onChange={() => setPortfolioMethod(false)}
-                  />
-                  <i className="form-icon" /> <Trans>Old Method</Trans>
-                </label>
-                <br />
-                <label className={"form-radio" + (useNewPortfolioMethod ? " active" : "")}>
-                  <input
-                    type="radio"
-                    name="New Version"
-                    checked={useNewPortfolioMethod}
-                    onChange={() => setPortfolioMethod(true)}
-                  />
-                  <i className="form-icon" /> <Trans>New Method (WOWZA!)</Trans>
-                </label>
-              </div>
-            )}
+            </div>
+            {allowChangingPortfolioMethod && <ToggleButtonBetweenPortfolioMethods />}
           </div>
           <div className="HomePage__samples">
             <h5 className="text-center">

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -20,7 +20,6 @@ import { INLINES } from "@contentful/rich-text-types";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 import { ContentfulCommonStrings } from "@justfixnyc/contentful-common-strings";
 import _commonStrings from "../data/common-strings.json";
-import { useState } from "react";
 import LandlordSearch, { algoliaAppId, algoliaSearchKey } from "components/LandlordSearch";
 import { ToggleButtonBetweenPortfolioMethods } from "components/WowzaToggle";
 

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -55,6 +55,7 @@ export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
   const pathPrefix = prefix || "";
   return {
     home: `${pathPrefix}/`,
+    wowzaHome: `${pathPrefix}/wowza`,
     addressPage: createAddressPageRoutes(`${pathPrefix}/address/:boro/:housenumber/:streetname`),
     wowzaAddressPage: createAddressPageRoutes(
       `${pathPrefix}/wowza/address/:boro/:housenumber/:streetname`


### PR DESCRIPTION
This PR makes some minor adjustments to the WOWZA view of who owns what in order to make it easier for beta testers to navigate the site:
- the portfolio graph on the summary tab no longer takes up the full page, and has a legend and new styling for legibility
- we now save whether the user is searching normally or searching using the new WOWZA method in the actual url of the homepage itself (users at the path `/` are searching normally but when they are at the path `/wowza` they are searching using the new method)
- toggling between the two methods on the site is now more comprehensive with a new button on the homepage and dynamic page links in the header menu

