### PR TITLE
Adjust placement and context of portfolio network graph

### DIFF
--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -6,6 +6,7 @@ import fcose from "cytoscape-fcose";
 import { AddressRecord, PortfolioGraphNode, RawPortfolioGraphJson } from "./APIDataTypes";
 import { withMachineInStateProps } from "state-machine";
 import helpers from "util/helpers";
+import { Trans } from "@lingui/macro";
 
 Cytoscape.use(fcose);
 
@@ -146,14 +147,14 @@ export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state
             color: "red",
           }}
         >
-          ● Landlords
+          ● <Trans>Owner Names</Trans>
         </span>{" "}
         <span
           style={{
             color: "gray",
           }}
         >
-          ● Business Addresses
+          ● <Trans>Business Addresses</Trans>
         </span>
       </div>
       <CytoscapeComponent

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -98,14 +98,61 @@ export default class PropertiesSummary extends Component<Props, {}> {
       return (
         <div className="Page PropertiesSummary">
           <div className="PropertiesSummary__content Page__content">
-            {state.context.useNewPortfolioMethod && state.context.portfolioData.portfolioGraph && (
-              <PortfolioGraph
-                graphJSON={state.context.portfolioData.portfolioGraph}
-                state={state}
-              />
-            )}
             <div>
-              <Trans render="h6">General info</Trans>
+              <Trans render="h6">Network of Landlords</Trans>
+              {state.context.useNewPortfolioMethod &&
+                state.context.portfolioData.portfolioGraph && (
+                  <PortfolioGraph
+                    graphJSON={state.context.portfolioData.portfolioGraph}
+                    state={state}
+                  />
+                )}
+              <p>
+                <Trans>
+                  Across owners and management staff, the most common
+                  <Plural
+                    value={agg.topowners.length}
+                    one="name that appears in this portfolio is"
+                    other="names that appear in this portfolio are"
+                  />{" "}
+                  <StringifyListWithConjunction
+                    values={agg.topowners}
+                    renderItem={(item) => <strong>{item}</strong>}
+                  />
+                  .
+                </Trans>{" "}
+                {agg.topcorp && agg.topbusinessaddr && (
+                  <Trans>
+                    {" "}
+                    The most common corporate entity is <b>{agg.topcorp}</b> and the most common
+                    business address is <b>{agg.topbusinessaddr}</b>.
+                  </Trans>
+                )}
+              </p>
+              <aside>
+                {agg.violationsaddr.lat && agg.violationsaddr.lng && (
+                  <figure className="figure">
+                    <img
+                      src={`https://maps.googleapis.com/maps/api/streetview?size=800x500&location=${agg.violationsaddr.lat},${agg.violationsaddr.lng}&key=${process.env.REACT_APP_STREETVIEW_API_KEY}`}
+                      alt="Google Street View"
+                      className="img-responsive"
+                    />
+                    <figcaption className="figure-caption text-center text-italic">
+                      <Trans>
+                        {agg.violationsaddr.housenumber} {agg.violationsaddr.streetname},{" "}
+                        {agg.violationsaddr.boro} currently has{" "}
+                        <Plural
+                          value={agg.violationsaddr.openviolations || 0}
+                          one="one open HPD violation"
+                          other="# open HPD violations"
+                        />{" "}
+                        - the most in this portfolio.
+                      </Trans>
+                    </figcaption>
+                  </figure>
+                )}
+              </aside>
+              <Trans render="h6">Building info</Trans>
               <p>
                 <Trans>
                   There{" "}
@@ -134,52 +181,7 @@ export default class PropertiesSummary extends Component<Props, {}> {
                   </Trans>
                 )}
               </p>
-              <aside>
-                {agg.violationsaddr.lat && agg.violationsaddr.lng && (
-                  <figure className="figure">
-                    <img
-                      src={`https://maps.googleapis.com/maps/api/streetview?size=800x500&location=${agg.violationsaddr.lat},${agg.violationsaddr.lng}&key=${process.env.REACT_APP_STREETVIEW_API_KEY}`}
-                      alt="Google Street View"
-                      className="img-responsive"
-                    />
-                    <figcaption className="figure-caption text-center text-italic">
-                      <Trans>
-                        {agg.violationsaddr.housenumber} {agg.violationsaddr.streetname},{" "}
-                        {agg.violationsaddr.boro} currently has{" "}
-                        <Plural
-                          value={agg.violationsaddr.openviolations || 0}
-                          one="one open HPD violation"
-                          other="# open HPD violations"
-                        />{" "}
-                        - the most in this portfolio.
-                      </Trans>
-                    </figcaption>
-                  </figure>
-                )}
-              </aside>
-              <Trans render="h6">Landlord</Trans>
-              <p>
-                <Trans>
-                  The most common
-                  <Plural
-                    value={agg.topowners.length}
-                    one="name that appears in this portfolio is"
-                    other="names that appear in this portfolio are"
-                  />{" "}
-                  <StringifyListWithConjunction
-                    values={agg.topowners}
-                    renderItem={(item) => <strong>{item}</strong>}
-                  />
-                  .
-                </Trans>{" "}
-                {agg.topcorp && agg.topbusinessaddr && (
-                  <Trans>
-                    {" "}
-                    The most common corporate entity is <b>{agg.topcorp}</b> and the most common
-                    business address is <b>{agg.topbusinessaddr}</b>.
-                  </Trans>
-                )}
-              </p>
+
               <ComplaintsSummary {...agg} />
               <ViolationsSummary {...agg} />
               <Trans render="h6">Evictions</Trans>

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/PropertiesSummary.tsx:138
+#: src/components/PropertiesSummary.tsx:140
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
@@ -45,7 +45,7 @@ msgstr "(this may take a while)"
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 
-#: src/containers/HomePage.tsx:115
+#: src/containers/HomePage.tsx:101
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
@@ -75,7 +75,7 @@ msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:72
+#: src/containers/App.tsx:81
 msgid "About"
 msgstr "About"
 
@@ -83,7 +83,11 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 
-#: src/components/PropertiesSummary.tsx:124
+#: src/components/PropertiesSummary.tsx:72
+msgid "Across owners and management staff, the most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
+msgstr "Across owners and management staff, the most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
+
+#: src/components/PropertiesSummary.tsx:126
 msgid "Additional links"
 msgstr "Additional links"
 
@@ -103,8 +107,8 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:358
-#: src/components/PropertiesList.tsx:366
+#: src/components/PropertiesList.tsx:368
+#: src/components/PropertiesList.tsx:376
 msgid "Amount"
 msgstr "Amount"
 
@@ -124,8 +128,8 @@ msgstr "BELL/BUZZER/INTERCOM"
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/PropertiesList.tsx:147
 #: src/components/PropertiesList.tsx:152
+#: src/components/PropertiesList.tsx:157
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -149,17 +153,22 @@ msgstr "Building Permit Applications"
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
+#: src/components/PropertiesSummary.tsx:97
+msgid "Building info"
+msgstr "Building info"
+
 #: src/containers/NotRegisteredPage.tsx:153
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:170
-#: src/components/PropertiesList.tsx:175
+#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:185
 msgid "Built"
 msgstr "Built"
 
 #: src/components/DetailView.tsx:303
 #: src/components/DetailView.tsx:312
+#: src/components/PortfolioGraph.tsx:101
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
@@ -261,12 +270,12 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PropertiesList.tsx:346
-#: src/components/PropertiesList.tsx:354
+#: src/components/PropertiesList.tsx:356
+#: src/components/PropertiesList.tsx:364
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:95
+#: src/containers/App.tsx:104
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -280,7 +289,7 @@ msgid "Display:"
 msgstr "Display:"
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:78
+#: src/containers/App.tsx:87
 msgid "Donate"
 msgstr "Donate"
 
@@ -308,7 +317,7 @@ msgstr "Email"
 msgid "Emergency"
 msgstr "Emergency"
 
-#: src/containers/HomePage.tsx:81
+#: src/containers/HomePage.tsx:80
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Enter an NYC address and find other buildings your landlord might own:"
 
@@ -317,8 +326,8 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:280
-#: src/components/PropertiesSummary.tsx:117
+#: src/components/PropertiesList.tsx:290
+#: src/components/PropertiesSummary.tsx:119
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
 msgstr "Evictions"
@@ -355,12 +364,8 @@ msgstr "Failure to register a building with HPD"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
-#: src/components/PropertiesSummary.tsx:69
-msgid "General info"
-msgstr "General info"
-
-#: src/components/PropertiesList.tsx:379
-#: src/components/PropertiesList.tsx:393
+#: src/components/PropertiesList.tsx:389
+#: src/components/PropertiesList.tsx:403
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -377,7 +382,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:217
+#: src/components/PropertiesList.tsx:227
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -386,7 +391,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:33
-#: src/components/PropertiesList.tsx:257
+#: src/components/PropertiesList.tsx:267
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -402,15 +407,11 @@ msgstr "HUD Complaint Form 958"
 msgid "Head Officer"
 msgstr "Head Officer"
 
-#: src/containers/HomePage.tsx:99
-msgid "How do you want to group landlord portfolios?"
-msgstr "How do you want to group landlord portfolios?"
-
 #: src/components/DetailView.tsx:78
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:75
+#: src/containers/App.tsx:84
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -423,7 +424,7 @@ msgstr "I just looked up this building on Who Owns What, a free tool built by Ju
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
-#: src/components/PropertiesSummary.tsx:140
+#: src/components/PropertiesSummary.tsx:142
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
@@ -435,7 +436,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesList.tsx:176
 msgid "Information"
 msgstr "Information"
 
@@ -463,8 +464,7 @@ msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PropertiesList.tsx:294
-#: src/components/PropertiesSummary.tsx:101
+#: src/components/PropertiesList.tsx:304
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -472,12 +472,12 @@ msgstr "Landlord"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:230
-#: src/components/PropertiesList.tsx:235
+#: src/components/PropertiesList.tsx:240
+#: src/components/PropertiesList.tsx:245
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PropertiesList.tsx:342
+#: src/components/PropertiesList.tsx:352
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -505,9 +505,9 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PropertiesList.tsx:369
-#: src/components/PropertiesList.tsx:371
-#: src/components/PropertiesList.tsx:375
+#: src/components/PropertiesList.tsx:379
+#: src/components/PropertiesList.tsx:381
+#: src/components/PropertiesList.tsx:385
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -524,11 +524,11 @@ msgstr "Loading"
 msgid "Loading {0} rows"
 msgstr "Loading {0} rows"
 
-#: src/components/PropertiesList.tsx:131
+#: src/components/PropertiesList.tsx:136
 msgid "Location"
 msgstr "Location"
 
-#: src/components/PropertiesSummary.tsx:128
+#: src/components/PropertiesSummary.tsx:130
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
@@ -589,9 +589,9 @@ msgstr "NON-CONSTRUCTION"
 msgid "NYCHA Directory"
 msgstr "NYCHA Directory"
 
-#: src/containers/HomePage.tsx:109
-msgid "New Method (WOWZA!)"
-msgstr "New Method (WOWZA!)"
+#: src/components/PropertiesSummary.tsx:68
+msgid "Network of Landlords"
+msgstr "Network of Landlords"
 
 #: src/components/AddressToolbar.tsx:19
 msgid "New Search"
@@ -605,7 +605,7 @@ msgstr "New York Regional Office:"
 msgid "Next"
 msgstr "Next"
 
-#: src/components/PropertiesList.tsx:390
+#: src/components/PropertiesList.tsx:400
 msgid "No"
 msgstr "No"
 
@@ -654,14 +654,10 @@ msgstr "OUTSIDE BUILDING"
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PropertiesList.tsx:298
-#: src/components/PropertiesList.tsx:307
+#: src/components/PropertiesList.tsx:308
+#: src/components/PropertiesList.tsx:317
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
-
-#: src/containers/HomePage.tsx:104
-msgid "Old Method"
-msgstr "Old Method"
 
 #: src/components/NetworkErrorMessage.tsx:5
 #: src/components/Subscribe.tsx:54
@@ -673,8 +669,8 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:261
-#: src/components/PropertiesList.tsx:266
+#: src/components/PropertiesList.tsx:271
+#: src/components/PropertiesList.tsx:276
 msgid "Open"
 msgstr "Open"
 
@@ -682,13 +678,17 @@ msgstr "Open"
 msgid "Open Violations"
 msgstr "Open Violations"
 
-#: src/containers/HomePage.tsx:92
+#: src/containers/HomePage.tsx:91
 msgid "Or search by your landlord's name:"
 msgstr "Or search by your landlord's name:"
 
 #: src/containers/AddressPage.tsx:110
 msgid "Overview"
 msgstr "Overview"
+
+#: src/components/PortfolioGraph.tsx:96
+msgid "Owner Names"
+msgstr "Owner Names"
 
 #: src/components/IndicatorsDatasets.tsx:73
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
@@ -741,11 +741,11 @@ msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:189
+#: src/components/PropertiesList.tsx:199
 msgid "RS Units"
 msgstr "RS Units"
 
-#: src/components/PropertiesSummary.tsx:119
+#: src/components/PropertiesSummary.tsx:121
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
@@ -765,7 +765,7 @@ msgstr "SIGNAGE MISSING"
 msgid "STAIRS"
 msgstr "STAIRS"
 
-#: src/containers/App.tsx:69
+#: src/containers/App.tsx:73
 msgid "Search"
 msgstr "Search"
 
@@ -790,15 +790,15 @@ msgstr "See the most common complaints reported by tenants to 311, now on the Ov
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:103
-#: src/containers/App.tsx:114
+#: src/containers/App.tsx:112
+#: src/containers/App.tsx:123
 msgid "Share"
 msgstr "Share"
 
 #: src/components/DetailView.tsx:246
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:134
-#: src/containers/App.tsx:125
+#: src/components/PropertiesSummary.tsx:136
+#: src/containers/App.tsx:134
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -815,8 +815,8 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:284
-#: src/components/PropertiesList.tsx:289
+#: src/components/PropertiesList.tsx:294
+#: src/components/PropertiesList.tsx:299
 msgid "Since 2017"
 msgstr "Since 2017"
 
@@ -873,7 +873,7 @@ msgstr "TENANT HARASSMENT"
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
 
-#: src/components/PropertiesList.tsx:315
+#: src/components/PropertiesList.tsx:325
 msgid "Tax Exemptions"
 msgstr "Tax Exemptions"
 
@@ -902,21 +902,17 @@ msgstr "The building with the most evictions is <0>{0} {1}, {2}</0> with {buildi
 msgid "The city borough where your search address is located"
 msgstr "The city borough where your search address is located"
 
-#: src/containers/HomePage.tsx:168
+#: src/containers/HomePage.tsx:154
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
-#: src/components/PropertiesSummary.tsx:109
+#: src/components/PropertiesSummary.tsx:78
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
 #: src/components/ComplaintsSummary.tsx:18
 msgid "The most common {0, plural, one {issue} other {issues}} reported in this portfolio over the last three years {1, plural, one {is} other {are}} <0/>."
 msgstr "The most common {0, plural, one {issue} other {issues}} reported in this portfolio over the last three years {1, plural, one {is} other {are}} <0/>."
-
-#: src/components/PropertiesSummary.tsx:103
-msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
-msgstr "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
 #: src/components/BuildingStatsTable.tsx:52
 msgid "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
@@ -934,11 +930,11 @@ msgstr "The number of residential units in this building, according to the Dept.
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "The year that this building was originally constructed, according to the Dept. of City Planning."
 
-#: src/components/PropertiesSummary.tsx:82
+#: src/components/PropertiesSummary.tsx:110
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 
-#: src/components/PropertiesSummary.tsx:71
+#: src/components/PropertiesSummary.tsx:99
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
@@ -970,11 +966,11 @@ msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per r
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "This is the official identifer for the building according to the Dept. of Finance tax records."
 
-#: src/components/PropertiesSummary.tsx:137
+#: src/components/PropertiesSummary.tsx:139
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 
-#: src/components/PropertiesSummary.tsx:139
+#: src/components/PropertiesSummary.tsx:141
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "This landlord’s buildings average {0} open HPD violations per apartment"
 
@@ -986,7 +982,7 @@ msgstr "This portfolio also had an estimated <0>net {changeType, select, gain {g
 msgid "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 msgstr "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 
-#: src/containers/HomePage.tsx:134
+#: src/containers/HomePage.tsx:120
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 
@@ -1014,16 +1010,16 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PropertiesList.tsx:239
 #: src/components/PropertiesList.tsx:249
+#: src/components/PropertiesList.tsx:259
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:338
-#: src/components/PropertiesList.tsx:221
-#: src/components/PropertiesList.tsx:226
-#: src/components/PropertiesList.tsx:270
-#: src/components/PropertiesList.tsx:275
+#: src/components/PropertiesList.tsx:231
+#: src/components/PropertiesList.tsx:236
+#: src/components/PropertiesList.tsx:280
+#: src/components/PropertiesList.tsx:285
 msgid "Total"
 msgstr "Total"
 
@@ -1040,8 +1036,8 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:179
-#: src/components/PropertiesList.tsx:184
+#: src/components/PropertiesList.tsx:189
+#: src/components/PropertiesList.tsx:194
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -1076,9 +1072,9 @@ msgstr "View by:"
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PropertiesList.tsx:399
-#: src/components/PropertiesList.tsx:405
 #: src/components/PropertiesList.tsx:409
+#: src/components/PropertiesList.tsx:415
+#: src/components/PropertiesList.tsx:419
 msgid "View detail"
 msgstr "View detail"
 
@@ -1090,9 +1086,9 @@ msgstr "View documents on <0>ACRIS</0>"
 msgid "View legend"
 msgstr "View legend"
 
-#: src/containers/HomePage.tsx:149
-#: src/containers/HomePage.tsx:191
-#: src/containers/HomePage.tsx:221
+#: src/containers/HomePage.tsx:135
+#: src/containers/HomePage.tsx:177
+#: src/containers/HomePage.tsx:207
 msgid "View portfolio"
 msgstr "View portfolio"
 
@@ -1154,14 +1150,14 @@ msgstr "What's New"
 msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 
-#: src/containers/App.tsx:33
+#: src/containers/App.tsx:35
 msgid "Who owns what in n y c?"
 msgstr "Who owns what in n y c?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:20
 #: src/components/Page.tsx:21
-#: src/containers/App.tsx:30
+#: src/containers/App.tsx:31
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 
@@ -1177,16 +1173,16 @@ msgstr "Who’s the landlord of this building?"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:389
+#: src/components/PropertiesList.tsx:399
 msgid "Yes"
 msgstr "Yes"
 
-#: src/containers/HomePage.tsx:210
+#: src/containers/HomePage.tsx:196
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/components/PropertiesList.tsx:137
 #: src/components/PropertiesList.tsx:142
+#: src/components/PropertiesList.tsx:147
 msgid "Zipcode"
 msgstr "Zipcode"
 
@@ -1222,7 +1218,7 @@ msgstr "year"
 msgid "{0} of {numberOfEntries}"
 msgstr "{0} of {numberOfEntries}"
 
-#: src/components/PropertiesSummary.tsx:92
+#: src/components/PropertiesSummary.tsx:88
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 31\n"
 
-#: src/components/PropertiesSummary.tsx:138
+#: src/components/PropertiesSummary.tsx:140
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
@@ -50,7 +50,7 @@ msgstr "(esto puede tardar un rato)"
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {pulsa} other {haz clic}} para ver detalles)"
 
