### PR TITLE
Legacy deprecation banner update

### DIFF
--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -307,7 +307,7 @@ const WowzaBanner = withI18n()((props: withI18nProps) => {
           <Trans>
             In April 2023, this link to{" "}
             <ToggleLinkBetweenPortfolioMethods>the old version</ToggleLinkBetweenPortfolioMethods>{" "}
-            of Who Owns What will will move to the About Page.
+            of Who Owns What will move to the About Page.
           </Trans>
         )}
       </div>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -298,16 +298,16 @@ const WowzaBanner = withI18n()((props: withI18nProps) => {
       <div className="content">
         {isLegacyPath(pathname) ? (
           <Trans>
-            In March 2023 this version of Who Owns What will no longer be available.{" "}
+            In July 2023 this version of Who Owns What will no longer be available.{" "}
             <ToggleLinkBetweenPortfolioMethods>
               Switch to new version.
             </ToggleLinkBetweenPortfolioMethods>
           </Trans>
         ) : (
           <Trans>
-            Starting March 2023{" "}
+            In April 2023, this link to{" "}
             <ToggleLinkBetweenPortfolioMethods>the old version</ToggleLinkBetweenPortfolioMethods>{" "}
-            of Who Owns What will no longer be available.
+            of Who Owns What will will move to the About Page.
           </Trans>
         )}
       </div>

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -166,9 +166,6 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
                     onChange={() => setSearchType("landlord")}
                   />
                   <i className="form-icon" /> <Trans>Landlord name</Trans>
-                  <span className="chip">
-                    <Trans>New</Trans>
-                  </span>
                 </label>
               </div>
               {searchType === "landlord" ? (

--- a/client/src/data/about.en.json
+++ b/client/src/data/about.en.json
@@ -57,6 +57,48 @@
         "nodeType": "paragraph"
       },
       {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "bold"
+              }
+            ],
+            "value": "Note:",
+            "nodeType": "text"
+          },
+          {
+            "data": {},
+            "marks": [],
+            "value": " You are viewing the new version of Who Owns What. Here’s the link to ",
+            "nodeType": "text"
+          },
+          {
+            "data": {
+              "uri": "https://whoownswhat.justfix.org/en/legacy/"
+            },
+            "content": [
+              {
+                "data": {},
+                "marks": [],
+                "value": "the old version",
+                "nodeType": "text"
+              }
+            ],
+            "nodeType": "hyperlink"
+          },
+          {
+            "data": {},
+            "marks": [],
+            "value": " if you need to access it for reference.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
         "data": {
           "target": {
             "metadata": {

--- a/client/src/data/about.es.json
+++ b/client/src/data/about.es.json
@@ -45,7 +45,55 @@
         "content": [
           {
             "nodeType": "text",
-            "value": "Cuando un dueño compra un edificio, a menudo utiliza Sociedades de Responsabilidad Limitada (LLC por sus siglas en inglés). Estas entidades ficticias se usan para ocultar quien es el dueño, y así crear un enredo de asociaciones administrativas. Así se consigue que sea muy complicado demostrar con precisión qué dueño o entidad administrativa es responsable de que se den condiciones peligrosas o insalubres, de que se cobre de más y de que se empleen otras prácticas discriminatorias.\n",
+            "value": "Cuando un dueño compra un edificio, a menudo utiliza Sociedades de Responsabilidad Limitada (LLC por sus siglas en inglés). Estas entidades ficticias se usan para ocultar quien es el dueño, y así crear un enredo de asociaciones administrativas. Así se consigue que sea muy complicado demostrar con precisión qué dueño o entidad administrativa es responsable de que se den condiciones peligrosas o insalubres, de que se cobre de más y de que se empleen otras prácticas discriminatorias.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Nota:",
+            "marks": [
+              {
+                "type": "bold"
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "text",
+            "value": " Está viendo ",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "hyperlink",
+            "data": {
+              "uri": "https://whoownswhat.justfix.org/es/legacy/"
+            },
+            "content": [
+              {
+                "nodeType": "text",
+                "value": "la nueva versión",
+                "marks": [],
+                "data": {}
+              }
+            ]
+          },
+          {
+            "nodeType": "text",
+            "value": " de ¿Quién Es El Dueño en Nueva York?. Aquí tiene el enlace a la versión antigua por si necesita acceder a ella como referencia.",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "text",
+            "value": "\n",
             "marks": [],
             "data": {}
           }

--- a/client/src/data/how-it-works.en.json
+++ b/client/src/data/how-it-works.en.json
@@ -2,931 +2,931 @@
   "title": "Methodology",
   "slug": "how-it-works",
   "content": {
-    "nodeType": "document",
     "data": {},
     "content": [
       {
-        "nodeType": "heading-4",
         "data": {},
         "content": [
           {
-            "nodeType": "text",
+            "data": {},
+            "marks": [],
             "value": "Who Owns What Data Methodology ",
-            "marks": [],
-            "data": {}
+            "nodeType": "text"
           }
-        ]
+        ],
+        "nodeType": "heading-4"
       },
       {
-        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "nodeType": "text",
+            "data": {},
+            "marks": [],
             "value": "",
-            "marks": [],
-            "data": {}
+            "nodeType": "text"
           }
-        ]
+        ],
+        "nodeType": "paragraph"
       },
       {
-        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "nodeType": "text",
-            "value": "In Who Owns What, we use ",
+            "data": {},
             "marks": [],
-            "data": {}
+            "value": "In Who Owns What, we use ",
+            "nodeType": "text"
           },
           {
-            "nodeType": "text",
-            "value": "property ownership mapping",
+            "data": {},
             "marks": [
               {
                 "type": "bold"
               }
             ],
-            "data": {}
+            "value": "property ownership mapping",
+            "nodeType": "text"
           },
           {
-            "nodeType": "text",
-            "value": " to find other buildings that your landlord or management company is associated with. Our algorithm relies on public ",
+            "data": {},
             "marks": [],
-            "data": {}
+            "value": " to find other buildings that your landlord or management company is associated with. Our algorithm relies on public ",
+            "nodeType": "text"
           },
           {
-            "nodeType": "hyperlink",
             "data": {
               "uri": "http://www1.nyc.gov/site/hpd/about/open-data.page"
             },
             "content": [
               {
-                "nodeType": "text",
-                "value": "HPD registration data",
+                "data": {},
                 "marks": [],
-                "data": {}
+                "value": "HPD registration data",
+                "nodeType": "text"
               }
-            ]
+            ],
+            "nodeType": "hyperlink"
           },
           {
-            "nodeType": "text",
+            "data": {},
+            "marks": [],
             "value": " for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city.",
-            "marks": [],
-            "data": {}
+            "nodeType": "text"
           }
-        ]
+        ],
+        "nodeType": "paragraph"
       },
       {
-        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "nodeType": "text",
+            "data": {},
+            "marks": [],
             "value": "To group together landlord portfolios, our database:",
-            "marks": [],
-            "data": {}
+            "nodeType": "text"
           }
-        ]
+        ],
+        "nodeType": "paragraph"
       },
       {
-        "nodeType": "ordered-list",
         "data": {},
         "content": [
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "gathers the ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "gathers the ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
                     "value": "\"Head Officer\", \"Individual Owner\", \"Corporate Owner\", and \"Joint Owner\" contact names ",
-                    "marks": [
-                      {
-                        "type": "bold"
-                      }
-                    ],
-                    "data": {}
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
+                    "data": {},
+                    "marks": [],
                     "value": "registered on HPD.",
-                    "marks": [],
-                    "data": {}
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           },
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "gathers the ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "gathers the ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "business addresses ",
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
+                    "value": "business addresses ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "registered with these contact names.",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "registered with these contact names.",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           },
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "uses the ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "uses the ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://networkx.org/"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "networkx Python package",
+                        "data": {},
                         "marks": [
                           {
                             "type": "underline"
                           }
                         ],
-                        "data": {}
+                        "value": "networkx Python package",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " to group owner contact names together that share the same registered business address, which also generates an aggregated list of buildings for each grouping of owner names.",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " to group owner contact names together that share the same registered business address, which also generates an aggregated list of buildings for each grouping of owner names.",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           }
-        ]
+        ],
+        "nodeType": "ordered-list"
       },
       {
-        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "nodeType": "text",
-            "value": "According to HPD policy, “property owners of residential buildings are required by law to register annually with HPD if the property is a multiple dwelling (3+ residential units) or a private dwelling (1–2 residential units) where neither the owner nor the owner’s immediate family resides.” This data must be made publicly available according to ",
+            "data": {},
             "marks": [],
-            "data": {}
+            "value": "According to HPD policy, “property owners of residential buildings are required by law to register annually with HPD if the property is a multiple dwelling (3+ residential units) or a private dwelling (1–2 residential units) where neither the owner nor the owner’s immediate family resides.” This data must be made publicly available according to ",
+            "nodeType": "text"
           },
           {
-            "nodeType": "hyperlink",
             "data": {
               "uri": "https://opendata.cityofnewyork.us/"
             },
             "content": [
               {
-                "nodeType": "text",
-                "value": "NYC’s Open Data law",
+                "data": {},
                 "marks": [],
-                "data": {}
+                "value": "NYC’s Open Data law",
+                "nodeType": "text"
               }
-            ]
+            ],
+            "nodeType": "hyperlink"
           },
           {
-            "nodeType": "text",
-            "value": ".",
+            "data": {},
             "marks": [],
-            "data": {}
+            "value": ".",
+            "nodeType": "text"
           }
