### PR TITLE
Create an internal redirect from the old WOWZA path

### DIFF
--- a/client/src/components/WowzaToggle.tsx
+++ b/client/src/components/WowzaToggle.tsx
@@ -34,8 +34,9 @@ export const WowzaRedirectPage = () => {
       <Loader loading={true} classNames="Loader-map">
         <Trans>Loading</Trans>
       </Loader>
-    </Page>)
-}
+    </Page>
+  );
+};
 
 export const ToggleLinkBetweenPortfolioMethods = () => {
   const history = useHistory();

--- a/client/src/components/WowzaToggle.tsx
+++ b/client/src/components/WowzaToggle.tsx
@@ -2,7 +2,9 @@ import { Trans } from "@lingui/macro";
 import { parseLocaleFromPath, removeLocalePrefix } from "i18n";
 import React from "react";
 import { useHistory, useLocation } from "react-router-dom";
-import { isAddressPageRoute } from "routes";
+import { createWhoOwnsWhatRoutePaths, isAddressPageRoute } from "routes";
+import Loader from "./Loader";
+import Page from "./Page";
 
 /**
  * Determines whether a url corresponds to a new WOWZA portfolio mapping page vs an old legacy page.
@@ -22,6 +24,18 @@ export const getPathForOtherPortfolioMethod = (pathname: string) => {
     return `/${locale}/legacy${removeLocalePrefix(pathname)}`;
   }
 };
+
+export const WowzaRedirectPage = () => {
+  const history = useHistory();
+  const { home } = createWhoOwnsWhatRoutePaths();
+  history.replace(home);
+  return (
+    <Page>
+      <Loader loading={true} classNames="Loader-map">
+        <Trans>Loading</Trans>
+      </Loader>
+    </Page>)
+}
 
 export const ToggleLinkBetweenPortfolioMethods = () => {
   const history = useHistory();

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -36,7 +36,7 @@ import { wowMachine } from "state-machine";
 import { NotFoundPage } from "./NotFoundPage";
 import widont from "widont";
 import { Dropdown } from "components/Dropdown";
-import { isLegacyPath, ToggleLinkBetweenPortfolioMethods } from "components/WowzaToggle";
+import { isLegacyPath, ToggleLinkBetweenPortfolioMethods, WowzaRedirectPage } from "components/WowzaToggle";
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -160,6 +160,7 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
       <Route path={paths.privacyPolicy} component={PrivacyPolicyPage} />
       <Route path={paths.legacy.privacyPolicy} component={PrivacyPolicyPage} />
       <Route path={paths.dev} component={DevPage} />
+      <Route path={paths.oldWowzaPath} component={WowzaRedirectPage} />
       <Route component={NotFoundPage} />
     </Switch>
   );

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -36,7 +36,11 @@ import { wowMachine } from "state-machine";
 import { NotFoundPage } from "./NotFoundPage";
 import widont from "widont";
 import { Dropdown } from "components/Dropdown";
-import { isLegacyPath, ToggleLinkBetweenPortfolioMethods, WowzaRedirectPage } from "components/WowzaToggle";
+import {
+  isLegacyPath,
+  ToggleLinkBetweenPortfolioMethods,
+  WowzaRedirectPage,
+} from "components/WowzaToggle";
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -75,7 +75,7 @@ msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:89
+#: src/containers/App.tsx:90
 msgid "About"
 msgstr "About"
 
@@ -228,7 +228,7 @@ msgstr "Click here to learn more."
 
 #: src/components/DetailView.tsx:57
 #: src/components/FeatureCalloutWidget.tsx:60
-#: src/containers/App.tsx:159
+#: src/containers/App.tsx:160
 msgid "Close"
 msgstr "Close"
 
@@ -277,7 +277,7 @@ msgstr "DOORS"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:108
+#: src/containers/App.tsx:109
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -291,7 +291,7 @@ msgid "Display:"
 msgstr "Display:"
 
 #: src/components/LegalFooter.tsx:35
-#: src/containers/App.tsx:95
+#: src/containers/App.tsx:96
 msgid "Donate"
 msgstr "Donate"
 
@@ -417,7 +417,7 @@ msgstr "Head Officer"
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:92
+#: src/containers/App.tsx:93
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -525,6 +525,7 @@ msgstr "Link to Deed"
 #: src/components/PropertiesList.tsx:92
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:61
+#: src/components/WowzaToggle.tsx:31
 #: src/containers/AddressPage.tsx:161
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
@@ -775,7 +776,7 @@ msgstr "SIGNAGE MISSING"
 msgid "STAIRS"
 msgstr "STAIRS"
 
-#: src/containers/App.tsx:81
+#: src/containers/App.tsx:82
 msgid "Search"
 msgstr "Search"
 
@@ -804,15 +805,15 @@ msgstr "See the most common complaints reported by tenants to 311, now on the Ov
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:116
-#: src/containers/App.tsx:127
+#: src/containers/App.tsx:117
+#: src/containers/App.tsx:128
 msgid "Share"
 msgstr "Share"
 
 #: src/components/DetailView.tsx:263
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:136
-#: src/containers/App.tsx:137
+#: src/containers/App.tsx:138
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -870,11 +871,11 @@ msgstr "Starts {year}"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/components/WowzaToggle.tsx:32
+#: src/components/WowzaToggle.tsx:44
 msgid "Switch to new version"
 msgstr "Switch to new version"
 
-#: src/components/WowzaToggle.tsx:32
+#: src/components/WowzaToggle.tsx:44
 msgid "Switch to old version"
 msgstr "Switch to old version"
 
@@ -1195,11 +1196,11 @@ msgstr "Yes"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 
-#: src/containers/App.tsx:156
+#: src/containers/App.tsx:157
 msgid "You are viewing the new version of Who Owns What."
 msgstr "You are viewing the new version of Who Owns What."
 
-#: src/containers/App.tsx:156
+#: src/containers/App.tsx:157
 msgid "You are viewing the old version of Who Owns What."
 msgstr "You are viewing the old version of Who Owns What."
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -80,7 +80,7 @@ msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:89
+#: src/containers/App.tsx:90
 msgid "About"
 msgstr "Acerca de"
 
@@ -233,7 +233,7 @@ msgstr "HaZ clic aquí para obtener más información."
 
 #: src/components/DetailView.tsx:57
 #: src/components/FeatureCalloutWidget.tsx:60
-#: src/containers/App.tsx:159
+#: src/containers/App.tsx:160
 msgid "Close"
 msgstr "Cerrar"
 
@@ -282,7 +282,7 @@ msgstr "PUERTAS"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:108
+#: src/containers/App.tsx:109
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -296,7 +296,7 @@ msgid "Display:"
 msgstr "Mostrar:"
 
 #: src/components/LegalFooter.tsx:35
-#: src/containers/App.tsx:95
+#: src/containers/App.tsx:96
 msgid "Donate"
 msgstr "Donar"
 
@@ -422,7 +422,7 @@ msgstr "Oficial Principal"
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:92
+#: src/containers/App.tsx:93
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
@@ -530,6 +530,7 @@ msgstr "Enlace a la Escritura"
 #: src/components/PropertiesList.tsx:92
 #: src/components/PropertiesMap.tsx:156
 #: src/components/PropertiesSummary.tsx:61
+#: src/components/WowzaToggle.tsx:31
 #: src/containers/AddressPage.tsx:161
 #: src/containers/BBLPage.tsx:58
 msgid "Loading"
@@ -780,7 +781,7 @@ msgstr "FALTA DE SEÑALIZACIÓN"
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
-#: src/containers/App.tsx:81
+#: src/containers/App.tsx:82
 msgid "Search"
 msgstr "Buscar"
 
@@ -809,15 +810,15 @@ msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en l
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:116
-#: src/containers/App.tsx:127
+#: src/containers/App.tsx:117
+#: src/containers/App.tsx:128
 msgid "Share"
 msgstr "Compartir"
 
 #: src/components/DetailView.tsx:263
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:136
-#: src/containers/App.tsx:137
+#: src/containers/App.tsx:138
 #: src/containers/NotRegisteredPage.tsx:14
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -875,11 +876,11 @@ msgstr "Comienza {year}"
 msgid "Summary"
 msgstr "Resúmen"
 
-#: src/components/WowzaToggle.tsx:32
+#: src/components/WowzaToggle.tsx:44
 msgid "Switch to new version"
 msgstr ""
 
-#: src/components/WowzaToggle.tsx:32
+#: src/components/WowzaToggle.tsx:44
 msgid "Switch to old version"
 msgstr ""
 
@@ -1200,11 +1201,11 @@ msgstr "Sí"
 msgid "Yoel Goldman's All Year Management has been at the <0>forefront of gentrification</0> in Brooklyn. Tenants in his buidlings in Williamsburg, Bushwick, and Crown Heights have been forced to live in horrendous and often dangerous conditions."
 msgstr "La entidad \"All Year Management\" perteneciente a Yoel Goldman, está en la <0>vanguardia de la gentrificación</0> de Brooklyn. Los inquilinos en sus edificios de Williamsburg, Bushwick, y las Crown Heights se han visto obligados a vivir en condiciones horrendas y a menudo peligrosas."
 
-#: src/containers/App.tsx:156
+#: src/containers/App.tsx:157
 msgid "You are viewing the new version of Who Owns What."
 msgstr ""
 
-#: src/containers/App.tsx:156
+#: src/containers/App.tsx:157
 msgid "You are viewing the old version of Who Owns What."
 msgstr ""
 

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -96,6 +96,7 @@ export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
      * pattern that we want to support so as not to break any old links that exist out in the web.
      */
     bblSeparatedIntoParts: `${pathPrefix}/bbl/:boro/:block/:lot`,
+    oldWowzaPath: `${pathPrefix}/wowza`,
     dev: `${pathPrefix}/dev`,
   };
 };

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -96,6 +96,10 @@ export const createWhoOwnsWhatRoutePaths = (prefix?: string) => {
      * pattern that we want to support so as not to break any old links that exist out in the web.
      */
     bblSeparatedIntoParts: `${pathPrefix}/bbl/:boro/:block/:lot`,
+    /** Some user testers have been accessing WOW via this pathname which we have since deprecated.
+     * Let's make sure all routes with this path structure redirect back to the homepage.
+     * See App.tsx and the `WowzaRedirectPage` component in WowzaToggle.tsx for more info.
+     */
     oldWowzaPath: `${pathPrefix}/wowza`,
     dev: `${pathPrefix}/dev`,
   };


### PR DESCRIPTION
This PR creates an internal redirect from all old `/wowza` paths to the root directory of the site where the wowza portfolio mapping is now currently found. This is in response to some user testers having issues on the demo site with old links to portfolios.