-#: src/containers/HomePage.tsx:115
+#: src/containers/HomePage.tsx:101
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de portafolios de edificios:"
 
@@ -80,7 +80,7 @@ msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:72
+#: src/containers/App.tsx:81
 msgid "About"
 msgstr "Acerca de"
 
@@ -88,7 +88,11 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha recibido un total de <0>{totalviolations}</0> violaciones."
 
-#: src/components/PropertiesSummary.tsx:124
+#: src/components/PropertiesSummary.tsx:72
+msgid "Across owners and management staff, the most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
+msgstr ""
+
+#: src/components/PropertiesSummary.tsx:126
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
@@ -108,8 +112,8 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:358
-#: src/components/PropertiesList.tsx:366
+#: src/components/PropertiesList.tsx:368
+#: src/components/PropertiesList.tsx:376
 msgid "Amount"
 msgstr "Importe"
 
@@ -129,8 +133,8 @@ msgstr "TIMBRE/INTERCOMUNICADOR"
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/PropertiesList.tsx:147
 #: src/components/PropertiesList.tsx:152
+#: src/components/PropertiesList.tsx:157
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -154,17 +158,22 @@ msgstr "Solicitudes de Permisos de Construcción"
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
 
+#: src/components/PropertiesSummary.tsx:97
+msgid "Building info"
+msgstr ""
+
 #: src/containers/NotRegisteredPage.tsx:153
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:170
-#: src/components/PropertiesList.tsx:175
+#: src/components/PropertiesList.tsx:180
+#: src/components/PropertiesList.tsx:185
 msgid "Built"
 msgstr "Construido"
 
 #: src/components/DetailView.tsx:303
 #: src/components/DetailView.tsx:312
