### PR TITLE
add amplitude logging on more events

### DIFF
--- a/client/src/components/Accordion.tsx
+++ b/client/src/components/Accordion.tsx
@@ -10,12 +10,13 @@ type AccordionProps = {
    * once it has been opened.
    */
   titleOnOpen?: string;
+  onClick?: () => void;
   children: React.ReactNode;
 };
 
-export const Accordion: React.FC<AccordionProps> = ({ title, titleOnOpen, children }) => {
+export const Accordion: React.FC<AccordionProps> = ({ title, onClick, titleOnOpen, children }) => {
   return (
-    <details className="accordion">
+    <details className="accordion" onClick={onClick}>
       <summary>
         {titleOnOpen ? (
           <>

--- a/client/src/components/AddressToolbar.tsx
+++ b/client/src/components/AddressToolbar.tsx
@@ -11,6 +11,7 @@ import { AddressRecord } from "./APIDataTypes";
 import ExportDataButton from "./ExportData";
 import { useLocation } from "react-router-dom";
 import { createWhoOwnsWhatRoutePaths } from "routes";
+import { logAmplitudeEvent } from "./Amplitude";
 
 export type AddressToolbarProps = {
   searchAddr: SearchAddress;
@@ -29,13 +30,21 @@ const AddressToolbar: React.FC<AddressToolbarProps> = ({ searchAddr, assocAddrs 
         <Link
           className="btn btn-primary"
           onClick={() => {
+            logAmplitudeEvent("newSearch");
             window.gtag("event", "new-search");
           }}
           to={isLegacyPath(pathname) ? legacy.home : home}
         >
           <Trans>New Search</Trans>
         </Link>
-        <button className="btn" onClick={() => setExportModalVisibility(true)}>
+        <button
+          className="btn"
+          onClick={() => {
+            setExportModalVisibility(true);
+            logAmplitudeEvent("clickExportData");
+            window.gtag("event", "click-export-data");
+          }}
+        >
           <Trans>Export Data</Trans>
         </button>
       </div>

--- a/client/src/components/Amplitude.ts
+++ b/client/src/components/Amplitude.ts
@@ -10,7 +10,7 @@ if (!API_KEY) throw new Error("No Amplitude API key defined!");
 
 amplitude.getInstance().init(API_KEY);
 
-type AmplitudeEvent =
+export type AmplitudeEvent =
   | "closeFeatureCalloutWidget"
   | "openFeatureCalloutWidget"
   | "viewPreviousEntryOnFeatureCalloutWidget"
@@ -27,7 +27,44 @@ type AmplitudeEvent =
   | "hpdRegistrationIsIncomplete"
   | "hpdRegistrationNotRequired"
   | "hpdRegistrationMaybeRequired"
-  | "hpdRegistrationRequiredAndNotThere";
+  | "hpdRegistrationRequiredAndNotThere"
+  | "navbarHowToUse"
+  | "switchToEnglish"
+  | "switchToSpanish"
+  | "emailSignUp"
+  | "newSearch"
+  | "acris-overview-tab"
+  | "hpd-overview-tab"
+  | "dob-overview-tab"
+  | "dof-overview-tab"
+  | "dap-overview-tab"
+  | "acris-timeline-tab"
+  | "hpd-timeline-tab"
+  | "dob-timeline-tab"
+  | "dof-timeline-tab"
+  | "dap-timeline-tab"
+  | "acris-not-registered-page"
+  | "hpd-not-registered-page"
+  | "dob-not-registered-page"
+  | "dof-not-registered-page"
+  | "dap-not-registered-page"
+  | "numAddrsClick"
+  | "timelineTab"
+  | "portfolioTab"
+  | "summaryTab"
+  | "whoIsLandlordAccordian"
+  | "detailsOpenContactCard"
+  | "clickExportData"
+  | "downloadPortfolioData"
+  | "hpdcomplaintsTimelineTab"
+  | "hpdviolationsTimelineTab"
+  | "dobpermitsTimelineTab"
+  | "dobviolationsTimelineTab"
+  | "monthTimelineTab"
+  | "quarterTimelineTab"
+  | "yearTimelineTab"
+  | "portfolioLinktoDeed"
+  | "portfolioViewDetail";
 
 type AmplitudeEventData = {
   portfolioSize?: number;

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -22,6 +22,7 @@ import { UsefulLinks } from "./UsefulLinks";
 import _groupBy from "lodash/groupBy";
 import { HpdContactAddress, HpdFullContact } from "./APIDataTypes";
 import { isLegacyPath } from "./WowzaToggle";
+import { logAmplitudeEvent } from "./Amplitude";
 
 type Props = withI18nProps &
   withMachineInStateProps<"portfolioFound"> & {
@@ -79,10 +80,13 @@ const FormattedContactAddress: React.FC<{ address: HpdContactAddress }> = ({ add
   );
 };
 
-const HpdContactCard: React.FC<{ contact: GroupedContact }> = ({ contact }) => (
+const HpdContactCard: React.FC<{ contact: GroupedContact; onClick?: () => void }> = ({
+  contact,
+  onClick,
+}) => (
   <I18n>
     {({ i18n }) => (
-      <Accordion title={contact[0]}>
+      <Accordion title={contact[0]} onClick={onClick}>
         {contact[1].map((info, j) => (
           <div className="landlord-contact-info" key={j}>
             <span className="text-bold text-dark">
@@ -102,7 +106,14 @@ const LearnMoreAccordion = () => {
   return (
     <I18n>
       {({ i18n }) => (
-        <Accordion title={i18n._(t`Learn more`)} titleOnOpen={i18n._(t`Close`)}>
+        <Accordion
+          title={i18n._(t`Learn more`)}
+          titleOnOpen={i18n._(t`Close`)}
+          onClick={() => {
+            logAmplitudeEvent("whoIsLandlordAccordian");
+            window.gtag("event", "who-is-landlord-accordian");
+          }}
+        >
           <br />
           <Trans>
             <p>
@@ -299,7 +310,14 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                               Object.entries(_groupBy(detailAddr.allcontacts, "value"))
                                 .sort(sortContactsByImportance)
                                 .map((contact, i) => (
-                                  <HpdContactCard contact={contact} key={i} />
+                                  <HpdContactCard
+                                    contact={contact}
+                                    key={i}
+                                    onClick={() => {
+                                      logAmplitudeEvent("detailsOpenContactCard");
+                                      window.gtag("event", "details-open-contact-card");
+                                    }}
+                                  />
                                 ))
                             }
                           </div>

--- a/client/src/components/ExportData.tsx
+++ b/client/src/components/ExportData.tsx
@@ -3,6 +3,7 @@ import { Trans } from "@lingui/macro";
 import { CSVDownloader } from "react-papaparse";
 import { AddressRecord, HpdComplaintCount, HpdFullContact, HpdOwnerContact } from "./APIDataTypes";
 import helpers from "util/helpers";
+import { logAmplitudeEvent } from "./Amplitude";
 
 export const formatOwnerNames = (names: HpdOwnerContact[] | null) => {
   return names ? names.map(({ title, value }) => `${value} (${title})`).join(", ") : "";
@@ -46,7 +47,8 @@ const ExportDataButton: React.FC<{ data: AddressRecord[] }> = ({ data }) => {
       <button
         className="btn centered"
         onClick={() => {
-          window.gtag("event", "export-data");
+          logAmplitudeEvent("downloadPortfolioData");
+          window.gtag("event", "download-portfolio-data");
         }}
       >
         <Trans>Download</Trans>

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -24,6 +24,7 @@ import {
 } from "./IndicatorsTypes";
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
 import { Dropdown } from "./Dropdown";
+import { AmplitudeEvent, logAmplitudeEvent } from "./Amplitude";
 
 type TimeSpanTranslationsMap = {
   [K in IndicatorsTimeSpan]: (i18n: I18n) => string;
@@ -103,6 +104,9 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
   /** Changes viewing timespan to be by 'year', 'quarter', or 'month' */
   handleTimeSpanChange(selectedTimeSpan: IndicatorsTimeSpan) {
     var monthsInGroup = selectedTimeSpan === "quarter" ? 3 : selectedTimeSpan === "year" ? 12 : 1;
+
+    logAmplitudeEvent(`${selectedTimeSpan}TimelineTab` as AmplitudeEvent);
+    window.gtag("event", `${selectedTimeSpan}-timeline-tab`);
 
     this.setState({
       activeTimeSpan: selectedTimeSpan,
@@ -279,9 +283,6 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
                               "form-radio" +
                               (this.state.activeTimeSpan === timespan ? " active" : "")
                             }
-                            onClick={() => {
-                              window.gtag("event", "month-timeline-tab");
-                            }}
                           >
                             <input
                               type="radio"

--- a/client/src/components/IndicatorsDatasets.tsx
+++ b/client/src/components/IndicatorsDatasets.tsx
@@ -3,6 +3,7 @@ import { I18n } from "@lingui/core";
 import { t, Trans, plural } from "@lingui/macro";
 import { withI18n } from "@lingui/react";
 import { IndicatorsDatasetId } from "./IndicatorsTypes";
+import { AmplitudeEvent, logAmplitudeEvent } from "./Amplitude";
 
 /**
  * This interface encapsulates metadata about an Indicators dataset.
@@ -12,9 +13,10 @@ export interface IndicatorsDataset {
   name: (i18n: I18n) => string;
 
   /**
-   * The name to use for the dataset in analytics. This defaults to the dataset ID but
-   * can be overridden by defining this property. */
-  analyticsName?: string;
+   * The name to use for the dataset in analytics. The type options must be defined here
+   * for it to recognize the template strings as valid values for the AmplitudeEvent type
+   */
+  analyticsName: "hpdcomplaints" | "hpdviolations" | "dobpermits" | "dobviolations";
 
   /**
    * The localized name for a particular "quantity" of the dataset, e.g.
@@ -40,6 +42,7 @@ type IndicatorsDatasetMap = {
 export const INDICATORS_DATASETS: IndicatorsDatasetMap = {
   hpdcomplaints: {
     name: (i18n) => i18n._(t`HPD Complaints`),
+    analyticsName: "hpdcomplaints",
     quantity: (i18n, value) =>
       i18n._(
         plural({
@@ -77,7 +80,7 @@ export const INDICATORS_DATASETS: IndicatorsDatasetMap = {
 
   hpdviolations: {
     name: (i18n) => i18n._(t`HPD Violations`),
-    analyticsName: "violations",
+    analyticsName: "hpdviolations",
     quantity: (i18n, value) =>
       i18n._(
         plural({
@@ -119,6 +122,7 @@ export const INDICATORS_DATASETS: IndicatorsDatasetMap = {
   },
   dobpermits: {
     name: (i18n) => i18n._(t`Building Permit Applications`),
+    analyticsName: "dobpermits",
     quantity: (i18n, value) =>
       i18n._(
         plural({
@@ -149,6 +153,7 @@ export const INDICATORS_DATASETS: IndicatorsDatasetMap = {
   },
   dobviolations: {
     name: (i18n) => i18n._(t`DOB/ECB Violations`),
+    analyticsName: "dobviolations",
     quantity: (i18n, value) =>
       i18n._(
         plural({
@@ -211,7 +216,7 @@ const IndicatorsDatasetRadioWithoutI18n: React.FC<{
 }> = ({ i18n, id, activeId, onChange }) => {
   const dataset = INDICATORS_DATASETS[id];
   const isActive = activeId === id;
-  const analyticsName = dataset.analyticsName || id;
+  const analyticsName = dataset.analyticsName;
   const name = dataset.name(i18n);
 
   return (
@@ -219,6 +224,7 @@ const IndicatorsDatasetRadioWithoutI18n: React.FC<{
       <label
         className={"form-radio" + (isActive ? " active" : "")}
         onClick={() => {
+          logAmplitudeEvent(`${analyticsName}TimelineTab` as AmplitudeEvent);
           window.gtag("event", `${analyticsName}-timeline-tab`);
         }}
       >

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -19,6 +19,7 @@ import { AddressRecord, HpdComplaintCount } from "./APIDataTypes";
 import { withMachineInStateProps } from "state-machine";
 import { AddressPageRoutes } from "routes";
 import classnames from "classnames";
+import { logAmplitudeEvent } from "../components/Amplitude";
 
 export const isPartOfGroupSale = (saleId: string, addrs: AddressRecord[]) => {
   const addrsWithMatchingSale = addrs.filter((addr) => addr.lastsaleacrisid === saleId);
@@ -525,6 +526,10 @@ const TableOfData = React.memo(
                 Cell: (row) =>
                   row.original.lastsaleacrisid ? (
                     <a
+                      onClick={() => {
+                        logAmplitudeEvent("portfolioLinktoDeed");
+                        window.gtag("event", "portfolio-link-to-deed");
+                      }}
                       href={`https://a836-acris.nyc.gov/DS/DocumentSearch/DocumentImageView?doc_id=${row.original.lastsaleacrisid}`}
                       className="btn"
                       target="_blank"
@@ -576,7 +581,11 @@ const TableOfData = React.memo(
                       to={props.addressPageRoutes.overview}
                       className="btn"
                       aria-label={i18n._(t`View detail`)}
-                      onClick={() => props.onOpenDetail(row.original.bbl)}
+                      onClick={() => {
+                        props.onOpenDetail(row.original.bbl);
+                        logAmplitudeEvent("portfolioViewDetail");
+                        window.gtag("event", "portfolio-view-detail");
+                      }}
                     >
                       <span style={{ padding: "0 3px" }}>&#10142;</span>
                     </Link>

--- a/client/src/components/Subscribe.tsx
+++ b/client/src/components/Subscribe.tsx
@@ -7,6 +7,7 @@ import { withI18n } from "@lingui/react";
 import { t } from "@lingui/macro";
 import { reportError } from "error-reporting";
 import { getDataLayer } from "google-tag-manager";
+import { logAmplitudeEvent } from "./Amplitude";
 
 //import 'styles/Subscribe.css';
 
@@ -36,6 +37,9 @@ class SubscribeWithoutI18n extends React.Component<SubscribeProps, State> {
 
   handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    logAmplitudeEvent("emailSignUp");
+    window.gtag("event", "email-sign-up");
 
     const email = this.state.email || null;
     const { i18n } = this.props;

--- a/client/src/components/UsefulLinks.tsx
+++ b/client/src/components/UsefulLinks.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Trans } from "@lingui/macro";
 import Helpers from "../util/helpers";
 import { AddressRecord } from "./APIDataTypes";
+import { AmplitudeEvent, logAmplitudeEvent } from "components/Amplitude";
 
 type UsefulLinksProps = {
   addrForLinks: Pick<AddressRecord, "bbl" | "housenumber" | "streetname">;
@@ -20,6 +21,7 @@ export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location
             View documents on{" "}
             <a
               onClick={() => {
+                logAmplitudeEvent(`acris-${location}` as AmplitudeEvent);
                 window.gtag("event", `acris-${location}`);
               }}
               href={`http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`}
@@ -33,6 +35,7 @@ export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location
         <li>
           <a
             onClick={() => {
+              logAmplitudeEvent(`hpd-${location}` as AmplitudeEvent);
               window.gtag("event", `hpd-${location}`);
             }}
             href={`https://hpdonline.hpdnyc.org/HPDonline/Provide_address.aspx?p1=${boro}&p2=${housenumber}&p3=${Helpers.formatStreetNameForHpdLink(
@@ -47,6 +50,7 @@ export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location
         <li>
           <a
             onClick={() => {
+              logAmplitudeEvent(`dob-${location}` as AmplitudeEvent);
               window.gtag("event", `dob-${location}`);
             }}
             href={`http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`}
@@ -59,6 +63,7 @@ export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location
         <li>
           <a
             onClick={() => {
+              logAmplitudeEvent(`dof-${location}` as AmplitudeEvent);
               window.gtag("event", `dof-${location}`);
             }}
             href={`https://a836-pts-access.nyc.gov/care/search/commonsearch.aspx?mode=persprop`}
@@ -71,6 +76,7 @@ export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location
         <li>
           <a
             onClick={() => {
+              logAmplitudeEvent(`dap-${location}` as AmplitudeEvent);
               window.gtag("event", `dap-${location}`);
             }}
             href={`https://portal.displacementalert.org/property/${boro}${block}${lot}`}

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -22,7 +22,7 @@ import { searchAddrsAreEqual } from "util/helpers";
 import { NetworkErrorMessage } from "components/NetworkErrorMessage";
 import { createAddressPageRoutes } from "routes";
 import { isLegacyPath } from "../components/WowzaToggle";
-import { logAmplitudeEventWithData } from "components/Amplitude";
+import { logAmplitudeEvent, logAmplitudeEventWithData } from "components/Amplitude";
 
 type RouteParams = {
   locale?: string;
@@ -165,6 +165,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                       to={routes.portfolio}
                       tabIndex={this.props.currentTab === 2 ? -1 : 0}
                       onClick={() => {
+                        logAmplitudeEvent("numAddrsClick");
                         window.gtag("event", "num-addrs-click");
                       }}
                     >
@@ -184,6 +185,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                       to={routes.timeline}
                       tabIndex={this.props.currentTab === 1 ? -1 : 0}
                       onClick={() => {
+                        logAmplitudeEvent("timelineTab");
                         window.gtag("event", "timeline-tab");
                       }}
                     >
@@ -195,6 +197,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                       to={routes.portfolio}
                       tabIndex={this.props.currentTab === 2 ? -1 : 0}
                       onClick={() => {
+                        logAmplitudeEvent("portfolioTab");
                         window.gtag("event", "portfolio-tab");
                       }}
                     >
@@ -206,6 +209,7 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                       to={routes.summary}
                       tabIndex={this.props.currentTab === 3 ? -1 : 0}
                       onClick={() => {
+                        logAmplitudeEvent("summaryTab");
                         window.gtag("event", "summary-tab");
                       }}
                     >

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -41,6 +41,7 @@ import {
   ToggleLinkBetweenPortfolioMethods,
   WowzaRedirectPage,
 } from "components/WowzaToggle";
+import { logAmplitudeEvent } from "../components/Amplitude";
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -189,7 +190,14 @@ const getMainNavLinks = (isLegacyPath?: boolean) => {
     <LocaleNavLink to={isLegacyPath ? legacy.about : about} key={2}>
       <Trans>About</Trans>
     </LocaleNavLink>,
-    <LocaleNavLink to={isLegacyPath ? legacy.howToUse : howToUse} key={3}>
+    <LocaleNavLink
+      to={isLegacyPath ? legacy.howToUse : howToUse}
+      key={3}
+      onClick={() => {
+        logAmplitudeEvent("navbarHowToUse");
+        window.gtag("event", "navbar-how-to-use");
+      }}
+    >
       <Trans>How to use</Trans>
     </LocaleNavLink>,
     <a href="https://www.justfix.nyc/donate" key={4}>

--- a/client/src/i18n.tsx
+++ b/client/src/i18n.tsx
@@ -16,6 +16,7 @@ import catalogEn from "./locales/en/messages";
 import catalogEs from "./locales/es/messages";
 import { LocationDescriptorObject, History } from "history";
 import { SupportedLocale, defaultLocale, isSupportedLocale } from "./i18n-base";
+import { logAmplitudeEvent } from "./components/Amplitude";
 
 /** The structure for message catalogs that lingui expects. */
 type LocaleCatalog = {
@@ -144,7 +145,25 @@ export const LocaleSwitcher = withRouter(function LocaleSwitcher(props: RouteCom
 
   return (
     <span className="language-toggle">
-      <NavLink to={to("en")}>EN</NavLink>/<NavLink to={to("es")}>ES</NavLink>
+      <NavLink
+        to={to("en")}
+        onClick={() => {
+          logAmplitudeEvent("switchToEnglish");
+          window.gtag("event", "switch-to-english");
+        }}
+      >
+        EN
+      </NavLink>
+      /
+      <NavLink
+        to={to("es")}
+        onClick={() => {
+          logAmplitudeEvent("switchToSpanish");
+          window.gtag("event", "switch-to-spanish");
+        }}
+      >
+        ES
+      </NavLink>
     </span>
   );
 });
@@ -163,9 +182,25 @@ export const LocaleSwitcherWithFullLanguageName = withRouter(function LocaleSwit
   const currentLocale = localeFromRouter(props);
 
   return currentLocale === "en" ? (
-    <NavLink to={to("es")}>Español</NavLink>
+    <NavLink
+      to={to("es")}
+      onClick={() => {
+        logAmplitudeEvent("switchToSpanish");
+        window.gtag("event", "switch-to-spanish");
+      }}
+    >
+      Español
+    </NavLink>
   ) : (
-    <NavLink to={to("en")}>English</NavLink>
+    <NavLink
+      to={to("en")}
+      onClick={() => {
+        logAmplitudeEvent("switchToEnglish");
+        window.gtag("event", "switch-to-english");
+      }}
+    >
+      English
+    </NavLink>
   );
 });
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -21,16 +21,16 @@ msgstr "#WhoOwnsWhat via @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
-#: src/components/DetailView.tsx:241
+#: src/components/DetailView.tsx:248
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:223
+#: src/components/DetailView.tsx:230
 #: src/containers/NotRegisteredPage.tsx:103
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:226
+#: src/components/DetailView.tsx:233
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -38,7 +38,7 @@ msgstr "(expires {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
-#: src/components/PropertiesList.tsx:91
+#: src/components/PropertiesList.tsx:92
 msgid "(this may take a while)"
 msgstr "(this may take a while)"
 
@@ -66,11 +66,11 @@ msgstr "<0>This property is not required to register with HPD</0> because it doe
 msgid "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 msgstr "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 
-#: src/components/DetailView.tsx:59
+#: src/components/DetailView.tsx:63
 msgid "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 msgstr "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 
-#: src/components/IndicatorsDatasets.tsx:94
+#: src/components/IndicatorsDatasets.tsx:98
 msgid "A DOB Violation is a notice that a property is not in compliance with applicable law, usually a building code. DOB Violations typically relate to building-wide services (like elevators or boilers), the structural integrity of a property, or illegal construction. Owners must cure all DOB Violations before they can file a new or amended Certificate of Occupancy (\"CO\").<0/><1/><2>Non-ECB</2> — typical violation, no court hearing needed<3/><4>ECB (Environment Control Board)</4> — a specific violation of New York City Construction Codes or Zoning Resolution. These violations come with additional penalties and require an owner to attend an <5>OATH hearing</5>. They fall into three classes: Class I (immediately hazardous), Class II (major), and Class III (lesser).<6/><7/>Read more about DOB Violations at the <8>official DOB page</8>."
 msgstr "A DOB Violation is a notice that a property is not in compliance with applicable law, usually a building code. DOB Violations typically relate to building-wide services (like elevators or boilers), the structural integrity of a property, or illegal construction. Owners must cure all DOB Violations before they can file a new or amended Certificate of Occupancy (\"CO\").<0/><1/><2>Non-ECB</2> — typical violation, no court hearing needed<3/><4>ECB (Environment Control Board)</4> — a specific violation of New York City Construction Codes or Zoning Resolution. These violations come with additional penalties and require an owner to attend an <5>OATH hearing</5>. They fall into three classes: Class I (immediately hazardous), Class II (major), and Class III (lesser).<6/><7/>Read more about DOB Violations at the <8>official DOB page</8>."
 
@@ -78,7 +78,7 @@ msgstr "A DOB Violation is a notice that a property is not in compliance with ap
 msgid "A new set of dropdown menus and design tweaks make it more comfortable to use Who Owns What on the go."
 msgstr "A new set of dropdown menus and design tweaks make it more comfortable to use Who Owns What on the go."
 
-#: src/components/UsefulLinks.tsx:45
+#: src/components/UsefulLinks.tsx:51
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
 msgstr "ANHD DAP Portal"
@@ -88,7 +88,7 @@ msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:90
+#: src/containers/App.tsx:91
 msgid "About"
 msgstr "About"
 
@@ -104,7 +104,7 @@ msgstr "Across owners and management staff, the most common {0, plural, one {nam
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PropertiesList.tsx:111
+#: src/components/PropertiesList.tsx:112
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Address"
@@ -113,7 +113,7 @@ msgstr "Address"
 msgid "Agent"
 msgstr "Agent"
 
-#: src/components/Subscribe.tsx:43
+#: src/components/Subscribe.tsx:46
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
@@ -121,12 +121,12 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PropertiesList.tsx:371
-#: src/components/PropertiesList.tsx:379
+#: src/components/PropertiesList.tsx:372
+#: src/components/PropertiesList.tsx:380
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/DetailView.tsx:254
+#: src/components/DetailView.tsx:261
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -138,12 +138,12 @@ msgstr "Are you having issues in this development?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:150
+#: src/components/DetailView.tsx:154
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/PropertiesList.tsx:152
-#: src/components/PropertiesList.tsx:157
+#: src/components/PropertiesList.tsx:153
+#: src/components/PropertiesList.tsx:158
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -152,11 +152,11 @@ msgstr "Borough"
 msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
-#: src/components/IndicatorsDatasets.tsx:66
+#: src/components/IndicatorsDatasets.tsx:68
 msgid "Building Permit Applications"
 msgstr "Building Permit Applications"
 
-#: src/components/IndicatorsDatasets.tsx:72
+#: src/components/IndicatorsDatasets.tsx:75
 #: src/components/IndicatorsViz.tsx:183
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
@@ -169,19 +169,19 @@ msgstr "Building info"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PropertiesList.tsx:180
-#: src/components/PropertiesList.tsx:185
+#: src/components/PropertiesList.tsx:181
+#: src/components/PropertiesList.tsx:186
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:313
-#: src/components/DetailView.tsx:322
+#: src/components/DetailView.tsx:320
+#: src/components/DetailView.tsx:329
 #: src/components/PortfolioGraph.tsx:129
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:293
-#: src/components/DetailView.tsx:302
+#: src/components/DetailView.tsx:300
+#: src/components/DetailView.tsx:309
 msgid "Business Entities"
 msgstr "Business Entities"
 
@@ -201,7 +201,7 @@ msgstr "CONSTRUCTION"
 msgid "COOKING GAS"
 msgstr "COOKING GAS"
 
-#: src/components/DetailView.tsx:26
+#: src/components/DetailView.tsx:27
 msgid "Check out the issues in this building"
 msgstr "Check out the issues in this building"
 
@@ -233,9 +233,9 @@ msgstr "Clearer Landlord Contact Info"
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
-#: src/components/DetailView.tsx:57
+#: src/components/DetailView.tsx:58
 #: src/components/FeatureCalloutWidget.tsx:60
-#: src/containers/App.tsx:160
+#: src/containers/App.tsx:164
 msgid "Close"
 msgstr "Close"
 
@@ -243,7 +243,7 @@ msgstr "Close"
 msgid "Close legend"
 msgstr "Close legend"
 
-#: src/components/IndicatorsDatasets.tsx:12
+#: src/components/IndicatorsDatasets.tsx:14
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
 
@@ -259,15 +259,15 @@ msgstr "Corporate Owner"
 msgid "Corporation"
 msgstr "Corporation"
 
-#: src/components/UsefulLinks.tsx:31
+#: src/components/UsefulLinks.tsx:35
 msgid "DOB Building Profile"
 msgstr "DOB Building Profile"
 
-#: src/components/IndicatorsDatasets.tsx:87
+#: src/components/IndicatorsDatasets.tsx:90
 msgid "DOB/ECB Violations"
 msgstr "DOB/ECB Violations"
 
-#: src/components/UsefulLinks.tsx:38
+#: src/components/UsefulLinks.tsx:43
 msgid "DOF Property Tax Bills"
 msgstr "DOF Property Tax Bills"
 
@@ -279,12 +279,12 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PropertiesList.tsx:359
-#: src/components/PropertiesList.tsx:367
+#: src/components/PropertiesList.tsx:360
+#: src/components/PropertiesList.tsx:368
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:109
+#: src/containers/App.tsx:113
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -292,17 +292,17 @@ msgstr "Demo Site"
 msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
-#: src/components/Indicators.tsx:166
-#: src/components/Indicators.tsx:169
+#: src/components/Indicators.tsx:167
+#: src/components/Indicators.tsx:170
 msgid "Display:"
 msgstr "Display:"
 
 #: src/components/LegalFooter.tsx:35
-#: src/containers/App.tsx:96
+#: src/containers/App.tsx:100
 msgid "Donate"
 msgstr "Donate"
 
-#: src/components/ExportData.tsx:48
+#: src/components/ExportData.tsx:50
 msgid "Download"
 msgstr "Download"
 
@@ -330,12 +330,12 @@ msgstr "Emergency"
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Enter an NYC address and find other buildings your landlord might own:"
 
-#: src/components/Subscribe.tsx:76
+#: src/components/Subscribe.tsx:79
 msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:290
+#: src/components/PropertiesList.tsx:291
 #: src/components/PropertiesSummary.tsx:123
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -349,7 +349,7 @@ msgstr "Evictions executed by NYC Marshals since 2017. ANHD and the Housing Data
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
-#: src/components/AddressToolbar.tsx:24
+#: src/components/AddressToolbar.tsx:29
 msgid "Export Data"
 msgstr "Export Data"
 
@@ -377,8 +377,8 @@ msgstr "Find other buildings your landlord might own:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
-#: src/components/PropertiesList.tsx:392
-#: src/components/PropertiesList.tsx:406
+#: src/components/PropertiesList.tsx:396
+#: src/components/PropertiesList.tsx:410
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -390,25 +390,25 @@ msgstr "HEAT/HOT WATER"
 msgid "HEATING"
 msgstr "HEATING"
 
-#: src/components/UsefulLinks.tsx:24
+#: src/components/UsefulLinks.tsx:27
 msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
-#: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:227
+#: src/components/IndicatorsDatasets.tsx:7
+#: src/components/PropertiesList.tsx:228
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
-#: src/components/IndicatorsDatasets.tsx:13
+#: src/components/IndicatorsDatasets.tsx:15
 msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
-#: src/components/IndicatorsDatasets.tsx:33
-#: src/components/PropertiesList.tsx:267
+#: src/components/IndicatorsDatasets.tsx:35
+#: src/components/PropertiesList.tsx:268
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
-#: src/components/IndicatorsDatasets.tsx:41
+#: src/components/IndicatorsDatasets.tsx:43
 msgid "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner—however, HPD Violations are notoriously unenforced by the City. These violations fall into four categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8>Class I</8> — fundamental property issue (e.g. landlord failed to register, building in Alt. Enforcement Program, Vacate Order issued)<9/><10/>Read more about HPD Violations at the <11>official HPD page</11>."
 msgstr "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner—however, HPD Violations are notoriously unenforced by the City. These violations fall into four categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8>Class I</8> — fundamental property issue (e.g. landlord failed to register, building in Alt. Enforcement Program, Vacate Order issued)<9/><10/>Read more about HPD Violations at the <11>official HPD page</11>."
 
@@ -420,20 +420,20 @@ msgstr "HUD Complaint Form 958"
 msgid "Head Officer"
 msgstr "Head Officer"
 
-#: src/components/DetailView.tsx:83
+#: src/components/DetailView.tsx:87
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:93
+#: src/containers/App.tsx:97
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
 
-#: src/components/DetailView.tsx:27
+#: src/components/DetailView.tsx:28
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 
-#: src/components/DetailView.tsx:25
+#: src/components/DetailView.tsx:26
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
@@ -453,7 +453,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PropertiesList.tsx:176
+#: src/components/PropertiesList.tsx:177
 msgid "Information"
 msgstr "Information"
 
@@ -481,7 +481,7 @@ msgstr "Known for <0>unscrupulously deregulating rent stabilized apartments</0>,
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PropertiesList.tsx:304
+#: src/components/PropertiesList.tsx:305
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -493,12 +493,12 @@ msgstr "Landlord name"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PropertiesList.tsx:240
-#: src/components/PropertiesList.tsx:245
+#: src/components/PropertiesList.tsx:241
+#: src/components/PropertiesList.tsx:246
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PropertiesList.tsx:355
+#: src/components/PropertiesList.tsx:356
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -506,17 +506,17 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:218
+#: src/components/DetailView.tsx:225
 #: src/containers/NotRegisteredPage.tsx:98
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:231
+#: src/components/DetailView.tsx:238
 msgid "Last sold:"
 msgstr "Last sold:"
 
 #: src/components/BigPortfolioWarning.tsx:27
-#: src/components/DetailView.tsx:57
+#: src/components/DetailView.tsx:58
 msgid "Learn more"
 msgstr "Learn more"
 
@@ -528,23 +528,23 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PropertiesList.tsx:382
-#: src/components/PropertiesList.tsx:384
+#: src/components/PropertiesList.tsx:383
 #: src/components/PropertiesList.tsx:388
+#: src/components/PropertiesList.tsx:392
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:92
+#: src/components/PropertiesList.tsx:93
 #: src/components/PropertiesMap.tsx:158
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:89
+#: src/components/PropertiesList.tsx:90
 msgid "Loading {0} rows"
 msgstr "Loading {0} rows"
 
-#: src/components/PropertiesList.tsx:136
+#: src/components/PropertiesList.tsx:137
 msgid "Location"
 msgstr "Location"
 
@@ -585,15 +585,15 @@ msgstr "Methodology"
 msgid "More Mobile Friendly"
 msgstr "More Mobile Friendly"
 
-#: src/components/DetailView.tsx:178
+#: src/components/DetailView.tsx:182
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
-#: src/components/Indicators.tsx:199
+#: src/components/Indicators.tsx:201
 msgid "Move chart data left."
 msgstr "Move chart data left."
 
-#: src/components/Indicators.tsx:208
+#: src/components/Indicators.tsx:210
 msgid "Move chart data right."
 msgstr "Move chart data right."
 
@@ -617,7 +617,7 @@ msgstr "Network of Landlords"
 msgid "New"
 msgstr "New"
 
-#: src/components/AddressToolbar.tsx:21
+#: src/components/AddressToolbar.tsx:22
 msgid "New Search"
 msgstr "New Search"
 
@@ -629,7 +629,7 @@ msgstr "New York Regional Office:"
 msgid "Next"
 msgstr "Next"
 
-#: src/components/PropertiesList.tsx:403
+#: src/components/PropertiesList.tsx:407
 msgid "No"
 msgstr "No"
 
@@ -642,7 +642,7 @@ msgstr "No address found"
 msgid "No data available"
 msgstr "No data available"
 
-#: src/components/LandlordSearch.tsx:51
+#: src/components/LandlordSearch.tsx:71
 msgid "No landlords match your search."
 msgstr "No landlords match your search."
 
@@ -662,7 +662,7 @@ msgstr "Non-ECB"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:186
+#: src/components/DetailView.tsx:190
 msgid "None"
 msgstr "None"
 
@@ -683,23 +683,23 @@ msgstr "OWNS"
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PropertiesList.tsx:308
-#: src/components/PropertiesList.tsx:320
+#: src/components/PropertiesList.tsx:309
+#: src/components/PropertiesList.tsx:321
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
 #: src/components/NetworkErrorMessage.tsx:5
-#: src/components/Subscribe.tsx:54
-#: src/components/Subscribe.tsx:60
+#: src/components/Subscribe.tsx:57
+#: src/components/Subscribe.tsx:63
 msgid "Oops! A network error occurred. Try again later."
 msgstr "Oops! A network error occurred. Try again later."
 
-#: src/components/Subscribe.tsx:48
+#: src/components/Subscribe.tsx:51
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PropertiesList.tsx:271
-#: src/components/PropertiesList.tsx:276
+#: src/components/PropertiesList.tsx:272
+#: src/components/PropertiesList.tsx:277
 msgid "Open"
 msgstr "Open"
 
@@ -707,7 +707,7 @@ msgstr "Open"
 msgid "Open Violations"
 msgstr "Open Violations"
 
-#: src/containers/AddressPage.tsx:127
+#: src/containers/AddressPage.tsx:133
 msgid "Overview"
 msgstr "Overview"
 
@@ -715,7 +715,7 @@ msgstr "Overview"
 msgid "Owner Names"
 msgstr "Owner Names"
 
-#: src/components/IndicatorsDatasets.tsx:73
+#: src/components/IndicatorsDatasets.tsx:76
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 
@@ -735,16 +735,16 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/DetailView.tsx:333
-#: src/components/DetailView.tsx:343
+#: src/components/DetailView.tsx:340
+#: src/components/DetailView.tsx:350
 msgid "People"
 msgstr "People"
 
-#: src/components/Subscribe.tsx:22
+#: src/components/Subscribe.tsx:25
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/containers/AddressPage.tsx:141
+#: src/containers/AddressPage.tsx:149
 msgid "Portfolio"
 msgstr "Portfolio"
 
@@ -766,7 +766,7 @@ msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:199
+#: src/components/PropertiesList.tsx:200
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -798,11 +798,11 @@ msgstr "SIGNAGE MISSING"
 msgid "STAIRS"
 msgstr "STAIRS"
 
-#: src/containers/App.tsx:82
+#: src/containers/App.tsx:83
 msgid "Search"
 msgstr "Search"
 
-#: src/components/LandlordSearch.tsx:19
+#: src/components/LandlordSearch.tsx:26
 msgid "Search by your landlord's name"
 msgstr "Search by your landlord's name"
 
@@ -815,7 +815,7 @@ msgstr "Search by:"
 msgid "Search for a different address"
 msgstr "Search for a different address"
 
-#: src/components/LandlordSearch.tsx:19
+#: src/components/LandlordSearch.tsx:26
 msgid "Search landlords"
 msgstr "Search landlords"
 
@@ -827,15 +827,15 @@ msgstr "See the most common complaints reported by tenants to 311, now on the Ov
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:117
-#: src/containers/App.tsx:128
+#: src/containers/App.tsx:121
+#: src/containers/App.tsx:132
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:263
+#: src/components/DetailView.tsx:270
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:140
-#: src/containers/App.tsx:138
+#: src/containers/App.tsx:142
 #: src/containers/NotRegisteredPage.tsx:18
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -844,7 +844,7 @@ msgstr "Share this page with your neighbors"
 msgid "Shareholder"
 msgstr "Shareholder"
 
-#: src/components/Subscribe.tsx:77
+#: src/components/Subscribe.tsx:80
 msgid "Sign up"
 msgstr "Sign up"
 
@@ -852,8 +852,8 @@ msgstr "Sign up"
 msgid "Sign up for email updates"
 msgstr "Sign up for email updates"
 
-#: src/components/PropertiesList.tsx:294
-#: src/components/PropertiesList.tsx:299
+#: src/components/PropertiesList.tsx:295
+#: src/components/PropertiesList.tsx:300
 msgid "Since 2017"
 msgstr "Since 2017"
 
@@ -861,7 +861,7 @@ msgstr "Since 2017"
 msgid "Since 2017, NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/components/PropertiesList.tsx:23
+#: src/components/PropertiesList.tsx:24
 msgid "Since {year}"
 msgstr "Since {year}"
 
@@ -889,11 +889,11 @@ msgstr "Sorry, the page you are looking for doesn't seem to exist."
 msgid "Source code"
 msgstr "Source code"
 
-#: src/components/PropertiesList.tsx:23
+#: src/components/PropertiesList.tsx:24
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
-#: src/containers/AddressPage.tsx:148
+#: src/containers/AddressPage.tsx:157
 msgid "Summary"
 msgstr "Summary"
 
@@ -909,12 +909,12 @@ msgstr "Switch to old version"
 msgid "TENANT HARASSMENT"
 msgstr "TENANT HARASSMENT"
 
-#: src/components/DetailView.tsx:257
+#: src/components/DetailView.tsx:264
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "Take action on JustFix.nyc!"
 
-#: src/components/PropertiesList.tsx:328
+#: src/components/PropertiesList.tsx:329
 msgid "Tax Exemptions"
 msgstr "Tax Exemptions"
 
@@ -987,7 +987,7 @@ msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "This building is owned by the NYC Housing Authority (NYCHA)"
 
-#: src/components/AddressToolbar.tsx:32
+#: src/components/AddressToolbar.tsx:37
 msgid "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 msgstr "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 
@@ -1039,24 +1039,24 @@ msgstr "This represents the total number of HPD Violations (both open & closed) 
 msgid "This tracks how rent stabilized units in the building have changed (i.e. \"{delta}\") from 2007 to {0}. If the number for {1} is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
 msgstr "This tracks how rent stabilized units in the building have changed (i.e. \"{delta}\") from 2007 to {0}. If the number for {1} is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
 
-#: src/components/AddressToolbar.tsx:28
+#: src/components/AddressToolbar.tsx:33
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:134
+#: src/containers/AddressPage.tsx:141
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PropertiesList.tsx:249
-#: src/components/PropertiesList.tsx:259
+#: src/components/PropertiesList.tsx:250
+#: src/components/PropertiesList.tsx:260
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:338
-#: src/components/PropertiesList.tsx:231
-#: src/components/PropertiesList.tsx:236
-#: src/components/PropertiesList.tsx:280
-#: src/components/PropertiesList.tsx:285
+#: src/components/PropertiesList.tsx:232
+#: src/components/PropertiesList.tsx:237
+#: src/components/PropertiesList.tsx:281
+#: src/components/PropertiesList.tsx:286
 msgid "Total"
 msgstr "Total"
 
@@ -1073,17 +1073,17 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:189
-#: src/components/PropertiesList.tsx:194
+#: src/components/PropertiesList.tsx:190
+#: src/components/PropertiesList.tsx:195
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
 
-#: src/components/LandlordSearch.tsx:61
+#: src/components/LandlordSearch.tsx:50
 msgid "Use the escape key to quit searching."
 msgstr "Use the escape key to quit searching."
 
-#: src/components/LandlordSearch.tsx:61
+#: src/components/LandlordSearch.tsx:50
 msgid "Use the tab key to navigate. Press the enter key to select."
 msgstr "Use the tab key to navigate. Press the enter key to select."
 
@@ -1091,7 +1091,7 @@ msgstr "Use the tab key to navigate. Press the enter key to select."
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 
-#: src/components/UsefulLinks.tsx:8
+#: src/components/UsefulLinks.tsx:9
 #: src/containers/NychaPage.tsx:153
 msgid "Useful links"
 msgstr "Useful links"
@@ -1100,22 +1100,22 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
-#: src/components/Indicators.tsx:177
-#: src/components/Indicators.tsx:180
+#: src/components/Indicators.tsx:178
+#: src/components/Indicators.tsx:181
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:172
+#: src/components/DetailView.tsx:176
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PropertiesList.tsx:412
-#: src/components/PropertiesList.tsx:418
+#: src/components/PropertiesList.tsx:416
 #: src/components/PropertiesList.tsx:422
+#: src/components/PropertiesList.tsx:430
 msgid "View detail"
 msgstr "View detail"
 
-#: src/components/UsefulLinks.tsx:11
+#: src/components/UsefulLinks.tsx:12
 msgid "View documents on <0>ACRIS</0>"
 msgstr "View documents on <0>ACRIS</0>"
 
@@ -1129,12 +1129,12 @@ msgstr "View legend"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:142
+#: src/components/DetailView.tsx:146
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
-#: src/components/IndicatorsDatasets.tsx:40
-#: src/components/IndicatorsDatasets.tsx:93
+#: src/components/IndicatorsDatasets.tsx:42
+#: src/components/IndicatorsDatasets.tsx:97
 msgid "Violations Issued"
 msgstr "Violations Issued"
 
@@ -1158,11 +1158,11 @@ msgstr "WINDOWS"
 msgid "Warning"
 msgstr "Warning"
 
-#: src/components/DetailView.tsx:210
+#: src/components/DetailView.tsx:217
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 
-#: src/components/DetailView.tsx:87
+#: src/components/DetailView.tsx:91
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -1178,7 +1178,7 @@ msgstr "We reorganized the contact details for each individual and corporate ent
 msgid "We’ve improved Who Owns What to dig deeper into the data and offer you a more complete picture of buildings associated with your landlord. <0>Read more on our Methodology page</0>"
 msgstr "We’ve improved Who Owns What to dig deeper into the data and offer you a more complete picture of buildings associated with your landlord. <0>Read more on our Methodology page</0>"
 
-#: src/components/Indicators.tsx:222
+#: src/components/Indicators.tsx:224
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
@@ -1199,14 +1199,14 @@ msgstr "When two parties share the same business address, we group them as part 
 msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 
-#: src/containers/App.tsx:37
+#: src/containers/App.tsx:38
 msgid "Who owns what in n y c?"
 msgstr "Who owns what in n y c?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:20
 #: src/components/Page.tsx:21
-#: src/containers/App.tsx:32
+#: src/containers/App.tsx:33
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 
@@ -1214,7 +1214,7 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:193
+#: src/components/DetailView.tsx:197
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -1227,20 +1227,20 @@ msgstr "Why am I seeing such a big portfolio?"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PropertiesList.tsx:402
+#: src/components/PropertiesList.tsx:406
 msgid "Yes"
 msgstr "Yes"
 
-#: src/containers/App.tsx:157
+#: src/containers/App.tsx:161
 msgid "You are viewing the new version of Who Owns What."
 msgstr "You are viewing the new version of Who Owns What."
 
-#: src/containers/App.tsx:157
+#: src/containers/App.tsx:161
 msgid "You are viewing the old version of Who Owns What."
 msgstr "You are viewing the old version of Who Owns What."
 
-#: src/components/PropertiesList.tsx:142
-#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:143
+#: src/components/PropertiesList.tsx:148
 msgid "Zipcode"
 msgstr "Zipcode"
 
@@ -1260,15 +1260,15 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:235
+#: src/components/DetailView.tsx:242
 msgid "for ${0}"
 msgstr "for ${0}"
 
-#: src/components/Indicators.tsx:15
+#: src/components/Indicators.tsx:16
 msgid "month"
 msgstr "month"
 
-#: src/components/Indicators.tsx:16
+#: src/components/Indicators.tsx:17
 msgid "quarter"
 msgstr "quarter"
 
@@ -1276,7 +1276,7 @@ msgstr "quarter"
 msgid "search address"
 msgstr "search address"
 
-#: src/components/Indicators.tsx:17
+#: src/components/Indicators.tsx:18
 msgid "year"
 msgstr "year"
 
@@ -1288,22 +1288,22 @@ msgstr "{0} of {numberOfEntries}"
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 
-#: src/components/LandlordSearch.tsx:58
+#: src/components/LandlordSearch.tsx:47
 msgid "{numberOfHits} {numberOfHits, plural, one {search result} other {search results}}."
 msgstr "{numberOfHits} {numberOfHits, plural, one {search result} other {search results}}."
 
-#: src/components/IndicatorsDatasets.tsx:67
+#: src/components/IndicatorsDatasets.tsx:70
 msgid "{value, plural, one {One Building Permit Application since 2010} other {# Building Permit Applications since 2010}}"
 msgstr "{value, plural, one {One Building Permit Application since 2010} other {# Building Permit Applications since 2010}}"
 
-#: src/components/IndicatorsDatasets.tsx:88
+#: src/components/IndicatorsDatasets.tsx:92
 msgid "{value, plural, one {One DOB/ECB Violation Issued since 2010} other {# DOB/ECB Violations Issued since 2010}}"
 msgstr "{value, plural, one {One DOB/ECB Violation Issued since 2010} other {# DOB/ECB Violations Issued since 2010}}"
 
-#: src/components/IndicatorsDatasets.tsx:7
+#: src/components/IndicatorsDatasets.tsx:9
 msgid "{value, plural, one {One HPD Complaint Issued since 2014} other {# HPD Complaints Issued since 2014}}"
 msgstr "{value, plural, one {One HPD Complaint Issued since 2014} other {# HPD Complaints Issued since 2014}}"
 
-#: src/components/IndicatorsDatasets.tsx:35
+#: src/components/IndicatorsDatasets.tsx:37
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -26,16 +26,16 @@ msgstr "#QuiénEsElDueño por @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
-#: src/components/DetailView.tsx:241
+#: src/components/DetailView.tsx:248
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:223
+#: src/components/DetailView.tsx:230
 #: src/containers/NotRegisteredPage.tsx:103
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:226
+#: src/components/DetailView.tsx:233
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -43,7 +43,7 @@ msgstr "(caduca {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
-#: src/components/PropertiesList.tsx:91
+#: src/components/PropertiesList.tsx:92
 msgid "(this may take a while)"
 msgstr "(esto puede tardar un rato)"
 
@@ -71,11 +71,11 @@ msgstr "<0>Esta propiedad no necesita estar registrada con en HPD</0> porque no 
 msgid "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 msgstr "<0>Esta propiedad debe estar registrada con en HPD</0> porque tiene más de 2 unidades residenciales."
 
-#: src/components/DetailView.tsx:59
+#: src/components/DetailView.tsx:63
 msgid "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 msgstr "<0>Mientras el dueño legal de un edificio es, con frecuencia, una compañía (se llama muchas veces un “LLC”), estos nombres y direcciones de negocio registrado con HPD se ofrecen una idea más clara de quién controla el edificio.</0><1>Las personas enumeradas aquí como “Oficial Principal” o “Dueño” normalmente tienen una conexión con la propiedad del edificio, mientras que los \"Administradores del Sitio\" formen parte de la gerencia. Dicho eso, estos nombres son autoinformados por el dueño, y entonces pueden ser engañosos.</1><2>Aprende más acerca de registros de HPD y cómo esta información impulsa la herramienta en la <3>página “Acerca de”</3>.</2>"
 
-#: src/components/IndicatorsDatasets.tsx:94
+#: src/components/IndicatorsDatasets.tsx:98
 msgid "A DOB Violation is a notice that a property is not in compliance with applicable law, usually a building code. DOB Violations typically relate to building-wide services (like elevators or boilers), the structural integrity of a property, or illegal construction. Owners must cure all DOB Violations before they can file a new or amended Certificate of Occupancy (\"CO\").<0/><1/><2>Non-ECB</2> — typical violation, no court hearing needed<3/><4>ECB (Environment Control Board)</4> — a specific violation of New York City Construction Codes or Zoning Resolution. These violations come with additional penalties and require an owner to attend an <5>OATH hearing</5>. They fall into three classes: Class I (immediately hazardous), Class II (major), and Class III (lesser).<6/><7/>Read more about DOB Violations at the <8>official DOB page</8>."
 msgstr "Una violación de DOB es un aviso de que una propiedad no cumple con la ley aplicable, generalmente un código de edificios. Las violaciones de DOB generalmente se relacionan con servicios en todo el edificio (como ascensores o calderas), la integridad estructural de una propiedad o la construcción ilegal. Los dueños deben arreglar todas las violaciones de DOB antes de poder presentar un Certificado de ocupación (\"CO\") nuevo o enmendado.<0/><1/><2>No ECB</2> — infracción típica, no se necesita audiencia judicial<3/><4>ECB (Junta de Control Medioambiental)</4> — una violación específica de los Códigos de Construcción de la Ciudad de Nueva York o la Resolución de Zonificación. Estas violaciones vienen con sanciones adicionales y requieren que el dueño asista a una <5>audiencia de OATH</5>. Se dividen en tres clases: Clase I (peligro inmediato), Clase II (mayor) y Clase III (menor).<6/><7/>Encontrarás más información sobre las violaciones del DOB en la <8>página oficial del DOB</8>."
 
@@ -83,7 +83,7 @@ msgstr "Una violación de DOB es un aviso de que una propiedad no cumple con la 
 msgid "A new set of dropdown menus and design tweaks make it more comfortable to use Who Owns What on the go."
 msgstr "Un nuevo conjunto de menús desplegables y ajustes de diseño hacen que sea más cómodo usar ¿Quién Es El Dueño? donde vaya."
 
-#: src/components/UsefulLinks.tsx:45
+#: src/components/UsefulLinks.tsx:51
 #: src/containers/NychaPage.tsx:168
 msgid "ANHD DAP Portal"
 msgstr "Portal DAP de ANHD"
@@ -93,7 +93,7 @@ msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:90
+#: src/containers/App.tsx:91
 msgid "About"
 msgstr "Acerca de"
 
@@ -109,7 +109,7 @@ msgstr "En todos los dueños y administradores, {0, plural, one {el nombre más 
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PropertiesList.tsx:111
+#: src/components/PropertiesList.tsx:112
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Dirección"
@@ -118,7 +118,7 @@ msgstr "Dirección"
 msgid "Agent"
 msgstr "Agente"
 
-#: src/components/Subscribe.tsx:43
+#: src/components/Subscribe.tsx:46
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
@@ -126,12 +126,12 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PropertiesList.tsx:371
-#: src/components/PropertiesList.tsx:379
+#: src/components/PropertiesList.tsx:372
+#: src/components/PropertiesList.tsx:380
 msgid "Amount"
 msgstr "Importe"
 
-#: src/components/DetailView.tsx:254
+#: src/components/DetailView.tsx:261
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -143,12 +143,12 @@ msgstr "¿Tienes problemas en tu edificio?"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:150
+#: src/components/DetailView.tsx:154
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/PropertiesList.tsx:152
-#: src/components/PropertiesList.tsx:157
+#: src/components/PropertiesList.tsx:153
+#: src/components/PropertiesList.tsx:158
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -157,11 +157,11 @@ msgstr "Municipio"
 msgid "Borough Management Office:"
 msgstr "Oficina de Gestión Municipal:"
 
-#: src/components/IndicatorsDatasets.tsx:66
+#: src/components/IndicatorsDatasets.tsx:68
 msgid "Building Permit Applications"
 msgstr "Solicitudes de Permisos de Construcción"
 
-#: src/components/IndicatorsDatasets.tsx:72
+#: src/components/IndicatorsDatasets.tsx:75
 #: src/components/IndicatorsViz.tsx:183
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
@@ -174,19 +174,19 @@ msgstr "Información de edificios"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PropertiesList.tsx:180
-#: src/components/PropertiesList.tsx:185
+#: src/components/PropertiesList.tsx:181
+#: src/components/PropertiesList.tsx:186
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:313
-#: src/components/DetailView.tsx:322
+#: src/components/DetailView.tsx:320
+#: src/components/DetailView.tsx:329
 #: src/components/PortfolioGraph.tsx:129
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:293
-#: src/components/DetailView.tsx:302
+#: src/components/DetailView.tsx:300
+#: src/components/DetailView.tsx:309
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
@@ -206,7 +206,7 @@ msgstr "CONSTRUCCIÓN"
 msgid "COOKING GAS"
 msgstr "GAS DE COCINA"
 
-#: src/components/DetailView.tsx:26
+#: src/components/DetailView.tsx:27
 msgid "Check out the issues in this building"
 msgstr "Mira los problemas en este edificio"
 
@@ -238,9 +238,9 @@ msgstr "Información de contacto del dueño más clara"
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
-#: src/components/DetailView.tsx:57
+#: src/components/DetailView.tsx:58
 #: src/components/FeatureCalloutWidget.tsx:60
-#: src/containers/App.tsx:160
+#: src/containers/App.tsx:164
 msgid "Close"
 msgstr "Cerrar"
 
@@ -248,7 +248,7 @@ msgstr "Cerrar"
 msgid "Close legend"
 msgstr "Cerrar leyenda"
 
-#: src/components/IndicatorsDatasets.tsx:12
+#: src/components/IndicatorsDatasets.tsx:14
 msgid "Complaints Issued"
 msgstr "Quejas Emitidas"
 
@@ -264,15 +264,15 @@ msgstr "Dueño Corporativo"
 msgid "Corporation"
 msgstr "Corporación"
 
-#: src/components/UsefulLinks.tsx:31
+#: src/components/UsefulLinks.tsx:35
 msgid "DOB Building Profile"
 msgstr "Perfil de edificio en DOB"
 
-#: src/components/IndicatorsDatasets.tsx:87
+#: src/components/IndicatorsDatasets.tsx:90
 msgid "DOB/ECB Violations"
 msgstr "Violaciones del DOB/ECB"
 
-#: src/components/UsefulLinks.tsx:38
+#: src/components/UsefulLinks.tsx:43
 msgid "DOF Property Tax Bills"
 msgstr "Facturas de Impuestos del DOF"
 
@@ -284,12 +284,12 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PropertiesList.tsx:359
-#: src/components/PropertiesList.tsx:367
+#: src/components/PropertiesList.tsx:360
+#: src/components/PropertiesList.tsx:368
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:109
+#: src/containers/App.tsx:113
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -297,17 +297,17 @@ msgstr "Sitio Demo"
 msgid "Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "Descargo de responsabilidad: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarte a dirigirte a servicios legales gratuitos si es necesario."
 
-#: src/components/Indicators.tsx:166
-#: src/components/Indicators.tsx:169
+#: src/components/Indicators.tsx:167
+#: src/components/Indicators.tsx:170
 msgid "Display:"
 msgstr "Mostrar:"
 
 #: src/components/LegalFooter.tsx:35
-#: src/containers/App.tsx:96
+#: src/containers/App.tsx:100
 msgid "Donate"
 msgstr "Donar"
 
-#: src/components/ExportData.tsx:48
+#: src/components/ExportData.tsx:50
 msgid "Download"
 msgstr "Descargar"
 
@@ -335,12 +335,12 @@ msgstr "Emergencia"
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
 
-#: src/components/Subscribe.tsx:76
+#: src/components/Subscribe.tsx:79
 msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/BuildingStatsTable.tsx:71
-#: src/components/PropertiesList.tsx:290
+#: src/components/PropertiesList.tsx:291
 #: src/components/PropertiesSummary.tsx:123
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
@@ -354,7 +354,7 @@ msgstr "Desalojos ejecutados en este edificio por el Mariscal de NYC desde el 20
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 2017. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes del DOI."
 
-#: src/components/AddressToolbar.tsx:24
+#: src/components/AddressToolbar.tsx:29
 msgid "Export Data"
 msgstr "Exportar datos"
 
@@ -382,8 +382,8 @@ msgstr "Encuentra otros edificios que tu propietario podría poseer:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
-#: src/components/PropertiesList.tsx:392
-#: src/components/PropertiesList.tsx:406
+#: src/components/PropertiesList.tsx:396
+#: src/components/PropertiesList.tsx:410
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -395,25 +395,25 @@ msgstr "CALEFACCIÓN/AGUA CALIENTE"
 msgid "HEATING"
 msgstr "CALEFACCIÓN"
 
-#: src/components/UsefulLinks.tsx:24
+#: src/components/UsefulLinks.tsx:27
 msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
-#: src/components/IndicatorsDatasets.tsx:6
-#: src/components/PropertiesList.tsx:227
+#: src/components/IndicatorsDatasets.tsx:7
+#: src/components/PropertiesList.tsx:228
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
-#: src/components/IndicatorsDatasets.tsx:13
+#: src/components/IndicatorsDatasets.tsx:15
 msgid "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontrarás más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
-#: src/components/IndicatorsDatasets.tsx:33
-#: src/components/PropertiesList.tsx:267
+#: src/components/IndicatorsDatasets.tsx:35
+#: src/components/PropertiesList.tsx:268
 msgid "HPD Violations"
 msgstr "Violaciones del HPD"
 
-#: src/components/IndicatorsDatasets.tsx:41
+#: src/components/IndicatorsDatasets.tsx:43
 msgid "HPD Violations occur when an official City Inspector finds the conditions of a home in violation of the law. If not corrected, these violations incur fines for the owner—however, HPD Violations are notoriously unenforced by the City. These violations fall into four categories:<0/><1/><2>Class A</2> — non-hazardous<3/><4>Class B</4> — hazardous<5/><6>Class C</6> — immediately hazardous<7/><8>Class I</8> — fundamental property issue (e.g. landlord failed to register, building in Alt. Enforcement Program, Vacate Order issued)<9/><10/>Read more about HPD Violations at the <11>official HPD page</11>."
 msgstr "Infracciones del HPD se dan cuando un Inspector oficial de la Ciudad determina que las condiciones de un hogar están en violación de la ley. Si no se corrigen, estas infracciones incurren multas para el propietario, sin embargo, las infracciones del HPD son notoriamente incumplidas por la Ciudad. Existen cuatro categorías de Infracciones:<0/><1/><2>Clase A</2> — no-peligrosa<3/><4>Clase B</4> — peligrosa<5/><6>Clase C</6> — de peligro inmediato<7/><8>Clase I</8> — asunto fundamental de la propiedad (por ejemplo, el dueño no se ha registrado, el edificio está en el Programa de Cumplimiento Alternativo, se ha emitido una orden de desocupación) <9/><10/>Encontraras más información sobre las Infracciones del HPD en la <11>página oficial del HPD</11>."
 
@@ -425,20 +425,20 @@ msgstr "Formulario de queja HUD 958"
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
-#: src/components/DetailView.tsx:83
+#: src/components/DetailView.tsx:87
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:93
+#: src/containers/App.tsx:97
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
 
-#: src/components/DetailView.tsx:27
+#: src/components/DetailView.tsx:28
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix.nyc to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix.nyc que hace que la información sobre los dueños de edificios sea más transparente para los inquilinos. Sería bueno si buscaras tu edificio también. Míralo aquí: {url}"
 
-#: src/components/DetailView.tsx:25
+#: src/components/DetailView.tsx:26
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
@@ -458,7 +458,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
-#: src/components/PropertiesList.tsx:176
+#: src/components/PropertiesList.tsx:177
 msgid "Information"
 msgstr "Información"
 
@@ -486,7 +486,7 @@ msgstr "Conocido por <0>desregulando apartamentos de renta estabilizada sin escr
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PropertiesList.tsx:304
+#: src/components/PropertiesList.tsx:305
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -498,12 +498,12 @@ msgstr "Nombre del dueño"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PropertiesList.tsx:240
-#: src/components/PropertiesList.tsx:245
+#: src/components/PropertiesList.tsx:241
+#: src/components/PropertiesList.tsx:246
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PropertiesList.tsx:355
+#: src/components/PropertiesList.tsx:356
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -511,17 +511,17 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:218
+#: src/components/DetailView.tsx:225
 #: src/containers/NotRegisteredPage.tsx:98
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:231
+#: src/components/DetailView.tsx:238
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
 #: src/components/BigPortfolioWarning.tsx:27
-#: src/components/DetailView.tsx:57
+#: src/components/DetailView.tsx:58
 msgid "Learn more"
 msgstr "Aprende más"
 
@@ -533,23 +533,23 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PropertiesList.tsx:382
-#: src/components/PropertiesList.tsx:384
+#: src/components/PropertiesList.tsx:383
 #: src/components/PropertiesList.tsx:388
+#: src/components/PropertiesList.tsx:392
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:92
+#: src/components/PropertiesList.tsx:93
 #: src/components/PropertiesMap.tsx:158
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:89
+#: src/components/PropertiesList.tsx:90
 msgid "Loading {0} rows"
 msgstr "Cargando {0} filas"
 
-#: src/components/PropertiesList.tsx:136
+#: src/components/PropertiesList.tsx:137
 msgid "Location"
 msgstr "Ubicación"
 
@@ -590,15 +590,15 @@ msgstr "Metodología"
 msgid "More Mobile Friendly"
 msgstr "Más útil para dispositivos móviles"
 
-#: src/components/DetailView.tsx:178
+#: src/components/DetailView.tsx:182
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
-#: src/components/Indicators.tsx:199
+#: src/components/Indicators.tsx:201
 msgid "Move chart data left."
 msgstr "Mover datos del gráfico a la izquierda."
 
-#: src/components/Indicators.tsx:208
+#: src/components/Indicators.tsx:210
 msgid "Move chart data right."
 msgstr "Mover datos del gráfico a la derecha."
 
@@ -622,7 +622,7 @@ msgstr "Red de Dueños"
 msgid "New"
 msgstr "Nuevo"
 
-#: src/components/AddressToolbar.tsx:21
+#: src/components/AddressToolbar.tsx:22
 msgid "New Search"
 msgstr "Nueva búsqueda"
 
@@ -634,7 +634,7 @@ msgstr "Oficina Regional de Nueva York:"
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/components/PropertiesList.tsx:403
+#: src/components/PropertiesList.tsx:407
 msgid "No"
 msgstr "No"
 
@@ -647,7 +647,7 @@ msgstr "No se encontraron direcciones"
 msgid "No data available"
 msgstr "No hay datos disponibles"
 
-#: src/components/LandlordSearch.tsx:51
+#: src/components/LandlordSearch.tsx:71
 msgid "No landlords match your search."
 msgstr "No hay nombres de dueños coincidan con su búsqueda."
 
@@ -667,7 +667,7 @@ msgstr "No ECB"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:186
+#: src/components/DetailView.tsx:190
 msgid "None"
 msgstr "Ninguna"
 
@@ -688,23 +688,23 @@ msgstr "POSEE"
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PropertiesList.tsx:308
-#: src/components/PropertiesList.tsx:320
+#: src/components/PropertiesList.tsx:309
+#: src/components/PropertiesList.tsx:321
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
 #: src/components/NetworkErrorMessage.tsx:5
-#: src/components/Subscribe.tsx:54
-#: src/components/Subscribe.tsx:60
+#: src/components/Subscribe.tsx:57
+#: src/components/Subscribe.tsx:63
 msgid "Oops! A network error occurred. Try again later."
 msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 
-#: src/components/Subscribe.tsx:48
+#: src/components/Subscribe.tsx:51
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PropertiesList.tsx:271
-#: src/components/PropertiesList.tsx:276
+#: src/components/PropertiesList.tsx:272
+#: src/components/PropertiesList.tsx:277
 msgid "Open"
 msgstr "Actuales"
 
@@ -712,7 +712,7 @@ msgstr "Actuales"
 msgid "Open Violations"
 msgstr "Violaciones Actuales"
 
-#: src/containers/AddressPage.tsx:127
+#: src/containers/AddressPage.tsx:133
 msgid "Overview"
 msgstr "General"
 
@@ -720,7 +720,7 @@ msgstr "General"
 msgid "Owner Names"
 msgstr "Dueños"
 
-#: src/components/IndicatorsDatasets.tsx:73
+#: src/components/IndicatorsDatasets.tsx:76
 msgid "Owners submit Building Permit Applications to the Department of Buildings before any construction project to get necessary approval. The number of applications filed can indicate how much construction the owner was planning.<0/><1/>Read more about DOB Building Applications/Permits at the <2>official NYC Buildings page</2>."
 msgstr "Antes de empezar cualquier proyecto de construcción, el propietario somete un solicitud para conseguir permisos de construcción al Departamento de Edificios para obtener la autorización necesaria. El número de solicitudes que asociadas a un edificio te puede dar una idea de cuánta construcción planea hacer el propietario. <0/><1/> Encontrarás más información sobre Permisos de Construcción del DOB en la <2>página oficial de Edificios de NYC</2>."
 
@@ -740,16 +740,16 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/DetailView.tsx:333
-#: src/components/DetailView.tsx:343
+#: src/components/DetailView.tsx:340
+#: src/components/DetailView.tsx:350
 msgid "People"
 msgstr "Personas"
 
-#: src/components/Subscribe.tsx:22
+#: src/components/Subscribe.tsx:25
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/containers/AddressPage.tsx:141
+#: src/containers/AddressPage.tsx:149
 msgid "Portfolio"
 msgstr "Portafolio"
 
@@ -771,7 +771,7 @@ msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
 #: src/components/BuildingStatsTable.tsx:81
-#: src/components/PropertiesList.tsx:199
+#: src/components/PropertiesList.tsx:200
 msgid "RS Units"
 msgstr "Unidades RS"
 
@@ -803,11 +803,11 @@ msgstr "FALTA DE SEÑALIZACIÓN"
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
-#: src/containers/App.tsx:82
+#: src/containers/App.tsx:83
 msgid "Search"
 msgstr "Buscar"
 
-#: src/components/LandlordSearch.tsx:19
+#: src/components/LandlordSearch.tsx:26
 msgid "Search by your landlord's name"
 msgstr "Busca por el nombre de tu dueño"
 
@@ -820,7 +820,7 @@ msgstr "Buscar por:"
 msgid "Search for a different address"
 msgstr "Buscar otra dirección"
 
-#: src/components/LandlordSearch.tsx:19
+#: src/components/LandlordSearch.tsx:26
 msgid "Search landlords"
 msgstr "Buscar dueños"
 
@@ -832,15 +832,15 @@ msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en l
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:117
-#: src/containers/App.tsx:128
+#: src/containers/App.tsx:121
+#: src/containers/App.tsx:132
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:263
+#: src/components/DetailView.tsx:270
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:140
-#: src/containers/App.tsx:138
+#: src/containers/App.tsx:142
 #: src/containers/NotRegisteredPage.tsx:18
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -849,7 +849,7 @@ msgstr "Comparte esta página con tus vecinos"
 msgid "Shareholder"
 msgstr "Accionista"
 
-#: src/components/Subscribe.tsx:77
+#: src/components/Subscribe.tsx:80
 msgid "Sign up"
 msgstr "Regístrate"
 
@@ -857,8 +857,8 @@ msgstr "Regístrate"
 msgid "Sign up for email updates"
 msgstr "Regístrate para recibir noticias por email"
 
-#: src/components/PropertiesList.tsx:294
-#: src/components/PropertiesList.tsx:299
+#: src/components/PropertiesList.tsx:295
+#: src/components/PropertiesList.tsx:300
 msgid "Since 2017"
 msgstr "Desde 2017"
 
@@ -866,7 +866,7 @@ msgstr "Desde 2017"
 msgid "Since 2017, NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde el 2017, los Mariscales de NYC ejecutaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en este portafolio de edificios."
 
-#: src/components/PropertiesList.tsx:23
+#: src/components/PropertiesList.tsx:24
 msgid "Since {year}"
 msgstr "Desde {year}"
 
@@ -894,11 +894,11 @@ msgstr "Lo sentimos, la página que estás buscando no existe."
 msgid "Source code"
 msgstr "Código fuente"
 
-#: src/components/PropertiesList.tsx:23
+#: src/components/PropertiesList.tsx:24
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
-#: src/containers/AddressPage.tsx:148
+#: src/containers/AddressPage.tsx:157
 msgid "Summary"
 msgstr "Resúmen"
 
@@ -914,12 +914,12 @@ msgstr "Cambiar a la versión anterior"
 msgid "TENANT HARASSMENT"
 msgstr "ACOSO DE INQUILINO"
 
-#: src/components/DetailView.tsx:257
+#: src/components/DetailView.tsx:264
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.nyc!"
 msgstr "¡Toma acción en JustFix.nyc!"
 
-#: src/components/PropertiesList.tsx:328
+#: src/components/PropertiesList.tsx:329
 msgid "Tax Exemptions"
 msgstr "Exenciones de impuestos"
 
@@ -992,7 +992,7 @@ msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edif
 msgid "This building is owned by the NYC Housing Authority (NYCHA)"
 msgstr "Este edificio es propiedad de la NYC Housing Authority (NYCHA)"
 
-#: src/components/AddressToolbar.tsx:32
+#: src/components/AddressToolbar.tsx:37
 msgid "This data is in <0>CSV file format</0>, which can easily be used in Excel, Google Sheets, or any other spreadsheet program."
 msgstr "Estos datos están en <0>formato de archivo CSV</0>, que puede utilizarse fácilmente en Excel, Google Sheets o cualquier otro programa de hoja de cálculo."
 
@@ -1044,24 +1044,24 @@ msgstr "Esto representa el número total de violaciones del HPD (tanto actuales 
 msgid "This tracks how rent stabilized units in the building have changed (i.e. \"{delta}\") from 2007 to {0}. If the number for {1} is red, this means there has been a loss in stabilzied units! These counts are estimated from the DOF Property Tax Bills."
 msgstr "El cambio en apartamentos de renta estabilizada que hay en el edificio (es decir, \"{delta}\") del 2007 al {0}. Si el número en {1} está en rojo, ¡esto significa que ha habido una pérdida en las cantidad de apartamentos de renta estabilizada! Estos recuentos se calculan a partir de las facturas de impuestos del Departamento de Finanzas."
 
-#: src/components/AddressToolbar.tsx:28
+#: src/components/AddressToolbar.tsx:33
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:134
+#: src/containers/AddressPage.tsx:141
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PropertiesList.tsx:249
-#: src/components/PropertiesList.tsx:259
+#: src/components/PropertiesList.tsx:250
+#: src/components/PropertiesList.tsx:260
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:338
-#: src/components/PropertiesList.tsx:231
-#: src/components/PropertiesList.tsx:236
-#: src/components/PropertiesList.tsx:280
-#: src/components/PropertiesList.tsx:285
+#: src/components/PropertiesList.tsx:232
+#: src/components/PropertiesList.tsx:237
+#: src/components/PropertiesList.tsx:281
+#: src/components/PropertiesList.tsx:286
 msgid "Total"
 msgstr "Total"
 
@@ -1078,17 +1078,17 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PropertiesList.tsx:189
-#: src/components/PropertiesList.tsx:194
+#: src/components/PropertiesList.tsx:190
+#: src/components/PropertiesList.tsx:195
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades"
 
-#: src/components/LandlordSearch.tsx:61
+#: src/components/LandlordSearch.tsx:50
 msgid "Use the escape key to quit searching."
 msgstr "Utilice la clave de escape para salir de la búsqueda."
 
-#: src/components/LandlordSearch.tsx:61
+#: src/components/LandlordSearch.tsx:50
 msgid "Use the tab key to navigate. Press the enter key to select."
 msgstr "Utilice la tecla de pestaña para navegar. Pulse la tecla Intro para seleccionar."
 
@@ -1096,7 +1096,7 @@ msgstr "Utilice la tecla de pestaña para navegar. Pulse la tecla Intro para sel
 msgid "Use this free tool from JustFix.nyc to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Utilice esta herramienta gratuita de JustFix.nyc para investigar tu edificio e investigar a los arrendadores de Nueva York! Utilizamos el mapeo de propiedad para identificar el portafolio de edificios de un arrendador y proporcionar datos para revelar posibles casos de hostigamiento y desplazamiento de inquilinos."
 
-#: src/components/UsefulLinks.tsx:8
+#: src/components/UsefulLinks.tsx:9
 #: src/containers/NychaPage.tsx:153
 msgid "Useful links"
 msgstr "Enlaces útiles"
@@ -1105,22 +1105,22 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
-#: src/components/Indicators.tsx:177
-#: src/components/Indicators.tsx:180
+#: src/components/Indicators.tsx:178
+#: src/components/Indicators.tsx:181
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:172
+#: src/components/DetailView.tsx:176
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PropertiesList.tsx:412
-#: src/components/PropertiesList.tsx:418
+#: src/components/PropertiesList.tsx:416
 #: src/components/PropertiesList.tsx:422
+#: src/components/PropertiesList.tsx:430
 msgid "View detail"
 msgstr "Ver detalles"
 
-#: src/components/UsefulLinks.tsx:11
+#: src/components/UsefulLinks.tsx:12
 msgid "View documents on <0>ACRIS</0>"
 msgstr "Ver documentos en <0>ACRIS</0>"
 
@@ -1134,12 +1134,12 @@ msgstr "Ver leyenda"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:142
+#: src/components/DetailView.tsx:146
 msgid "View portfolio map"
 msgstr "Ver mapa del portafolio de edificios"
 
-#: src/components/IndicatorsDatasets.tsx:40
-#: src/components/IndicatorsDatasets.tsx:93
+#: src/components/IndicatorsDatasets.tsx:42
+#: src/components/IndicatorsDatasets.tsx:97
 msgid "Violations Issued"
 msgstr "Violaciones emitidas"
 
@@ -1163,11 +1163,11 @@ msgstr "VENTANAS"
 msgid "Warning"
 msgstr "Aviso"
 
-#: src/components/DetailView.tsx:210
+#: src/components/DetailView.tsx:217
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Aviso: Este edificio tiene un registro vencido y se vendió después del vencimiento del registro. La información del dueño que se incluye aquí puede estar desactualizada."
 
-#: src/components/DetailView.tsx:87
+#: src/components/DetailView.tsx:91
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -1183,7 +1183,7 @@ msgstr "Reorganizamos los datos de contacto de cada entidad individual y corpora
 msgid "We’ve improved Who Owns What to dig deeper into the data and offer you a more complete picture of buildings associated with your landlord. <0>Read more on our Methodology page</0>"
 msgstr "Hemos mejorado Quien es el Dueño para investigar más profundamente en los datos y ofrecerte una imagen más clara de los edificios asociados con tu dueño. <0>Obtiene más información en nuestra metodología</0>"
 
-#: src/components/Indicators.tsx:222
+#: src/components/Indicators.tsx:224
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
@@ -1204,14 +1204,14 @@ msgstr "Cuando dos partes comparten la misma dirección comercial, los agrupamos
 msgid "Who Owns What is a free tool built by JustFix.nyc to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Quién Es El Dueño es una herramienta gratis construida por JustFix.nyc para investigar los dueños de edificios en NYC. Ha asistido más de 200.000 neoyorquinos a enterarse quien realmente son los responsables por su edificio, cuáles otros edificios su dueño o compañía de administración poseen, y otra información crítica sobre violaciones del código de vivienda, desalojos, apartamentos con renta estabilizada y mucho más en cualquier edificio. Puedes buscar información sobre cualquier edificio residencial, también incluyen viviendas públicas (NYCHA). Busca tu dirección aquí: {url}"
 
-#: src/containers/App.tsx:37
+#: src/containers/App.tsx:38
 msgid "Who owns what in n y c?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:20
 #: src/components/Page.tsx:21
-#: src/containers/App.tsx:32
+#: src/containers/App.tsx:33
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
@@ -1219,7 +1219,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:193
+#: src/components/DetailView.tsx:197
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
@@ -1232,20 +1232,20 @@ msgstr "¿Por qué estoy viendo un portafolio tan grande?"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PropertiesList.tsx:402
+#: src/components/PropertiesList.tsx:406
 msgid "Yes"
 msgstr "Sí"
 
-#: src/containers/App.tsx:157
+#: src/containers/App.tsx:161
 msgid "You are viewing the new version of Who Owns What."
 msgstr "Estás viendo la nueva versión de Quién es el Dueño."
 
-#: src/containers/App.tsx:157
+#: src/containers/App.tsx:161
 msgid "You are viewing the old version of Who Owns What."
 msgstr "Estás viendo la versión anterior de Quién es el Dueño."
 
-#: src/components/PropertiesList.tsx:142
-#: src/components/PropertiesList.tsx:147
+#: src/components/PropertiesList.tsx:143
+#: src/components/PropertiesList.tsx:148
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -1265,15 +1265,15 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:235
+#: src/components/DetailView.tsx:242
 msgid "for ${0}"
 msgstr "por ${0}"
 
-#: src/components/Indicators.tsx:15
+#: src/components/Indicators.tsx:16
 msgid "month"
 msgstr "mes"
 
-#: src/components/Indicators.tsx:16
+#: src/components/Indicators.tsx:17
 msgid "quarter"
 msgstr "trimestre"
 
@@ -1281,7 +1281,7 @@ msgstr "trimestre"
 msgid "search address"
 msgstr "dirección de búsqueda"
 
-#: src/components/Indicators.tsx:17
+#: src/components/Indicators.tsx:18
 msgid "year"
 msgstr "año"
 
@@ -1293,23 +1293,22 @@ msgstr "{0} de {numberOfEntries}"
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una violación del HPD actual} other {# violaciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 
-#: src/components/LandlordSearch.tsx:58
+#: src/components/LandlordSearch.tsx:47
 msgid "{numberOfHits} {numberOfHits, plural, one {search result} other {search results}}."
 msgstr "{numberOfHits} {numberOfHits, plural, one {resultado de búsqueda} other {resultados de búsqueda}}."
 
-#: src/components/IndicatorsDatasets.tsx:67
+#: src/components/IndicatorsDatasets.tsx:70
 msgid "{value, plural, one {One Building Permit Application since 2010} other {# Building Permit Applications since 2010}}"
 msgstr "{value, plural, one {Una Solicitud de Permiso de Construcción desde el 2010} other {# Solicitudes de Permiso de Construcción desde el 2010}}"
 
-#: src/components/IndicatorsDatasets.tsx:88
+#: src/components/IndicatorsDatasets.tsx:92
 msgid "{value, plural, one {One DOB/ECB Violation Issued since 2010} other {# DOB/ECB Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del DOB/ECB emitida desde el 2010} other {# Violaciones del DOB/ECB emitidas desde el 2010}}"
 
-#: src/components/IndicatorsDatasets.tsx:7
+#: src/components/IndicatorsDatasets.tsx:9
 msgid "{value, plural, one {One HPD Complaint Issued since 2014} other {# HPD Complaints Issued since 2014}}"
 msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Quejas del HPD emitidas desde el 2014}}"
 
-#: src/components/IndicatorsDatasets.tsx:35
+#: src/components/IndicatorsDatasets.tsx:37
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2010} other {# Violaciones del HPD emitidas desde el 2010}}"
-


### PR DESCRIPTION
After talking with Tahnee and Risha last week we identified a bunch of analyses they'd like to see in amplitude, and so this PR adds more event logging to make sure we have all the data necessary. 

Mostly I just was simply adding logs, but I also noticed that an existing one on the timeline period switcher was logging twice with each click, so I moved that and fixed it. I also added an optional `onClick` to the `Accordion` components props so you can more easily log the click to expand event. 