### PR TITLE
Ensure that only one landlord corresponds to a given `registrationid` from HPD

### DIFF
--- a/portfoliograph/graph.py
+++ b/portfoliograph/graph.py
@@ -52,7 +52,7 @@ def build_graph(dict_cursor) -> nx.Graph:
     dict_cursor.execute(
         f"""
         WITH landlord_contacts AS (
-            SELECT DISTINCT 
+            SELECT DISTINCT
                 firstname,
                 lastname,
                 businesshousenumber,
@@ -72,22 +72,22 @@ def build_graph(dict_cursor) -> nx.Graph:
                 AND LENGTH(CONCAT(businesshousenumber, businessstreetname)) > 2
                 AND (firstname IS NOT NULL OR lastname IS NOT NULL)
         ),
-        
+
         landlord_contacts_ordered AS (
             SELECT *
             FROM landlord_contacts
             ORDER BY (
                 -- First, we prioritize certain owner types over others:
                 ARRAY_POSITION(
-                    ARRAY['IndividualOwner','HeadOfficer','JointOwner','CorporateOwner'], 
+                    ARRAY['IndividualOwner','HeadOfficer','JointOwner','CorporateOwner'],
                     landlord_contacts.type
-                ), 
+                ),
                 -- Then, we order by landlord name, just to make sure our sorting is deterministic:
                 concat(firstname,' ',lastname)
             )
         )
 
-        SELECT 
+        SELECT
             registrationid,
             FIRST(firstname) AS firstname,
             FIRST(lastname) AS lastname,

--- a/portfoliograph/table.py
+++ b/portfoliograph/table.py
@@ -45,7 +45,13 @@ def iter_portfolio_rows(conn) -> Iterable[PortfolioRow]:
                 if reginfo.reg_id in reg_bbl_map:
                     bbls = bbls.union(reg_bbl_map[reginfo.reg_id])
                 else:
-                    print(f"WARNING: HPD registration {reginfo.reg_id} not found.")
+                    # TODO: Clarify that this is not an error, but expected for older regs
+                    print(
+                        f"""
+                        HPD registration {reginfo.reg_id} skipped in portfolio generation. 
+                        Likely that a newer registration exists for the same building.
+                        """
+                    )
         yield PortfolioRow(
             bbls=list(bbls), landlord_names=names, graph=induced_subgraph
         )

--- a/portfoliograph/table.py
+++ b/portfoliograph/table.py
@@ -48,7 +48,7 @@ def iter_portfolio_rows(conn) -> Iterable[PortfolioRow]:
                     # TODO: Clarify that this is not an error, but expected for older regs
                     print(
                         f"""
-                        HPD registration {reginfo.reg_id} skipped in portfolio generation. 
+                        HPD registration {reginfo.reg_id} skipped in portfolio generation.
                         Likely that a newer registration exists for the same building.
                         """
                     )


### PR DESCRIPTION
This PR creates an interim fix for the issue of [bbls belonging to multiple landlord portfolios](https://app.shortcut.com/justfixnyc/story/8989/multiple-wow-portfolios-records-cover-same-bbl-set) on WOWZA. So, we changed our SQL query in generating the raw data for the networkx graph to make sure that only one landlord contact corresponds to each registrationid from HPD. In the rare cases where there are multiple owners on a given registration, we have a ranking for prioritizing which owner type we define as the best one to use for portfolio generation. 

Given that the vast majority of these edge casey buildings belong to a portfolio of 1, these changes likely will not affect the scale of our portfolio generation very much, even though we are trimming down the level of possible links a building can have with others. See the [comments section of this Shortcut card](https://app.shortcut.com/justfixnyc/story/8989/multiple-wow-portfolios-records-cover-same-bbl-set) for more analysis.