+#: src/components/PortfolioGraph.tsx:101
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
@@ -266,12 +275,12 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PropertiesList.tsx:346
-#: src/components/PropertiesList.tsx:354
+#: src/components/PropertiesList.tsx:356
+#: src/components/PropertiesList.tsx:364
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:95
+#: src/containers/App.tsx:104
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -285,7 +294,7 @@ msgid "Display:"
 msgstr "Mostrar:"
 
 #: src/components/LegalFooter.tsx:33
-#: src/containers/App.tsx:78
+#: src/containers/App.tsx:87
 msgid "Donate"
 msgstr "Donar"
 
@@ -313,7 +322,7 @@ msgstr "Email"
 msgid "Emergency"
 msgstr "Emergencia"
 
-#: src/containers/HomePage.tsx:81
+#: src/containers/HomePage.tsx:80
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
 
@@ -322,8 +331,8 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:280
-#: src/components/PropertiesSummary.tsx:117
+#: src/components/PropertiesList.tsx:290
+#: src/components/PropertiesSummary.tsx:119
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
 msgstr "Desalojos"
@@ -360,12 +369,8 @@ msgstr "Si no se registra un edificio con el HPD"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
-#: src/components/PropertiesSummary.tsx:69
-msgid "General info"
-msgstr "Información general"
-
-#: src/components/PropertiesList.tsx:379
-#: src/components/PropertiesList.tsx:393
+#: src/components/PropertiesList.tsx:389
+#: src/components/PropertiesList.tsx:403
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -382,7 +387,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:217
+#: src/components/PropertiesList.tsx:227
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -391,7 +396,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontrarás más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:33
-#: src/components/PropertiesList.tsx:257
+#: src/components/PropertiesList.tsx:267
 msgid "HPD Violations"
 msgstr "Violaciones del HPD"
 
