### PR TITLE
add fb domain code to index.html

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -23,6 +23,15 @@
     -->
 
     <!-- 
+      Facebook Pixel Domain Verification.
+      Facebook scraping tool used to verify is not navigating the location
+      redirect (.org to .org/en) so adding it here as well. Once we get to the
+      bottom of the verification we can clean this up so it isn't duplicated
+      here and in Page.tsx  
+    -->
+    <meta name="facebook-domain-verification" content="o2zqsblxwru6hs8nojpihj5l7lacv4" />
+
+    <!-- 
       Google Tag Manager
        
       Note that we insert the GTM script tag from JS to ensure that


### PR DESCRIPTION
The problems continue with verifying our domains (wow and org site) with facebook. The scraping tool FB uses is not successfully navigating the redirect from `.org` to `.org/en` and so it's not seeing the tag we first added in #652 to Page.tsx. This PR adds the same meta tag to index.html directly as well. Once we finally sort out exactly what the problem is I'll come back and clean this up so it's not duplicated. 