### PR TITLE
add JointOwner to wow_portfolios table

### DIFF
--- a/portfoliograph/graph.py
+++ b/portfoliograph/graph.py
@@ -65,7 +65,7 @@ def build_graph(dict_cursor) -> nx.Graph:
         INNER JOIN hpd_registrations
             ON hpd_contacts.registrationid = hpd_registrations.registrationid
         WHERE
-            type = ANY('{{HeadOfficer, IndividualOwner, CorporateOwner}}')
+            type = ANY('{{HeadOfficer, IndividualOwner, CorporateOwner, JointOwner}}')
             AND (businesshousenumber IS NOT NULL OR businessstreetname IS NOT NULL)
             AND LENGTH(CONCAT(businesshousenumber, businessstreetname)) > 2
             AND (firstname IS NOT NULL OR lastname IS NOT NULL)


### PR DESCRIPTION
When building the `wow_portfolios` table we previously included only `HeadOfficer, IndividualOwner, CorporateOwner`, this PR adds `JointOwner` as well. Sam identified that we should add JointOwner already, since some only show up in that category. But we now also might need to include it to ensure that all `wow_bldgs` records appear in `wow_portfolios`, since we found that not all of them do currently (see second SC card)

[sc-8951]