@@ -407,15 +412,11 @@ msgstr "Formulario de queja HUD 958"
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
-#: src/containers/HomePage.tsx:99
-msgid "How do you want to group landlord portfolios?"
-msgstr "¿Cómo quieres agrupar a los portafolios de los dueños?"
-
 #: src/components/DetailView.tsx:78
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:75
+#: src/containers/App.tsx:84
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
@@ -428,7 +429,7 @@ msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta grat
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
-#: src/components/PropertiesSummary.tsx:140
+#: src/components/PropertiesSummary.tsx:142
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix.nyc. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
@@ -440,7 +441,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
-#: src/components/PropertiesList.tsx:166
+#: src/components/PropertiesList.tsx:176
 msgid "Information"
 msgstr "Información"
 
@@ -468,8 +469,7 @@ msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucr
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PropertiesList.tsx:294
-#: src/components/PropertiesSummary.tsx:101
+#: src/components/PropertiesList.tsx:304
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -477,12 +477,12 @@ msgstr "Dueño del edificio"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:230
-#: src/components/PropertiesList.tsx:235
+#: src/components/PropertiesList.tsx:240
+#: src/components/PropertiesList.tsx:245
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PropertiesList.tsx:342
+#: src/components/PropertiesList.tsx:352
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -510,9 +510,9 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PropertiesList.tsx:369
-#: src/components/PropertiesList.tsx:371
-#: src/components/PropertiesList.tsx:375
+#: src/components/PropertiesList.tsx:379
+#: src/components/PropertiesList.tsx:381
+#: src/components/PropertiesList.tsx:385
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -529,11 +529,11 @@ msgstr "Cargando"
 msgid "Loading {0} rows"
 msgstr "Cargando {0} filas"
 
