### PR TITLE
Test: add netlify redirect to _redirects file

### DIFF
--- a/client/public/_redirects
+++ b/client/public/_redirects
@@ -1,2 +1,3 @@
 /static/* /not-found.html 404
 /*        /index.html     200
+https://demo-whoownswhat.justfix.nyc/* https://demo-whoownswhat.justfix.org/:splat 301


### PR DESCRIPTION
It seems that the redirect config in our `_redirects` file is being read over our `netlify.toml` configuration. This is a test to see if moving a redirect specification between the two files changes behavior. 