### PR TITLE
Remove duplicate `.csv` file suffix from data export

### DIFF
--- a/client/src/components/ExportData.tsx
+++ b/client/src/components/ExportData.tsx
@@ -43,7 +43,7 @@ const ExportDataButton: React.FC<{ data: AddressRecord[] }> = ({ data }) => {
   });
 
   return (
-    <CSVDownloader data={formattedData} filename="who_owns_what_export.csv">
+    <CSVDownloader data={formattedData} filename="who_owns_what_export">
       <button
         className="btn centered"
         onClick={() => {


### PR DESCRIPTION
I noticed that data exports from WOW were being named `who_owns_what_export.csv.csv`. This PR removes the duplicate filename extension.