-#: src/components/PropertiesList.tsx:131
+#: src/components/PropertiesList.tsx:136
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/PropertiesSummary.tsx:128
+#: src/components/PropertiesSummary.tsx:130
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
@@ -594,9 +594,9 @@ msgstr "NO CONSTRUCCIÓN"
 msgid "NYCHA Directory"
 msgstr "Directorio de NYCHA"
 
-#: src/containers/HomePage.tsx:109
-msgid "New Method (WOWZA!)"
-msgstr "Nuevo método (¡WOWZA!)"
+#: src/components/PropertiesSummary.tsx:68
+msgid "Network of Landlords"
+msgstr ""
 
 #: src/components/AddressToolbar.tsx:19
 msgid "New Search"
@@ -610,7 +610,7 @@ msgstr "Oficina Regional de Nueva York:"
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/components/PropertiesList.tsx:390
+#: src/components/PropertiesList.tsx:400
 msgid "No"
 msgstr "No"
 
@@ -659,14 +659,10 @@ msgstr "AFUERA DEL EDIFICIO"
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PropertiesList.tsx:298
-#: src/components/PropertiesList.tsx:307
+#: src/components/PropertiesList.tsx:308
+#: src/components/PropertiesList.tsx:317
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
-
-#: src/containers/HomePage.tsx:104
-msgid "Old Method"
-msgstr "Método anterior"
 
 #: src/components/NetworkErrorMessage.tsx:5
 #: src/components/Subscribe.tsx:54
