### PR TITLE
add Algolia objectID as hash of contents + tests

### DIFF
--- a/portfoliograph/landlord_index.py
+++ b/portfoliograph/landlord_index.py
@@ -1,10 +1,39 @@
 import numpy
 import math
+from typing import Dict, Any
+import hashlib
+import json
 from psycopg2.extras import DictCursor
 from algoliasearch.search_client import SearchClient
 
 
+def split_sort_join(x: str, sep: str = ", ") -> str:
+    """
+    Takes a delimited string, splits it by a given seperator,
+    sorts the parts, and concatenates it back together using
+    the same seperator, returning a single delimited string
+    """
+    return sep.join(sorted(x.split(sep)))
+
+
+def dict_hash(dictionary: Dict[str, Any]) -> str:
+    """MD5 hash of a dictionary."""
+    # doc.ic.ac.uk/~nuric/coding/how-to-hash-a-dictionary-in-python.html
+    dhash = hashlib.md5()
+    encoded = json.dumps(dictionary, sort_keys=True).encode()
+    dhash.update(encoded)
+    return dhash.hexdigest()
+
+
 def get_landlord_data_for_algolia(conn, max_index_char_length: int = 2000):
+    """
+    Query the "wow_portfolios" table to get landlord names we want to search by in Algolia.
+    We then sort bbls and landlord names to ensure consistent results despite inconsistent
+    order in the db table. Then we split portfolios with large number of landlord names so
+    that we don't exceed Algolia's charater limit. We also hash the contents of the record
+    to create the unique objectID that Algolia requires. (later we can use this hash objectID
+    to determine if we need to update the record or not to save some operations/credits)
+    """
     # TODO: Only update when contents of wow_portfolios table has changed
 
     cleaned_rows = []
@@ -24,22 +53,34 @@ def get_landlord_data_for_algolia(conn, max_index_char_length: int = 2000):
             # Avoid Algolia's limit on article size by breaking up the landlord
             # names list into multiple records that each point to the same BBLs.
             num_parts = math.ceil(len(row["landlord_names"]) / max_index_char_length)
+            # We want to take a single bbl associated with each portfolio, but their order is
+            # not concsistent in the wow_portfolios db table array, so we sort and take out
+            # the first one to ensure it's consistent between runs
             portfolio_bbl = sorted(row["bbls"])[0]
+            # We also need the names order to be consistent before hashing for objectID
+            landlord_names = split_sort_join(row["landlord_names"])
             if num_parts > 1:
-                names_array = row["landlord_names"].split(", ")
-                parts = numpy.array_split(names_array, num_parts)
+                names_array = landlord_names.split(", ")
+                names_array_subsets = numpy.array_split(names_array, num_parts)
+                portfolio_part_dict_list = [
+                    {
+                        "portfolio_bbl": portfolio_bbl,
+                        "landlord_names": ", ".join(names_subset),
+                    }
+                    for names_subset in names_array_subsets
+                ]
                 new_rows = [
-                    {"portfolio_bbl": portfolio_bbl, "landlord_names": ", ".join(part)}
-                    for part in parts
+                    {"objectID": dict_hash(row), **row}
+                    for row in portfolio_part_dict_list
                 ]
                 cleaned_rows.extend(new_rows)
             else:
-                cleaned_rows.append(
-                    {
-                        "portfolio_bbl": portfolio_bbl,
-                        "landlord_names": row["landlord_names"],
-                    }
-                )
+                portfolio = {
+                    "portfolio_bbl": portfolio_bbl,
+                    "landlord_names": landlord_names,
+                }
+                row = {"objectID": dict_hash(portfolio), **portfolio}
+                cleaned_rows.append(row)
 
     return cleaned_rows
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -5,7 +5,7 @@ from psycopg2.extras import DictCursor
 import freezegun
 import pytest
 
-from portfoliograph.landlord_index import get_landlord_data_for_algolia
+from portfoliograph.landlord_index import get_landlord_data_for_algolia, dict_hash
 
 from .factories.hpd_contacts import HpdContacts
 from .factories.hpd_registrations import HpdRegistrations
@@ -331,6 +331,16 @@ class TestSQL:
             with freezegun.freeze_time("2018-01-01"):
                 r = get_landlord_data_for_algolia(conn, 20)
                 assert len(r) == 4
+
+                # The result is a list of dicts, and each dict includes the ObjectID, which
+                # is the hash of the rest of the dict. To simplify the expected data testing
+                # we remove all those objectIDs and test those separately first before checking
+                # the rest of the contents
+                r_hashes = []
+                for row in r:
+                    r_hashes.append(row.pop("objectID"))
+                assert r_hashes[0] == dict_hash(r[0])
+
                 assert {
                     "portfolio_bbl": "1000010002",
                     "landlord_names": "BOOP JONES",
@@ -350,6 +360,12 @@ class TestSQL:
 
                 r2 = get_landlord_data_for_algolia(conn)
                 assert len(r2) == 3
+
+                r2_hashes = []
+                for row in r2:
+                    r2_hashes.append(row.pop("objectID"))
+                assert r2_hashes[0] == dict_hash(r2[0])
+
                 assert {
                     "portfolio_bbl": "1000010002",
                     "landlord_names": "BOOP JONES",
@@ -358,20 +374,10 @@ class TestSQL:
                     "portfolio_bbl": "3000040006",
                     "landlord_names": "LANDLORDO CALRISIAN",
                 } in r2
-                assert any(
-                    [
-                        {
-                            "portfolio_bbl": "3000010002",
-                            "landlord_names": "LANDLORDO CALRISSIAN, LOBOT JONES",
-                        }
-                        in r2,
-                        {
-                            "portfolio_bbl": "3000010002",
-                            "landlord_names": "LOBOT JONES, LANDLORDO CALRISSIAN",
-                        }
-                        in r2,
-                    ]
-                )
+                assert {
+                    "portfolio_bbl": "3000010002",
+                    "landlord_names": "LANDLORDO CALRISSIAN, LOBOT JONES",
+                } in r2
 
     def test_portfolio_graph_json_works(self):
         with self.db.connect() as conn:


### PR DESCRIPTION
this PR adds the unique `objectID` for each record that Aloglia requires. It is created as a hash of the rest of the contents of the record (`{"portfolio_bbl": 1234567890, "landlord_names": "name1, name2"}`), so that later we can use the hash to determine if we need to update the record, and hopefully save us some Algolia operations/credits.

Also add tests of this new hash, and adjust the existing tests now that we can ensure consistent ordering of landlord names in the concatenated string.