-        ]
+        ],
+        "nodeType": "paragraph"
       },
       {
-        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "nodeType": "text",
-            "value": "HPD updates this registration data (which updates live on this site) monthly.",
+            "data": {},
             "marks": [
               {
                 "type": "bold"
               }
             ],
-            "data": {}
+            "value": "HPD updates this registration data (which updates live on this site) monthly.",
+            "nodeType": "text"
           },
           {
-            "nodeType": "text",
-            "value": " We also use datasets from the following sources to provide additional information:",
+            "data": {},
             "marks": [],
-            "data": {}
+            "value": " We also use datasets from the following sources to provide additional information:",
+            "nodeType": "text"
           }
-        ]
+        ],
+        "nodeType": "paragraph"
       },
       {
-        "nodeType": "unordered-list",
         "data": {},
         "content": [
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "HPD complaints ",
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
+                    "value": "HPD complaints ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "from ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "from ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://data.cityofnewyork.us/Housing-Development/Housing-Maintenance-Code-Complaints/uwyv-629c"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "NYC Open Data",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "NYC Open Data",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " — ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " — ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "updated monthly",
+                    "data": {},
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "data": {}
+                    "value": "updated monthly",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           },
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "DOB job application filings ",
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
+                    "value": "DOB job application filings ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "from ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "from ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://data.cityofnewyork.us/Housing-Development/DOB-Job-Application-Filings/ic3t-wcy2"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "NYC Open Data",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "NYC Open Data",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " — ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " — ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "updated daily",
+                    "data": {},
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "data": {}
+                    "value": "updated daily",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           },
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "Primary Land Use Tax Lot data (\"PLUTO\")",
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
+                    "value": "Primary Land Use Tax Lot data (\"PLUTO\")",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " from ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " from ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "NYC Dept. of City Planning",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "NYC Dept. of City Planning",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " — ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " — ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "updated yearly",
+                    "data": {},
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "data": {}
+                    "value": "updated yearly",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           },
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "Eviction Filings data",
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
+                    "value": "Eviction Filings data",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " from the ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " from the ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://ww2.nycourts.gov/Admin/oca.shtml"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "New York State Office of Court Administration",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "New York State Office of Court Administration",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " via the ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " via the ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://www.housingdatanyc.org/"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "Housing Data Coalition",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "Housing Data Coalition",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " in collaboration with the ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " in collaboration with the ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://www.righttocounselnyc.org/"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "Right to Counsel Coalition",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "Right to Counsel Coalition",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " —",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " —",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " updated daily",
+                    "data": {},
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "data": {}
+                    "value": " updated daily",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           },
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
                     "value": "Executed Evictions data",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
