### PR TITLE
Filters mobile

### DIFF
--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -612,19 +612,23 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
             <Trans>Error</Trans>
           </Alert>
         )}
-        {!hideSelectedList && this.renderSelectedList()}
-        {selectedValues.length > 0 && (
-          <button
-            className="clear-all button is-text"
-            key={2}
-            onClick={() => {
-              this.resetSelectedValues();
-              onApply([]);
-            }}
-          >
-            <Trans>Clear</Trans>
-          </button>
-        )}
+        <div className="selectedListContainer">
+          {!hideSelectedList && this.renderSelectedList()}
+        </div>
+        <div className="clear-all-container">
+          {selectedValues.length > 0 && (
+            <button
+              className="clear-all button is-text"
+              key={2}
+              onClick={() => {
+                this.resetSelectedValues();
+                onApply([]);
+              }}
+            >
+              <Trans>Clear</Trans>
+            </button>
+          )}
+        </div>
         <div
           className={classnames("search-wrapper searchWrapper", { hasError: hasError })}
           ref={this.searchWrapper}

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -30,6 +30,7 @@ export interface IMultiselectProps {
   onSearch?: (value: string) => void;
   onKeyPressFn?: (event: any, value: string) => void;
   onApply: (selectedList: any) => void;
+  onFocusInput: () => void;
   infoAlert?: React.ReactNode;
   caseSensitiveSearch?: boolean;
   id?: string;
@@ -563,6 +564,7 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
     } else {
       this.toggelOptionList();
     }