@@ -678,8 +674,8 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:261
-#: src/components/PropertiesList.tsx:266
+#: src/components/PropertiesList.tsx:271
+#: src/components/PropertiesList.tsx:276
 msgid "Open"
 msgstr "Actuales"
 
@@ -687,13 +683,17 @@ msgstr "Actuales"
 msgid "Open Violations"
 msgstr "Violaciones Actuales"
 
-#: src/containers/HomePage.tsx:92
+#: src/containers/HomePage.tsx:91
 msgid "Or search by your landlord's name:"
 msgstr "O busca por el nombre de tu dueño:"
 
 #: src/containers/AddressPage.tsx:110
 msgid "Overview"
 msgstr "General"
+
+#: src/components/PortfolioGraph.tsx:96
+msgid "Owner Names"
+msgstr ""
 
 #: src/components/IndicatorsDatasets.tsx:73
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
@@ -746,11 +746,11 @@ msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:189
+#: src/components/PropertiesList.tsx:199
 msgid "RS Units"
 msgstr "Unidades RS"
 
-#: src/components/PropertiesSummary.tsx:119
+#: src/components/PropertiesSummary.tsx:121
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
@@ -770,7 +770,7 @@ msgstr "FALTA DE SEÑALIZACIÓN"
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
-#: src/containers/App.tsx:69
+#: src/containers/App.tsx:73
 msgid "Search"
 msgstr "Buscar"
 