-                  },
-                  {
-                    "nodeType": "text",
                     "value": " ",
-                    "marks": [
-                      {
-                        "type": "bold"
-                      }
-                    ],
-                    "data": {}
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "from ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "from ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://anhd.org/"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "ANHD",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "ANHD",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " and the ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " and the ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://www.housingdatanyc.org/"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "Housing Data Coalition",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "Housing Data Coalition",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " via ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " via ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://www1.nyc.gov/site/doi/offices/cpr2.page"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "NYC Marshals",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "NYC Marshals",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " —",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " —",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " updated daily",
+                    "data": {},
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "data": {}
+                    "value": " updated daily",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           },
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "Tax Exemption (J51/421a) data ",
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
+                    "value": "Tax Exemption (J51/421a) data ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "from ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "from ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://data.cityofnewyork.us/City-Government/Property-Exemption-Detail/muvi-b6kx"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "NYC Open Data",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "NYC Open Data",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " — ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " — ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "updated yearly",
+                    "data": {},
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "data": {}
+                    "value": "updated yearly",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           },
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "ACRIS deed records ",
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
+                    "value": "ACRIS deed records ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "from ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "from ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://data.cityofnewyork.us/City-Government/ACRIS-Real-Property-Master/bnx9-e6tj"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "NYC Open Data",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "NYC Open Data",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": ". Note: we only include deeds with an associated amount greater than $1. — ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": ". Note: we only include deeds with an associated amount greater than $1. — ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "updated bimonthly",
+                    "data": {},
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "data": {}
+                    "value": "updated bimonthly",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           },
           {
-            "nodeType": "list-item",
             "data": {},
             "content": [
               {
-                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "nodeType": "text",
-                    "value": "Rent Stabilization unit estimates ",
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
+                    "value": "Rent Stabilization unit estimates ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "from ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": "from ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://github.com/talos/nyc-stabilization-unit-counts"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "taxbills.nyc",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "taxbills.nyc",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " and ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " and ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://github.com/JustFixNYC/nyc-doffer"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "NYC Doffer",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "NYC Doffer",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": ", adapted from Dept. of Finance tax bills. This data is ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": ", adapted from Dept. of Finance tax bills. This data is ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "not",
+                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "data": {}
+                    "value": "not",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " conclusive, but should be seen as an approximation. See ",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " conclusive, but should be seen as an approximation. See ",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "http://blog.johnkrauss.com/where-is-decontrol/"
                     },
                     "content": [
                       {
-                        "nodeType": "text",
-                        "value": "this page",
+                        "data": {},
                         "marks": [],
-                        "data": {}
+                        "value": "this page",
+                        "nodeType": "text"
                       }
-                    ]
+                    ],
+                    "nodeType": "hyperlink"
                   },
                   {
-                    "nodeType": "text",
-                    "value": " for more information.",
+                    "data": {},
                     "marks": [],
-                    "data": {}
+                    "value": " for more information.",
+                    "nodeType": "text"
                   },
                   {
-                    "nodeType": "text",
-                    "value": "— updated yearly",
+                    "data": {},
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "data": {}
+                    "value": "— updated yearly",
+                    "nodeType": "text"
                   }
-                ]
+                ],
+                "nodeType": "paragraph"
               }
-            ]
+            ],
+            "nodeType": "list-item"
           }
-        ]
+        ],
+        "nodeType": "unordered-list"
       },
       {
-        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "nodeType": "text",
-            "value": "Our code is open source and accessible ",
+            "data": {},
             "marks": [],
-            "data": {}
+            "value": "Our code is open source and accessible ",
+            "nodeType": "text"
           },
           {
-            "nodeType": "hyperlink",
             "data": {
               "uri": "https://github.com/JustFixNYC/who-owns-what"
             },
             "content": [
               {
-                "nodeType": "text",
-                "value": "via our GitHub",
+                "data": {},
                 "marks": [],
-                "data": {}
+                "value": "via our GitHub",
+                "nodeType": "text"
               }
-            ]
+            ],
+            "nodeType": "hyperlink"
           },
           {
-            "nodeType": "text",
-            "value": ". For additional questions, or help with research, you can email us at ",
+            "data": {},
             "marks": [],
-            "data": {}
+            "value": ". For additional questions, or help with research, you can email us at ",
+            "nodeType": "text"
           },
           {
-            "nodeType": "hyperlink",
             "data": {
               "uri": "mailto:support@justfix.org"
             },
             "content": [
               {
-                "nodeType": "text",
-                "value": "support@justfix.org",
+                "data": {},
                 "marks": [],
-                "data": {}
+                "value": "support@justfix.org",
+                "nodeType": "text"
               }
-            ]
+            ],
+            "nodeType": "hyperlink"
           },
           {
-            "nodeType": "text",
-            "value": ".",
+            "data": {},
             "marks": [],
-            "data": {}
+            "value": ".",
+            "nodeType": "text"
           }
-        ]
+        ],
+        "nodeType": "paragraph"
       }
-    ]
+    ],
+    "nodeType": "document"
   }
 }

