### PR TITLE
Migrate WOWZA routes across the site to the default root pathname

### DIFF
--- a/client/src/components/AddressToolbar.tsx
+++ b/client/src/components/AddressToolbar.tsx
@@ -6,9 +6,11 @@ import "styles/AddressToolbar.css";
 import { Trans } from "@lingui/macro";
 import { SearchAddress } from "./AddressSearch";
 import { useState } from "react";
-import { ToggleButtonBetweenPortfolioMethods } from "./WowzaToggle";
+import { isLegacyPath, ToggleButtonBetweenPortfolioMethods } from "./WowzaToggle";
 import { AddressRecord } from "./APIDataTypes";
 import ExportDataButton from "./ExportData";
+import { useLocation } from "react-router-dom";
+import { createWhoOwnsWhatRoutePaths } from "routes";
 
 export type AddressToolbarProps = {
   searchAddr: SearchAddress;
@@ -19,7 +21,8 @@ const AddressToolbar: React.FC<AddressToolbarProps> = ({ searchAddr, assocAddrs 
   const allowChangingPortfolioMethod =
     process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1";
   const [showExportModal, setExportModalVisibility] = useState(false);
-
+  const { pathname } = useLocation();
+  const { home, legacy } = createWhoOwnsWhatRoutePaths();
   const userAddrStr = `${searchAddr.housenumber} ${searchAddr.streetname}, ${searchAddr.boro}`;
 
   return (
@@ -31,7 +34,7 @@ const AddressToolbar: React.FC<AddressToolbarProps> = ({ searchAddr, assocAddrs 
           onClick={() => {
             window.gtag("event", "new-search");
           }}
-          to="/"
+          to={isLegacyPath(pathname) ? legacy.home : home}
         >
           <Trans>New Search</Trans>
         </Link>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -163,6 +163,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const locale = (i18n.language as SupportedLocale) || defaultLocale;
     const { useNewPortfolioMethod, portfolioData } = this.props.state.context;
     const { assocAddrs, detailAddr, searchAddr } = portfolioData;
+    const { methodology, legacy } = createWhoOwnsWhatRoutePaths();
 
     // Let's save some variables that will be helpful in rendering the front-end component
     let takeActionURL, formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
@@ -393,7 +394,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                 <LocaleLink
                   to={
                     // This link only shows up on our legacy version of WOW:
-                    createWhoOwnsWhatRoutePaths().legacy.methodology
+                    useNewPortfolioMethod ? legacy.methodology : methodology
                   }
                 >
                   our methodology

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -11,7 +11,7 @@ import { withI18n, withI18nProps, I18n } from "@lingui/react";
 import { t, Trans } from "@lingui/macro";
 import { SocialShareAddressPage } from "./SocialShare";
 import { isPartOfGroupSale } from "./PropertiesList";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { LocaleLink } from "../i18n";
 import BuildingStatsTable from "./BuildingStatsTable";
 import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
@@ -21,6 +21,7 @@ import { Accordion } from "./Accordion";
 import { UsefulLinks } from "./UsefulLinks";
 import _groupBy from "lodash/groupBy";
 import { HpdContactAddress, HpdFullContact } from "./APIDataTypes";
+import { isWowzaPath } from "./WowzaToggle";
 
 type Props = withI18nProps &
   withMachineInStateProps<"portfolioFound"> & {
@@ -95,39 +96,43 @@ const HpdContactCard: React.FC<{ contact: GroupedContact }> = ({ contact }) => (
   </I18n>
 );
 
-const LearnMoreAccordion = () => (
-  <I18n>
-    {({ i18n }) => (
-      <Accordion title={i18n._(t`Learn more`)} titleOnOpen={i18n._(t`Close`)}>
-        <br />
-        <Trans>
-          <p>
-            While the legal owner of a building is often a company (usually called an “LLC”), these
-            names and business addresses registered with HPD offer a clearer picture of who really
-            controls the building.
-          </p>
-          <p>
-            People listed here as “Head Officer” or “Owner” usually have ties to building ownership,
-            while “Site Managers” are part of management. That being said, these names are self
-            reported by the landlord, so they can be misleading.
-          </p>
-          <p>
-            Learn more about HPD registrations and how this information powers this tool on the{" "}
-            <LocaleLink
-              to={createWhoOwnsWhatRoutePaths().about}
-              onClick={() => {
-                window.gtag("event", "about-page-overview-tab");
-              }}
-            >
-              About page
-            </LocaleLink>
-            .
-          </p>
-        </Trans>
-      </Accordion>
-    )}
-  </I18n>
-);
+const LearnMoreAccordion = () => {
+  const { pathname } = useLocation();
+  const { about, legacy } = createWhoOwnsWhatRoutePaths();
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <Accordion title={i18n._(t`Learn more`)} titleOnOpen={i18n._(t`Close`)}>
+          <br />
+          <Trans>
+            <p>
+              While the legal owner of a building is often a company (usually called an “LLC”),
+              these names and business addresses registered with HPD offer a clearer picture of who
+              really controls the building.
+            </p>
+            <p>
+              People listed here as “Head Officer” or “Owner” usually have ties to building
+              ownership, while “Site Managers” are part of management. That being said, these names
+              are self reported by the landlord, so they can be misleading.
+            </p>
+            <p>
+              Learn more about HPD registrations and how this information powers this tool on the{" "}
+              <LocaleLink
+                to={isWowzaPath(pathname) ? about : legacy.about}
+                onClick={() => {
+                  window.gtag("event", "about-page-overview-tab");
+                }}
+              >
+                About page
+              </LocaleLink>
+              .
+            </p>
+          </Trans>
+        </Accordion>
+      )}
+    </I18n>
+  );
+};
 
 const HowIsBldgAssociatedHeader = () => (
   <Trans>How is this building associated to this portfolio?</Trans>
@@ -385,7 +390,12 @@ class DetailViewWithoutI18n extends Component<Props, State> {
               <Trans render="p">
                 We compare your search address with a database of over 200k buildings to identify a
                 landlord or management company's portfolio. To learn more, check out{" "}
-                <LocaleLink to={createWhoOwnsWhatRoutePaths().methodology}>
+                <LocaleLink
+                  to={
+                    //This link only shows up on our legacy version of WOW:
+                    createWhoOwnsWhatRoutePaths().legacy.methodology
+                  }
+                >
                   our methodology
                 </LocaleLink>
                 .

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -138,6 +138,20 @@ const HowIsBldgAssociatedHeader = () => (
   <Trans>How is this building associated to this portfolio?</Trans>
 );
 
+const HowIsBldgAssociatedDescription = () => {
+  const { pathname } = useLocation();
+  const { methodology, legacy } = createWhoOwnsWhatRoutePaths();
+  return (
+    <Trans render="p">
+      We compare your search address with a database of over 200k buildings to identify a landlord
+      or management company's portfolio. To learn more, check out{" "}
+      <LocaleLink to={isLegacyPath(pathname) ? legacy.methodology : methodology}>
+        our methodology
+      </LocaleLink>
+      .
+    </Trans>
+  );
+};
 class DetailViewWithoutI18n extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -163,7 +177,6 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const locale = (i18n.language as SupportedLocale) || defaultLocale;
     const { useNewPortfolioMethod, portfolioData } = this.props.state.context;
     const { assocAddrs, detailAddr, searchAddr } = portfolioData;
-    const { methodology, legacy } = createWhoOwnsWhatRoutePaths();
 
     // Let's save some variables that will be helpful in rendering the front-end component
     let takeActionURL, formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
@@ -388,19 +401,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                   <HowIsBldgAssociatedHeader />
                 </b>
               </h6>
-              <Trans render="p">
-                We compare your search address with a database of over 200k buildings to identify a
-                landlord or management company's portfolio. To learn more, check out{" "}
-                <LocaleLink
-                  to={
-                    // This link only shows up on our legacy version of WOW:
-                    useNewPortfolioMethod ? legacy.methodology : methodology
-                  }
-                >
-                  our methodology
-                </LocaleLink>
-                .
-              </Trans>
+              <HowIsBldgAssociatedDescription />
               <table className="DetailView__compareTable">
                 <thead>
                   <tr>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -21,7 +21,7 @@ import { Accordion } from "./Accordion";
 import { UsefulLinks } from "./UsefulLinks";
 import _groupBy from "lodash/groupBy";
 import { HpdContactAddress, HpdFullContact } from "./APIDataTypes";
-import { isWowzaPath } from "./WowzaToggle";
+import { isLegacyPath } from "./WowzaToggle";
 
 type Props = withI18nProps &
   withMachineInStateProps<"portfolioFound"> & {
@@ -118,7 +118,7 @@ const LearnMoreAccordion = () => {
             <p>
               Learn more about HPD registrations and how this information powers this tool on the{" "}
               <LocaleLink
-                to={isWowzaPath(pathname) ? about : legacy.about}
+                to={isLegacyPath(pathname) ? legacy.about : about}
                 onClick={() => {
                   window.gtag("event", "about-page-overview-tab");
                 }}
@@ -392,7 +392,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                 landlord or management company's portfolio. To learn more, check out{" "}
                 <LocaleLink
                   to={
-                    //This link only shows up on our legacy version of WOW:
+                    // This link only shows up on our legacy version of WOW:
                     createWhoOwnsWhatRoutePaths().legacy.methodology
                   }
                 >

--- a/client/src/components/LandlordSearch.tsx
+++ b/client/src/components/LandlordSearch.tsx
@@ -83,7 +83,7 @@ const SearchHits = ({ hits }: SearchHitsProps) => {
             .map((hit: Hit) => (
               <Link
                 key={hit.portfolio_bbl}
-                to={createRouteForFullBbl(hit.portfolio_bbl, i18n.language, true)}
+                to={createRouteForFullBbl(hit.portfolio_bbl, i18n.language)}
                 className="algolia__item"
                 aria-hidden="true" // Make sure search results don't get announced until user is focused on them
               >

--- a/client/src/components/LegalFooter.tsx
+++ b/client/src/components/LegalFooter.tsx
@@ -5,7 +5,7 @@ import "styles/LegalFooter.css";
 import { Trans } from "@lingui/macro";
 import { createWhoOwnsWhatRoutePaths } from "../routes";
 import { useLocation } from "react-router-dom";
-import { isWowzaPath } from "./WowzaToggle";
+import { isLegacyPath } from "./WowzaToggle";
 
 const LegalFooter = () => {
   const { termsOfUse, privacyPolicy, methodology, legacy } = createWhoOwnsWhatRoutePaths();
@@ -41,14 +41,14 @@ const LegalFooter = () => {
               >
                 <Trans>Donate</Trans>
               </a>
-              <NavLink to={isWowzaPath(pathname) ? termsOfUse : legacy.termsOfUse}>
+              <NavLink to={isLegacyPath(pathname) ? legacy.termsOfUse : termsOfUse}>
                 <Trans>Terms of use</Trans>
               </NavLink>
-              <NavLink to={isWowzaPath(pathname) ? privacyPolicy : legacy.privacyPolicy}>
+              <NavLink to={isLegacyPath(pathname) ? legacy.privacyPolicy : privacyPolicy}>
                 <Trans>Privacy policy</Trans>
               </NavLink>
               <br className="hide-md" />
-              <NavLink to={isWowzaPath(pathname) ? methodology : legacy.methodology}>
+              <NavLink to={isLegacyPath(pathname) ? legacy.methodology : methodology}>
                 <Trans>Methodology</Trans>
               </NavLink>
               <a

--- a/client/src/components/LegalFooter.tsx
+++ b/client/src/components/LegalFooter.tsx
@@ -4,74 +4,75 @@ import { LocaleNavLink as NavLink } from "../i18n";
 import "styles/LegalFooter.css";
 import { Trans } from "@lingui/macro";
 import { createWhoOwnsWhatRoutePaths } from "../routes";
+import { useLocation } from "react-router-dom";
+import { isWowzaPath } from "./WowzaToggle";
 
-class LegalFooter extends Component {
-  render() {
-    const paths = createWhoOwnsWhatRoutePaths();
-    return (
-      <div className="Footer LegalFooter container">
-        <div className="columns">
-          <div className="Disclaimer column col-8 col-md-12">
+const LegalFooter = () => {
+  const { termsOfUse, privacyPolicy, methodology, legacy } = createWhoOwnsWhatRoutePaths();
+  const { pathname } = useLocation();
+  return (
+    <div className="Footer LegalFooter container">
+      <div className="columns">
+        <div className="Disclaimer column col-8 col-md-12">
+          <p>
+            <Trans>
+              Disclaimer: The information in JustFix.nyc does not constitute legal advice and must
+              not be used as a substitute for the advice of a lawyer qualified to give advice on
+              legal issues pertaining to housing. We can help direct you to free legal services if
+              necessary.
+            </Trans>
+          </p>
+          <p>
+            <Trans>JustFix, Inc is a registered 501(c)(3) nonprofit organization.</Trans>
+          </p>
+        </div>
+        <div className="Links column col-4 col-md-12">
+          <div className="d-flex">
             <p>
               <Trans>
-                Disclaimer: The information in JustFix.nyc does not constitute legal advice and must
-                not be used as a substitute for the advice of a lawyer qualified to give advice on
-                legal issues pertaining to housing. We can help direct you to free legal services if
-                necessary.
+                Made with NYC ♥ by the team at <a href="https://www.justfix.nyc/">JustFix.nyc</a>
               </Trans>
             </p>
-            <p>
-              <Trans>JustFix, Inc is a registered 501(c)(3) nonprofit organization.</Trans>
-            </p>
-          </div>
-          <div className="Links column col-4 col-md-12">
-            <div className="d-flex">
-              <p>
-                <Trans>
-                  Made with NYC ♥ by the team at <a href="https://www.justfix.nyc/">JustFix.nyc</a>
-                </Trans>
-              </p>
-              <nav className="inline">
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://donorbox.org/donate-to-justfix-nyc"
-                >
-                  <Trans>Donate</Trans>
-                </a>
-                <NavLink to={paths.termsOfUse}>
-                  <Trans>Terms of use</Trans>
-                </NavLink>
-                <NavLink to={paths.privacyPolicy}>
-                  <Trans>Privacy policy</Trans>
-                </NavLink>
-                <br className="hide-md" />
-                <NavLink to={paths.methodology}>
-                  <Trans>Methodology</Trans>
-                </NavLink>
-                <a
-                  href="https://github.com/JustFixNYC/who-owns-what"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Trans>Source code</Trans>
-                </a>
-              </nav>
-              <div className="hide-md">
-                <a href="https://www.netlify.com" target="_blank" rel="noopener noreferrer">
-                  <img
-                    src="https://www.netlify.com/img/global/badges/netlify-dark.svg"
-                    alt="Netlify"
-                    width="75"
-                  />
-                </a>
-              </div>
+            <nav className="inline">
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://donorbox.org/donate-to-justfix-nyc"
+              >
+                <Trans>Donate</Trans>
+              </a>
+              <NavLink to={isWowzaPath(pathname) ? termsOfUse : legacy.termsOfUse}>
+                <Trans>Terms of use</Trans>
+              </NavLink>
+              <NavLink to={isWowzaPath(pathname) ? privacyPolicy : legacy.privacyPolicy}>
+                <Trans>Privacy policy</Trans>
+              </NavLink>
+              <br className="hide-md" />
+              <NavLink to={isWowzaPath(pathname) ? methodology : legacy.methodology}>
+                <Trans>Methodology</Trans>
+              </NavLink>
+              <a
+                href="https://github.com/JustFixNYC/who-owns-what"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Trans>Source code</Trans>
+              </a>
+            </nav>
+            <div className="hide-md">
+              <a href="https://www.netlify.com" target="_blank" rel="noopener noreferrer">
+                <img
+                  src="https://www.netlify.com/img/global/badges/netlify-dark.svg"
+                  alt="Netlify"
+                  width="75"
+                />
+              </a>
             </div>
           </div>
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 export default LegalFooter;

--- a/client/src/components/LegalFooter.tsx
+++ b/client/src/components/LegalFooter.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import { LocaleNavLink as NavLink } from "../i18n";
 
 import "styles/LegalFooter.css";

--- a/client/src/components/WowzaToggle.test.tsx
+++ b/client/src/components/WowzaToggle.test.tsx
@@ -1,11 +1,10 @@
-import { getPathForOtherPortfolioMethod, isWowzaPath } from "./WowzaToggle";
+import { getPathForOtherPortfolioMethod, isLegacyPath } from "./WowzaToggle";
 
-describe("isWowzaPath()", () => {
+describe("isLegacyPath()", () => {
   it("works", () => {
-    expect(isWowzaPath("/boop")).toBe(true);
-    expect(isWowzaPath("/wowza")).toBe(true);
-    expect(isWowzaPath("/en/address/1425/wowza/avenue")).toBe(true);
-    expect(isWowzaPath("/en/legacy/blah?bee=1")).toBe(false);
+    expect(isLegacyPath("/boop")).toBe(false);
+    expect(isLegacyPath("/en/address/1425/wowza/avenue")).toBe(false);
+    expect(isLegacyPath("/en/legacy/blah?bee=1")).toBe(true);
   });
 });
 

--- a/client/src/components/WowzaToggle.test.tsx
+++ b/client/src/components/WowzaToggle.test.tsx
@@ -2,16 +2,16 @@ import { getPathForOtherPortfolioMethod, isWowzaPath } from "./WowzaToggle";
 
 describe("isWowzaPath()", () => {
   it("works", () => {
-    expect(isWowzaPath("/boop")).toBe(false);
-    expect(isWowzaPath("/wowza")).toBe(false);
-    expect(isWowzaPath("/en/address/1425/wowza/avenue")).toBe(false);
-    expect(isWowzaPath("/en/wowza/blah?bee=1")).toBe(true);
+    expect(isWowzaPath("/boop")).toBe(true);
+    expect(isWowzaPath("/wowza")).toBe(true);
+    expect(isWowzaPath("/en/address/1425/wowza/avenue")).toBe(true);
+    expect(isWowzaPath("/en/legacy/blah?bee=1")).toBe(false);
   });
 });
 
 describe("getPathForOtherPortfolioMethod()", () => {
   it("works", () => {
-    expect(getPathForOtherPortfolioMethod("/en/address/boop")).toBe("/en/wowza/address/boop");
-    expect(getPathForOtherPortfolioMethod("/es/wowza/address/blah")).toBe("/es/address/blah");
+    expect(getPathForOtherPortfolioMethod("/en/address/boop")).toBe("/en/legacy/address/boop");
+    expect(getPathForOtherPortfolioMethod("/es/legacy/address/blah")).toBe("/es/address/blah");
   });
 });

--- a/client/src/components/WowzaToggle.tsx
+++ b/client/src/components/WowzaToggle.tsx
@@ -4,17 +4,17 @@ import React from "react";
 import { useHistory, useLocation } from "react-router-dom";
 
 /**
- * Determines whether a url corresponds to a new WOWZA portfolio mapping page vs an original.
+ * Determines whether a url corresponds to a new WOWZA portfolio mapping page vs an old legacy page.
  */
-export const isWowzaPath = (pathname: string) =>
-  !removeLocalePrefix(pathname).startsWith("/legacy");
+export const isLegacyPath = (pathname: string) =>
+  removeLocalePrefix(pathname).startsWith("/legacy");
 
 /**
  * If the user is on a normal WOW address page, this function generates a pathname for the corresponding
  * WOWZA page with updated portfolio mapping, and vice versa.
  */
 export const getPathForOtherPortfolioMethod = (pathname: string) => {
-  if (!isWowzaPath(pathname)) {
+  if (isLegacyPath(pathname)) {
     return pathname.replace("/legacy", "");
   } else {
     const locale = parseLocaleFromPath(pathname);
@@ -33,10 +33,10 @@ export const ToggleButtonBetweenPortfolioMethods = () => {
         history.go(0);
       }}
     >
-      {isWowzaPath(pathname) ? (
-        <Trans>Switch to Old Version</Trans>
-      ) : (
+      {isLegacyPath(pathname) ? (
         <Trans>Switch to New Version</Trans>
+      ) : (
+        <Trans>Switch to Old Version</Trans>
       )}
     </button>
   );

--- a/client/src/components/WowzaToggle.tsx
+++ b/client/src/components/WowzaToggle.tsx
@@ -6,18 +6,19 @@ import { useHistory, useLocation } from "react-router-dom";
 /**
  * Determines whether a url corresponds to a new WOWZA portfolio mapping page vs an original.
  */
-export const isWowzaPath = (pathname: string) => removeLocalePrefix(pathname).startsWith("/wowza");
+export const isWowzaPath = (pathname: string) =>
+  !removeLocalePrefix(pathname).startsWith("/legacy");
 
 /**
  * If the user is on a normal WOW address page, this function generates a pathname for the corresponding
  * WOWZA page with updated portfolio mapping, and vice versa.
  */
 export const getPathForOtherPortfolioMethod = (pathname: string) => {
-  if (isWowzaPath(pathname)) {
-    return pathname.replace("/wowza", "");
+  if (!isWowzaPath(pathname)) {
+    return pathname.replace("/legacy", "");
   } else {
     const locale = parseLocaleFromPath(pathname);
-    return `/${locale}/wowza${removeLocalePrefix(pathname)}`;
+    return `/${locale}/legacy${removeLocalePrefix(pathname)}`;
   }
 };
 

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -126,7 +126,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
       const { assocAddrs, searchAddr } = state.context.portfolioData;
       const routes = createAddressPageRoutes(
         validateRouteParams(this.props.match.params),
-        useNewPortfolioMethod
+        !useNewPortfolioMethod
       );
 
       return (

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -50,7 +50,7 @@ const HomeLink = withI18n()((props: withI18nProps) => {
       onClick={() => {
         window.gtag("event", "site-title");
       }}
-      to={isWowzaPath(pathname) ? "/wowza" : "/"}
+      to={isWowzaPath(pathname) ? "/" : "/legacy"}
     >
       <h4>{widont(title)}</h4>
     </Link>
@@ -63,60 +63,57 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
   const machineProps = { state, send };
   return (
     <Switch>
-      <Route exact path={paths.home} component={HomePage} />
+      <Route exact path={paths.legacyHome} component={HomePage} />
       <Route
         exact
-        path={paths.wowzaHome}
+        path={paths.home}
         render={(props) => <HomePage useNewPortfolioMethod {...machineProps} {...props} />}
       />
       <Route
-        path={paths.addressPage.overview}
+        path={paths.legacyAddressPage.overview}
         render={(props) => <AddressPage currentTab={0} {...machineProps} {...props} />}
         exact
       />
       <Route
-        path={paths.addressPage.timeline}
+        path={paths.legacyAddressPage.timeline}
         render={(props) => <AddressPage currentTab={1} {...machineProps} {...props} />}
       />
       <Route
-        path={paths.addressPage.portfolio}
+        path={paths.legacyAddressPage.portfolio}
         render={(props) => <AddressPage currentTab={2} {...machineProps} {...props} />}
       />
       <Route
-        path={paths.addressPage.summary}
+        path={paths.legacyAddressPage.summary}
         render={(props) => <AddressPage currentTab={3} {...machineProps} {...props} />}
       />
       <Route
-        path={paths.wowzaAddressPage.overview}
+        path={paths.addressPage.overview}
         render={(props) => (
           <AddressPage currentTab={0} {...machineProps} {...props} useNewPortfolioMethod />
         )}
         exact
       />
       <Route
-        path={paths.wowzaAddressPage.timeline}
+        path={paths.addressPage.timeline}
         render={(props) => (
           <AddressPage currentTab={1} {...machineProps} {...props} useNewPortfolioMethod />
         )}
       />
       <Route
-        path={paths.wowzaAddressPage.portfolio}
+        path={paths.addressPage.portfolio}
         render={(props) => (
           <AddressPage currentTab={2} {...machineProps} {...props} useNewPortfolioMethod />
         )}
       />
       <Route
-        path={paths.wowzaAddressPage.summary}
+        path={paths.addressPage.summary}
         render={(props) => (
           <AddressPage currentTab={3} {...machineProps} {...props} useNewPortfolioMethod />
         )}
       />
       <Route path={paths.bblSeparatedIntoParts} component={BBLPage} />
-      <Route path={paths.bbl} component={BBLPage} />
-      <Route
-        path={paths.wowzaBbl}
-        render={(props) => <BBLPage {...props} useNewPortfolioMethod />}
-      />
+      <Route path={paths.legacyBbl} component={BBLPage} />
+      <Route path={paths.bbl} render={(props) => <BBLPage {...props} useNewPortfolioMethod />} />
       <Route path={paths.about} component={AboutPage} />
       <Route path={paths.howToUse} component={HowToUsePage} />
       <Route path={paths.methodology} component={MethodologyPage} />
@@ -130,8 +127,8 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
 
 const SearchLink = () => {
   const { pathname } = useLocation();
-  const { home, wowzaHome } = createWhoOwnsWhatRoutePaths();
-  const searchRoute = isWowzaPath(pathname) ? wowzaHome : home;
+  const { home, legacyHome } = createWhoOwnsWhatRoutePaths();
+  const searchRoute = isWowzaPath(pathname) ? home : legacyHome;
 
   return (
     <LocaleNavLink exact to={searchRoute} key={1}>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -63,27 +63,27 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
   const machineProps = { state, send };
   return (
     <Switch>
-      <Route exact path={paths.legacyHome} component={HomePage} />
+      <Route exact path={paths.legacy.home} component={HomePage} />
       <Route
         exact
         path={paths.home}
         render={(props) => <HomePage useNewPortfolioMethod {...machineProps} {...props} />}
       />
       <Route
-        path={paths.legacyAddressPage.overview}
+        path={paths.legacy.addressPage.overview}
         render={(props) => <AddressPage currentTab={0} {...machineProps} {...props} />}
         exact
       />
       <Route
-        path={paths.legacyAddressPage.timeline}
+        path={paths.legacy.addressPage.timeline}
         render={(props) => <AddressPage currentTab={1} {...machineProps} {...props} />}
       />
       <Route
-        path={paths.legacyAddressPage.portfolio}
+        path={paths.legacy.addressPage.portfolio}
         render={(props) => <AddressPage currentTab={2} {...machineProps} {...props} />}
       />
       <Route
-        path={paths.legacyAddressPage.summary}
+        path={paths.legacy.addressPage.summary}
         render={(props) => <AddressPage currentTab={3} {...machineProps} {...props} />}
       />
       <Route
@@ -112,7 +112,7 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
         )}
       />
       <Route path={paths.bblSeparatedIntoParts} component={BBLPage} />
-      <Route path={paths.legacyBbl} component={BBLPage} />
+      <Route path={paths.legacy.bbl} component={BBLPage} />
       <Route path={paths.bbl} render={(props) => <BBLPage {...props} useNewPortfolioMethod />} />
       <Route path={paths.about} component={AboutPage} />
       <Route path={paths.howToUse} component={HowToUsePage} />
@@ -127,8 +127,8 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
 
 const SearchLink = () => {
   const { pathname } = useLocation();
-  const { home, legacyHome } = createWhoOwnsWhatRoutePaths();
-  const searchRoute = isWowzaPath(pathname) ? home : legacyHome;
+  const { home, legacy } = createWhoOwnsWhatRoutePaths();
+  const searchRoute = isWowzaPath(pathname) ? home : legacy.home;
 
   return (
     <LocaleNavLink exact to={searchRoute} key={1}>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -35,7 +35,7 @@ import { wowMachine } from "state-machine";
 import { NotFoundPage } from "./NotFoundPage";
 import widont from "widont";
 import { Dropdown } from "components/Dropdown";
-import { isWowzaPath } from "components/WowzaToggle";
+import { isLegacyPath } from "components/WowzaToggle";
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -51,7 +51,7 @@ const HomeLink = withI18n()((props: withI18nProps) => {
       onClick={() => {
         window.gtag("event", "site-title");
       }}
-      to={isWowzaPath(pathname) ? home : legacy.home}
+      to={isLegacyPath(pathname) ? legacy.home : home}
     >
       <h4>{widont(title)}</h4>
     </Link>
@@ -134,7 +134,7 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
 const SearchLink = () => {
   const { pathname } = useLocation();
   const { home, legacy } = createWhoOwnsWhatRoutePaths();
-  const searchRoute = isWowzaPath(pathname) ? home : legacy.home;
+  const searchRoute = isLegacyPath(pathname) ? legacy.home : home;
 
   return (
     <LocaleNavLink exact to={searchRoute} key={1}>
@@ -143,14 +143,14 @@ const SearchLink = () => {
   );
 };
 
-const getMainNavLinks = (isWowzaPath?: boolean) => {
+const getMainNavLinks = (isLegacyPath?: boolean) => {
   const { about, howToUse, legacy } = createWhoOwnsWhatRoutePaths();
   return [
     <SearchLink />,
-    <LocaleNavLink to={isWowzaPath ? about : legacy.about} key={2}>
+    <LocaleNavLink to={isLegacyPath ? legacy.about : about} key={2}>
       <Trans>About</Trans>
     </LocaleNavLink>,
-    <LocaleNavLink to={isWowzaPath ? howToUse : legacy.howToUse} key={3}>
+    <LocaleNavLink to={isLegacyPath ? legacy.howToUse : howToUse} key={3}>
       <Trans>How to use</Trans>
     </LocaleNavLink>,
     <a href="https://www.justfix.nyc/donate" key={4}>
@@ -175,7 +175,7 @@ const Navbar = () => {
       <nav className="inline">
         {addFeatureCalloutWidget && <FeatureCalloutWidget />}
         <span className="hide-lg">
-          {getMainNavLinks(isWowzaPath(pathname))}
+          {getMainNavLinks(isLegacyPath(pathname))}
           {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
           <a href="#" onClick={() => setEngageModalVisibility(true)}>
             <Trans>Share</Trans>
@@ -183,7 +183,7 @@ const Navbar = () => {
           <LocaleSwitcher />
         </span>
         <Dropdown>
-          {getMainNavLinks(isWowzaPath(pathname)).map((link, i) => (
+          {getMainNavLinks(isLegacyPath(pathname)).map((link, i) => (
             <li className="menu-item" key={i}>
               {link}
             </li>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -41,6 +41,7 @@ const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const title = i18n._(t`Who owns what in nyc?`);
 
+  const { home, legacy } = createWhoOwnsWhatRoutePaths();
   const { pathname } = useLocation();
 
   return (
@@ -50,7 +51,7 @@ const HomeLink = withI18n()((props: withI18nProps) => {
       onClick={() => {
         window.gtag("event", "site-title");
       }}
-      to={isWowzaPath(pathname) ? "/" : "/legacy"}
+      to={isWowzaPath(pathname) ? home : legacy.home}
     >
       <h4>{widont(title)}</h4>
     </Link>
@@ -115,10 +116,15 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
       <Route path={paths.legacy.bbl} component={BBLPage} />
       <Route path={paths.bbl} render={(props) => <BBLPage {...props} useNewPortfolioMethod />} />
       <Route path={paths.about} component={AboutPage} />
+      <Route path={paths.legacy.about} component={AboutPage} />
       <Route path={paths.howToUse} component={HowToUsePage} />
+      <Route path={paths.legacy.howToUse} component={HowToUsePage} />
       <Route path={paths.methodology} component={MethodologyPage} />
+      <Route path={paths.legacy.methodology} component={MethodologyPage} />
       <Route path={paths.termsOfUse} component={TermsOfUsePage} />
+      <Route path={paths.legacy.termsOfUse} component={TermsOfUsePage} />
       <Route path={paths.privacyPolicy} component={PrivacyPolicyPage} />
+      <Route path={paths.legacy.privacyPolicy} component={PrivacyPolicyPage} />
       <Route path={paths.dev} component={DevPage} />
       <Route component={NotFoundPage} />
     </Switch>
@@ -137,14 +143,14 @@ const SearchLink = () => {
   );
 };
 
-const getMainNavLinks = () => {
-  const paths = createWhoOwnsWhatRoutePaths();
+const getMainNavLinks = (isWowzaPath?: boolean) => {
+  const { about, howToUse, legacy } = createWhoOwnsWhatRoutePaths();
   return [
     <SearchLink />,
-    <LocaleNavLink to={paths.about} key={2}>
+    <LocaleNavLink to={isWowzaPath ? about : legacy.about} key={2}>
       <Trans>About</Trans>
     </LocaleNavLink>,
-    <LocaleNavLink to={paths.howToUse} key={3}>
+    <LocaleNavLink to={isWowzaPath ? howToUse : legacy.howToUse} key={3}>
       <Trans>How to use</Trans>
     </LocaleNavLink>,
     <a href="https://www.justfix.nyc/donate" key={4}>
@@ -153,13 +159,58 @@ const getMainNavLinks = () => {
   ];
 };
 
-const App = () => {
+const Navbar = () => {
+  const { pathname } = useLocation();
   const [isEngageModalVisible, setEngageModalVisibility] = useState(false);
-
-  const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
   const addFeatureCalloutWidget = process.env.REACT_APP_ENABLE_FEATURE_CALLOUT_WIDGET === "1";
-  const version = process.env.REACT_APP_VERSION;
+  const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
+  return (
+    <div className="App__header navbar">
+      <HomeLink />
+      {isDemoSite && (
+        <span className="label label-warning ml-2 text-uppercase">
+          <Trans>Demo Site</Trans>
+        </span>
+      )}
+      <nav className="inline">
+        {addFeatureCalloutWidget && <FeatureCalloutWidget />}
+        <span className="hide-lg">
+          {getMainNavLinks(isWowzaPath(pathname))}
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a href="#" onClick={() => setEngageModalVisibility(true)}>
+            <Trans>Share</Trans>
+          </a>
+          <LocaleSwitcher />
+        </span>
+        <Dropdown>
+          {getMainNavLinks(isWowzaPath(pathname)).map((link, i) => (
+            <li className="menu-item" key={i}>
+              {link}
+            </li>
+          ))}
+          <li className="menu-item">
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <a href="#" onClick={() => setEngageModalVisibility(true)}>
+              <Trans>Share</Trans>
+            </a>
+          </li>
+          <li className="menu-item">
+            <LocaleSwitcherWithFullLanguageName />
+          </li>
+        </Dropdown>
+      </nav>
+      <Modal showModal={isEngageModalVisible} onClose={() => setEngageModalVisibility(false)}>
+        <h5 className="first-header">
+          <Trans>Share this page with your neighbors</Trans>
+        </h5>
+        <SocialShare location="share-modal" />
+      </Modal>
+    </div>
+  );
+};
 
+const App = () => {
+  const version = process.env.REACT_APP_VERSION;
   return (
     <Router>
       <I18n>
@@ -172,51 +223,7 @@ const App = () => {
             />
           )}
           <div className="App">
-            <div className="App__header navbar">
-              <HomeLink />
-              {isDemoSite && (
-                <span className="label label-warning ml-2 text-uppercase">
-                  <Trans>Demo Site</Trans>
-                </span>
-              )}
-              <nav className="inline">
-                {addFeatureCalloutWidget && <FeatureCalloutWidget />}
-                <span className="hide-lg">
-                  {getMainNavLinks()}
-                  {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                  <a href="#" onClick={() => setEngageModalVisibility(true)}>
-                    <Trans>Share</Trans>
-                  </a>
-                  <LocaleSwitcher />
-                </span>
-                <Dropdown>
-                  {getMainNavLinks().map((link, i) => (
-                    <li className="menu-item" key={i}>
-                      {link}
-                    </li>
-                  ))}
-                  <li className="menu-item">
-                    {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                    <a href="#" onClick={() => setEngageModalVisibility(true)}>
-                      <Trans>Share</Trans>
-                    </a>
-                  </li>
-                  <li className="menu-item">
-                    <LocaleSwitcherWithFullLanguageName />
-                  </li>
-                </Dropdown>
-              </nav>
-
-              <Modal
-                showModal={isEngageModalVisible}
-                onClose={() => setEngageModalVisibility(false)}
-              >
-                <h5 className="first-header">
-                  <Trans>Share this page with your neighbors</Trans>
-                </h5>
-                <SocialShare location="share-modal" />
-              </Modal>
-            </div>
+            <Navbar />
             <div className="App__body">
               <WhoOwnsWhatRoutes />
             </div>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -62,13 +62,21 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
   const paths = createWhoOwnsWhatRoutePaths("/:locale");
   const [state, send] = useMachine(wowMachine);
   const machineProps = { state, send };
+  const allowChangingPortfolioMethod =
+    process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1";
   return (
     <Switch>
       <Route exact path={paths.legacy.home} component={HomePage} />
       <Route
         exact
         path={paths.home}
-        render={(props) => <HomePage useNewPortfolioMethod {...machineProps} {...props} />}
+        render={(props) => (
+          <HomePage
+            useNewPortfolioMethod={allowChangingPortfolioMethod}
+            {...machineProps}
+            {...props}
+          />
+        )}
       />
       <Route
         path={paths.legacy.addressPage.overview}
@@ -90,31 +98,56 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
       <Route
         path={paths.addressPage.overview}
         render={(props) => (
-          <AddressPage currentTab={0} {...machineProps} {...props} useNewPortfolioMethod />
+          <AddressPage
+            currentTab={0}
+            {...machineProps}
+            {...props}
+            useNewPortfolioMethod={allowChangingPortfolioMethod}
+          />
         )}
         exact
       />
       <Route
         path={paths.addressPage.timeline}
         render={(props) => (
-          <AddressPage currentTab={1} {...machineProps} {...props} useNewPortfolioMethod />
+          <AddressPage
+            currentTab={1}
+            {...machineProps}
+            {...props}
+            useNewPortfolioMethod={allowChangingPortfolioMethod}
+          />
         )}
       />
       <Route
         path={paths.addressPage.portfolio}
         render={(props) => (
-          <AddressPage currentTab={2} {...machineProps} {...props} useNewPortfolioMethod />
+          <AddressPage
+            currentTab={2}
+            {...machineProps}
+            {...props}
+            useNewPortfolioMethod={allowChangingPortfolioMethod}
+          />
         )}
       />
       <Route
         path={paths.addressPage.summary}
         render={(props) => (
-          <AddressPage currentTab={3} {...machineProps} {...props} useNewPortfolioMethod />
+          <AddressPage
+            currentTab={3}
+            {...machineProps}
+            {...props}
+            useNewPortfolioMethod={allowChangingPortfolioMethod}
+          />
         )}
       />
       <Route path={paths.bblSeparatedIntoParts} component={BBLPage} />
       <Route path={paths.legacy.bbl} component={BBLPage} />
-      <Route path={paths.bbl} render={(props) => <BBLPage {...props} useNewPortfolioMethod />} />
+      <Route
+        path={paths.bbl}
+        render={(props) => (
+          <BBLPage {...props} useNewPortfolioMethod={allowChangingPortfolioMethod} />
+        )}
+      />
       <Route path={paths.about} component={AboutPage} />
       <Route path={paths.legacy.about} component={AboutPage} />
       <Route path={paths.howToUse} component={HowToUsePage} />

--- a/client/src/containers/BBLPage.tsx
+++ b/client/src/containers/BBLPage.tsx
@@ -64,7 +64,7 @@ const BBLPage: React.FC<BBLPageProps> = (props) => {
               ...results.result[0],
               locale,
             },
-            props.useNewPortfolioMethod
+            !props.useNewPortfolioMethod
           );
           history.replace(addressPage);
         })

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -83,7 +83,7 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
     if (error) {
       window.gtag("event", "search-error");
     } else {
-      const addressPage = createRouteForAddressPage(searchAddress, useNewPortfolioMethod);
+      const addressPage = createRouteForAddressPage(searchAddress, !useNewPortfolioMethod);
       history.push(addressPage);
     }
   };
@@ -95,7 +95,7 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
         housenumber: "89",
         streetname: "HICKS STREET",
       },
-      useNewPortfolioMethod
+      !useNewPortfolioMethod
     ),
     createRouteForAddressPage(
       {
@@ -103,7 +103,7 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
         housenumber: "4125",
         streetname: "CASE STREET",
       },
-      useNewPortfolioMethod
+      !useNewPortfolioMethod
     ),
     createRouteForAddressPage(
       {
@@ -111,7 +111,7 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
         housenumber: "196",
         streetname: "RALPH AVENUE",
       },
-      useNewPortfolioMethod
+      !useNewPortfolioMethod
     ),
   ];
 

--- a/client/src/routes.test.tsx
+++ b/client/src/routes.test.tsx
@@ -26,7 +26,7 @@ describe("createAddressPageRoutes()", () => {
     ).toBe("/es/legacy/address/BROOKLYN/654/PARK%20PLACE/timeline");
   });
 
-  it("correctly sets the right path when route is specified as a wowza route", () => {
+  it("correctly sets the right path when route is specified as a legacy route", () => {
     expect(
       createAddressPageRoutes(
         {
@@ -37,6 +37,6 @@ describe("createAddressPageRoutes()", () => {
         },
         true
       ).timeline
-    ).toBe("/es/address/BROOKLYN/654/PARK%20PLACE/timeline");
+    ).toBe("/es/legacy/address/BROOKLYN/654/PARK%20PLACE/timeline");
   });
 });

--- a/client/src/routes.test.tsx
+++ b/client/src/routes.test.tsx
@@ -52,4 +52,19 @@ describe("createAddressPageRoutes()", () => {
       ).timeline
     ).toBe("/es/legacy/address/BROOKLYN/654/PARK%20PLACE/timeline");
   });
+
+  it("defaults to the standard path when env variable is not defined", () => {
+    process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING = undefined;
+    expect(
+      createAddressPageRoutes(
+        {
+          boro: "BROOKLYN",
+          housenumber: "654",
+          streetname: "PARK PLACE",
+          locale: "es",
+        },
+        true
+      ).timeline
+    ).toBe("/es/address/BROOKLYN/654/PARK%20PLACE/timeline");
+  });
 });

--- a/client/src/routes.test.tsx
+++ b/client/src/routes.test.tsx
@@ -1,6 +1,18 @@
 import { createAddressPageRoutes } from "routes";
 
 describe("createAddressPageRoutes()", () => {
+  const OLD_ENV = process.env;
+
+  // https://stackoverflow.com/questions/48033841/test-process-env-with-jest
+  beforeEach(() => {
+    jest.resetModules(); // Most important - it clears the cache
+    process.env = { ...OLD_ENV }; // Make a copy
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
   it("prefixes with string when given one", () => {
     expect(createAddressPageRoutes("/boop").timeline).toBe("/boop/timeline");
   });
@@ -27,6 +39,7 @@ describe("createAddressPageRoutes()", () => {
   });
 
   it("correctly sets the right path when route is specified as a legacy route", () => {
+    process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING = "1";
     expect(
       createAddressPageRoutes(
         {

--- a/client/src/routes.test.tsx
+++ b/client/src/routes.test.tsx
@@ -12,7 +12,7 @@ describe("createAddressPageRoutes()", () => {
         housenumber: "654",
         streetname: "PARK PLACE",
       }).timeline
-    ).toBe("/legacy/address/BROOKLYN/654/PARK%20PLACE/timeline");
+    ).toBe("/address/BROOKLYN/654/PARK%20PLACE/timeline");
   });
 
   it("prefixes with address page params and locale when given one", () => {
@@ -23,7 +23,7 @@ describe("createAddressPageRoutes()", () => {
         streetname: "PARK PLACE",
         locale: "es",
       }).timeline
-    ).toBe("/es/legacy/address/BROOKLYN/654/PARK%20PLACE/timeline");
+    ).toBe("/es/address/BROOKLYN/654/PARK%20PLACE/timeline");
   });
 
   it("correctly sets the right path when route is specified as a legacy route", () => {

--- a/client/src/routes.test.tsx
+++ b/client/src/routes.test.tsx
@@ -12,7 +12,7 @@ describe("createAddressPageRoutes()", () => {
         housenumber: "654",
         streetname: "PARK PLACE",
       }).timeline
-    ).toBe("/address/BROOKLYN/654/PARK%20PLACE/timeline");
+    ).toBe("/legacy/address/BROOKLYN/654/PARK%20PLACE/timeline");
   });
 
   it("prefixes with address page params and locale when given one", () => {
@@ -23,6 +23,20 @@ describe("createAddressPageRoutes()", () => {
         streetname: "PARK PLACE",
         locale: "es",
       }).timeline
+    ).toBe("/es/legacy/address/BROOKLYN/654/PARK%20PLACE/timeline");
+  });
+
+  it("correctly sets the right path when route is specified as a wowza route", () => {
+    expect(
+      createAddressPageRoutes(
+        {
+          boro: "BROOKLYN",
+          housenumber: "654",
+          streetname: "PARK PLACE",
+          locale: "es",
+        },
+        true
+      ).timeline
     ).toBe("/es/address/BROOKLYN/654/PARK%20PLACE/timeline");
   });
 });

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -15,7 +15,7 @@ export const createRouteForAddressPage = (
     params.housenumber ? params.housenumber : " "
   )}/${encodeURIComponent(params.streetname)}`;
 
-  if (addWowzaToRoute) route = "/wowza" + route;
+  if (!addWowzaToRoute) route = "/legacy" + route;
 
   if (route.includes(" ")) {
     reportError("An Address Page URL was not encoded properly! There's a space in the URL.");
@@ -31,7 +31,7 @@ export const createRouteForAddressPage = (
 
 export const createRouteForFullBbl = (bbl: string, prefix?: string, addWowzaToRoute?: boolean) => {
   let route = `/bbl/${bbl}`;
-  if (addWowzaToRoute) route = "/wowza" + route;
+  if (!addWowzaToRoute) route = "/legacy" + route;
   if (prefix) route = `/${prefix}` + route;
   return route;
 };
@@ -54,22 +54,22 @@ export const createAddressPageRoutes = (
 export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
   const pathPrefix = prefix || "";
   return {
+    legacyHome: `${pathPrefix}/legacy`,
     home: `${pathPrefix}/`,
-    wowzaHome: `${pathPrefix}/wowza`,
-    addressPage: createAddressPageRoutes(`${pathPrefix}/address/:boro/:housenumber/:streetname`),
-    wowzaAddressPage: createAddressPageRoutes(
-      `${pathPrefix}/wowza/address/:boro/:housenumber/:streetname`
+    legacyAddressPage: createAddressPageRoutes(
+      `${pathPrefix}/legacy/address/:boro/:housenumber/:streetname`
     ),
+    addressPage: createAddressPageRoutes(`${pathPrefix}/address/:boro/:housenumber/:streetname`),
     /** Note: this path doesn't correspond to a stable page on the site. It simply provides an entry point that
      * immediately redirects to an addressPageOverview. This path is helpful for folks who, say, have a list of
      * bbl values in a spreadsheet and want to easily generate direct links to WhoOwnsWhat.
      * See `BBLPage.tsx` for more details.
      */
-    bbl: `${pathPrefix}/bbl/:bbl`,
+    legacyBbl: `${pathPrefix}/legacy/bbl/:bbl`,
     /** This route path corresponds to a page identical to the `bbl` path above, just specifying that the user
      * requests to use the new "WOWZA" portfolio method.
      */
-    wowzaBbl: `${pathPrefix}/wowza/bbl/:bbl`,
+    bbl: `${pathPrefix}/bbl/:bbl`,
     /** This route path corresponds to a page identical to the `bbl` route above, but with an older url
      * pattern that we want to support so as not to break any old links that exist out in the web.
      */

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -48,34 +48,36 @@ export const createAddressPageRoutes = (
   };
 };
 
-export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
+export const createCoreRoutePaths = (prefix?: string) => {
   const pathPrefix = prefix || "";
   return {
-    legacyHome: `${pathPrefix}/legacy`,
     home: `${pathPrefix}/`,
-    legacyAddressPage: createAddressPageRoutes(
-      `${pathPrefix}/legacy/address/:boro/:housenumber/:streetname`
-    ),
     addressPage: createAddressPageRoutes(`${pathPrefix}/address/:boro/:housenumber/:streetname`),
     /** Note: this path doesn't correspond to a stable page on the site. It simply provides an entry point that
      * immediately redirects to an addressPageOverview. This path is helpful for folks who, say, have a list of
      * bbl values in a spreadsheet and want to easily generate direct links to WhoOwnsWhat.
      * See `BBLPage.tsx` for more details.
      */
-    legacyBbl: `${pathPrefix}/legacy/bbl/:bbl`,
-    /** This route path corresponds to a page identical to the `bbl` path above, just specifying that the user
-     * requests to use the new "WOWZA" portfolio method.
-     */
     bbl: `${pathPrefix}/bbl/:bbl`,
-    /** This route path corresponds to a page identical to the `bbl` route above, but with an older url
-     * pattern that we want to support so as not to break any old links that exist out in the web.
-     */
-    bblSeparatedIntoParts: `${pathPrefix}/bbl/:boro/:block/:lot`,
     about: `${pathPrefix}/about`,
     howToUse: `${pathPrefix}/how-to-use`,
     methodology: `${pathPrefix}/how-it-works`,
     termsOfUse: `${pathPrefix}/terms-of-use`,
     privacyPolicy: `${pathPrefix}/privacy-policy`,
+  };
+};
+
+export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
+  const pathPrefix = prefix || "";
+  return {
+    ...createCoreRoutePaths(pathPrefix),
+    legacy: {
+      ...createCoreRoutePaths(`${pathPrefix}/legacy`),
+    },
+    /** This route path corresponds to a page identical to the `bbl` route above, but with an older url
+     * pattern that we want to support so as not to break any old links that exist out in the web.
+     */
+    bblSeparatedIntoParts: `${pathPrefix}/bbl/:boro/:block/:lot`,
     dev: `${pathPrefix}/dev`,
   };
 };

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -7,12 +7,15 @@ export type AddressPageUrlParams = SearchAddressWithoutBbl & {
 
 export type AddressPageRoutes = ReturnType<typeof createAddressPageRoutes>;
 
-export const createRouteForAddressPage = (params: AddressPageUrlParams, isWowzaRoute?: boolean) => {
+export const createRouteForAddressPage = (
+  params: AddressPageUrlParams,
+  isLegacyRoute?: boolean
+) => {
   let route = `/address/${encodeURIComponent(params.boro)}/${encodeURIComponent(
     params.housenumber ? params.housenumber : " "
   )}/${encodeURIComponent(params.streetname)}`;
 
-  if (!isWowzaRoute) route = "/legacy" + route;
+  if (isLegacyRoute) route = "/legacy" + route;
 
   if (route.includes(" ")) {
     reportError("An Address Page URL was not encoded properly! There's a space in the URL.");
@@ -26,19 +29,19 @@ export const createRouteForAddressPage = (params: AddressPageUrlParams, isWowzaR
   return route;
 };
 
-export const createRouteForFullBbl = (bbl: string, prefix?: string, isWowzaRoute?: boolean) => {
+export const createRouteForFullBbl = (bbl: string, prefix?: string, isLegacyRoute?: boolean) => {
   let route = `/bbl/${bbl}`;
-  if (!isWowzaRoute) route = "/legacy" + route;
+  if (isLegacyRoute) route = "/legacy" + route;
   if (prefix) route = `/${prefix}` + route;
   return route;
 };
 
 export const createAddressPageRoutes = (
   prefix: string | AddressPageUrlParams,
-  isWowzaRoute?: boolean
+  isLegacyRoute?: boolean
 ) => {
   if (typeof prefix === "object") {
-    prefix = createRouteForAddressPage(prefix, isWowzaRoute);
+    prefix = createRouteForAddressPage(prefix, isLegacyRoute);
   }
   return {
     overview: `${prefix}`,

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -15,7 +15,10 @@ export const createRouteForAddressPage = (
     params.housenumber ? params.housenumber : " "
   )}/${encodeURIComponent(params.streetname)}`;
 
-  if (isLegacyRoute) route = "/legacy" + route;
+  const allowChangingPortfolioMethod =
+    process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1";
+
+  if (isLegacyRoute && allowChangingPortfolioMethod) route = "/legacy" + route;
 
   if (route.includes(" ")) {
     reportError("An Address Page URL was not encoded properly! There's a space in the URL.");
@@ -31,7 +34,9 @@ export const createRouteForAddressPage = (
 
 export const createRouteForFullBbl = (bbl: string, prefix?: string, isLegacyRoute?: boolean) => {
   let route = `/bbl/${bbl}`;
-  if (isLegacyRoute) route = "/legacy" + route;
+  const allowChangingPortfolioMethod =
+    process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1";
+  if (isLegacyRoute && allowChangingPortfolioMethod) route = "/legacy" + route;
   if (prefix) route = `/${prefix}` + route;
   return route;
 };

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -7,15 +7,12 @@ export type AddressPageUrlParams = SearchAddressWithoutBbl & {
 
 export type AddressPageRoutes = ReturnType<typeof createAddressPageRoutes>;
 
-export const createRouteForAddressPage = (
-  params: AddressPageUrlParams,
-  addWowzaToRoute?: boolean
-) => {
+export const createRouteForAddressPage = (params: AddressPageUrlParams, isWowzaRoute?: boolean) => {
   let route = `/address/${encodeURIComponent(params.boro)}/${encodeURIComponent(
     params.housenumber ? params.housenumber : " "
   )}/${encodeURIComponent(params.streetname)}`;
 
-  if (!addWowzaToRoute) route = "/legacy" + route;
+  if (!isWowzaRoute) route = "/legacy" + route;
 
   if (route.includes(" ")) {
     reportError("An Address Page URL was not encoded properly! There's a space in the URL.");
@@ -29,9 +26,9 @@ export const createRouteForAddressPage = (
   return route;
 };
 
-export const createRouteForFullBbl = (bbl: string, prefix?: string, addWowzaToRoute?: boolean) => {
+export const createRouteForFullBbl = (bbl: string, prefix?: string, isWowzaRoute?: boolean) => {
   let route = `/bbl/${bbl}`;
-  if (!addWowzaToRoute) route = "/legacy" + route;
+  if (!isWowzaRoute) route = "/legacy" + route;
   if (prefix) route = `/${prefix}` + route;
   return route;
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,12 @@
   status = 301
   force = true
 
+[[redirects]]
+  from = "https://demo-whoownswhat.justfix.nyc/en/wowza/*"
+  to = "https://demo-whoownswhat.justfix.nyc/en/"
+  status = 301
+  force = true
+
 # Settings in the [build] context are global and are applied to all contexts
 # unless otherwise overridden by more specific contexts.
 [build]


### PR DESCRIPTION
This PR makes sure that all of our `/wowza` pages are now found at the root, and all of the existing root pages, that utilize the old version of WOW, have been moved to the `/legacy` directory. This PR also simplifies our route structure to make sure that all pages, including our about, methodology, etc., have a "legacy" and wowza version so users stay within their selected version of the site upon navigation. 