### PR TITLE
Redirect WOW demo domain from .nyc to .org

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,13 @@
 
 [[redirects]]
   from = "https://demo-whoownswhat.justfix.nyc/en/wowza/*"
-  to = "https://demo-whoownswhat.justfix.nyc/en/"
+  to = "https://demo-whoownswhat.justfix.org/en/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://demo-whoownswhat.justfix.nyc/*"
+  to = "https://demo-whoownswhat.justfix.org/:splat"
   status = 301
   force = true
 


### PR DESCRIPTION
This PR builds on investigative work in https://github.com/JustFixNYC/justfix-website/pull/204 to redirect all URLs at the current `demo-whoownswhat.justfix.nyc` DEMO SITE domain to `demo-whoownswhat.justfix.org`, preserving all paths in the redirect. 