--- a/client/src/data/how-it-works.es.json
+++ b/client/src/data/how-it-works.es.json
@@ -2,861 +2,924 @@
   "title": "Metodología",
   "slug": "how-it-works",
   "content": {
+    "nodeType": "document",
     "data": {},
     "content": [
       {
+        "nodeType": "heading-4",
         "data": {},
         "content": [
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": "Metodología de Datos de Quién Es El Dueño",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           }
-        ],
-        "nodeType": "heading-4"
+        ]
       },
       {
+        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": "",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           }
-        ],
-        "nodeType": "paragraph"
+        ]
       },
       {
+        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": "En Quién Es El Dueño, usamos el ",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           },
           {
-            "data": {},
+            "nodeType": "text",
+            "value": "trazado de derecho de propiedad",
             "marks": [
               {
                 "type": "bold"
               }
             ],
-            "value": "trazado de derecho de propiedad",
-            "nodeType": "text"
+            "data": {}
           },
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": " para encontrar otros edificios a los que esté asociado el dueño de tu edificio o su entidad administrativa. Nuestro algoritmo se basa en datos públicos del ",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           },
           {
+            "nodeType": "hyperlink",
             "data": {
               "uri": "http://www1.nyc.gov/site/hpd/about/open-data.page"
             },
             "content": [
               {
-                "data": {},
-                "marks": [],
+                "nodeType": "text",
                 "value": "registro de edificios residenciales del Departamento de Preservación y Desarrollo de la Vivienda",
-                "nodeType": "text"
+                "marks": [],
+                "data": {}
               }
-            ],
-            "nodeType": "hyperlink"
+            ]
           },
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": " (HPD por sus siglas en inglés), que contienen información auto-reportada por el propietario sobre aproximadamente 170,000 edificios en toda la ciudad.",
-            "nodeType": "text"
-          }
-        ],
-        "nodeType": "paragraph"
-      },
-      {
-        "data": {},
-        "content": [
-          {
-            "data": {},
             "marks": [],
-            "value": "Para agrupar a los portafolios de los dueños, nuestra base de datos:",
-            "nodeType": "text"
+            "data": {}
           }
-        ],
-        "nodeType": "paragraph"
+        ]
       },
       {
+        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
+            "nodeType": "text",
+            "value": "Para agrupar a los portafolios de los dueños, nuestra base de datos:",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "ordered-list",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": "reúne los nombres de contacto de ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
-                    "marks": [
-                      {
-                        "type": "bold"
-                      }
-                    ],
+                    "nodeType": "text",
                     "value": "\"Oficial Principal\", \"Dueño Individual\", \"Dueño Corporativo\", y \"Dueño Conjunto\"",
-                    "nodeType": "text"
-                  },
-                  {
-                    "data": {},
-                    "marks": [],
-                    "value": " que están registrados en el HPD.",
-                    "nodeType": "text"
-                  }
-                ],
-                "nodeType": "paragraph"
-              }
-            ],
-            "nodeType": "list-item"
-          },
-          {
-            "data": {},
-            "content": [
-              {
-                "data": {},
-                "content": [
-                  {
-                    "data": {},
-                    "marks": [],
-                    "value": "recopila las ",
-                    "nodeType": "text"
-                  },
-                  {
-                    "data": {},
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": "direcciones comerciales",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": " que están registrados en el HPD.",
                     "marks": [],
-                    "value": " que están registradas con estos nombres de contacto.",
-                    "nodeType": "text"
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           },
           {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "recopila las ",
                     "marks": [],
-                    "value": "utiliza el ",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
+                    "nodeType": "text",
+                    "value": "direcciones comerciales",
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": " que están registradas con estos nombres de contacto.",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "utiliza el ",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://networkx.org/"
                     },
                     "content": [
                       {
-                        "data": {},
+                        "nodeType": "text",
+                        "value": "paquete de Python networkx",
                         "marks": [
                           {
                             "type": "underline"
                           }
                         ],
-                        "value": "paquete de Python networkx",
-                        "nodeType": "text"
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " para agrupar a los nombres de contacto de los dueños que comparten las mismas direcciones comerciales, y también genera una lista agregada de edificios para cada grupo de nombres de dueños.",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           }
-        ],
-        "nodeType": "ordered-list"
+        ]
       },
       {
+        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": "De acuerdo con la política del HPD, “la ley requiere que los propietarios de edificios residenciales se registren anualmente con el HPD si la propiedad es una vivienda múltiple (más de 3 unidades residenciales) o una vivienda privada (1–2 unidades residenciales) donde no vive ni el dueño ni su familia inmediata\". Estos datos deben estar disponibles públicamente de acuerdo con la ley de datos abiertos de Nueva York.\n",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           }
-        ],
-        "nodeType": "paragraph"
+        ]
       },
       {
+        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "data": {},
+            "nodeType": "text",
+            "value": "El HPD actualiza estos datos de registro (que se actualizan en vivo en este sitio web) mensualmente",
             "marks": [
               {
                 "type": "bold"
               }
             ],
-            "value": "El HPD actualiza estos datos de registro (que se actualizan en vivo en este sitio web) mensualmente",
-            "nodeType": "text"
+            "data": {}
           },
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": ". También usamos conjuntos de datos de las siguientes fuentes para proporcionar información adicional:",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           }
-        ],
-        "nodeType": "paragraph"
+        ]
       },
       {
+        "nodeType": "unordered-list",
         "data": {},
         "content": [
           {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "Infracciones en el HPD",
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": "Infracciones en el HPD",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " de ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://data.cityofnewyork.us/Housing-Development/Housing-Maintenance-Code-Violations/wvxf-dwi5"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "NYC Open Data",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " —",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": " actualizado a diario",
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "value": " actualizado a diario",
-                    "nodeType": "text"
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           },
           {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "Quejas al HPD",
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": "Quejas al HPD",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " de ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://data.cityofnewyork.us/Housing-Development/Housing-Maintenance-Code-Complaints/uwyv-629c"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "NYC Open Data",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " — ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "actualizado mensualmente",
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "value": "actualizado mensualmente",
-                    "nodeType": "text"
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           },
           {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "Solicitudes de Trabajo del Departamento de Edificios (DOB por sus siglas en inglés) ",
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": "Solicitudes de Trabajo del Departamento de Edificios (DOB por sus siglas en inglés) ",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": "de ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://data.cityofnewyork.us/Housing-Development/DOB-Job-Application-Filings/ic3t-wcy2"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "NYC Open Data",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " — ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "actualizado a diario",
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "value": "actualizado a diario",
-                    "nodeType": "text"
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           },
           {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "Datos de Impuestos de Uso de Terreno Primario (PLUTO por sus siglas en inglés)",
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": "Datos de Impuestos de Uso de Terreno Primario (PLUTO por sus siglas en inglés)",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " de ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "NYC Dept. of City Planning",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " — ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "actualizado anualmente",
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "value": "actualizado anualmente",
-                    "nodeType": "text"
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           },
           {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "Datos de desalojos ejecutados",
+                    "marks": [
+                      {
+                        "type": "italic"
+                      },
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": " ",
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": "Datos de Desalojo ",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": "de  ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://anhd.org/"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "ANHD",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " y la ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://www.housingdatanyc.org/"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "Housing Data Coalition",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " a través de ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://www1.nyc.gov/site/doi/offices/cpr2.page"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "NYC Marshals",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "— actualizado a diario",
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "value": "— actualizado a diario",
-                    "nodeType": "text"
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           },
           {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "Datos sobre desalojos",
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": "Datos de Exención de Impuestos (J51/421a) ",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": " de la Oficina de Administración Judicial del Estado de Nueva York a través de la Coalición de Datos sobre la Vivienda en colaboración con la Coalición por el Derecho a la Defensa ",
                     "marks": [],
-                    "value": "de ",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
+                    "nodeType": "text",
+                    "value": "—",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": " ",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "actualizados semanalmente",
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "Datos de Exención de Impuestos (J51/421a) ",
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "de ",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://data.cityofnewyork.us/City-Government/Property-Exemption-Detail/muvi-b6kx"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "NYC Open Data",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " — ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "actualizado anualmente",
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "value": "actualizado anualmente",
-                    "nodeType": "text"
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           },
           {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "Registros de escrituras de ACRIS ",
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": "Registros de escrituras de ACRIS ",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": "de ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://data.cityofnewyork.us/City-Government/ACRIS-Real-Property-Master/bnx9-e6tj"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "NYC Open Data",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": ". Nota: solo incluimos escrituras que tienen una cantidad asociada de más de $1.— ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "actualizado bimensualmente",
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "value": "actualizado bimensualmente",
-                    "nodeType": "text"
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           },
           {
+            "nodeType": "list-item",
             "data": {},
             "content": [
               {
+                "nodeType": "paragraph",
                 "data": {},
                 "content": [
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "Aproximaciones de las cantidades de Apartamentos de Renta Estabilizada ",
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": "Aproximaciones de las cantidades de Apartamentos de Renta Estabilizada ",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": "de ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://github.com/talos/nyc-stabilization-unit-counts"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "taxbills.nyc",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " y ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "https://github.com/JustFixNYC/nyc-doffer"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "NYC Doffer",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": ", adaptadas de las facturas de impuestos del Departamento de Finanzas",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": ".",
                     "marks": [
                       {
                         "type": "bold"
                       }
                     ],
-                    "value": ".",
-                    "nodeType": "text"
+                    "data": {}
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " Este conjunto de datos no es concluyente y debe verse como una aproximación. Consulte ",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
+                    "nodeType": "hyperlink",
                     "data": {
                       "uri": "http://blog.johnkrauss.com/where-is-decontrol/"
                     },
                     "content": [
                       {
-                        "data": {},
-                        "marks": [],
+                        "nodeType": "text",
                         "value": "esta página",
-                        "nodeType": "text"
+                        "marks": [],
+                        "data": {}
                       }
-                    ],
-                    "nodeType": "hyperlink"
+                    ]
                   },
                   {
-                    "data": {},
-                    "marks": [],
+                    "nodeType": "text",
                     "value": " para obtener más información.",
-                    "nodeType": "text"
+                    "marks": [],
+                    "data": {}
                   },
                   {
-                    "data": {},
+                    "nodeType": "text",
+                    "value": "— actualizado anualmente",
                     "marks": [
                       {
                         "type": "italic"
                       }
                     ],
-                    "value": "— actualizado anualmente",
-                    "nodeType": "text"
+                    "data": {}
                   }
-                ],
-                "nodeType": "paragraph"
+                ]
               }
-            ],
-            "nodeType": "list-item"
+            ]
           }
