### PR TITLE
Add custom zoom widget to portfolio graph viz

### DIFF
--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import Cytoscape from "cytoscape";
 import CytoscapeComponent from "react-cytoscapejs";
 // @ts-ignore

--- a/client/src/components/PortfolioGraph.tsx
+++ b/client/src/components/PortfolioGraph.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Cytoscape from "cytoscape";
 import CytoscapeComponent from "react-cytoscapejs";
 // @ts-ignore
@@ -6,7 +6,8 @@ import fcose from "cytoscape-fcose";
 import { AddressRecord, PortfolioGraphNode, RawPortfolioGraphJson } from "./APIDataTypes";
 import { withMachineInStateProps } from "state-machine";
 import helpers from "util/helpers";
-import { Trans } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
+import { withI18n, withI18nProps } from "@lingui/react";
 
 Cytoscape.use(fcose);
 
@@ -127,11 +128,12 @@ const formatGraphJSON = (
   return nodes.concat(edges);
 };
 
-type PortfolioGraphProps = Pick<withMachineInStateProps<"portfolioFound">, "state"> & {
-  graphJSON: RawPortfolioGraphJson;
-};
+type PortfolioGraphProps = withI18nProps &
+  Pick<withMachineInStateProps<"portfolioFound">, "state"> & {
+    graphJSON: RawPortfolioGraphJson;
+  };
 
-export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state }) => {
+const PortfolioGraphWithoutI18: React.FC<PortfolioGraphProps> = ({ graphJSON, state, i18n }) => {
   const { searchAddr, detailAddr } = state.context.portfolioData;
   const distinctDetailAddr = !helpers.addrsAreEqual(searchAddr, detailAddr)
     ? detailAddr
@@ -139,8 +141,13 @@ export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state
   const additionalNodes = generateAdditionalNodes(searchAddr, distinctDetailAddr);
   const additionalEdges = generateAdditionalEdges(graphJSON.nodes, searchAddr, distinctDetailAddr);
 
+  const ZOOM_LEVEL_INCREMENT = 0.2;
+  const ZOOM_ANIMATION_DURATION = 100;
+
+  let myCyRef: Cytoscape.Core;
+
   return (
-    <>
+    <div className="portfolio-graph">
       <div className="float-left">
         <span
           style={{
@@ -157,10 +164,49 @@ export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state
           ● <Trans>Business Addresses</Trans>
         </span>
       </div>
+      <div className="btn-group btn-group-block">
+        <button
+          className="btn btn-action"
+          aria-label={i18n._(t`Zoom in`)}
+          onClick={() =>
+            myCyRef.animate(
+              {
+                zoom: myCyRef.zoom() + ZOOM_LEVEL_INCREMENT * myCyRef.zoom(),
+              },
+              {
+                duration: ZOOM_ANIMATION_DURATION,
+              }
+            )
+          }
+        >
+          +
+        </button>
+        <button
+          className="btn btn-action"
+          aria-label={i18n._(t`Zoom out`)}
+          onClick={() =>
+            myCyRef.animate(
+              {
+                zoom: myCyRef.zoom() - ZOOM_LEVEL_INCREMENT * myCyRef.zoom(),
+              },
+              {
+                duration: ZOOM_ANIMATION_DURATION,
+              }
+            )
+          }
+        >
+          -
+        </button>
+      </div>
       <CytoscapeComponent
         elements={formatGraphJSON(graphJSON, additionalNodes, additionalEdges)}
         style={{ width: "100%", height: "60vh" }}
         layout={layout}
+        cy={(cy) => {
+          // Get a reference to the Cytoscape object:
+          // https://github.com/plotly/react-cytoscapejs#cy-1
+          myCyRef = cy;
+        }}
         stylesheet={[
           {
             selector: "node",
@@ -193,9 +239,11 @@ export const PortfolioGraph: React.FC<PortfolioGraphProps> = ({ graphJSON, state
         ]}
       />
       <br />
-    </>
+    </div>
   );
 };
+
+export const PortfolioGraph = withI18n()(PortfolioGraphWithoutI18);
 
 const NODE_TYPE_TO_COLOR: Record<string, string> = {
   name: "red",

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -169,7 +169,7 @@ msgstr "Built"
 
 #: src/components/DetailView.tsx:313
 #: src/components/DetailView.tsx:322
-#: src/components/PortfolioGraph.tsx:101
+#: src/components/PortfolioGraph.tsx:105
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
@@ -695,7 +695,7 @@ msgstr "Open Violations"
 msgid "Overview"
 msgstr "Overview"
 
-#: src/components/PortfolioGraph.tsx:96
+#: src/components/PortfolioGraph.tsx:100
 msgid "Owner Names"
 msgstr "Owner Names"
 
@@ -1206,6 +1206,14 @@ msgstr "You are viewing the old version of Who Owns What."
 #: src/components/PropertiesList.tsx:147
 msgid "Zipcode"
 msgstr "Zipcode"
+
+#: src/components/PortfolioGraph.tsx:109
+msgid "Zoom in"
+msgstr "Zoom in"
+
+#: src/components/PortfolioGraph.tsx:116
+msgid "Zoom out"
+msgstr "Zoom out"
 
 #: src/components/StringifyList.tsx:18
 msgid "and"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -174,7 +174,7 @@ msgstr "Construido"
 
 #: src/components/DetailView.tsx:313
 #: src/components/DetailView.tsx:322
-#: src/components/PortfolioGraph.tsx:101
+#: src/components/PortfolioGraph.tsx:105
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
@@ -700,7 +700,7 @@ msgstr "Violaciones Actuales"
 msgid "Overview"
 msgstr "General"
 
-#: src/components/PortfolioGraph.tsx:96
+#: src/components/PortfolioGraph.tsx:100
 msgid "Owner Names"
 msgstr ""
 
@@ -1211,6 +1211,14 @@ msgstr ""
 #: src/components/PropertiesList.tsx:147
 msgid "Zipcode"
 msgstr "Código postal"
+
+#: src/components/PortfolioGraph.tsx:109
+msgid "Zoom in"
+msgstr ""
+
+#: src/components/PortfolioGraph.tsx:116
+msgid "Zoom out"
+msgstr ""
 
 #: src/components/StringifyList.tsx:18
 msgid "and"

--- a/client/src/styles/PropertiesSummary.scss
+++ b/client/src/styles/PropertiesSummary.scss
@@ -38,6 +38,20 @@
         margin-bottom: 0;
       }
     }
+
+    .portfolio-graph {
+      position: relative;
+      .btn-group {
+        position: absolute;
+        flex-direction: column;
+        margin-top: 3.5rem;
+        z-index: 1000;
+        .btn {
+          flex-grow: 0;
+          margin-left: 0;
+        }
+      }
+    }
   }
 
   .PropertiesSummary__links {


### PR DESCRIPTION
This pr adds a very simple set of zoom buttons onto our Cytoscape network visualization on the summary tab. 

<img width="518" alt="image" src="https://user-images.githubusercontent.com/12834575/162741649-15ff2875-1aea-4b52-9190-3d9bd22188a6.png">
