### PR TITLE
Add "Joint Owner" as a valid owner contact type across Who Owns What

### DIFF
--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -439,7 +439,10 @@ const TableOfData = React.memo(
                   var owner =
                     d.ownernames &&
                     d.ownernames.find(
-                      (o) => o.title === "HeadOfficer" || o.title === "IndividualOwner"
+                      (o) =>
+                        o.title === "HeadOfficer" ||
+                        o.title === "IndividualOwner" ||
+                        o.title === "JointOwner"
                     );
                   return owner ? owner.value : "";
                 },

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -442,6 +442,7 @@ const TableOfData = React.memo(
                       (o) =>
                         o.title === "HeadOfficer" ||
                         o.title === "IndividualOwner" ||
+                        o.title === "CorporateOwner" ||
                         o.title === "JointOwner"
                     );
                   return owner ? owner.value : "";

--- a/client/src/util/helpers.test.ts
+++ b/client/src/util/helpers.test.ts
@@ -115,7 +115,7 @@ describe("getLandlordNameFromAddress()", () => {
         ownernames: [
           { title: "HeadOfficer", value: "MOSES GUTMAN" },
           { title: "HeadOfficer", value: "BOOP GUTMAN" },
-          { title: "IndividualOwner", value: "BOOP JONES" },
+          { title: "JointOwner", value: "BOOP JONES" },
           { title: "Agent", value: "NATHAN SCHWARCZ" },
         ],
       })

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -190,7 +190,7 @@ export default {
     const { ownernames } = addr;
     if (!ownernames) return [];
     const landlords = ownernames.filter((owner) =>
-      ["HeadOfficer", "IndividualOwner", "CorporateOwner"].includes(owner.title)
+      ["HeadOfficer", "IndividualOwner", "CorporateOwner", "JointOwner"].includes(owner.title)
     );
     const landlordNames = landlords.map((landlord) => landlord.value);
     // Remove duplicate names:


### PR DESCRIPTION
This PR makes sure that `JointOwner` names are shown on the "Owners" column of the Portfolio tab, and that `JointOwner` names also can define the `name` property of a node on the portfolio network graph visualization.