-        ],
-        "nodeType": "unordered-list"
+        ]
       },
       {
+        "nodeType": "paragraph",
         "data": {},
         "content": [
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": "Nuestro código es Open Source y es accesible ",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           },
           {
+            "nodeType": "hyperlink",
             "data": {
               "uri": "https://github.com/JustFixNYC/who-owns-what"
             },
             "content": [
               {
-                "data": {},
-                "marks": [],
+                "nodeType": "text",
                 "value": "a través de nuestro GitHub",
-                "nodeType": "text"
+                "marks": [],
+                "data": {}
               }
-            ],
-            "nodeType": "hyperlink"
+            ]
           },
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": ". Para preguntas adicionales o ayuda con la investigación, puedes enviarnos un correo electrónico a ",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           },
           {
+            "nodeType": "hyperlink",
             "data": {
               "uri": "mailto:support@justfix.org"
             },
             "content": [
               {
-                "data": {},
-                "marks": [],
+                "nodeType": "text",
                 "value": "support@justfix.org",
-                "nodeType": "text"
+                "marks": [],
+                "data": {}
               }
-            ],
-            "nodeType": "hyperlink"
+            ]
           },
           {
-            "data": {},
-            "marks": [],
+            "nodeType": "text",
             "value": ".",
-            "nodeType": "text"
+            "marks": [],
+            "data": {}
           }
