### PR TITLE
Remove pyproj from Docker requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,8 +9,4 @@ flake8==3.8.3
 networkx==2.5.1
 freezegun==1.1.0
 black== 21.9b0
-# Pyproj is evolving very fast and is already logging some deprecation
-# warnings when we use nycdb; let's use the minimum supported version
-# so we don't get those warnings, at least.
-pyproj==2.1.3
 sshtunnel==0.4.0


### PR DESCRIPTION
pyproj was removed here: https://github.com/nycdb/nycdb/pull/183/files so this removes it from the dev requirements as well (was getting an error when I attempted setup with pyproj included)