### PR TITLE
use geosearch v2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "@babel/core": "^7.7.2",
     "@contentful/rich-text-react-renderer": "^15.0.0",
     "@justfixnyc/contentful-common-strings": "^0.1.0",
-    "@justfixnyc/geosearch-requester": "0.0.6",
+    "@justfixnyc/geosearch-requester": "1.0.0",
     "@justfixnyc/util": "0.3.0",
     "@lingui/cli": "^2.9.1",
     "@lingui/macro": "^2.9.1",

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -43,7 +43,10 @@ function searchForAddressWithGeosearch(
             geosearch: undefined,
           });
         resolve(
-          searchForBBL(helpers.splitBBL(firstResult.properties.pad_bbl), useNewPortfolioMethod)
+          searchForBBL(
+            helpers.splitBBL(firstResult.properties.addendum.pad.bbl),
+            useNewPortfolioMethod
+          )
         );
       },
       throttleMs: 0,

--- a/client/src/components/AddressSearch.tsx
+++ b/client/src/components/AddressSearch.tsx
@@ -73,7 +73,7 @@ function toSearchAddresses(results: GeoSearchResults): SearchAddress[] {
       housenumber: feature.properties.housenumber,
       streetname: feature.properties.street,
       boro: formattedBoroName,
-      bbl: feature.properties.pad_bbl,
+      bbl: feature.properties.addendum.pad.bbl,
     };
     return sa;
   });

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2375,10 +2375,10 @@
     cross-fetch "^3.1.4"
     yargs "^17.0.1"
 
-"@justfixnyc/geosearch-requester@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.6.tgz#af3144a8b599e45ad3ce5c2190fc60da81106475"
-  integrity sha512-wHsY9DbiQUp7H/KiQ4+ejTShR6lY3iagiFhw4VoP1kljyem+WIwEkiZNnvUHkOAQIkTtPulLaiKHEMpzaw9xZQ==
+"@justfixnyc/geosearch-requester@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-1.0.0.tgz#7677fdde3e80eb1b4fcffacfa1621fbff783705d"
+  integrity sha512-apPtPi1U78ac59bw2PrC84JaTXQJxNyWBfq3g8BcjdQ0RQ1L0Hd4WEL79ctjjYsRYHE1wY5qSa6JNvEgWRvKYg==
 
 "@justfixnyc/util@0.3.0":
   version "0.3.0"


### PR DESCRIPTION
This PR updates wow to use the new Geosearch v2 endpoint, via our geosearch-requester package, that was [updated](https://github.com/JustFixNYC/justfix-ts/pull/39) to use this new endpoint with slight changes to the response structure. 

All the details on the new endpoint are included in this helpful issue from the DCP team (#666). 

[sc-11187]