-        ],
-        "nodeType": "paragraph"
+        ]
       }
-    ],
-    "nodeType": "document"
+    ]
   }
 }

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -46,7 +46,7 @@ msgstr "(this may take a while)"
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 
-#: src/containers/HomePage.tsx:123
+#: src/containers/HomePage.tsx:120
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
@@ -88,7 +88,7 @@ msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:94
+#: src/containers/App.tsx:95
 msgid "About"
 msgstr "About"
 
@@ -244,7 +244,7 @@ msgstr "Click here to learn more."
 #: src/components/CloseButton.tsx:9
 #: src/components/DetailView.tsx:58
 #: src/components/FeatureCalloutWidget.tsx:61
-#: src/containers/App.tsx:175
+#: src/containers/App.tsx:176
 msgid "Close"
 msgstr "Close"
 
@@ -293,7 +293,7 @@ msgstr "DOORS"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:116
+#: src/containers/App.tsx:117
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -307,7 +307,7 @@ msgid "Display:"
 msgstr "Display:"
 
 #: src/components/LegalFooter.tsx:35
-#: src/containers/App.tsx:103
+#: src/containers/App.tsx:104
 msgid "Donate"
 msgstr "Donate"
 
@@ -464,7 +464,7 @@ msgstr "Head Officer"
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:100
+#: src/containers/App.tsx:101
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -481,17 +481,29 @@ msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open viol
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
+#: src/containers/App.tsx:170
+msgid "In April 2023, this link to <0>the old version</0> of Who Owns What will will move to the About Page."
+msgstr "In April 2023, this link to <0>the old version</0> of Who Owns What will will move to the About Page."
+
+#: src/containers/App.tsx:165
+msgid "In July 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"
+msgstr "In July 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"
+
 #: src/containers/App.tsx:164
 #~ msgid "In March 2023 this version of Who Owns What will no longer be available <0>Switch to new version</0>"
 #~ msgstr "In March 2023 this version of Who Owns What will no longer be available <0>Switch to new version</0>"
 
 #: src/containers/App.tsx:164
-msgid "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"
-msgstr "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"
+#~ msgid "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"
+#~ msgstr "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"
 
 #: src/containers/App.tsx:164
 #~ msgid "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version</0>"
 #~ msgstr "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version</0>"
+
+#: src/components/DeprecationModal.tsx:19
+msgid "In March 2023 this version will be discontinued. Switch to the new version or learn more."
+msgstr "In March 2023 this version will be discontinued. Switch to the new version or learn more."
 
 #: src/containers/NotRegisteredPage.tsx:63
 msgid "Incomplete registration for {usersInputAddressFragment}."
@@ -525,7 +537,7 @@ msgstr "Joint Owner"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
-#: src/containers/HomePage.tsx:218
+#: src/containers/HomePage.tsx:215
 msgid "Known for <0>unscrupulously deregulating rent stabilized apartments</0>, Larry Gluck’s Stellar Management has also secured a prominent place as one of <1>New York City’s Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where Gluck operates the majority of his properties. Stellar has a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
 msgstr "Known for <0>unscrupulously deregulating rent stabilized apartments</0>, Larry Gluck’s Stellar Management has also secured a prominent place as one of <1>New York City’s Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where Gluck operates the majority of his properties. Stellar has a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
 
@@ -666,8 +678,8 @@ msgid "Network of Landlords"
 msgstr "Network of Landlords"
 
 #: src/containers/HomePage.tsx:110
-msgid "New"
-msgstr "New"
+#~ msgid "New"
+#~ msgstr "New"
 
 #: src/components/AddressToolbar.tsx:23
 msgid "New Search"
@@ -854,7 +866,7 @@ msgstr "SIGNAGE MISSING"
 msgid "STAIRS"
 msgstr "STAIRS"
 
-#: src/containers/App.tsx:86
+#: src/containers/App.tsx:87
 msgid "Search"
 msgstr "Search"
 
@@ -883,15 +895,15 @@ msgstr "See the most common complaints reported by tenants to 311, now on the Ov
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
-#: src/containers/App.tsx:124
-#: src/containers/App.tsx:135
+#: src/containers/App.tsx:125
+#: src/containers/App.tsx:136
 msgid "Share"
 msgstr "Share"
 
 #: src/components/DetailView.tsx:270
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:140
-#: src/containers/App.tsx:145
+#: src/containers/App.tsx:146
 #: src/containers/NotRegisteredPage.tsx:18
 msgid "Share this page with your neighbors"
 msgstr "Share this page with your neighbors"
@@ -954,8 +966,8 @@ msgstr "Source code"
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available"
 
 #: src/containers/App.tsx:169
-msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
-msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
+#~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
+#~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
 #: src/components/PropertiesList.tsx:24
 msgid "Starts {year}"
@@ -1019,7 +1031,7 @@ msgstr "The building with the most executed evictions is <0>{0} {1}, {2}</0> wit
 msgid "The city borough where your search address is located"
 msgstr "The city borough where your search address is located"
 
-#: src/containers/HomePage.tsx:176
+#: src/containers/HomePage.tsx:173
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
@@ -1099,7 +1111,7 @@ msgstr "This portfolio also had an estimated <0>net {changeType, select, gain {g
 msgid "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 msgstr "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 
-#: src/containers/HomePage.tsx:142
+#: src/containers/HomePage.tsx:139
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 
@@ -1203,9 +1215,9 @@ msgstr "View documents on <0>ACRIS</0>"
 msgid "View legend"
 msgstr "View legend"
 
-#: src/containers/HomePage.tsx:157
-#: src/containers/HomePage.tsx:199
-#: src/containers/HomePage.tsx:236
+#: src/containers/HomePage.tsx:154
+#: src/containers/HomePage.tsx:196
+#: src/containers/HomePage.tsx:233
 msgid "View portfolio"
 msgstr "View portfolio"
 
