### PR TITLE
Fix sticky modal z-index, positioning on Overview and Portfolio tabs

### DIFF
--- a/client/src/components/StickyModal.tsx
+++ b/client/src/components/StickyModal.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from "react";
 
-import "styles/Accordion.scss";
-
 type StickyModalProps = {
   label?: string;
   verticalPosition?: "top" | "bottom";

--- a/client/src/styles/_modal.scss
+++ b/client/src/styles/_modal.scss
@@ -1,6 +1,7 @@
 @import "_vars.scss";
 
 $sticky-modal-padding: $spacing-07;
+$sticky-modal-zindex: 20;
 
 .sticky-modal {
   @include desktop-h4();
@@ -14,6 +15,7 @@ $sticky-modal-padding: $spacing-07;
   color: $justfix-white;
   background-color: $justfix-black;
   box-shadow: 1px 4px 4px 0px $justfix-black;
+  z-index: $sticky-modal-zindex;
 
   &.top {
     top: 0;
@@ -48,6 +50,11 @@ $sticky-modal-padding: $spacing-07;
 .sticky-modal-body {
   display: flex;
   justify-content: center;
+}
+
+.App__body:has(.AddressPage__viz.AddressPage__content-active) + .sticky-modal,
+.App__body:has(.AddressPage__table.AddressPage__content-active) + .sticky-modal  {
+  margin-bottom: 5rem;
 }
 
 @include for-tablet-landscape-up() {

--- a/client/src/styles/_modal.scss
+++ b/client/src/styles/_modal.scss
@@ -53,7 +53,7 @@ $sticky-modal-zindex: 20;
 }
 
 .App__body:has(.AddressPage__viz.AddressPage__content-active) + .sticky-modal,
-.App__body:has(.AddressPage__table.AddressPage__content-active) + .sticky-modal  {
+.App__body:has(.AddressPage__table.AddressPage__content-active) + .sticky-modal {
   margin-bottom: 5rem;
 }
 


### PR DESCRIPTION
- adds z index
- css class is a little gnarly but it basically bumps up the margin when the overview or portfolio tabs are active, so that the user can click/see things under the survey CTA:
- small cleanup in StickyModal.tsx

<img width="932" alt="Screen Shot 2022-10-28 at 9 33 28 AM" src="https://user-images.githubusercontent.com/34112083/198687477-978b817e-0740-4980-829c-77560d78ae1e.png">
