### PR TITLE
reorg design system typography, refactor filter styles

### DIFF
--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -114,7 +114,7 @@ export const PortfolioFilters = React.memo(
             <button
               aria-pressed={rsunitslatestActive}
               onClick={updateRsunitslatest}
-              className="filter-toggle"
+              className="filter filter-toggle"
             >
               <div className="checkbox">{rsunitslatestActive && <CheckIcon />}</div>
               <Trans>Rent Stabilized Units</Trans>
@@ -127,7 +127,7 @@ export const PortfolioFilters = React.memo(
               isOpen={ownernamesIsOpen}
               setIsOpen={setOwnernamesIsOpen}
               selectionsCount={filterContext.filterSelections.ownernames.length}
-              id="ownernames-accordion"
+              className="ownernames-accordion"
             >
               <Multiselect
                 options={ownernamesOptions.map((value: any) => ({ name: value, id: value }))}
@@ -145,7 +145,7 @@ export const PortfolioFilters = React.memo(
               isActive={unitsresActive}
               isOpen={unitsresIsOpen}
               setIsOpen={setUnitsresIsOpen}
-              id="unitsres-accordion"
+              className="unitsres-accordion"
             >
               <MinMaxSelect
                 options={filterContext.filterOptions.unitsres}
@@ -158,7 +158,7 @@ export const PortfolioFilters = React.memo(
               isOpen={zipIsOpen}
               setIsOpen={setZipIsOpen}
               selectionsCount={filterContext.filterSelections.zip.length}
-              id="zip-accordion"
+              className="zip-accordion"
             >
               <Multiselect
                 options={zipOptions.map((value: any) => ({ name: value, id: value }))}
@@ -266,7 +266,6 @@ function FilterAccordion(props: {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   selectionsCount?: number;
   className?: string;
-  id: string;
 }) {
   const {
     title,
@@ -278,7 +277,6 @@ function FilterAccordion(props: {
     setIsOpen,
     selectionsCount,
     className,
-    id,
   } = props;
 
   return (
@@ -291,8 +289,7 @@ function FilterAccordion(props: {
       }}
     >
       <details
-        className={classnames("filter-accordion", className, { active: isActive })}
-        id={id}
+        className={classnames("filter filter-accordion", className, { active: isActive })}
         open={isOpen}
       >
         <summary

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -1,8 +1,7 @@
 @import "_vars.scss";
 @import "_scrollbar.scss";
 @import "_button.scss";
-
-$justfix-table-grey: #f2f2f2;
+@import "_typography.scss";
 
 .PortfolioFilters {
   display: flex;
@@ -11,8 +10,7 @@ $justfix-table-grey: #f2f2f2;
   background-color: $justfix-table-grey;
   text-transform: uppercase;
 
-  // TODO: design system typography
-  font-family: "Inconsolata";
+  font-family: $wow-font;
   font-style: normal;
   font-weight: 600;
   font-size: 1.4rem;
@@ -28,7 +26,7 @@ $justfix-table-grey: #f2f2f2;
 
     .pill-new {
       align-self: flex-end;
-      font-family: "Degular", Arial, Helvetica, sans-serif;
+      font-family: $body-font;
       letter-spacing: 0.02em;
       background: $justfix-yellow;
       padding: 0.5rem 1rem;
@@ -43,42 +41,53 @@ $justfix-table-grey: #f2f2f2;
     flex-direction: column;
 
     .filters {
+      --checkbox-height: 2.4rem;
+
       display: flex;
       gap: 1.8rem;
 
-      .filter-toggle {
+      .filter {
         border: 0.1rem solid $justfix-black;
         border-radius: 0.8rem;
         text-transform: uppercase;
         padding: 1rem;
         display: flex;
         align-items: center;
+        // height based on toggle toggle checkbox plus 1rem padding
+        height: calc(var(--checkbox-height) + 1rem * 2);
 
-        &:focus-visible {
-          box-shadow: none;
-          outline: 2px solid #727e96;
-          outline-offset: 2px;
+        &.active:not([open]),
+        &[aria-pressed="true"] {
+          background-color: $justfix-black;
+          color: $justfix-white;
+          border-color: $justfix-white;
         }
-        &:hover {
+        &:not([open]):hover,
+        &[open] summary {
           text-decoration: underline;
           text-underline-position: under;
         }
+        &:focus-visible {
+          box-shadow: none;
+          outline: 2px solid $focus-outline-color;
+          outline-offset: 2px;
+        }
+      }
+
+      .filter-toggle {
         .checkbox {
           box-sizing: border-box;
           border: 0.1rem solid $justfix-black;
           border-radius: 0.4rem;
-          width: 2.4rem;
-          height: 2.4rem;
+          width: var(--checkbox-height);
+          height: var(--checkbox-height);
           margin-right: 1rem;
           display: flex;
           justify-content: center;
           align-items: center;
           color: $justfix-white;
         }
-
         &[aria-pressed="true"] {
-          background-color: $justfix-black;
-          color: $justfix-white;
           .checkbox {
             border-color: $justfix-white;
           }
@@ -86,22 +95,7 @@ $justfix-table-grey: #f2f2f2;
       }
 
       .filter-accordion {
-        border: 0.1rem solid $justfix-black;
-        border-radius: 0.8rem;
-        text-transform: uppercase;
-        display: flex;
-        align-items: center;
         position: relative;
-
-        &:not([open]):hover {
-          text-decoration: underline;
-          text-underline-position: under;
-        }
-
-        &.active:not([open]) {
-          background-color: $justfix-black;
-          color: $justfix-white;
-        }
 
         summary {
           // typical flex stretch doesn't seem to work in summary/details
@@ -109,7 +103,6 @@ $justfix-table-grey: #f2f2f2;
           display: flex;
           align-items: center;
           position: relative;
-          padding: 0 1rem;
           cursor: pointer;
 
           &::-webkit-details-marker {
@@ -118,28 +111,19 @@ $justfix-table-grey: #f2f2f2;
           .chevonIcon {
             margin-left: 0.8rem;
             stroke-width: 2px;
-            stroke-linejoin: miter;
           }
         }
         &[open] {
-          summary {
-            text-decoration: underline;
-            text-underline-position: under;
-            svg {
-              transform: scaleY(-1);
-            }
+          summary svg {
+            transform: scaleY(-1);
           }
 
-          &#ownernames-accordion {
-            .dropdown-container {
-              width: 25.2rem;
-            }
+          &.ownernames-accordion .dropdown-container {
+            width: 25.2rem;
           }
 
-          &#zip-accordion {
-            .dropdown-container {
-              width: 14.1rem;
-            }
+          &.zip-accordion .dropdown-container {
+            width: 14.1rem;
           }
 
           .dropdown-container {
@@ -166,7 +150,7 @@ $justfix-table-grey: #f2f2f2;
 
               .filter-info:focus-visible {
                 box-shadow: none;
-                outline: 2px solid #727e96;
+                outline: 2px solid $focus-outline-color;
                 outline-offset: 2px;
               }
             }
@@ -238,7 +222,7 @@ $justfix-table-grey: #f2f2f2;
               border-radius: unset;
             }
             .optionListContainer {
-              background-color: #f2f2f2;
+              background-color: $justfix-table-grey;
               border-bottom: 1px solid $justfix-grey;
               border-radius: unset;
               .optionsContainer,

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -2,7 +2,6 @@
 @import "_scrollbar.scss";
 @import "_button.scss";
 
-$justfix-table-grey: #f2f2f2;
 $table-border-light: 1px solid $gray-light;
 $table-border-dark: 1px solid $dark;
 
@@ -64,7 +63,7 @@ $table-border-dark: 1px solid $dark;
         border-top: 1px solid $gray-dark;
         font-weight: bold;
         color: #000;
-        background-color: #f7f7f7;
+        background-color: $justfix-table-white;
       }
 
       tr:last-child th {
@@ -88,7 +87,7 @@ $table-border-dark: 1px solid $dark;
         border-bottom: $table-border-light;
 
         &.row-odd {
-          background-color: #f7f7f7;
+          background-color: $justfix-table-white;
           &:hover {
             background-color: $justfix-table-grey;
           }

--- a/client/src/styles/_button.scss
+++ b/client/src/styles/_button.scss
@@ -189,7 +189,6 @@
     transform: translateX(0.7rem);
   }
 
-  // TODO: review in design system - current figma focus state is too subtle
   &:focus-visible {
     box-shadow: none;
     outline: 2px solid #727e96;

--- a/client/src/styles/_button.scss
+++ b/client/src/styles/_button.scss
@@ -191,7 +191,7 @@
 
   &:focus-visible {
     box-shadow: none;
-    outline: 2px solid #727e96;
+    outline: 2px solid $focus-outline-color;
     outline-offset: 2px;
   }
 

--- a/client/src/styles/_button.scss
+++ b/client/src/styles/_button.scss
@@ -1,4 +1,5 @@
 @import "_vars.scss";
+@import "_typography.scss";
 
 @mixin button() {
   border: 1px solid $dark;
@@ -141,20 +142,13 @@
   opacity: 0.7;
 }
 
-// Copied from justfix-website
+// Copied/adapted from https://github.com/JustFixNYC/justfix-website/blob/master/src/styles/_design-system.scss
+// NOTE: wow using root 10px, org-site uses 16px. All rem units here have been adjusted
 
 @mixin button-variant($color: $justfix-black) {
   background-color: $color;
 
-  // mobile-eyebrow:
-  font-weight: 400;
-  font-style: normal;
-  letter-spacing: 0.01rem;
-  font-family: "Suisse Int'l Mono", "Courier New", Courier, monospace;
-  font-size: 1.4rem; // to 10rem
-  line-height: 115%;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
+  @include mobile-eyebrow();
 
   @if $color ==$justfix-white {
     color: $justfix-black;

--- a/client/src/styles/_typography.scss
+++ b/client/src/styles/_typography.scss
@@ -130,3 +130,55 @@ $eyebrow-font: "Suisse Int'l Mono", "Courier New", Courier, monospace;
   @include desktop-eyebrow();
   font-size: 1rem;
 }
+
+// TYPOGRAPHY-MOBILE:
+@mixin mobile-body-standard {
+  @include body-standard();
+  line-height: 125%;
+  font-size: 2rem;
+}
+
+@mixin mobile-h1 {
+  @include body-standard();
+  font-weight: 600;
+  font-size: 3.6rem;
+}
+
+@mixin mobile-h2 {
+  @include body-standard();
+  font-weight: 600;
+  font-size: 1.8rem;
+  letter-spacing: 0.02em;
+  font-variant: all-small-caps;
+}
+
+@mixin mobile-h3 {
+  @include body-standard();
+  font-size: 2.4rem;
+  line-height: 110%;
+}
+
+@mixin mobile-eyebrow {
+  @include body-standard();
+  font-family: $eyebrow-font;
+  font-size: 1.4rem;
+  line-height: 115%;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+@mixin mobile-text-small {
+  @include body-standard();
+  font-size: 1.4rem;
+}
+
+@mixin mobile-text-small-bold {
+  @include mobile-text-small();
+  font-weight: 600;
+}
+
+@mixin mobile-text-small-link {
+  @include mobile-text-small();
+  @include link();
+  line-height: 115%;
+}

--- a/client/src/styles/_typography.scss
+++ b/client/src/styles/_typography.scss
@@ -1,0 +1,132 @@
+// Copied/adapted from https://github.com/JustFixNYC/justfix-website/blob/master/src/styles/_design-system.scss
+// NOTE: wow using root 10px, org-site uses 16px. All rem units here have been adjusted
+
+// FONTS:
+
+@font-face {
+  font-family: "Degular";
+  font-weight: normal;
+  font-style: normal;
+  src: url("../fonts/Degular-Medium.woff2") format("woff2"),
+    url("../fonts/Degular-Medium.woff") format("woff");
+}
+
+@font-face {
+  font-family: "Degular";
+  font-weight: 600;
+  font-style: normal;
+  src: url("../fonts/Degular-Semibold.woff2") format("woff2"),
+    url("../fonts/Degular-Semibold.woff") format("woff");
+}
+
+@font-face {
+  font-family: "Degular Display";
+  font-weight: normal;
+  font-style: normal;
+  src: url("../fonts/Degular_Display-Medium.woff2") format("woff2"),
+    url("../fonts/Degular_Display-Medium.woff") format("woff");
+}
+
+@font-face {
+  font-family: "Suisse Int'l Mono";
+  font-weight: normal;
+  font-style: normal;
+  src: url("../fonts/SuisseIntlMono-Regular-WebS.woff2") format("woff2"),
+    url("../fonts/SuisseIntlMono-Regular-WebS.woff") format("woff");
+}
+
+$wow-font: "Inconsolata", monospace;
+$body-font: "Degular", Arial, Helvetica, sans-serif;
+$title-font: "Degular Display", Arial, Helvetica, sans-serif;
+$eyebrow-font: "Suisse Int'l Mono", "Courier New", Courier, monospace;
+
+// FONTS:
+@font-face {
+  font-family: "Degular";
+  font-weight: normal;
+  font-style: normal;
+  src: url("../fonts/Degular-Medium.woff2") format("woff2"),
+    url("../fonts/Degular-Medium.woff") format("woff");
+}
+
+@font-face {
+  font-family: "Degular Display";
+  font-weight: normal;
+  font-style: normal;
+  src: url("../fonts/Degular_Display-Medium.woff2") format("woff2"),
+    url("../fonts/Degular_Display-Medium.woff") format("woff");
+}
+
+@font-face {
+  font-family: "Suisse Int'l Mono";
+  font-weight: normal;
+  font-style: normal;
+  src: url("../fonts/SuisseIntlMono-Regular-WebS.woff2") format("woff2"),
+    url("../fonts/SuisseIntlMono-Regular-WebS.woff") format("woff");
+}
+
+$body-font: "Degular", Arial, Helvetica, sans-serif;
+$title-font: "Degular Display", Arial, Helvetica, sans-serif;
+$eyebrow-font: "Suisse Int'l Mono", "Courier New", Courier, monospace;
+
+@mixin body-standard {
+  font-family: $body-font;
+  font-size: 1.125rem;
+  line-height: 100%;
+  font-weight: 400;
+  font-style: normal;
+  letter-spacing: 0.01rem;
+}
+
+// TYPOGRAPHY-DESKTOP:
+@mixin desktop-h1 {
+  @include body-standard();
+  font-family: $title-font;
+  font-size: 6rem;
+  letter-spacing: 0.03em;
+}
+
+@mixin desktop-h2 {
+  @include body-standard();
+  font-family: $title-font;
+  font-size: 4rem;
+  line-height: 90%;
+  letter-spacing: 0.03em;
+}
+
+@mixin desktop-h3 {
+  @include body-standard();
+  font-weight: 600;
+  font-size: 2.25rem;
+}
+
+@mixin desktop-h4 {
+  @include body-standard();
+  font-weight: 600;
+  font-size: 1.8rem;
+  line-height: 120%;
+}
+
+@mixin desktop-text-small {
+  @include body-standard();
+  font-size: 0.875rem;
+}
+
+@mixin desktop-text-small-bold {
+  @include body-standard();
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+@mixin desktop-eyebrow {
+  @include body-standard();
+  font-family: $eyebrow-font;
+  line-height: 115%;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+@mixin desktop-eyebrow-small {
+  @include desktop-eyebrow();
+  font-size: 1rem;
+}

--- a/client/src/styles/_vars.scss
+++ b/client/src/styles/_vars.scss
@@ -13,6 +13,10 @@ $success: #32b643;
 $warning: #ffb700;
 $error: #e85600;
 
+$justfix-table-grey: #f2f2f2;
+$justfix-table-white: #f7f7f7;
+$focus-outline-color: #727e96;
+
 $wowza-background: #faf8f4;
 $wowza-dark: #242323;
 $wowza-orange: #ff813a;
@@ -88,97 +92,6 @@ $size-lg: 899px;
 }
 
 // REBRAND VARIABLES
-
-// FONTS:
-@font-face {
-  font-family: "Degular";
-  font-weight: normal;
-  font-style: normal;
-  src: url("../fonts/Degular-Medium.woff2") format("woff2"),
-    url("../fonts/Degular-Medium.woff") format("woff");
-}
-
-@font-face {
-  font-family: "Degular Display";
-  font-weight: normal;
-  font-style: normal;
-  src: url("../fonts/Degular_Display-Medium.woff2") format("woff2"),
-    url("../fonts/Degular_Display-Medium.woff") format("woff");
-}
-
-@font-face {
-  font-family: "Suisse Int'l Mono";
-  font-weight: normal;
-  font-style: normal;
-  src: url("../fonts/SuisseIntlMono-Regular-WebS.woff2") format("woff2"),
-    url("../fonts/SuisseIntlMono-Regular-WebS.woff") format("woff");
-}
-
-$body-font: "Degular", Arial, Helvetica, sans-serif;
-$title-font: "Degular Display", Arial, Helvetica, sans-serif;
-$eyebrow-font: "Suisse Int'l Mono", "Courier New", Courier, monospace;
-
-@mixin body-standard {
-  font-family: $body-font;
-  font-size: 1.125rem;
-  line-height: 100%;
-  font-weight: 400;
-  font-style: normal;
-  letter-spacing: 0.01rem;
-}
-
-// TYPOGRAPHY-DESKTOP:
-@mixin desktop-h1 {
-  @include body-standard();
-  font-family: $title-font;
-  font-size: 6rem;
-  letter-spacing: 0.03em;
-}
-
-@mixin desktop-h2 {
-  @include body-standard();
-  font-family: $title-font;
-  font-size: 4rem;
-  line-height: 90%;
-  letter-spacing: 0.03em;
-}
-
-@mixin desktop-h3 {
-  @include body-standard();
-  font-weight: 600;
-  font-size: 2.25rem;
-}
-
-@mixin desktop-h4 {
-  @include body-standard();
-  font-weight: 600;
-  font-size: 1.8rem;
-  line-height: 120%;
-}
-
-@mixin desktop-text-small {
-  @include body-standard();
-  font-size: 0.875rem;
-}
-
-@mixin desktop-text-small-bold {
-  @include body-standard();
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-@mixin desktop-eyebrow {
-  @include body-standard();
-  font-family: $eyebrow-font;
-  line-height: 115%;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-}
-
-@mixin desktop-eyebrow-small {
-  @include desktop-eyebrow();
-  font-size: 1rem;
-}
 
 // COLORS:
 $justfix-black: #242323;


### PR DESCRIPTION
Moved the new design system typography out of _vars, and used those mixins/variables where possible (we're still not using much of the new system)

This PR also includes a refactor of the portfolio filter styles, simplifying things now that the markup is mostly finalized and to make things easier to adapt for mobile. 