@@ -1287,14 +1299,14 @@ msgstr "When two parties share the same business address, we group them as part 
 msgid "Who Owns What is a free tool built by JustFix to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Who Owns What is a free tool built by JustFix to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 
-#: src/containers/App.tsx:41
+#: src/containers/App.tsx:42
 msgid "Who owns what in n y c?"
 msgstr "Who owns what in n y c?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:21
 #: src/components/Page.tsx:22
-#: src/containers/App.tsx:36
+#: src/containers/App.tsx:37
 msgid "Who owns what in nyc?"
 msgstr "Who owns what in nyc?"
 
@@ -1318,6 +1330,10 @@ msgstr "Year Built"
 #: src/components/PropertiesList.tsx:433
 msgid "Yes"
 msgstr "Yes"
+
+#: src/components/DeprecationModal.tsx:16
+msgid "You are viewing a legacy version of Who Owns What"
+msgstr "You are viewing a legacy version of Who Owns What"
 
 #: src/containers/App.tsx:164
 #~ msgid "You are viewing the new version of Who Owns What."

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -482,8 +482,12 @@ msgid "I was checking out this building on Who Owns What, a free landlord resear
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
 #: src/containers/App.tsx:170
-msgid "In April 2023, this link to <0>the old version</0> of Who Owns What will will move to the About Page."
-msgstr "In April 2023, this link to <0>the old version</0> of Who Owns What will will move to the About Page."
+msgid "In April 2023, this link to <0>the old version</0> of Who Owns What will move to the About Page."
+msgstr "In April 2023, this link to <0>the old version</0> of Who Owns What will move to the About Page."
+
+#: src/containers/App.tsx:170
+#~ msgid "In April 2023, this link to <0>the old version</0> of Who Owns What will will move to the About Page."
+#~ msgstr "In April 2023, this link to <0>the old version</0> of Who Owns What will will move to the About Page."
 
 #: src/containers/App.tsx:165
 msgid "In July 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -487,8 +487,12 @@ msgid "I was checking out this building on Who Owns What, a free landlord resear
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
 #: src/containers/App.tsx:170
-msgid "In April 2023, this link to <0>the old version</0> of Who Owns What will will move to the About Page."
+msgid "In April 2023, this link to <0>the old version</0> of Who Owns What will move to the About Page."
 msgstr ""
+
+#: src/containers/App.tsx:170
+#~ msgid "In April 2023, this link to <0>the old version</0> of Who Owns What will will move to the About Page."
+#~ msgstr ""
 
 #: src/containers/App.tsx:165
 msgid "In July 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -51,7 +51,7 @@ msgstr "(esto puede tardar un rato)"
 msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 msgstr "({browserType, select, mobile {pulsa} other {haz clic}} para ver detalles)"
 
-#: src/containers/HomePage.tsx:123
+#: src/containers/HomePage.tsx:120
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de portafolios de edificios:"
 
@@ -93,7 +93,7 @@ msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:94
+#: src/containers/App.tsx:95
 msgid "About"
 msgstr "Acerca de"
 
@@ -249,7 +249,7 @@ msgstr "HaZ clic aquí para obtener más información."
 #: src/components/CloseButton.tsx:9
 #: src/components/DetailView.tsx:58
 #: src/components/FeatureCalloutWidget.tsx:61
-#: src/containers/App.tsx:175
+#: src/containers/App.tsx:176
 msgid "Close"
 msgstr "Cerrar"
 
@@ -298,7 +298,7 @@ msgstr "PUERTAS"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:116
+#: src/containers/App.tsx:117
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -312,7 +312,7 @@ msgid "Display:"
 msgstr "Mostrar:"
 
 #: src/components/LegalFooter.tsx:35
-#: src/containers/App.tsx:103
+#: src/containers/App.tsx:104
 msgid "Donate"
 msgstr "Donar"
 
@@ -469,7 +469,7 @@ msgstr "Oficial Principal"
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:100
+#: src/containers/App.tsx:101
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
@@ -486,17 +486,29 @@ msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
+#: src/containers/App.tsx:170
+msgid "In April 2023, this link to <0>the old version</0> of Who Owns What will will move to the About Page."
+msgstr ""
+
+#: src/containers/App.tsx:165
+msgid "In July 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"
+msgstr ""
+
 #: src/containers/App.tsx:164
 #~ msgid "In March 2023 this version of Who Owns What will no longer be available <0>Switch to new version</0>"
 #~ msgstr "In March 2023 this version of Who Owns What will no longer be available <0>Switch to new version</0>"
 
 #: src/containers/App.tsx:164
-msgid "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"
-msgstr "En marzo de 2023, esta versión de ¿Quién es el Dueño en NY? dejará de estar disponible. <0>Cambie a la nueva versión.</0>"
+#~ msgid "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version.</0>"
+#~ msgstr "En marzo de 2023, esta versión de ¿Quién es el Dueño en NY? dejará de estar disponible. <0>Cambie a la nueva versión.</0>"
 
 #: src/containers/App.tsx:164
 #~ msgid "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version</0>"
 #~ msgstr "In March 2023 this version of Who Owns What will no longer be available. <0>Switch to new version</0>"
+
+#: src/components/DeprecationModal.tsx:19
+msgid "In March 2023 this version will be discontinued. Switch to the new version or learn more."
+msgstr ""
 
 #: src/containers/NotRegisteredPage.tsx:63
 msgid "Incomplete registration for {usersInputAddressFragment}."
