### PR TITLE
Only check urls when WOWZA portfolio mapping enabled

### DIFF
--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -143,7 +143,10 @@ export default class AddressPage extends Component<AddressPageProps, State> {
        *
        * This check makes sure that we show the Loading Page while the url and data are mismatched:
        */
-      if (!!portfolioGraph === isLegacyPath(location.pathname)) {
+      if (
+        process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1" &&
+        !!portfolioGraph === isLegacyPath(location.pathname)
+      ) {
         return <LoadingPage />;
       }
 


### PR DESCRIPTION
This PR puts the functionality that checks the Address Page component's url structure behind the REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING feature flag. This way, we can push all of our current changes to production without actually launching the new WOWZA portfolio mapping method yet. 