### PR TITLE
Small CSS adjustments for survey button

### DIFF
--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -336,7 +336,7 @@ const App = () => {
             <AppBody />
             {surveyId && surveyEncountered !== "2" && (
               <StickyModal
-                label={"Help us build tenant power in NYC"}
+                label={"Help us build tenant power in NYC!"}
                 verticalPosition="bottom"
                 horizontalPosition="right"
                 onClose={() => browser.setCookie(browser.WOAU_COOKIE_NAME, "2", 30)}

--- a/client/src/styles/_button.scss
+++ b/client/src/styles/_button.scss
@@ -132,6 +132,7 @@
   text-align: center;
   color: $justfix-black;
   background-color: $justfix-pink;
+  height: 4rem;
 }
 
 .waou-survey-button:hover,

--- a/client/src/styles/_modal.scss
+++ b/client/src/styles/_modal.scss
@@ -14,7 +14,7 @@ $sticky-modal-zindex: 20;
   width: calc(100% - #{$sticky-modal-padding * 2});
   color: $justfix-white;
   background-color: $justfix-black;
-  box-shadow: 1px 4px 4px 0px $justfix-black;
+  box-shadow: 1px 4px 4px 0px rgba(36, 35, 35, 0.25);
   z-index: $sticky-modal-zindex;
 
   &.top {
@@ -41,10 +41,16 @@ $sticky-modal-zindex: 20;
 }
 
 .sticky-modal-close {
-  width: 2rem;
-  line-height: $spacing-05;
-  text-align: right;
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: 3.5rem;
+  width: 3.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   cursor: pointer;
+  font-size: 1.8rem;
 }
 
 .sticky-modal-body {
@@ -59,7 +65,8 @@ $sticky-modal-zindex: 20;
 
 @include for-tablet-landscape-up() {
   .sticky-modal {
+    font-weight: 400;
     width: 31rem;
-    margin-right: $spacing-05;
+    margin-right: $spacing-07;
   }
 }

--- a/client/src/styles/_vars.scss
+++ b/client/src/styles/_vars.scss
@@ -151,7 +151,8 @@ $eyebrow-font: "Suisse Int'l Mono", "Courier New", Courier, monospace;
 
 @mixin desktop-h4 {
   @include body-standard();
-  font-size: 1.5rem;
+  font-weight: 600;
+  font-size: 1.8rem;
   line-height: 120%;
 }
 


### PR DESCRIPTION
[sc-11179]

- add exclamation point to label copy
- make button a fixed 40px height
- change drop shadow opacity to 0.25
- adjust sizing and positioning of the close button
- increase margin-right for the modal to prevent scrollbar overlap (desktop only)
- increase the font weight to semibold/600 (mobile only) and the size to 18px

![image](https://user-images.githubusercontent.com/34112083/199078554-c7ca144b-a349-4280-85e5-6fd231d13f30.png) ![image](https://user-images.githubusercontent.com/34112083/199078579-41644ba2-c6c7-4d31-910f-a5ef480e50a4.png)