@@ -530,7 +542,7 @@ msgstr "Dueño Conjunto"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: src/containers/HomePage.tsx:218
+#: src/containers/HomePage.tsx:215
 msgid "Known for <0>unscrupulously deregulating rent stabilized apartments</0>, Larry Gluck’s Stellar Management has also secured a prominent place as one of <1>New York City’s Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where Gluck operates the majority of his properties. Stellar has a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
 msgstr "Conocido por <0>desregulando apartamentos de renta estabilizada sin escrúpulos</0>, Larry Gluck de Stellar Management ha asegurado un lugar prominente como unos de los <1>peores desalojadores en la Cuidad de Nueva York</1>. Stellar es una fuerza de gentrificación, especialmente en el Norte de Manhattan, en donde Gluck opera la mayoría de sus propiedades. Stellar tiene fama de desplazar inquilinos a largo plazo, renovando sus apartamentos mientras están vacantes, y aumentando rápidamente las rentas a la tasa de mercado."
 
@@ -671,8 +683,8 @@ msgid "Network of Landlords"
 msgstr "Red de Dueños"
 
 #: src/containers/HomePage.tsx:110
-msgid "New"
-msgstr "Nuevo"
+#~ msgid "New"
+#~ msgstr "Nuevo"
 
 #: src/components/AddressToolbar.tsx:23
 msgid "New Search"
@@ -859,7 +871,7 @@ msgstr "FALTA DE SEÑALIZACIÓN"
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
-#: src/containers/App.tsx:86
+#: src/containers/App.tsx:87
 msgid "Search"
 msgstr "Buscar"
 
@@ -888,15 +900,15 @@ msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en l
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
-#: src/containers/App.tsx:124
-#: src/containers/App.tsx:135
+#: src/containers/App.tsx:125
+#: src/containers/App.tsx:136
 msgid "Share"
 msgstr "Compartir"
 
 #: src/components/DetailView.tsx:270
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:140
-#: src/containers/App.tsx:145
+#: src/containers/App.tsx:146
 #: src/containers/NotRegisteredPage.tsx:18
 msgid "Share this page with your neighbors"
 msgstr "Comparte esta página con tus vecinos"
@@ -959,8 +971,8 @@ msgstr "Código fuente"
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available"
 
 #: src/containers/App.tsx:169
-msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
-msgstr "A partir de marzo de 2023 dejará de estar disponible <0>la versión antigua</0> de ¿Quién es el Dueño en NY?"
+#~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
+#~ msgstr "A partir de marzo de 2023 dejará de estar disponible <0>la versión antigua</0> de ¿Quién es el Dueño en NY?"
 
 #: src/components/PropertiesList.tsx:24
 msgid "Starts {year}"
@@ -1024,7 +1036,7 @@ msgstr "El edificio con más desalojos ejecutados es <0>{0} {1}, {2}</0> con {bu
 msgid "The city borough where your search address is located"
 msgstr "El municipio donde se encuentra la dirección que has buscado"
 
-#: src/containers/HomePage.tsx:176
+#: src/containers/HomePage.tsx:173
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
@@ -1104,7 +1116,7 @@ msgstr "Este portafolio de edificios tuvo una <0>{changeType, select, gain {gana
 msgid "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 msgstr "Esta cartera de edificios tiene un promedio de <0>{0}</0> infracciones del HPD Actuales por cada unidad residencial."
 
-#: src/containers/HomePage.tsx:142
+#: src/containers/HomePage.tsx:139
 msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 msgstr "Esta empresa de gestión inmobiliaria es propiedad de la familia Kushner y es notoria por <0>violar las normas de vivienda</0> y por <1>comportamientos abusivos</1>. La participación financiera actualmente sostenida por Jared Kushner e Ivanka Trump asciende a 761 millones de dólares."
 
@@ -1208,9 +1220,9 @@ msgstr "Ver documentos en <0>ACRIS</0>"
 msgid "View legend"
 msgstr "Ver leyenda"
 
-#: src/containers/HomePage.tsx:157
-#: src/containers/HomePage.tsx:199
-#: src/containers/HomePage.tsx:236
+#: src/containers/HomePage.tsx:154
+#: src/containers/HomePage.tsx:196
+#: src/containers/HomePage.tsx:233
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
@@ -1292,14 +1304,14 @@ msgstr "Cuando dos partes comparten la misma dirección comercial, los agrupamos
 msgid "Who Owns What is a free tool built by JustFix to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Quién Es El Dueño es una herramienta gratis construida por JustFix para investigar los dueños de edificios en NYC. Ha asistido más de 200.000 neoyorquinos a enterarse quien realmente son los responsables por su edificio, cuáles otros edificios su dueño o compañía de administración poseen, y otra información crítica sobre violaciones del código de vivienda, desalojos, apartamentos con renta estabilizada y mucho más en cualquier edificio. Puedes buscar información sobre cualquier edificio residencial, también incluyen viviendas públicas (NYCHA). Busca tu dirección aquí: {url}"
 
-#: src/containers/App.tsx:41
+#: src/containers/App.tsx:42
 msgid "Who owns what in n y c?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:21
 #: src/components/Page.tsx:22
-#: src/containers/App.tsx:36
+#: src/containers/App.tsx:37
 msgid "Who owns what in nyc?"
 msgstr "¿Quién Es El Dueño en Nueva York?"
 
@@ -1323,6 +1335,10 @@ msgstr "Año de construcción"
 #: src/components/PropertiesList.tsx:433
 msgid "Yes"
 msgstr "Sí"
+
+#: src/components/DeprecationModal.tsx:16
+msgid "You are viewing a legacy version of Who Owns What"
+msgstr ""
 
 #: src/containers/App.tsx:164
 #~ msgid "You are viewing the new version of Who Owns What."
@@ -1404,4 +1420,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:37
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2010} other {# Violaciones del HPD emitidas desde el 2010}}"
-


### PR DESCRIPTION
As part of our WOW legacy deprecation plan we are updating the copy on the banner, and adding a note to the about page. 
We also remove the "new" pill for the search by landlord name feature on the homepage. 

[sc-11583]