### PR TITLE
link from number of buildings to portfolio tab

### DIFF
--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -165,7 +165,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                       to={routes.portfolio}
                       tabIndex={this.props.currentTab === 2 ? -1 : 0}
                       onClick={() => {
-                        window.gtag("event", "portfolio-tab");
+                        window.gtag("event", "num-addrs-click");
                       }}
                     >
                       {assocAddrs.length}

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -160,7 +160,16 @@ export default class AddressPage extends Component<AddressPageProps, State> {
               <div className="float-left">
                 <h1 className="primary">
                   <Trans>
-                    PORTFOLIO: Your search address is associated with <u>{assocAddrs.length}</u>{" "}
+                    PORTFOLIO: Your search address is associated with{" "}
+                    <Link
+                      to={routes.portfolio}
+                      tabIndex={this.props.currentTab === 2 ? -1 : 0}
+                      onClick={() => {
+                        window.gtag("event", "portfolio-tab");
+                      }}
+                    >
+                      {assocAddrs.length}
+                    </Link>{" "}
                     <Plural value={assocAddrs.length} one="building" other="buildings" />
                   </Trans>
                 </h1>

--- a/client/src/styles/AddressPage.scss
+++ b/client/src/styles/AddressPage.scss
@@ -42,6 +42,16 @@
         @include for-phone-only() {
           font-size: 1.8rem;
         }
+
+        a {
+          color: inherit;
+          text-decoration: underline;
+        }
+
+        a:hover,
+        a:focus {
+          text-decoration: none !important;
+        }
       }
     }
 


### PR DESCRIPTION
On an address page there is a line at the top saying "your search address is associated with __X__ other buildings" with the number underlined, and it feels like you should be able to click it but it wasn't a link. This PR makes it a link to open the Portfolio tab. I didn't make this focusable because it felt like this would only be confusing and redundant since you can toggle through all the available tabs already, but let me know if it should be or there is any other accessibility change I should make. 

![image](https://user-images.githubusercontent.com/16906516/165152964-addf9bb9-fc7d-401e-8730-afb2bfc2773c.png)

[sc-9182]