### PR TITLE
Add API endpoint to get portfolio size for DAP Portal

### DIFF
--- a/tests/exported_test_data.sql
+++ b/tests/exported_test_data.sql
@@ -256,4 +256,12 @@ INSERT INTO public.wow_bldgs (housenumber, streetname, zip, boro, registrationid
 -- PostgreSQL database dump complete
 --
 
+--
+-- Manual creation of sample wow_portfolios table for testing:
+--
 
+INSERT INTO public.wow_portfolios (bbls, landlord_names, graph) VALUES ('{3016780054}','{"DAVID SIMKOWITZ"}','{"nodes": [{"id": 1, "value": {"kind": "bizaddr", "value": "206 JOHNSON AVENUE, STATEN ISLAND NY"}}, {"id": 2, "value": {"kind": "name", "value": "ANTHONY DEMEO"}}], "edges": [{"from": 1, "to": 2, "reg_contacts": 1}]}');
+
+--
+-- Manual table creation complete
+--

--- a/wow/sql/address_portfoliosize.sql
+++ b/wow/sql/address_portfoliosize.sql
@@ -1,0 +1,6 @@
+-- For a given bbl, find the size of its
+-- associated portfolio
+SELECT ARRAY_LENGTH(BBLS,1) AS PORTFOLIO_SIZE
+FROM WOW_PORTFOLIOS
+WHERE %(bbl)s = ANY(BBLS)
+LIMIT 1;

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -90,7 +90,7 @@ class TestAddressDapPortfolioSize(ApiTest):
         assert res.status_code == 200
         assert len(res.json()["result"]) == 1
         assert res.json()["result"]["portfolio_size"] > 0
-    
+
     def test_it_returns_none_for_unregistered_bbl(self, db, client):
         # Using the BBL for the Hudson River!
         res = client.get("/api/address/dap-portfoliosize?bbl=1011100001")

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -79,6 +79,25 @@ class TestAddressDapAggregate(ApiTest):
         assert len(res.json()["result"]) > 0
 
 
+class TestAddressDapPortfolioSize(ApiTest):
+    HTTP_400_URLS = [
+        "/api/address/dap-portfoliosize",
+        "/api/address/dap-portfoliosize?bbl=1",
+    ]
+
+    def test_it_returns_portfolio_size_given_bbl(self, db, client):
+        res = client.get("/api/address/dap-portfoliosize?bbl=4015640058")
+        assert res.status_code == 200
+        assert len(res.json()["result"]) == 1
+        assert res.json()["result"]["portfolio_size"] > 0
+    
+    def test_it_returns_none_for_unregistered_bbl(self, db, client):
+        # Using the BBL for the Hudson River!
+        res = client.get("/api/address/dap-portfoliosize?bbl=1011100001")
+        assert res.status_code == 200
+        assert res.json()["result"] is None
+
+
 class TestAddressBuildingInfo(ApiTest):
     HTTP_400_URLS = [
         "/api/address/buildinginfo",

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -86,7 +86,7 @@ class TestAddressDapPortfolioSize(ApiTest):
     ]
 
     def test_it_returns_portfolio_size_given_bbl(self, db, client):
-        res = client.get("/api/address/dap-portfoliosize?bbl=4015640058")
+        res = client.get("/api/address/dap-portfoliosize?bbl=3016780054")
         assert res.status_code == 200
         assert len(res.json()["result"]) == 1
         assert res.json()["result"]["portfolio_size"] > 0

--- a/wow/urls.py
+++ b/wow/urls.py
@@ -18,6 +18,11 @@ urlpatterns = [
         name="address_dap_aggregate",
     ),
     path(
+        "address/dap-portfoliosize",
+        views.address_dap_portfoliosize,
+        name="address_dap_portfoliosize",
+    ),
+    path(
         "address/buildinginfo", views.address_buildinginfo, name="address_buildinginfo"
     ),
     path(

--- a/wow/views.py
+++ b/wow/views.py
@@ -102,6 +102,28 @@ def address_dap_aggregate(request):
     return address_aggregate(request)
 
 
+@api
+def address_dap_portfoliosize(request):
+    """
+    This API endpoint receives requests with a 10-digit BBL and
+    responds with:
+    - the size of the portfolio associated with the BBL
+    OR
+    - None, if the BBL is not registered with HPD
+
+    This endpoint is used specifically by the DAP Portal:
+
+        https://portal.displacementalert.org/
+
+    We should make sure we don't change its behavior without
+    notifying them.
+    """
+
+    bbl = get_request_bbl(request)
+    result = exec_db_query(SQL_DIR / "address_portfoliosize.sql", {"bbl": bbl})
+    return JsonResponse({"result": (result[0] if result else None)})
+
+
 def get_request_bbl(request) -> str:
     return get_validated_form_data(PaddedBBLForm, request.GET)["bbl"]
 


### PR DESCRIPTION
This PR addresses an issue where the count of associated properties for a building on ANHD's [DAP Portal](https://portal.displacementalert.org/property/3012380016) did not match up with the new count of associated properties on Who Owns What given our new portfolio mapping method.

<img width="316" alt="image" src="https://user-images.githubusercontent.com/12834575/171277541-85b93390-4016-4f9d-9c2b-5dcf3e87c36e.png">

Turns out that ANHD's [DAP Portal](https://portal.displacementalert.org/property/3012380016) actually relies on a special API endpoint (`/api/address/dap-aggregate`) we created just for them that sends their tool a bunch of aggregate information on a building's portfolio if they send a request with a bbl in it. However, this API endpoint still references the old portfolio method, so in order to fix this, I created a new API endpoint at `/api/address/dap-portfoliosize` that retrieves portfolio sizes based on our new version of WOW.

I also simplified the response of this API endpoint, and it works like this:
- The only request parameter needed is bbl. If the request includes an hpd-registered bbl, the response will include the portfolio size on WOW:

`/api/address/dap-portfoliosize?bbl=4015640058` responds with `{"result": {"portfolio_size": 154}}`

- If the bbl in the request is not registered or not a real bbl, the response will be null:

`/api/address/dap-portfoliosize?bbl=4015640000` responds with `{"result": null}`

- If the bbl in the request is not 10 characters, the response will include an error:

`/api/address/dap-portfoliosize?bbl=40156400000` responds with 

```
{"error": "Bad request", "validationErrors": {"bbl": [{"message": "This should be a 10-digit padded BBL.", "code": "invalid"}]}}
```