@@ -795,15 +795,15 @@ msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en l
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:103
-#: src/containers/App.tsx:114
+#: src/containers/App.tsx:112
+#: src/containers/App.tsx:123
 msgid "Share"
 msgstr "Compartir"
 
 #: src/components/DetailView.tsx:246
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:134
-#: src/containers/App.tsx:125
+#: src/components/PropertiesSummary.tsx:136
+#: src/containers/App.tsx:134
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -820,8 +820,8 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:284
-#: src/components/PropertiesList.tsx:289
+#: src/components/PropertiesList.tsx:294
+#: src/components/PropertiesList.tsx:299
 msgid "Since 2017"
 msgstr "Desde 2017"
 
@@ -878,7 +878,7 @@ msgstr "ACOSO DE INQUILINO"
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
 
-#: src/components/PropertiesList.tsx:315
+#: src/components/PropertiesList.tsx:325
 msgid "Tax Exemptions"
 msgstr "Exenciones de impuestos"
 
@@ -907,21 +907,17 @@ msgstr "El edificio con la major cantidad de desalojos es <0>{0} {1}, {2}</0> co
 msgid "The city borough where your search address is located"
 msgstr "El municipio donde se encuentra la dirección que has buscado"
 
-#: src/containers/HomePage.tsx:168
+#: src/containers/HomePage.tsx:154
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
-#: src/components/PropertiesSummary.tsx:109
+#: src/components/PropertiesSummary.tsx:78
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
 #: src/components/ComplaintsSummary.tsx:18
 msgid "The most common {0, plural, one {issue} other {issues}} reported in this portfolio over the last three years {1, plural, one {is} other {are}} <0/>."
 msgstr "{0, plural, one {La queja más común reportada} other {Las quejas más comunes reportadas}} en este portafolio en los últimos tres años {1, plural, one {es} other {son}} <0/>."
-
-#: src/components/PropertiesSummary.tsx:103
-msgid "The most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
-msgstr "{0, plural, one {El nombre más común que aparece en este portafolio de edificios es} other {Los nombres más comunes que aparecen en este portafolio de edificios son}} <0/>."
 
 #: src/components/BuildingStatsTable.tsx:52
 msgid "The number of open HPD violations for this building, updated monthly. Click the HPD Building Profile button below for the most up-to-date information."
@@ -939,11 +935,11 @@ msgstr "El número de unidades residenciales en este edificio, según el Departa
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "El año en que este edificio fue construido, según el Departamento de Planificación de la Ciudad."
 
-#: src/components/PropertiesSummary.tsx:82
+#: src/components/PropertiesSummary.tsx:110
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
-#: src/components/PropertiesSummary.tsx:71
+#: src/components/PropertiesSummary.tsx:99
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
@@ -975,11 +971,11 @@ msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por
 msgid "This is the official identifer for the building according to the Dept. of Finance tax records."
 msgstr "El identificador oficial del edificio según los registros del Departamento de Finanzas."
 
-#: src/components/PropertiesSummary.tsx:137
+#: src/components/PropertiesSummary.tsx:139
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "Este dueño de edificio posee {0} edificios, y según @NYCHousing, ha recibido un total de {1} violaciones del código de vivienda. ¿Puedes adivinar como se llama el dueño? Encuentra su nombre y ve más estadísticas aquí:"
 
-#: src/components/PropertiesSummary.tsx:139
+#: src/components/PropertiesSummary.tsx:141
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "Los edificios de este dueño tienen un promedio de {0} violaciones abiertas de HPD por cada apartamento"
 
@@ -991,7 +987,7 @@ msgstr "Este portafolio de edificios tuvo una <0>{changeType, select, gain {gana
 msgid "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 msgstr "Esta cartera de edificios tiene un promedio de <0>{0}</0> infracciones del HPD Actuales por cada unidad residencial."
 
