### PR TITLE
add robots.txt to disallow /api/

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+User-agent: AdsBot-Google
+Disallow: /api/


### PR DESCRIPTION
We've been getting a lot of bots hitting the `wow-django.herokuapp.com/api/*` path around midnight, and at that time some functions get redefined and are unavailable for a short window leading to lots of errors getting logged in rollbar. We are also working on solving the function issue directly to eliminate/reduce that window, but we also don't need bots crawling the `/api/` anyway so we'll add this robots.txt file to disallow that path. 

[sc-11028]