### PR TITLE
add wow schema for oca table in create_wow_bldgs

### DIFF
--- a/sql/create_bldgs_table.sql
+++ b/sql/create_bldgs_table.sql
@@ -88,7 +88,7 @@ select distinct on (registrations.bbl)
   firstdeeds.docdate as lastsaledate,
   firstdeeds.docamount as lastsaleamount,
   case
-    when coalesce(pluto.unitsres, 0) <= 11 then NULL
+    when coalesce(pluto.unitsres, 0) < 11 then NULL
     else coalesce(oca.eviction_filings_since_2017, 0) 
   end as evictionfilings
 from hpd_registrations_with_contacts as registrations
@@ -129,7 +129,7 @@ left join (
 left join rentstab on (registrations.bbl = rentstab.ucbbl)
 left join complaints on (registrations.bbl = complaints.bbl)
 left join firstdeeds on (registrations.bbl = firstdeeds.bbl)
-left join oca_evictions_bldgs as oca on (registrations.bbl = oca.bbl);
+left join wow.oca_evictions_bldgs as oca on (registrations.bbl = oca.bbl);
 
 drop table if exists wow_bldgs cascade;
 alter table wow_bldgs_temporary rename to wow_bldgs;


### PR DESCRIPTION
This PR adds the `wow` schema prefix to OCA table when building `wow_bldgs`. Initially this was left off because OCA was going to be part of the same k8s job, and all those tables are first built in a temp schema. But now that the OCA is a separate job and creates the tables in the wow schema, we need to explicitly give the schema in that SQL statement since the search path only includes the temp schema and public but not wow. 

It also corrects a typo in the building size cutoff for OCA data. 