+    this.props.onFocusInput();
   }
 
   onBlur() {
@@ -728,6 +730,7 @@ Multiselect.defaultProps = {
   onSelect: () => {},
   onRemove: () => {},
   onKeyPressFn: () => {},
+  onFocusInput: () => {},
   caseSensitiveSearch: false,
   id: "",
   name: "",

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -30,7 +30,7 @@ export interface IMultiselectProps {
   onSearch?: (value: string) => void;
   onKeyPressFn?: (event: any, value: string) => void;
   onApply: (selectedList: any) => void;
-  onFocusInput: () => void;
+  onFocusInput?: () => void;
   infoAlert?: React.ReactNode;
   caseSensitiveSearch?: boolean;
   id?: string;

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -405,7 +405,7 @@ function MinMaxSelect(props: {
   onFocusInput?: () => void;
 }) {
   const { options, onApply, onFocusInput } = props;
-  const [minMax, setMinMax] = React.useState(options);
+  const [minMax, setMinMax] = React.useState<FilterNumberRange>(MINMAX_DEFAULT);
   const [minMaxErrors, setMinMaxErrors] = React.useState([false, false]);
 
   return (

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -113,7 +113,11 @@ export const PortfolioFilters = React.memo(
           <span className="pill-new">
             <Trans>New</Trans>
           </span>
-          {isMobile ? <></> : <Trans>Filters:</Trans>}
+          {!isMobile && (
+            <span>
+              <Trans>Filters:</Trans>
+            </span>
+          )}
         </div>
         <FiltersWrapper
           isMobile={isMobile}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -480,12 +480,12 @@ function cleanNumberInput(value: string): number | undefined {
 }
 
 function minMaxHasError(values: FilterNumberRange, options: FilterNumberRange): [boolean, boolean] {
-  if (typeof options[0] === "undefined" || typeof options[1] === "undefined") {
-    return [true, true];
-  }
+  const minHasError =
+    values[0] == null
+      ? false
+      : values[0] < 0 || (options[1] == null ? false : values[0] >= options[1]);
 
-  const minHasError = typeof values[0] === "undefined" ? false : values[0] < options[0];
-  const maxHasError = typeof values[1] === "undefined" ? false : values[1] > options[1];
+  const maxHasError = values[1] == null || options[0] == null ? false : values[1] <= options[0];
 
   return [minHasError, maxHasError];
 }

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -109,100 +109,98 @@ export const PortfolioFilters = React.memo(
 
     return (
       <div className="PortfolioFilters" ref={ref}>
-        <div className="filter-for">
+        <div className="new-container">
           <span className="pill-new">
             <Trans>New</Trans>
           </span>
           {isMobile ? <></> : <Trans>Filters:</Trans>}
         </div>
-        <div className="filters-container">
-          <FiltersWrapper
-            isMobile={isMobile}
-            activeFilters={activeFilters}
-            resultsCount={filteredBuildings}
+        <FiltersWrapper
+          isMobile={isMobile}
+          activeFilters={activeFilters}
+          resultsCount={filteredBuildings}
+        >
+          {" "}
+          <button
+            aria-pressed={rsunitslatestActive}
+            onClick={updateRsunitslatest}
+            className="filter filter-toggle"
           >
-            {" "}
-            <button
-              aria-pressed={rsunitslatestActive}
-              onClick={updateRsunitslatest}
-              className="filter filter-toggle"
-            >
-              <div className="checkbox">{rsunitslatestActive && <CheckIcon />}</div>
-              <span>
-                <Trans>Rent Stabilized Units</Trans>
-              </span>
+            <div className="checkbox">{rsunitslatestActive && <CheckIcon />}</div>
+            <span>
+              <Trans>Rent Stabilized Units</Trans>
+            </span>
+          </button>
+          <FilterAccordion
+            title={i18n._(t`Landlord`)}
+            subtitle={i18n._(t`Officer/Owner`)}
+            infoOnClick={() => setShowOwnerModal(true)}
+            isMobile={isMobile}
+            isActive={ownernamesActive}
+            isOpen={ownernamesIsOpen}
+            setIsOpen={setOwnernamesIsOpen}
+            selectionsCount={filterContext.filterSelections.ownernames.length}
+            className="ownernames-accordion"
+          >
+            <Multiselect
+              options={ownernamesOptions.map((value: any) => ({ name: value, id: value }))}
+              selectedValues={ownernamesSelections}
+              displayValue="name"
+              placeholder={i18n._(t`Search`) + `... (${ownernamesOptions.length})`}
+              onApply={onOwnernamesApply}
+              infoAlert={OwnerInfoAlert}
+              avoidHighlightFirstOption={true}
+            />
+          </FilterAccordion>
+          <FilterAccordion
+            title={i18n._(t`Building Size`)}
+            subtitle={i18n._(t`Number of Units`)}
+            isMobile={isMobile}
+            isActive={unitsresActive}
+            isOpen={unitsresIsOpen}
+            setIsOpen={setUnitsresIsOpen}
+            className="unitsres-accordion"
+          >
+            <MinMaxSelect
+              options={filterContext.filterOptions.unitsres}
+              onApply={onUnitsresApply}
+            />
+          </FilterAccordion>
+          <FilterAccordion
+            title={i18n._(t`Zipcode`)}
+            isMobile={isMobile}
+            isActive={zipActive}
+            isOpen={zipIsOpen}
+            setIsOpen={setZipIsOpen}
+            selectionsCount={filterContext.filterSelections.zip.length}
+            className="zip-accordion"
+          >
+            <Multiselect
+              options={zipOptions.map((value: any) => ({ name: value, id: value }))}
+              selectedValues={zipSelections}
+              displayValue="name"
+              placeholder={i18n._(t`Search`) + `... (${zipOptions.length})`}
+              onApply={onZipApply}
+              avoidHighlightFirstOption={true}
+            />
+          </FilterAccordion>
+        </FiltersWrapper>
+        {[rsunitslatestActive, ownernamesActive, unitsresActive, zipActive].includes(true) && (
+          <div className="filter-status">
+            <span className="results-count">
+              <Trans>
+                Showing {filteredBuildings || 0}{" "}
+                <Plural value={filteredBuildings || 0} one="result" other="results" />.
+              </Trans>
+            </span>
+            <button className="results-info" onClick={() => setShowInfoModal(true)}>
+              <InfoIcon />
             </button>
-            <FilterAccordion
-              title={i18n._(t`Landlord`)}
-              subtitle={i18n._(t`Officer/Owner`)}
-              infoOnClick={() => setShowOwnerModal(true)}
-              isMobile={isMobile}
-              isActive={ownernamesActive}
-              isOpen={ownernamesIsOpen}
-              setIsOpen={setOwnernamesIsOpen}
-              selectionsCount={filterContext.filterSelections.ownernames.length}
-              className="ownernames-accordion"
-            >
-              <Multiselect
-                options={ownernamesOptions.map((value: any) => ({ name: value, id: value }))}
-                selectedValues={ownernamesSelections}
-                displayValue="name"
-                placeholder={i18n._(t`Search`) + `... (${ownernamesOptions.length})`}
-                onApply={onOwnernamesApply}
-                infoAlert={OwnerInfoAlert}
-                avoidHighlightFirstOption={true}
-              />
-            </FilterAccordion>
-            <FilterAccordion
-              title={i18n._(t`Building Size`)}
-              subtitle={i18n._(t`Number of Units`)}
-              isMobile={isMobile}
-              isActive={unitsresActive}
-              isOpen={unitsresIsOpen}
-              setIsOpen={setUnitsresIsOpen}
-              className="unitsres-accordion"
-            >
-              <MinMaxSelect
-                options={filterContext.filterOptions.unitsres}
-                onApply={onUnitsresApply}
-              />
-            </FilterAccordion>
-            <FilterAccordion
-              title={i18n._(t`Zipcode`)}
-              isMobile={isMobile}
-              isActive={zipActive}
-              isOpen={zipIsOpen}
-              setIsOpen={setZipIsOpen}
-              selectionsCount={filterContext.filterSelections.zip.length}
-              className="zip-accordion"
-            >
-              <Multiselect
-                options={zipOptions.map((value: any) => ({ name: value, id: value }))}
-                selectedValues={zipSelections}
-                displayValue="name"
-                placeholder={i18n._(t`Search`) + `... (${zipOptions.length})`}
-                onApply={onZipApply}
-                avoidHighlightFirstOption={true}
-              />
-            </FilterAccordion>
-          </FiltersWrapper>
-          {[rsunitslatestActive, ownernamesActive, unitsresActive, zipActive].includes(true) && (
-            <div className="filter-status">
-              <span className="results-count">
-                <Trans>
-                  Showing {filteredBuildings || 0}{" "}
-                  <Plural value={filteredBuildings || 0} one="result" other="results" />.
-                </Trans>
-              </span>
-              <button className="results-info" onClick={() => setShowInfoModal(true)}>
-                <InfoIcon />
-              </button>
-              <button className="clear-filters button is-text" onClick={clearFilters}>
-                <Trans>Clear Filters</Trans>
-              </button>
-            </div>
-          )}
-        </div>
+            <button className="clear-filters button is-text" onClick={clearFilters}>
+              <Trans>Clear Filters</Trans>
+            </button>
+          </div>
+        )}
         <Modal key={1} showModal={showInfoModal} width={20} onClose={() => setShowInfoModal(false)}>
           <h4>
             <Trans>How are the results calculated?</Trans>

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -291,7 +291,7 @@ const FiltersWrapper = (props: {
             )}
             {isOpen ? <CloseIcon className="closeIcon" /> : <ChevronIcon className="chevronIcon" />}
           </summary>
-          <div className="dropdown-container">
+          <div className="dropdown-container scroll-gradient">
             {children}
             {!!activeFilters && (
               <button onClick={() => setIsOpen(!isOpen)} className="button is-primary">

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -110,7 +110,7 @@ export const PortfolioFilters = React.memo(
 
     return (
       <div className="PortfolioFilters" ref={ref}>
-        <div className="new-container">
+        <div className="filter-new-container">
           <span className="pill-new">
             <Trans>New</Trans>
           </span>
@@ -125,7 +125,6 @@ export const PortfolioFilters = React.memo(
           activeFilters={activeFilters}
           resultsCount={filteredBuildings}
         >
-          {" "}
           <button
             aria-pressed={rsunitslatestActive}
             onClick={updateRsunitslatest}
@@ -193,7 +192,7 @@ export const PortfolioFilters = React.memo(
             />
           </FilterAccordion>
         </FiltersWrapper>
-        {[rsunitslatestActive, ownernamesActive, unitsresActive, zipActive].includes(true) && (
+        {(rsunitslatestActive || ownernamesActive || unitsresActive || zipActive) && (
           <div className="filter-status">
             <span className="results-count">
               <Trans>
@@ -300,7 +299,7 @@ const FiltersWrapper = (props: {
             {!!activeFilters && (
               <button onClick={() => setIsOpen(!isOpen)} className="button is-primary">
                 <Trans>View Results</Trans>
-                {resultsCount && <span className="view-results-count">{resultsCount}</span>}
+                {resultsCount != null && <span className="view-results-count">{resultsCount}</span>}
               </button>
             )}
           </div>

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -14,6 +14,7 @@ import { createWhoOwnsWhatRoutePaths } from "routes";
 import { isLegacyPath } from "./WowzaToggle";
 import { useLocation } from "react-router-dom";
 import Browser from "../util/browser";
+import helpers from "util/helpers";
 
 type PortfolioFiltersProps = {
   i18n: I18n;
@@ -152,6 +153,7 @@ export const PortfolioFilters = React.memo(
               displayValue="name"
               placeholder={i18n._(t`Search`) + `... (${ownernamesOptions.length})`}
               onApply={onOwnernamesApply}
+              onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
               infoAlert={OwnerInfoAlert}
               avoidHighlightFirstOption={true}
             />
@@ -168,6 +170,7 @@ export const PortfolioFilters = React.memo(
             <MinMaxSelect
               options={filterContext.filterOptions.unitsres}
               onApply={onUnitsresApply}
+              onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
             />
           </FilterAccordion>
           <FilterAccordion
@@ -185,6 +188,7 @@ export const PortfolioFilters = React.memo(
               displayValue="name"
               placeholder={i18n._(t`Search`) + `... (${zipOptions.length})`}
               onApply={onZipApply}
+              onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
               avoidHighlightFirstOption={true}
             />
           </FilterAccordion>
@@ -291,7 +295,7 @@ const FiltersWrapper = (props: {
             )}
             {isOpen ? <CloseIcon className="closeIcon" /> : <ChevronIcon className="chevronIcon" />}
           </summary>
-          <div className="dropdown-container scroll-gradient">
+          <div className="dropdown-container scroll-gradient mobile-wrapper-dropdown">
             {children}
             {!!activeFilters && (
               <button onClick={() => setIsOpen(!isOpen)} className="button is-primary">
@@ -398,8 +402,9 @@ function FilterAccordion(props: {
 function MinMaxSelect(props: {
   options: FilterNumberRange;
   onApply: (selectedList: FilterNumberRange) => void;
+  onFocusInput?: () => void;
 }) {
-  const { options, onApply } = props;
+  const { options, onApply, onFocusInput } = props;
   const [minMax, setMinMax] = React.useState(options);
   const [minMaxErrors, setMinMaxErrors] = React.useState([false, false]);
 
@@ -433,6 +438,7 @@ function MinMaxSelect(props: {
             setMinMaxErrors([false, false]);
             setMinMax([cleanNumberInput(e.target.value), minMax[1]]);
           }}
+          onFocus={onFocusInput}
           className={classnames("min-input", { hasError: minMaxErrors[0] })}
         />
         <Trans>and</Trans>
@@ -446,6 +452,7 @@ function MinMaxSelect(props: {
             setMinMaxErrors([false, false]);
             setMinMax([minMax[0], cleanNumberInput(e.target.value)]);
           }}
+          onFocus={onFocusInput}
           className={classnames("max-input", { hasError: minMaxErrors[1] })}
         />
       </div>

--- a/client/src/styles/Multiselect.scss
+++ b/client/src/styles/Multiselect.scss
@@ -83,9 +83,6 @@
   cursor: pointer;
   text-decoration: underline;
 }
-.checkbox {
-  margin-right: 10px;
-}
 .disableSelection {
   pointer-events: none;
   opacity: 0.5;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -143,18 +143,16 @@
           margin-left: 0.8rem;
         }
       }
-      &:not([open]) {
-        .filter-selection-count {
-          @include for-tablet-portrait-up() {
-            margin-left: 1em;
-            @include wrap-with-parentheses();
-          }
-          @include for-phone-only() {
-            @include white-on-black();
-            padding: 0.25rem 0.5rem;
-            border-radius: 1rem;
-            margin-left: 0.8rem;
-          }
+      .filter-selection-count {
+        @include for-tablet-portrait-up() {
+          margin-left: 1em;
+          @include wrap-with-parentheses();
+        }
+        @include for-phone-only() {
+          @include white-on-black();
+          padding: 0.25rem 0.5rem;
+          border-radius: 1rem;
+          margin-left: 0.8rem;
         }
       }
       &[open] {
@@ -178,7 +176,7 @@
         }
 
         &.zip-accordion .dropdown-container {
-          width: 14.1rem;
+          width: 15rem;
           @include for-phone-only {
             width: unset;
           }
@@ -196,6 +194,10 @@
           box-sizing: border-box;
           border: 0.1rem solid $justfix-black;
           border-radius: 0.8rem;
+
+          & > div {
+            width: 100%;
+          }
 
           .filter-subtitle-container {
             font-size: 1.2rem;
@@ -302,9 +304,6 @@
             display: flex;
             flex-wrap: wrap;
             gap: 0.4rem;
-            @include for-tablet-portrait-up() {
-              padding: 0 1.2rem;
-            }
 
             .chip {
               align-self: flex-start;
@@ -340,11 +339,9 @@
               color: $justfix-grey-700;
               &.show-less {
                 margin: 1.2rem 0 0 1.2rem;
-                // align-self: flex-start;
               }
               &.clear-all {
-                margin: 0.8rem 1.2rem 0.9rem auto;
-                // align-self: flex-end;
+                margin: 0.8rem 0 0.9rem auto;
               }
             }
           }

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -39,7 +39,7 @@
     gap: 1.2rem;
   }
 
-  .new-container {
+  .filter-new-container {
     text-align: right;
     width: var(--new-container-width);
     letter-spacing: 0.04em;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -54,7 +54,7 @@
       padding: 0.5rem 1rem;
       border-radius: 1.6rem;
       width: fit-content;
-      margin-bottom: 1rem;
+      margin-bottom: auto;
     }
 
     @include for-phone-only() {
@@ -224,6 +224,7 @@
             border-top: 1px solid $justfix-grey;
             @include for-phone-only {
               border-top: none;
+              padding-left: 0;
             }
 
             .labels-container {
@@ -341,6 +342,11 @@
             align-self: center;
             margin: 0.9rem 0 1rem 0;
           }
+          @include for-phone-only() {
+            .minmax-container .button.is-primary {
+              align-self: flex-start;
+            }
+          }
         }
       }
     }
@@ -401,6 +407,7 @@
             }
             @include for-phone-only {
               .dropdown-container {
+                align-items: flex-start;
                 padding: 2.4rem;
                 .filter-subtitle-container {
                   padding: 0;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -19,8 +19,11 @@
 }
 
 .PortfolioFilters {
+  --new-container-width: 10.2rem;
+  --filter-bar-gap: 1.8rem;
   display: flex;
-  gap: 1.8rem;
+  flex-wrap: wrap;
+  gap: var(--filter-bar-gap);
   padding: 1.4rem;
   background-color: $justfix-table-grey;
   text-transform: uppercase;
@@ -36,9 +39,9 @@
     gap: 1.2rem;
   }
 
-  .filter-for {
+  .new-container {
     text-align: right;
-    min-width: 10.2rem;
+    width: var(--new-container-width);
     letter-spacing: 0.04em;
     display: flex;
     flex-direction: column;
@@ -55,7 +58,7 @@
     }
 
     @include for-phone-only() {
-      min-width: unset;
+      width: unset;
       justify-content: center;
       .pill-new {
         margin: 0;
@@ -63,400 +66,399 @@
     }
   }
 
-  .filters-container {
+  .filters {
+    --checkbox-height: 2.4rem;
+
     display: flex;
-    flex-direction: column;
+    flex-grow: 1;
+    gap: 1.8rem;
 
-    .filters {
-      --checkbox-height: 2.4rem;
-
+    .filter {
+      border: 0.1rem solid $justfix-black;
+      border-radius: 0.8rem;
+      text-transform: uppercase;
+      padding: 1rem;
       display: flex;
-      gap: 1.8rem;
+      align-items: center;
+      // height based on toggle toggle checkbox plus 1rem padding
+      height: calc(var(--checkbox-height) + 1rem * 2);
 
-      .filter {
+      &.active:not([open]),
+      &[aria-pressed="true"] {
+        @include white-on-black();
+      }
+      &:not([open]):hover,
+      [open] summary {
+        text-decoration: underline;
+        text-underline-position: under;
+      }
+      &:focus-visible {
+        box-shadow: none;
+        outline: 2px solid $focus-outline-color;
+        outline-offset: 2px;
+      }
+    }
+
+    .filter-toggle {
+      gap: 1rem;
+      .checkbox {
+        box-sizing: border-box;
         border: 0.1rem solid $justfix-black;
-        border-radius: 0.8rem;
-        text-transform: uppercase;
-        padding: 1rem;
+        border-radius: 0.4rem;
+        width: var(--checkbox-height);
+        height: var(--checkbox-height);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        color: $justfix-white;
+        @include for-phone-only {
+          order: 1;
+          margin-left: auto;
+        }
+      }
+      &[aria-pressed="true"] {
+        .checkbox {
+          border-color: $justfix-white;
+        }
+      }
+    }
+
+    .filter-accordion {
+      position: relative;
+
+      summary {
+        // typical flex stretch doesn't seem to work in summary/details
+        height: 100%;
         display: flex;
         align-items: center;
-        // height based on toggle toggle checkbox plus 1rem padding
-        height: calc(var(--checkbox-height) + 1rem * 2);
-
-        &.active:not([open]),
-        &[aria-pressed="true"] {
-          @include white-on-black();
-        }
-        &:not([open]):hover,
-        [open] summary {
-          text-decoration: underline;
-          text-underline-position: under;
-        }
-        &:focus-visible {
-          box-shadow: none;
-          outline: 2px solid $focus-outline-color;
-          outline-offset: 2px;
-        }
-      }
-
-      .filter-toggle {
-        gap: 1rem;
-        .checkbox {
-          box-sizing: border-box;
-          border: 0.1rem solid $justfix-black;
-          border-radius: 0.4rem;
-          width: var(--checkbox-height);
-          height: var(--checkbox-height);
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          color: $justfix-white;
-          @include for-phone-only {
-            order: 1;
-            margin-left: auto;
-          }
-        }
-        &[aria-pressed="true"] {
-          .checkbox {
-            border-color: $justfix-white;
-          }
-        }
-      }
-
-      .filter-accordion {
         position: relative;
+        cursor: pointer;
 
-        summary {
-          // typical flex stretch doesn't seem to work in summary/details
-          height: 100%;
-          display: flex;
-          align-items: center;
-          position: relative;
-          cursor: pointer;
-
-          &::-webkit-details-marker {
-            display: none;
+        &::-webkit-details-marker {
+          display: none;
+        }
+        .chevronIcon,
+        .closeIcon {
+          stroke-width: 2px;
+          margin-left: 0.8rem;
+        }
+      }
+      &:not([open]) {
+        .filter-selection-count {
+          @include for-tablet-portrait-up() {
+            margin-left: 1em;
+            @include wrap-with-parentheses();
           }
-          .chevronIcon,
-          .closeIcon {
-            stroke-width: 2px;
+          @include for-phone-only() {
+            @include white-on-black();
+            padding: 0.25rem 0.5rem;
+            border-radius: 1rem;
             margin-left: 0.8rem;
           }
         }
-        &:not([open]) {
-          .filter-selection-count {
-            @include for-tablet-portrait-up() {
-              margin-left: 1em;
-              @include wrap-with-parentheses();
-            }
-            @include for-phone-only() {
-              @include white-on-black();
-              padding: 0.25rem 0.5rem;
-              border-radius: 1rem;
-              margin-left: 0.8rem;
+      }
+      &[open] {
+        > summary {
+          svg {
+            transform: scaleY(-1);
+          }
+          @include for-phone-only() {
+            .chevronIcon,
+            .closeIcon {
+              margin-left: auto;
             }
           }
         }
-        &[open] {
-          > summary {
-            svg {
-              transform: scaleY(-1);
+
+        &.ownernames-accordion .dropdown-container {
+          width: 25.2rem;
+          @include for-phone-only {
+            width: unset;
+          }
+        }
+
+        &.zip-accordion .dropdown-container {
+          width: 14.1rem;
+          @include for-phone-only {
+            width: unset;
+          }
+        }
+
+        .dropdown-container {
+          position: absolute;
+          top: 5rem;
+          left: -0.1rem;
+          z-index: 100;
+          overflow-y: scroll;
+          max-height: calc(100dvh - 25rem);
+          padding: 0.6rem 0 1.2rem 0;
+          background-color: $justfix-table-grey;
+          box-sizing: border-box;
+          border: 0.1rem solid $justfix-black;
+          border-radius: 0.8rem;
+
+          .filter-subtitle-container {
+            padding: 0 1.2rem;
+            font-size: 1.2rem;
+            color: $justfix-grey-700;
+            display: flex;
+            .filter-subtitle {
+              margin-right: auto;
             }
-            @include for-phone-only() {
-              .chevronIcon,
+
+            .filter-info:focus-visible {
+              box-shadow: none;
+              outline: 2px solid $focus-outline-color;
+              outline-offset: 2px;
+            }
+          }
+
+          .multiselect-container,
+          .minmax-container {
+            display: flex;
+            flex-direction: column;
+            margin-top: 0.8rem;
+          }
+          .minmax-container {
+            padding: 1.2rem;
+            border-top: 1px solid $justfix-grey;
+            @include for-phone-only {
+              border-top: none;
+            }
+
+            .labels-container {
+              display: flex;
+              color: $justfix-grey-700;
+              margin-bottom: 0.4rem;
+              label:first-child {
+                margin-right: auto;
+              }
+            }
+            .inputs-container {
+              display: flex;
+              gap: 1rem;
+              align-items: center;
+              justify-content: center;
+              input {
+                background-color: $justfix-table-grey;
+                width: 4.4rem;
+                height: 4.4rem;
+                border: 0.1rem solid $justfix-black;
+                border-radius: 0.2rem;
+                padding: 1rem 1.2rem;
+                // remove increment arrows
+                &::-webkit-outer-spin-button,
+                &::-webkit-inner-spin-button {
+                  -webkit-appearance: none;
+                  margin: 0;
+                }
+                -moz-appearance: textfield;
+
+                &:focus-visible {
+                  outline: none;
+                }
+                &.hasError {
+                  outline: 2px $justfix-orange solid;
+                  outline-offset: -2px;
+                }
+              }
+            }
+          }
+          .multiselect-container {
+            .optionListContainer {
+              position: static;
+            }
+            .owner-info-alert {
+              color: $justfix-grey-600;
+              outline: $justfix-grey-400 solid 1px;
+              margin: 1.2rem 1.2rem 0 1.2rem;
+              button {
+                outline: none;
+              }
+            }
+          }
+
+          .search-wrapper,
+          .optionListContainer {
+            background-color: $justfix-table-grey;
+            outline: 1px solid $justfix-grey;
+            border-radius: unset;
+            border: none;
+          }
+          .search-wrapper {
+            &.hasError {
+              outline: 2px $justfix-orange solid;
+              outline-offset: -2px;
+            }
+          }
+
+          .optionsContainer,
+          ul {
+            border: none;
+            list-style-type: none;
+          }
+
+          .chip {
+            align-self: flex-start;
+            background-color: $justfix-black;
+            color: $justfix-white;
+            border-radius: 0.8rem;
+            padding: 0 0 0 1.4rem;
+            margin: 0 1.2rem 0.6rem 1.2rem;
+            white-space: pre-line;
+            height: unset;
+
+            button {
+              margin-left: 1.2rem;
+              padding: 1.25rem;
               .closeIcon {
+                height: 1rem;
+                width: 1rem;
+                stroke-width: 0.2rem;
+              }
+            }
+
+            &.chip-more {
+              background-color: $justfix-table-grey;
+              color: $justfix-black;
+              border: 1px solid $justfix-black;
+              padding: 0.8rem 0.6rem;
+              margin-bottom: 1.1rem;
+            }
+          }
+          .button.is-text {
+            color: $justfix-grey-700;
+            &.show-less {
+              margin: 1.2rem 0 0 1.2rem;
+              align-self: flex-start;
+            }
+            &.clear-all {
+              margin: 0.8rem 1.2rem 0.9rem 0;
+              align-self: flex-end;
+            }
+          }
+          .button.is-primary {
+            align-self: center;
+            margin: 0.9rem 0 1rem 0;
+          }
+        }
+      }
+    }
+    .filters-mobile-wrapper {
+      &.active:not([open]) {
+        @include white-on-black();
+        .active-filter-count {
+          margin-left: 1em;
+          @include wrap-with-parentheses();
+        }
+      }
+      &[open] {
+        --filter-bar-top-height: 4.6rem;
+        --filter-bar-height: 6.6rem;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: var(--filter-bar-top-height);
+        z-index: 100;
+        background-color: $justfix-table-grey;
+        border-radius: 0.8rem 0.8rem 0 0;
+        box-sizing: border-box;
+        border: none;
+        border-bottom: 0.2rem solid $justfix-grey-700;
+        outline: 1rem solid $justfix-grey-700;
+        .dropdown-container {
+          position: absolute;
+          display: flex;
+          flex-direction: column;
+          top: calc(var(--filter-bar-top-height)); // borders
+          left: 0;
+          max-height: none;
+          height: calc(100vh - var(--filter-bar-top-height));
+          height: calc(100dvh - var(--filter-bar-top-height));
+          width: 100%;
+          padding: 0;
+          background-color: $justfix-table-grey;
+          border-radius: 0;
+          border: none;
+          .filter {
+            height: var(--filter-bar-height);
+            border-radius: 0;
+            box-sizing: border-box;
+            border: none;
+            border-bottom: 0.1rem solid $justfix-grey-400;
+            &.active:not(.filter-toggle) {
+              background-color: $justfix-table-grey;
+              color: $justfix-black;
+              text-decoration: none;
+            }
+            &.filter-toggle[aria-pressed="true"] {
+              text-decoration: none;
+            }
+            &[open] {
+              outline: none;
+              text-decoration: none;
+            }
+            @include for-phone-only {
+              .dropdown-container {
+                padding: 2.4rem;
+                .filter-subtitle-container {
+                  padding: 0;
+                  .filter-subtitle {
+                    font-size: 1.6rem;
+                  }
+                  .filter-info {
+                    font-size: 1.4rem;
+                  }
+                }
+                .jf-alert {
+                  margin-left: 0;
+                  margin-right: 0;
+                }
+              }
+            }
+          }
+          .filter-accordion summary {
+            position: relative;
+            .chevronIcon {
+              @include for-phone-only() {
                 margin-left: auto;
               }
             }
           }
-
-          &.ownernames-accordion .dropdown-container {
-            width: 25.2rem;
-            @include for-phone-only {
-              width: unset;
-            }
-          }
-
-          &.zip-accordion .dropdown-container {
-            width: 14.1rem;
-            @include for-phone-only {
-              width: unset;
-            }
-          }
-
-          .dropdown-container {
-            position: absolute;
-            top: 5rem;
-            left: -0.1rem;
-            z-index: 100;
-            overflow-y: scroll;
-            max-height: calc(100dvh - 25rem);
-            padding: 0.6rem 0 1.2rem 0;
-            background-color: $justfix-table-grey;
-            box-sizing: border-box;
-            border: 0.1rem solid $justfix-black;
-            border-radius: 0.8rem;
-
-            .filter-subtitle-container {
-              padding: 0 1.2rem;
-              font-size: 1.2rem;
-              color: $justfix-grey-700;
-              display: flex;
-              .filter-subtitle {
-                margin-right: auto;
-              }
-
-              .filter-info:focus-visible {
-                box-shadow: none;
-                outline: 2px solid $focus-outline-color;
-                outline-offset: 2px;
-              }
-            }
-
-            .multiselect-container,
-            .minmax-container {
-              display: flex;
-              flex-direction: column;
-              margin-top: 0.8rem;
-            }
-            .minmax-container {
-              padding: 1.2rem;
-              border-top: 1px solid $justfix-grey;
-              @include for-phone-only {
-                border-top: none;
-              }
-
-              .labels-container {
-                display: flex;
-                color: $justfix-grey-700;
-                margin-bottom: 0.4rem;
-                label:first-child {
-                  margin-right: auto;
-                }
-              }
-              .inputs-container {
-                display: flex;
-                gap: 1rem;
-                align-items: center;
-                justify-content: center;
-                input {
-                  background-color: $justfix-table-grey;
-                  width: 4.4rem;
-                  height: 4.4rem;
-                  border: 0.1rem solid $justfix-black;
-                  border-radius: 0.2rem;
-                  padding: 1rem 1.2rem;
-                  // remove increment arrows
-                  &::-webkit-outer-spin-button,
-                  &::-webkit-inner-spin-button {
-                    -webkit-appearance: none;
-                    margin: 0;
-                  }
-                  -moz-appearance: textfield;
-
-                  &:focus-visible {
-                    outline: none;
-                  }
-                  &.hasError {
-                    outline: 2px $justfix-orange solid;
-                    outline-offset: -2px;
-                  }
-                }
-              }
-            }
-            .multiselect-container {
-              .optionListContainer {
-                position: static;
-              }
-              .owner-info-alert {
-                color: $justfix-grey-600;
-                outline: $justfix-grey-400 solid 1px;
-                margin: 1.2rem 1.2rem 0 1.2rem;
-                button {
-                  outline: none;
-                }
-              }
-            }
-
-            .search-wrapper,
-            .optionListContainer {
-              background-color: $justfix-table-grey;
-              outline: 1px solid $justfix-grey;
-              border-radius: unset;
-              border: none;
-            }
-            .search-wrapper {
-              &.hasError {
-                outline: 2px $justfix-orange solid;
-                outline-offset: -2px;
-              }
-            }
-
-            .optionsContainer,
-            ul {
-              border: none;
-              list-style-type: none;
-            }
-
-            .chip {
-              align-self: flex-start;
-              background-color: $justfix-black;
-              color: $justfix-white;
-              border-radius: 0.8rem;
-              padding: 0 0 0 1.4rem;
-              margin: 0 1.2rem 0.6rem 1.2rem;
-              white-space: pre-line;
-              height: unset;
-
-              button {
-                margin-left: 1.2rem;
-                padding: 1.25rem;
-                .closeIcon {
-                  height: 1rem;
-                  width: 1rem;
-                  stroke-width: 0.2rem;
-                }
-              }
-
-              &.chip-more {
-                background-color: $justfix-table-grey;
-                color: $justfix-black;
-                border: 1px solid $justfix-black;
-                padding: 0.8rem 0.6rem;
-                margin-bottom: 1.1rem;
-              }
-            }
-            .button.is-text {
-              color: $justfix-grey-700;
-              &.show-less {
-                margin: 1.2rem 0 0 1.2rem;
-                align-self: flex-start;
-              }
-              &.clear-all {
-                margin: 0.8rem 1.2rem 0.9rem 0;
-                align-self: flex-end;
-              }
-            }
-            .button.is-primary {
-              align-self: center;
-              margin: 0.9rem 0 1rem 0;
-            }
-          }
-        }
-      }
-      .filters-mobile-wrapper {
-        &.active:not([open]) {
-          @include white-on-black();
-          .active-filter-count {
+          .view-results-count {
             margin-left: 1em;
             @include wrap-with-parentheses();
           }
         }
-        &[open] {
-          --filter-bar-top-height: 4.6rem;
-          --filter-bar-height: 6.6rem;
-          position: absolute;
-          top: 0;
-          left: 0;
-          right: 0;
-          height: var(--filter-bar-top-height);
-          z-index: 100;
-          background-color: $justfix-table-grey;
-          border-radius: 0.8rem 0.8rem 0 0;
-          box-sizing: border-box;
-          border: none;
-          border-bottom: 0.2rem solid $justfix-grey-700;
-          outline: 1rem solid $justfix-grey-700;
-          .dropdown-container {
-            position: absolute;
-            display: flex;
-            flex-direction: column;
-            top: calc(var(--filter-bar-top-height)); // borders
-            left: 0;
-            max-height: none;
-            height: calc(100vh - var(--filter-bar-top-height));
-            height: calc(100dvh - var(--filter-bar-top-height));
-            width: 100%;
-            padding: 0;
-            background-color: $justfix-table-grey;
-            border-radius: 0;
-            border: none;
-            .filter {
-              height: var(--filter-bar-height);
-              border-radius: 0;
-              box-sizing: border-box;
-              border: none;
-              border-bottom: 0.1rem solid $justfix-grey-400;
-              &.active:not(.filter-toggle) {
-                background-color: $justfix-table-grey;
-                color: $justfix-black;
-                text-decoration: none;
-              }
-              &.filter-toggle[aria-pressed="true"] {
-                text-decoration: none;
-              }
-              &[open] {
-                outline: none;
-                text-decoration: none;
-              }
-              @include for-phone-only {
-                .dropdown-container {
-                  padding: 2.4rem;
-                  .filter-subtitle-container {
-                    padding: 0;
-                    .filter-subtitle {
-                      font-size: 1.6rem;
-                    }
-                    .filter-info {
-                      font-size: 1.4rem;
-                    }
-                  }
-                  .jf-alert {
-                    margin-left: 0;
-                    margin-right: 0;
-                  }
-                }
-              }
-            }
-            .filter-accordion summary {
-              position: relative;
-              .chevronIcon {
-                @include for-phone-only() {
-                  margin-left: auto;
-                }
-              }
-            }
-            .view-results-count {
-              margin-left: 1em;
-              @include wrap-with-parentheses();
-            }
-          }
-        }
       }
     }
-    .filter-status {
-      display: flex;
-      gap: 0.85rem;
-      margin-top: 1.5rem;
-      text-transform: none;
+  }
+  .filter-status {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    text-transform: none;
+    margin-left: calc(var(--new-container-width) + var(--filter-bar-gap));
 
-      .results-count {
-        font-size: 1.6rem;
-        color: $justfix-grey-600;
-      }
-      .results-info {
-        color: $justfix-grey-600;
-      }
-      .clear-filters {
-        color: $justfix-grey-700;
-      }
+    @include for-phone-only() {
+      margin-left: unset;
+    }
+
+    .results-count {
+      font-size: 1.6rem;
+      color: $justfix-grey-600;
+    }
+    .results-info {
+      color: $justfix-grey-600;
+    }
+    .clear-filters {
+      color: $justfix-grey-700;
     }
   }
 }
 .ReactModal__Content {
-  p {
-    a {
-      color: $justfix-black;
-    }
+  p a {
+    color: $justfix-black;
   }
 }

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -190,7 +190,7 @@
           left: -0.1rem;
           z-index: 100;
           overflow-y: scroll;
-          max-height: calc(100dvh - 25rem);
+          max-height: calc(100vh - 25rem);
           padding: 0.6rem 0 1.2rem 0;
           background-color: $justfix-table-grey;
           box-sizing: border-box;
@@ -392,7 +392,6 @@
           left: 0;
           max-height: none;
           height: calc(100vh - var(--filter-bar-top-height));
-          height: calc(100dvh - var(--filter-bar-top-height));
           width: 100%;
           padding: 0;
           background-color: $justfix-table-grey;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -247,7 +247,7 @@
                 height: 4.4rem;
                 border: 0.1rem solid $justfix-black;
                 border-radius: 0.2rem;
-                padding: 1rem 1.2rem;
+                padding: 0.5rem;
                 // remove increment arrows
                 &::-webkit-outer-spin-button,
                 &::-webkit-inner-spin-button {

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -202,6 +202,7 @@
             font-size: 1.2rem;
             color: $justfix-grey-700;
             display: flex;
+            width: 100%;
             .filter-subtitle {
               margin-right: auto;
             }
@@ -298,44 +299,54 @@
             border: none;
             list-style-type: none;
           }
+          .selectedListContainer {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+            @include for-tablet-portrait-up() {
+              padding: 0 1.2rem;
+            }
 
-          .chip {
-            align-self: flex-start;
-            background-color: $justfix-black;
-            color: $justfix-white;
-            border-radius: 0.8rem;
-            padding: 0 0 0 1.4rem;
-            margin: 0 1.2rem 0.6rem 1.2rem;
-            white-space: pre-line;
-            height: unset;
+            .chip {
+              align-self: flex-start;
+              background-color: $justfix-black;
+              color: $justfix-white;
+              border-radius: 0.8rem;
+              padding: 0 0 0 1.4rem;
+              white-space: pre-line;
+              height: unset;
 
-            button {
-              margin-left: 1.2rem;
-              padding: 1.25rem;
-              .closeIcon {
-                height: 1rem;
-                width: 1rem;
-                stroke-width: 0.2rem;
+              button {
+                margin-left: 1.2rem;
+                padding: 1.25rem;
+                .closeIcon {
+                  height: 1rem;
+                  width: 1rem;
+                  stroke-width: 0.2rem;
+                }
+              }
+
+              &.chip-more {
+                background-color: $justfix-table-grey;
+                color: $justfix-black;
+                border: 1px solid $justfix-black;
+                padding: 0.8rem 0.6rem;
+                margin-bottom: 1.1rem;
               }
             }
-
-            &.chip-more {
-              background-color: $justfix-table-grey;
-              color: $justfix-black;
-              border: 1px solid $justfix-black;
-              padding: 0.8rem 0.6rem;
-              margin-bottom: 1.1rem;
-            }
           }
-          .button.is-text {
-            color: $justfix-grey-700;
-            &.show-less {
-              margin: 1.2rem 0 0 1.2rem;
-              align-self: flex-start;
-            }
-            &.clear-all {
-              margin: 0.8rem 1.2rem 0.9rem 0;
-              align-self: flex-end;
+          .clear-all-container {
+            display: flex;
+            .button.is-text {
+              color: $justfix-grey-700;
+              &.show-less {
+                margin: 1.2rem 0 0 1.2rem;
+                // align-self: flex-start;
+              }
+              &.clear-all {
+                margin: 0.8rem 1.2rem 0.9rem auto;
+                // align-self: flex-end;
+              }
             }
           }
           .button.is-primary {
@@ -408,6 +419,7 @@
             @include for-phone-only {
               .dropdown-container {
                 align-items: flex-start;
+                width: 100%;
                 padding: 2.4rem;
                 .filter-subtitle-container {
                   padding: 0;
@@ -431,6 +443,23 @@
               @include for-phone-only() {
                 margin-left: auto;
               }
+            }
+          }
+          .zip-accordion {
+            .clear-all-container,
+            .search-wrapper,
+            .optionListContainer {
+              width: 18.8rem;
+            }
+          }
+          .zip-accordion,
+          .ownernames-accordion {
+            .clear-all.button.is-text {
+              margin-left: auto;
+              margin-right: 0;
+            }
+            .button.is-primary {
+              align-self: unset;
             }
           }
           .view-results-count {

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -191,14 +191,13 @@
           z-index: 100;
           overflow-y: scroll;
           max-height: calc(100vh - 25rem);
-          padding: 0.6rem 0 1.2rem 0;
+          padding: 0.6rem 1.2rem 1.2rem 1.2rem;
           background-color: $justfix-table-grey;
           box-sizing: border-box;
           border: 0.1rem solid $justfix-black;
           border-radius: 0.8rem;
 
           .filter-subtitle-container {
-            padding: 0 1.2rem;
             font-size: 1.2rem;
             color: $justfix-grey-700;
             display: flex;
@@ -242,7 +241,7 @@
               align-items: center;
               justify-content: center;
               input {
-                background-color: $justfix-table-grey;
+                background-color: $justfix-white;
                 width: 4.4rem;
                 height: 4.4rem;
                 border: 0.1rem solid $justfix-black;
@@ -273,7 +272,7 @@
             .owner-info-alert {
               color: $justfix-grey-600;
               outline: $justfix-grey-400 solid 1px;
-              margin: 1.2rem 1.2rem 0 1.2rem;
+              margin-top: 1.2rem;
               button {
                 outline: none;
               }
@@ -282,7 +281,7 @@
 
           .search-wrapper,
           .optionListContainer {
-            background-color: $justfix-table-grey;
+            background-color: $justfix-white;
             outline: 1px solid $justfix-grey;
             border-radius: unset;
             border: none;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -3,6 +3,21 @@
 @import "_button.scss";
 @import "_typography.scss";
 
+@mixin white-on-black {
+  background-color: $justfix-black;
+  color: $justfix-white;
+  border-color: $justfix-white;
+}
+
+@mixin wrap-with-parentheses {
+  &::before {
+    content: "(";
+  }
+  &::after {
+    content: ")";
+  }
+}
+
 .PortfolioFilters {
   display: flex;
   gap: 1.8rem;
@@ -16,6 +31,10 @@
   font-size: 1.4rem;
   line-height: 100%;
   letter-spacing: 0.02em;
+
+  @include for-phone-only() {
+    gap: 1.2rem;
+  }
 
   .filter-for {
     text-align: right;
@@ -33,6 +52,14 @@
       border-radius: 1.6rem;
       width: fit-content;
       margin-bottom: 1rem;
+    }
+
+    @include for-phone-only() {
+      min-width: unset;
+      justify-content: center;
+      .pill-new {
+        margin: 0;
+      }
     }
   }
 
@@ -58,12 +85,10 @@
 
         &.active:not([open]),
         &[aria-pressed="true"] {
-          background-color: $justfix-black;
-          color: $justfix-white;
-          border-color: $justfix-white;
+          @include white-on-black();
         }
         &:not([open]):hover,
-        &[open] summary {
+        [open] summary {
           text-decoration: underline;
           text-underline-position: under;
         }
@@ -75,17 +100,21 @@
       }
 
       .filter-toggle {
+        gap: 1rem;
         .checkbox {
           box-sizing: border-box;
           border: 0.1rem solid $justfix-black;
           border-radius: 0.4rem;
           width: var(--checkbox-height);
           height: var(--checkbox-height);
-          margin-right: 1rem;
           display: flex;
           justify-content: center;
           align-items: center;
           color: $justfix-white;
+          @include for-phone-only {
+            order: 1;
+            margin-left: auto;
+          }
         }
         &[aria-pressed="true"] {
           .checkbox {
@@ -108,22 +137,51 @@
           &::-webkit-details-marker {
             display: none;
           }
-          .chevonIcon {
-            margin-left: 0.8rem;
+          .chevronIcon,
+          .closeIcon {
             stroke-width: 2px;
+            margin-left: 0.8rem;
+          }
+        }
+        &:not([open]) {
+          .filter-selection-count {
+            @include for-tablet-portrait-up() {
+              margin-left: 1em;
+              @include wrap-with-parentheses();
+            }
+            @include for-phone-only() {
+              @include white-on-black();
+              padding: 0.25rem 0.5rem;
+              border-radius: 1rem;
+              margin-left: 0.8rem;
+            }
           }
         }
         &[open] {
-          summary svg {
-            transform: scaleY(-1);
+          > summary {
+            svg {
+              transform: scaleY(-1);
+            }
+            @include for-phone-only() {
+              .chevronIcon,
+              .closeIcon {
+                margin-left: auto;
+              }
+            }
           }
 
           &.ownernames-accordion .dropdown-container {
             width: 25.2rem;
+            @include for-phone-only {
+              width: unset;
+            }
           }
 
           &.zip-accordion .dropdown-container {
             width: 14.1rem;
+            @include for-phone-only {
+              width: unset;
+            }
           }
 
           .dropdown-container {
@@ -132,7 +190,7 @@
             left: -0.1rem;
             z-index: 100;
             overflow-y: scroll;
-            max-height: calc(100vh - 25rem);
+            max-height: calc(100dvh - 25rem);
             padding: 0.6rem 0 1.2rem 0;
             background-color: $justfix-table-grey;
             box-sizing: border-box;
@@ -164,6 +222,9 @@
             .minmax-container {
               padding: 1.2rem;
               border-top: 1px solid $justfix-grey;
+              @include for-phone-only {
+                border-top: none;
+              }
 
               .labels-container {
                 display: flex;
@@ -193,12 +254,12 @@
                   }
                   -moz-appearance: textfield;
 
+                  &:focus-visible {
+                    outline: none;
+                  }
                   &.hasError {
                     outline: 2px $justfix-orange solid;
                     outline-offset: -2px;
-                  }
-                  &:focus-visible {
-                    outline: none;
                   }
                 }
               }
@@ -216,21 +277,27 @@
                 }
               }
             }
-            .search-wrapper {
-              border-top: 1px solid $justfix-grey;
-              border-bottom: 1px solid $justfix-grey;
-              border-radius: unset;
-            }
+
+            .search-wrapper,
             .optionListContainer {
               background-color: $justfix-table-grey;
-              border-bottom: 1px solid $justfix-grey;
+              outline: 1px solid $justfix-grey;
               border-radius: unset;
-              .optionsContainer,
-              ul {
-                border: none;
-                list-style-type: none;
+              border: none;
+            }
+            .search-wrapper {
+              &.hasError {
+                outline: 2px $justfix-orange solid;
+                outline-offset: -2px;
               }
             }
+
+            .optionsContainer,
+            ul {
+              border: none;
+              list-style-type: none;
+            }
+
             .chip {
               align-self: flex-start;
               background-color: $justfix-black;
@@ -273,6 +340,95 @@
             .button.is-primary {
               align-self: center;
               margin: 0.9rem 0 1rem 0;
+            }
+          }
+        }
+      }
+      .filters-mobile-wrapper {
+        &.active:not([open]) {
+          @include white-on-black();
+          .active-filter-count {
+            margin-left: 1em;
+            @include wrap-with-parentheses();
+          }
+        }
+        &[open] {
+          --filter-bar-top-height: 4.6rem;
+          --filter-bar-height: 6.6rem;
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          height: var(--filter-bar-top-height);
+          z-index: 100;
+          background-color: $justfix-table-grey;
+          border-radius: 0.8rem 0.8rem 0 0;
+          box-sizing: border-box;
+          border: none;
+          border-bottom: 0.2rem solid $justfix-grey-700;
+          outline: 1rem solid $justfix-grey-700;
+          .dropdown-container {
+            position: absolute;
+            display: flex;
+            flex-direction: column;
+            top: calc(var(--filter-bar-top-height)); // borders
+            left: 0;
+            max-height: none;
+            height: calc(100vh - var(--filter-bar-top-height));
+            height: calc(100dvh - var(--filter-bar-top-height));
+            width: 100%;
+            padding: 0;
+            background-color: $justfix-table-grey;
+            border-radius: 0;
+            border: none;
+            .filter {
+              height: var(--filter-bar-height);
+              border-radius: 0;
+              box-sizing: border-box;
+              border: none;
+              border-bottom: 0.1rem solid $justfix-grey-400;
+              &.active:not(.filter-toggle) {
+                background-color: $justfix-table-grey;
+                color: $justfix-black;
+                text-decoration: none;
+              }
+              &.filter-toggle[aria-pressed="true"] {
+                text-decoration: none;
+              }
+              &[open] {
+                outline: none;
+                text-decoration: none;
+              }
+              @include for-phone-only {
+                .dropdown-container {
+                  padding: 2.4rem;
+                  .filter-subtitle-container {
+                    padding: 0;
+                    .filter-subtitle {
+                      font-size: 1.6rem;
+                    }
+                    .filter-info {
+                      font-size: 1.4rem;
+                    }
+                  }
+                  .jf-alert {
+                    margin-left: 0;
+                    margin-right: 0;
+                  }
+                }
+              }
+            }
+            .filter-accordion summary {
+              position: relative;
+              .chevronIcon {
+                @include for-phone-only() {
+                  margin-left: auto;
+                }
+              }
+            }
+            .view-results-count {
+              margin-left: 1em;
+              @include wrap-with-parentheses();
             }
           }
         }

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -466,6 +466,19 @@
             margin-left: 1em;
             @include wrap-with-parentheses();
           }
+          &.scroll-gradient {
+            // https://css-scroll-shadows.vercel.app/
+            --clear: rgba(0, 0, 0, 0);
+            --dark: rgba(140, 140, 140, 0.5);
+            background: linear-gradient($justfix-table-grey 10%, var(--clear)),
+              linear-gradient(var(--clear), $justfix-table-grey 90%) 0 100%,
+              linear-gradient(var(--dark) 10%, var(--clear)),
+              linear-gradient(var(--clear), var(--dark) 90%) 0 100%;
+            background-color: $justfix-table-grey;
+            background-repeat: no-repeat;
+            background-attachment: local, local, scroll, scroll;
+            background-size: 100% 6rem, 100% 6rem, 100% 2rem, 100% 2rem;
+          }
         }
       }
     }

--- a/client/src/styles/_alert.scss
+++ b/client/src/styles/_alert.scss
@@ -6,7 +6,6 @@
   display: flex;
   position: relative;
   padding: 1.15rem 0.6rem 1.15rem 2.3rem;
-  margin: 0.9rem 0 0.5rem 0;
   width: fit-content;
   border-radius: 0.4rem;
   font-family: "Inconsolata", monospace;

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -411,6 +411,11 @@ const helpers = {
   regexEscape(str: string) {
     return str?.replace(/[-[\]/{}()*+?.\\^$|]/g, "\\$&");
   },
+
+  scrollToBottom(selectors: string) {
+    const elem = document.querySelector(selectors);
+    elem?.scroll(0, elem?.scrollHeight);
+  },
 };
 
 export default helpers;


### PR DESCRIPTION
This PR adds support for mobile to the filter bar. Makes the basic changes to the styles of filter components and the bar, plus adds the fullscreen wrapper of all filters - and the scroll snapping and shadow effects. Plus a small fix to the handling of min-max errors, and its default values I caught while in here.

Also included is an update to the filter input styling on desktop and mobile so they read more clearly as inputs (not full width, white background)

Not included is the mobile-specific behavior of applying in-progress filters when the user clicks outside of that filter's dropdown. It seems like this will require some more substantial reorganization of how/where that state is managed to allow for this. I'll make a separate PR for this once I figure things out.

[sc-11706]
[sc-11738]