-#: src/containers/HomePage.tsx:134
+#: src/containers/HomePage.tsx:120
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "Esta empresa de gestión inmobiliaria es propiedad de la familia Kushner y es notoria por <0>violar las normas de vivienda</0> y por <1>comportamientos abusivos</1>. La participación financiera actualmente sostenida por Jared Kushner e Ivanka Trump asciende a 761 millones de dólares."
 
@@ -1019,16 +1015,16 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PropertiesList.tsx:239
 #: src/components/PropertiesList.tsx:249
+#: src/components/PropertiesList.tsx:259
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:338
-#: src/components/PropertiesList.tsx:221
-#: src/components/PropertiesList.tsx:226
-#: src/components/PropertiesList.tsx:270
-#: src/components/PropertiesList.tsx:275
+#: src/components/PropertiesList.tsx:231
+#: src/components/PropertiesList.tsx:236
+#: src/components/PropertiesList.tsx:280
+#: src/components/PropertiesList.tsx:285
 msgid "Total"
 msgstr "Total"
 
@@ -1045,8 +1041,8 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:179
-#: src/components/PropertiesList.tsx:184
+#: src/components/PropertiesList.tsx:189
+#: src/components/PropertiesList.tsx:194
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades"
@@ -1081,9 +1077,9 @@ msgstr "Visualizar por:"
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PropertiesList.tsx:399
-#: src/components/PropertiesList.tsx:405
 #: src/components/PropertiesList.tsx:409
+#: src/components/PropertiesList.tsx:415
+#: src/components/PropertiesList.tsx:419
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -1095,9 +1091,9 @@ msgstr "Ver documentos en <0>ACRIS</0>"
 msgid "View legend"
 msgstr "Ver leyenda"
 
-#: src/containers/HomePage.tsx:149
-#: src/containers/HomePage.tsx:191
-#: src/containers/HomePage.tsx:221
+#: src/containers/HomePage.tsx:135
+#: src/containers/HomePage.tsx:177
+#: src/containers/HomePage.tsx:207
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
@@ -1159,14 +1155,14 @@ msgstr "Qué hay de nuevo"
 msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Quién Es El Dueño es una herramienta gratis construida por JustFix.nyc para investigar los dueños de edificios en NYC. Ha asistido más de 200.000 neoyorquinos a enterarse quien realmente son los responsables por su edificio, cuáles otros edificios su dueño o compañía de administración poseen, y otra información crítica sobre violaciones del código de vivienda, desalojos, apartamentos con renta estabilizada y mucho más en cualquier edificio. Puedes buscar información sobre cualquier edificio residencial, también incluyen viviendas públicas (NYCHA). Busca tu dirección aquí: {url}"
 
-#: src/containers/App.tsx:33
+#: src/containers/App.tsx:35
 msgid "Who owns what in n y c?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:20
 #: src/components/Page.tsx:21
-#: src/containers/App.tsx:30
+#: src/containers/App.tsx:31
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
@@ -1182,16 +1178,16 @@ msgstr "¿Quién es el dueño de este edificio?"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:389
+#: src/components/PropertiesList.tsx:399
 msgid "Yes"
 msgstr "Sí"
 
-#: src/containers/HomePage.tsx:210
+#: src/containers/HomePage.tsx:196
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/components/PropertiesList.tsx:137
 #: src/components/PropertiesList.tsx:142
+#: src/components/PropertiesList.tsx:147
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -1227,7 +1223,7 @@ msgstr "año"
 msgid "{0} of {numberOfEntries}"
 msgstr "{0} de {numberOfEntries}"
 
-#: src/components/PropertiesSummary.tsx:92
+#: src/components/PropertiesSummary.tsx:88
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una violación del HPD actual} other {# violaciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 
@@ -1250,4 +1246,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:35
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2010} other {# Violaciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/styles/PropertiesSummary.scss
+++ b/client/src/styles/PropertiesSummary.scss
@@ -19,6 +19,10 @@
       margin-bottom: 0.6rem;
       text-decoration: underline;
       font-weight: bold;
+      // Override default styling in App.scss
+      &:first-child {
+        width: 100%;
+      }
     }
 
     p {


### PR DESCRIPTION
This PR makes some minor styling and wording adjustments to the Summary tab to make the presence of the portfolio network graph on that page make sense. 

<img width="1226" alt="image" src="https://user-images.githubusercontent.com/12834575/162069948-ce0d48fe-4cef-4dc0-aac8-10217639ae30.png">
