### PR TITLE
Add corporation names to the Algolia landlord search index

### DIFF
--- a/portfoliograph/landlord_index.py
+++ b/portfoliograph/landlord_index.py
@@ -97,10 +97,10 @@ def get_corpname_data_for_algolia(conn):
     with conn.cursor(cursor_factory=DictCursor) as cursor:
         cursor.execute(
             f"""
-            SELECT 
+            SELECT
                 corpname,
                 array_agg(distinct bbl) as bbls
-            FROM    
+            FROM
                 (SELECT
                     unnest(corpnames) as corpname,
                     bbl

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -5,7 +5,11 @@ from psycopg2.extras import DictCursor
 import freezegun
 import pytest
 
-from portfoliograph.landlord_index import get_landlord_data_for_algolia, dict_hash
+from portfoliograph.landlord_index import (
+    get_corpname_data_for_algolia,
+    get_landlord_data_for_algolia,
+    dict_hash,
+)
 
 from .factories.hpd_contacts import HpdContacts
 from .factories.hpd_registrations import HpdRegistrations
@@ -326,7 +330,7 @@ class TestSQL:
         )
         assert set(r[0]) == {"LANDLORDO CALRISSIAN", "LOBOT JONES"}
 
-    def test_landlord_index_query(self):
+    def test_getting_landlord_names_for_algolia_index(self):
         with self.db.connect() as conn:
             with freezegun.freeze_time("2018-01-01"):
                 r = get_landlord_data_for_algolia(conn, 20)
@@ -378,6 +382,38 @@ class TestSQL:
                     "portfolio_bbl": "3000010002",
                     "landlord_names": "LANDLORDO CALRISSIAN, LOBOT JONES",
                 } in r2
+
+    def test_getting_corporation_names_for_algolia_index(self):
+        with self.db.connect() as conn:
+            with freezegun.freeze_time("2018-01-01"):
+                r = get_corpname_data_for_algolia(conn)
+                assert len(r) == 4
+
+                # The result is a list of dicts, and each dict includes the ObjectID, which
+                # is the hash of the rest of the dict. To simplify the expected data testing
+                # we remove all those objectIDs and test those separately first before checking
+                # the rest of the contents
+                r_hashes = []
+                for row in r:
+                    r_hashes.append(row.pop("objectID"))
+                assert r_hashes[0] == dict_hash(r[0])
+
+                assert {
+                    "portfolio_bbl": "1000010002",
+                    "landlord_names": "THE UNRELATED COMPANIES, L.P.",
+                } in r
+                assert {
+                    "portfolio_bbl": "3000010002",
+                    "landlord_names": "1 FUNKY STREET LLC",
+                } in r
+                assert {
+                    "portfolio_bbl": "3000040005",
+                    "landlord_names": "CLOUD CITY MEGAPROPERTIES",
+                } in r
+                assert {
+                    "portfolio_bbl": "3000040006",
+                    "landlord_names": "4 SPUNKY STREET LLC",
+                } in r
 
     def test_portfolio_graph_json_works(self):
         with self.db.connect() as conn:


### PR DESCRIPTION
This PR adds a new helper function called `get_corpname_data_for_algolia` which grabs the names of all corporations listed in the `wow_bldgs` as well as one of their associated bbls and creates a new individual algolia search record for each unique corporation name. We then just append these records to the list we send our Algolia app when updating the landlord search index.