### PR TITLE
Reduce number of algolia network calls in LandlordSearch component

### DIFF
--- a/client/src/components/LandlordSearch.tsx
+++ b/client/src/components/LandlordSearch.tsx
@@ -45,8 +45,11 @@ const SearchBox = ({ currentRefinement, refine, updateSearchQuery }: SearchBoxPr
           aria-label={i18n._(t`Search by your landlord's name`)}
           value={currentRefinement}
           onChange={(event) => {
-            refine(event.currentTarget.value);
-            updateSearchQuery(event.currentTarget.value);
+            const searchText = event.currentTarget.value;
+            refine(searchText);
+            if (searchText.length > 3) {
+              updateSearchQuery(searchText);
+            }
           }}
         />
       </form>

--- a/client/src/components/LandlordSearch.tsx
+++ b/client/src/components/LandlordSearch.tsx
@@ -12,7 +12,6 @@ import { I18n } from "@lingui/react";
 import { t, Trans, Plural } from "@lingui/macro";
 import { Link } from "react-router-dom";
 import { createRouteForFullBbl } from "routes";
-import classnames from "classnames";
 
 import "../styles/LandlordSearch.css";
 import FocusTrap from "focus-trap-react";
@@ -31,10 +30,10 @@ type SearchBoxProps = SearchBoxProvided & {
    * This function allows us to set the global search query state of the parent
    * `<LandlordSearch>` component from within this child `<SearchBox>` component
    */
-  updateSearchQuery: (q: string) => void;
+  setIfUserTypedInput: (q: boolean) => void;
 };
 
-const SearchBox = ({ currentRefinement, refine, updateSearchQuery }: SearchBoxProps) => (
+const SearchBox = ({ currentRefinement, refine, setIfUserTypedInput }: SearchBoxProps) => (
   <I18n>
     {({ i18n }) => (
       <form noValidate action="" role="search">
@@ -45,8 +44,9 @@ const SearchBox = ({ currentRefinement, refine, updateSearchQuery }: SearchBoxPr
           aria-label={i18n._(t`Search by your landlord's name`)}
           value={currentRefinement}
           onChange={(event) => {
-            refine(event.currentTarget.value);
-            updateSearchQuery(event.currentTarget.value);
+            const searchText = event.currentTarget.value;
+            refine(searchText);
+            setIfUserTypedInput(searchText.length > 0);
           }}
         />
       </form>
@@ -135,14 +135,14 @@ const ScreenReaderAnnouncementOfSearchHits: React.FC<{ numberOfHits: number }> =
 );
 
 const LandlordSearch = () => {
-  const [query, setQuery] = useState("");
   const [numberOfHits, setNumberOfHits] = useState(0);
   const [searchIsInFocus, setSearchFocus] = useState(true);
-  const updateSearchQuery = (newQuery: string) => {
+  const [userTypedInput, setIfUserTypedInput] = useState(false);
+  const setIfUserTypedInputAndFocus = (userTypedSomethingIn: boolean) => {
     // Whenever the user changes their search query,
     // let's make our search bar in focus.
     setSearchFocus(true);
-    setQuery(newQuery);
+    setIfUserTypedInput(userTypedSomethingIn);
   };
 
   /**
@@ -150,7 +150,7 @@ const LandlordSearch = () => {
    * - the search bar is in focus
    * - they have typed in at least one character into the search bar
    */
-  const userIsCurrentlySearching = searchIsInFocus && query.length > 0;
+  const userIsCurrentlySearching = searchIsInFocus && userTypedInput;
 
   return algoliaAppId && algoliaSearchKey ? (
     <FocusTrap
@@ -169,34 +169,31 @@ const LandlordSearch = () => {
           searchClient={algoliasearch(algoliaAppId, algoliaSearchKey)}
           indexName={ALGOLIA_INDEX_NAME}
         >
-          <CustomSearchBox updateSearchQuery={updateSearchQuery} />
+          <CustomSearchBox setIfUserTypedInput={setIfUserTypedInputAndFocus} />
 
-          <div
-            // hide the search results when the user is not currently searching a name here
-            className={classnames(!userIsCurrentlySearching && "d-hide")}
-            role="region"
-            aria-live="polite"
-            aria-atomic={true}
-          >
-            <AlgoliaAPIConfiguration />
+          {userIsCurrentlySearching && (
+            <div
+              // hide the search results when the user is not currently searching a name here
+              role="region"
+              aria-live="polite"
+              aria-atomic={true}
+            >
+              <AlgoliaAPIConfiguration />
 
-            <NumberOfHitsContext.Provider value={{ numberOfHits, setNumberOfHits }}>
-              <CustomHits />
-            </NumberOfHitsContext.Provider>
+              <NumberOfHitsContext.Provider value={{ numberOfHits, setNumberOfHits }}>
+                <CustomHits />
+              </NumberOfHitsContext.Provider>
 
-            <ScreenReaderAnnouncementOfSearchHits numberOfHits={numberOfHits} />
-          </div>
+              <ScreenReaderAnnouncementOfSearchHits numberOfHits={numberOfHits} />
+            </div>
+          )}
         </InstantSearch>
 
-        <div
-          className={classnames(
-            "search-by",
-            "is-pulled-right",
-            !userIsCurrentlySearching && "d-hide"
-          )}
-        >
-          <img width="140" height="20" alt="Algolia" src={require("../assets/img/algolia.svg")} />
-        </div>
+        {userIsCurrentlySearching && (
+          <div className="search-by is-pulled-right">
+            <img width="140" height="20" alt="Algolia" src={require("../assets/img/algolia.svg")} />
+          </div>
+        )}
       </div>
     </FocusTrap>
   ) : (

--- a/client/src/components/LandlordSearch.tsx
+++ b/client/src/components/LandlordSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from "react";
+import React, { useState } from "react";
 import algoliasearch from "algoliasearch/lite";
 import {
   InstantSearch,

--- a/client/src/components/LandlordSearch.tsx
+++ b/client/src/components/LandlordSearch.tsx
@@ -45,11 +45,8 @@ const SearchBox = ({ currentRefinement, refine, updateSearchQuery }: SearchBoxPr
           aria-label={i18n._(t`Search by your landlord's name`)}
           value={currentRefinement}
           onChange={(event) => {
-            const searchText = event.currentTarget.value;
-            refine(searchText);
-            if (searchText.length > 3) {
-              updateSearchQuery(searchText);
-            }
+            refine(event.currentTarget.value);
+            updateSearchQuery(event.currentTarget.value);
           }}
         />
       </form>


### PR DESCRIPTION
This PR addresses a very unfortunate problem with the Algolia instantsearch library: where any re-rendering of the <InstantSearch> component causes a duplicate network request to Algolia, which in turn costs us one of our precious search credits that we only get a certain amount of. So, this PR does some refactoring to reduce the number of times we re-render our custom LandlordSearch component to mitigate the problem.

Previously, our search bar was making 2 duplicate network requests on every user keystroke, which meant we were draining credits twice as fast as we should. I was able to optimize our rendering processes so that now, we make:
- 1 network request on initial renter of the search bar (this is expected)
- 2 network requests on typing in our first character
- 1 network request on each additional character entered in to the search bar
- 0 network requests on deleting a character from our search bar and showing cached search results
- 3 network requests on clearing the search bar

There are likely ways we can even further reduce how many network requests that we make, but this is a solution for now while we work out with Algolia support team WHY we the default behavior is to rerun a network request on each re-render of the component. Hopefully they can help us figure out how we can actually adjust the API calls themselves so we don't need to fiddle with our react implementation that much. 