### PR TITLE
use new portfolio mapping for bbl parts route

### DIFF
--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -146,8 +146,13 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
           />
         )}
       />
-      <Route path={paths.bblSeparatedIntoParts} component={BBLPage} />
       <Route path={paths.legacy.bbl} component={BBLPage} />
+      <Route
+        path={paths.bblSeparatedIntoParts}
+        render={(props) => (
+          <BBLPage {...props} useNewPortfolioMethod={allowChangingPortfolioMethod} />
+        )}
+      />
       <Route
         path={paths.bbl}
         render={(props) => (


### PR DESCRIPTION
We have an old version of the BBL route that is still being used by ANHD's DAP Map and these are going to the `/legacy` version of WOW portfolio mapping method. This PR updates the route so they all go to the new WOW version.

![image](https://user-images.githubusercontent.com/16906516/197060048-b5398730-cfbf-4505-a8e8-8fbde06887c9.png)

[sc-11155]