### PR TITLE
When changing portfolio methods, only refresh the page if it's an address page

### DIFF
--- a/client/src/components/WowzaToggle.tsx
+++ b/client/src/components/WowzaToggle.tsx
@@ -27,11 +27,13 @@ export const ToggleLinkBetweenPortfolioMethods = () => {
   const history = useHistory();
   const { pathname } = useLocation();
 
-  return isAddressPageRoute(pathname) ? (
+  return (
     <button
       onClick={() => {
         history.push(getPathForOtherPortfolioMethod(pathname));
-        history.go(0);
+        if (isAddressPageRoute(pathname)) {
+          history.go(0);
+        }
       }}
     >
       {isLegacyPath(pathname) ? (
@@ -40,13 +42,5 @@ export const ToggleLinkBetweenPortfolioMethods = () => {
         <Trans>Switch to old version</Trans>
       )}
     </button>
-  ) : (
-    <Link to={getPathForOtherPortfolioMethod(pathname)}>
-      {isLegacyPath(pathname) ? (
-        <Trans>Switch to new version</Trans>
-      ) : (
-        <Trans>Switch to old version</Trans>
-      )}
-    </Link>
   );
 };

--- a/client/src/components/WowzaToggle.tsx
+++ b/client/src/components/WowzaToggle.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/macro";
 import { parseLocaleFromPath, removeLocalePrefix } from "i18n";
 import React from "react";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { isAddressPageRoute } from "routes";
 
 /**

--- a/client/src/components/WowzaToggle.tsx
+++ b/client/src/components/WowzaToggle.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/macro";
 import { parseLocaleFromPath, removeLocalePrefix } from "i18n";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { Link, useHistory, useLocation } from "react-router-dom";
 
 /**
  * Determines whether a url corresponds to a new WOWZA portfolio mapping page vs an old legacy page.
@@ -26,17 +26,12 @@ export const ToggleLinkBetweenPortfolioMethods = () => {
   const history = useHistory();
   const { pathname } = useLocation();
   return (
-    <button
-      onClick={() => {
-        history.push(getPathForOtherPortfolioMethod(pathname));
-        history.go(0);
-      }}
-    >
+    <Link to={getPathForOtherPortfolioMethod(pathname)}>
       {isLegacyPath(pathname) ? (
         <Trans>Switch to new version</Trans>
       ) : (
         <Trans>Switch to old version</Trans>
       )}
-    </button>
+    </Link>
   );
 };

--- a/client/src/components/WowzaToggle.tsx
+++ b/client/src/components/WowzaToggle.tsx
@@ -2,6 +2,7 @@ import { Trans } from "@lingui/macro";
 import { parseLocaleFromPath, removeLocalePrefix } from "i18n";
 import React from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
+import { isAddressPageRoute } from "routes";
 
 /**
  * Determines whether a url corresponds to a new WOWZA portfolio mapping page vs an old legacy page.
@@ -25,7 +26,21 @@ export const getPathForOtherPortfolioMethod = (pathname: string) => {
 export const ToggleLinkBetweenPortfolioMethods = () => {
   const history = useHistory();
   const { pathname } = useLocation();
-  return (
+
+  return isAddressPageRoute(pathname) ? (
+    <button
+      onClick={() => {
+        history.push(getPathForOtherPortfolioMethod(pathname));
+        history.go(0);
+      }}
+    >
+      {isLegacyPath(pathname) ? (
+        <Trans>Switch to new version</Trans>
+      ) : (
+        <Trans>Switch to old version</Trans>
+      )}
+    </button>
+  ) : (
     <Link to={getPathForOtherPortfolioMethod(pathname)}>
       {isLegacyPath(pathname) ? (
         <Trans>Switch to new version</Trans>

--- a/client/src/routes.test.tsx
+++ b/client/src/routes.test.tsx
@@ -1,4 +1,22 @@
-import { createAddressPageRoutes } from "routes";
+import { createAddressPageRoutes, isAddressPageRoute } from "routes";
+
+describe("isAddressPageRoute()", () => {
+  it("correctly identifies a regular address page", () => {
+    expect(isAddressPageRoute("/es/address/QUEENS/4125/CASE%20STREET")).toBe(true);
+  });
+
+  it("correctly identifies a legacy address page", () => {
+    expect(isAddressPageRoute("/es/legacy/address/QUEENS/4125/CASE%20STREET")).toBe(true);
+  });
+
+  it("correctly identifies a regular page as not an address page", () => {
+    expect(isAddressPageRoute("/en/legacy/how-to-use")).toBe(false);
+  });
+
+  it("handles cases where 'address' happens to be in the url somewhere", () => {
+    expect(isAddressPageRoute("/en/find-my-address")).toBe(false);
+  });
+});
 
 describe("createAddressPageRoutes()", () => {
   const OLD_ENV = process.env;

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -1,11 +1,21 @@
 import { SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { reportError } from "error-reporting";
+import { removeLocalePrefix } from "i18n";
 
 export type AddressPageUrlParams = SearchAddressWithoutBbl & {
   locale?: string;
 };
 
 export type AddressPageRoutes = ReturnType<typeof createAddressPageRoutes>;
+
+/**
+ * Determines whether a url corresponds to an Address Page.
+ */
+export const isAddressPageRoute = (pathname: string) => {
+  let path = removeLocalePrefix(pathname);
+  if (path.startsWith("/legacy")) path = path.replace("/legacy", "");
+  return path.startsWith("/address");
+};
 
 export const createRouteForAddressPage = (
   params: AddressPageUrlParams,


### PR DESCRIPTION
This PR fixes an issue where toggling between old and new WOW portfolio methods on the homepage made the page elements and assets flicker awkwardly. Turns out this was due to the fact that any switch between portfolio methods caused a page refresh. I changed our toggle logic to _only_ trigger a page reload when switching portfolio methods on an internal address page—which we need to do to load in new data for the page.