### PR TITLE
Lazy load the network visualization, and the photo of it within the Big Portfolio modal

### DIFF
--- a/client/src/components/BigPortfolioWarning.tsx
+++ b/client/src/components/BigPortfolioWarning.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { t, Trans } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 import warning from "../assets/img/icon-warning.svg";
@@ -18,6 +18,12 @@ export const BigPortfolioWarning = withI18n()(
   ({ i18n, sizeOfPortfolio }: BigPortfolioWarningProps) => {
     const { methodology } = createWhoOwnsWhatRoutePaths();
     const [isLearnMoreModalVisible, setModalVisibility] = useState(false);
+
+    // Preload modal image when BigPortfolioWarning mounts:
+    useEffect(() => {
+      new Image().src = networkDiagram;
+    }, []);
+
     return sizeOfPortfolio > PORTFOLIO_SIZE_THRESHOLD ? (
       <div className="warning-banner">
         <div className="float-left">

--- a/client/src/components/LazyLoadWhenVisible.tsx
+++ b/client/src/components/LazyLoadWhenVisible.tsx
@@ -1,8 +1,18 @@
 import React, { useRef, useState, useEffect } from "react";
+import { FixedLoadingLabel } from "./Loader";
 
-export const LazyLoadWhenVisible: React.FC = (props) => {
+type LazyLoadProps = {
+  children?: React.ReactNode;
+  showLoader?: boolean;
+};
+
+export const LazyLoadWhenVisible: React.FC<LazyLoadProps> = (props) => {
+  const { children, showLoader } = props;
+
   const ref = useRef<HTMLDivElement>(null);
   const [hasBeenVisible, setHasBeenVisible] = useState(false);
+
+  const componentBeforeVisible = showLoader ? <FixedLoadingLabel /> : <></>;
 
   useEffect(() => {
     const { current } = ref;
@@ -23,8 +33,8 @@ export const LazyLoadWhenVisible: React.FC = (props) => {
   }, [ref]);
 
   if (!("IntersectionObserver" in window)) {
-    return <div>{props.children}</div>;
+    return <div>{children}</div>;
   }
 
-  return <div ref={ref}>{hasBeenVisible && props.children}</div>;
+  return <div ref={ref}>{hasBeenVisible ? children : componentBeforeVisible}</div>;
 };

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -18,6 +18,7 @@ import { I18n as I18nComponent } from "@lingui/react";
 import { PortfolioGraph } from "./PortfolioGraph";
 import { ComplaintsSummary } from "./ComplaintsSummary";
 import { BigPortfolioWarning } from "./BigPortfolioWarning";
+import { LazyLoadWhenVisible } from "./LazyLoadWhenVisible";
 
 type Props = withMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
@@ -99,11 +100,13 @@ export default class PropertiesSummary extends Component<Props, {}> {
               <Trans render="h6">Network of Landlords</Trans>
               {state.context.useNewPortfolioMethod && state.context.portfolioData.portfolioGraph && (
                 <div className="portfolio-graph-container">
-                  <PortfolioGraph
-                    graphJSON={state.context.portfolioData.portfolioGraph}
-                    state={state}
-                  />
-                  <BigPortfolioWarning sizeOfPortfolio={agg.bldgs} />
+                  <LazyLoadWhenVisible showLoader>
+                    <PortfolioGraph
+                      graphJSON={state.context.portfolioData.portfolioGraph}
+                      state={state}
+                    />
+                    <BigPortfolioWarning sizeOfPortfolio={agg.bldgs} />
+                  </LazyLoadWhenVisible>
                 </div>
               )}
               <p>

--- a/client/src/styles/PropertiesSummary.scss
+++ b/client/src/styles/PropertiesSummary.scss
@@ -41,6 +41,9 @@
     }
     .portfolio-graph-container {
       position: relative;
+      .Loader-map {
+        height: calc(55vh + 6.25rem);
+      }
       .portfolio-graph {
         position: relative;
         padding: 1rem;


### PR DESCRIPTION
This PR reduces jank by accounting for the lengthy load times of two new elements:
- The network visualization on the Summary tab takes a longggg time to laod for big portfolios, particularly [the huge one with 2500 bldgs](https://demo-whoownswhat.justfix.nyc/en/address/BROOKLYN/196/RALPH%20AVENUE). I made use of the `LazyLoadWhenVisible` component to allow the user to navigate to the Summary page and see all other content while the network viz loads with a loading icon.
- The image on the BigPortfolioWarning modal flickers on after you open the modal. I added a step to pre-load the image source when the actual warning _banner_ loads so that by the time the user opens the modal it is already loaded.