### PR TITLE
add "toast" notifications on results

### DIFF
--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -610,7 +610,7 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
         style={style["multiselectContainer"]}
       >
         {hasError && (
-          <Alert type="error" variant="primary" closeType="none">
+          <Alert type="error" variant="primary" closeType="none" role="status">
             <Trans>Error</Trans>
           </Alert>
         )}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -190,9 +190,10 @@ export const PortfolioFilters = React.memo(
             />
           </FilterAccordion>
         </FiltersWrapper>
+
         {(rsunitslatestActive || ownernamesActive || unitsresActive || zipActive) && (
-          <>
-            <div className="filter-status">
+          <div className="filter-status">
+            <div className="filter-status-info">
               <span className="results-count" role="status">
                 <Trans>
                   Showing {filteredBuildings || 0}{" "}
@@ -207,7 +208,7 @@ export const PortfolioFilters = React.memo(
               </button>
             </div>
             {filteredBuildings === 0 ? ZeroResultsAlert : <></>}
-          </>
+          </div>
         )}
 
         <Modal key={1} showModal={showInfoModal} width={20} onClose={() => setShowInfoModal(false)}>
@@ -290,7 +291,7 @@ const FiltersWrapper = (props: {
           <div className="filters">
             <details
               className={classnames("filter filter-accordion filters-mobile-wrapper", {
-                active: !!numActiveFilters,
+                active: numActiveFilters > 0,
               })}
               open={isOpen}
             >
@@ -312,7 +313,7 @@ const FiltersWrapper = (props: {
               </summary>
               <div className="dropdown-container scroll-gradient mobile-wrapper-dropdown">
                 {children}
-                {!!activeFilters && (
+                {numActiveFilters > 0 && (
                   <button onClick={() => setIsOpen(!isOpen)} className="button is-primary">
                     <Trans>View Results</Trans>
                     {resultsCount != null && (
@@ -326,23 +327,25 @@ const FiltersWrapper = (props: {
           </div>
         </FocusTrap>
       )}
-      {activeFilters.rsunitslatestActive && (!isOpen || !isMobile) && resultsCount ? (
-        RsUnitsToastAlert
-      ) : (
-        <></>
-      )}
-      {activeFilters.ownernamesActive && (!isOpen || !isMobile) && resultsCount ? (
-        OwnernamesToastAlert
-      ) : (
-        <></>
-      )}
+      <div className="filter-toast-container">
+        {activeFilters.rsunitslatestActive && (!isOpen || !isMobile) && resultsCount ? (
+          RsUnitsToastAlert
+        ) : (
+          <></>
+        )}
+        {activeFilters.ownernamesActive && (!isOpen || !isMobile) && resultsCount ? (
+          OwnernamesToastAlert
+        ) : (
+          <></>
+        )}
+      </div>
     </>
   );
 };
 
 const OwnernamesToastAlert = (
   <Alert
-    className="ownernames-toast-alert filter-toast-alert"
+    className="filter-toast-alert"
     type="info"
     variant="secondary"
     closeType="none"
@@ -357,7 +360,7 @@ const OwnernamesToastAlert = (
 
 const RsUnitsToastAlert = (
   <Alert
-    className="ownernames-toast-alert filter-toast-alert"
+    className="filter-toast-alert"
     type="info"
     variant="secondary"
     closeType="none"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -142,7 +142,7 @@ msgstr "An “eviction filing” is a legal case for eviction commenced by a lan
 #~ msgstr "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 
 #: src/components/Multiselect.tsx:476
-#: src/components/PortfolioFilters.tsx:282
+#: src/components/PortfolioFilters.tsx:285
 msgid "Apply"
 msgstr "Apply"
 
@@ -251,7 +251,7 @@ msgstr "Class I"
 msgid "Clear"
 msgstr "Clear"
 
-#: src/components/PortfolioFilters.tsx:105
+#: src/components/PortfolioFilters.tsx:106
 msgid "Clear Filters"
 msgstr "Clear Filters"
 
@@ -377,7 +377,7 @@ msgid "Enter email"
 msgstr "Enter email"
 
 #: src/components/Multiselect.tsx:445
-#: src/components/PortfolioFilters.tsx:258
+#: src/components/PortfolioFilters.tsx:261
 msgid "Error"
 msgstr "Error"
 
@@ -417,7 +417,7 @@ msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD 
 msgid "Executed"
 msgstr "Executed"
 
-#: src/components/PortfolioFilters.tsx:188
+#: src/components/PortfolioFilters.tsx:191
 msgid "Expand the the Owner/Manager column in Table view to see all contacts associated with that building."
 msgstr "Expand the the Owner/Manager column in Table view to see all contacts associated with that building."
 
@@ -449,7 +449,7 @@ msgstr "Filed"
 #~ msgid "Filied"
 #~ msgstr "Filied"
 
-#: src/components/PortfolioFilters.tsx:168
+#: src/components/PortfolioFilters.tsx:169
 msgid "Filters"
 msgstr "Filters"
 
@@ -511,7 +511,7 @@ msgstr "HUD Complaint Form 958"
 msgid "Head Officer"
 msgstr "Head Officer"
 
-#: src/components/PortfolioFilters.tsx:113
+#: src/components/PortfolioFilters.tsx:114
 msgid "How are the results calculated?"
 msgstr "How are the results calculated?"
 
@@ -658,7 +658,7 @@ msgstr "Loading {0} rows"
 msgid "Location"
 msgstr "Location"
 
-#: src/components/PortfolioFilters.tsx:203
+#: src/components/PortfolioFilters.tsx:206
 msgid "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 msgstr "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 
@@ -670,11 +670,11 @@ msgstr "Looking for more information?"
 msgid "MAILBOX"
 msgstr "MAILBOX"
 
-#: src/components/PortfolioFilters.tsx:253
+#: src/components/PortfolioFilters.tsx:256
 msgid "MAX"
 msgstr "MAX"
 
-#: src/components/PortfolioFilters.tsx:250
+#: src/components/PortfolioFilters.tsx:253
 msgid "MIN"
 msgstr "MIN"
 
@@ -925,8 +925,8 @@ msgstr "Public Housing Development"
 msgid "RS Units"
 msgstr "RS Units"
 
-#: src/components/PortfolioFilters.tsx:125
-#: src/components/PortfolioFilters.tsx:145
+#: src/components/PortfolioFilters.tsx:126
+#: src/components/PortfolioFilters.tsx:146
 msgid "Read more in our Methodology section"
 msgstr "Read more in our Methodology section"
 
@@ -942,7 +942,7 @@ msgstr "Rent Stabilized Units"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/components/PortfolioFilters.tsx:194
+#: src/components/PortfolioFilters.tsx:197
 msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 msgstr "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 
@@ -1018,7 +1018,7 @@ msgstr "Shareholder"
 msgid "Show less"
 msgstr "Show less"
 
-#: src/components/PortfolioFilters.tsx:96
+#: src/components/PortfolioFilters.tsx:97
 msgid "Showing {0} {1, plural, one {result} other {results}}."
 msgstr "Showing {0} {1, plural, one {result} other {results}}."
 
@@ -1263,7 +1263,7 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Total Violations"
 
-#: src/components/PortfolioFilters.tsx:200
+#: src/components/PortfolioFilters.tsx:203
 msgid "Try adjusting or clearing the filters to yield more than 0 results."
 msgstr "Try adjusting or clearing the filters to yield more than 0 results."
 
@@ -1302,7 +1302,7 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
-#: src/components/PortfolioFilters.tsx:175
+#: src/components/PortfolioFilters.tsx:176
 msgid "View Results"
 msgstr "View Results"
 
@@ -1375,7 +1375,7 @@ msgstr "We compare your search address with a database of over 200k buildings to
 msgid "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 msgstr "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 
-#: src/components/PortfolioFilters.tsx:116
+#: src/components/PortfolioFilters.tsx:117
 msgid "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 msgstr "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 
@@ -1408,11 +1408,11 @@ msgstr "What happens if the landlord has failed to register?"
 msgid "What's New"
 msgstr "What's New"
 
-#: src/components/PortfolioFilters.tsx:235
+#: src/components/PortfolioFilters.tsx:238
 msgid "What's this?"
 msgstr "What's this?"
 
-#: src/components/PortfolioFilters.tsx:130
+#: src/components/PortfolioFilters.tsx:131
 msgid "What’s the difference between a landlord, an owner, and head officer?"
 msgstr "What’s the difference between a landlord, an owner, and head officer?"
 
@@ -1420,7 +1420,7 @@ msgstr "What’s the difference between a landlord, an owner, and head officer?"
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "When two parties share the same business address, we group them as part of the same portfolio."
 
-#: src/components/PortfolioFilters.tsx:133
+#: src/components/PortfolioFilters.tsx:134
 msgid "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 msgstr "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 
@@ -1485,7 +1485,7 @@ msgstr "Zoom in"
 msgid "Zoom out"
 msgstr "Zoom out"
 
-#: src/components/PortfolioFilters.tsx:266
+#: src/components/PortfolioFilters.tsx:269
 #: src/components/StringifyList.tsx:18
 msgid "and"
 msgstr "and"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Multiselect.tsx:513
+#: src/components/Multiselect.tsx:518
 msgid "\"No Options Available\""
 msgstr "\"No Options Available\""
 
-#: src/components/Multiselect.tsx:510
+#: src/components/Multiselect.tsx:515
 msgid "\"Select\""
 msgstr "\"Select\""
 
@@ -112,7 +112,7 @@ msgstr "Across owners and management staff, the most common {0, plural, one {nam
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PortfolioTable.tsx:42
+#: src/components/PortfolioTable.tsx:43
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Address"
@@ -129,7 +129,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PortfolioTable.tsx:299
+#: src/components/PortfolioTable.tsx:306
 msgid "Amount"
 msgstr "Amount"
 
@@ -141,8 +141,8 @@ msgstr "An “eviction filing” is a legal case for eviction commenced by a lan
 #~ msgid "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 #~ msgstr "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 
-#: src/components/Multiselect.tsx:471
-#: src/components/PortfolioFilters.tsx:220
+#: src/components/Multiselect.tsx:476
+#: src/components/PortfolioFilters.tsx:282
 msgid "Apply"
 msgstr "Apply"
 
@@ -162,7 +162,7 @@ msgstr "BELL/BUZZER/INTERCOM"
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/PortfolioTable.tsx:67
+#: src/components/PortfolioTable.tsx:68
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -180,7 +180,7 @@ msgstr "Building Permit Applications"
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
-#: src/components/PortfolioFilters.tsx:79
+#: src/components/PortfolioFilters.tsx:86
 msgid "Building Size"
 msgstr "Building Size"
 
@@ -192,7 +192,7 @@ msgstr "Building info"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PortfolioTable.tsx:101
+#: src/components/PortfolioTable.tsx:102
 msgid "Built"
 msgstr "Built"
 
@@ -247,11 +247,11 @@ msgstr "Class C"
 msgid "Class I"
 msgstr "Class I"
 
-#: src/components/Multiselect.tsx:451
+#: src/components/Multiselect.tsx:455
 msgid "Clear"
 msgstr "Clear"
 
-#: src/components/PortfolioFilters.tsx:97
+#: src/components/PortfolioFilters.tsx:105
 msgid "Clear Filters"
 msgstr "Clear Filters"
 
@@ -298,7 +298,7 @@ msgstr "Corporate Owner"
 msgid "Corporation"
 msgstr "Corporation"
 
-#: src/components/PortfolioTable.tsx:87
+#: src/components/PortfolioTable.tsx:88
 msgid "Council"
 msgstr "Council"
 
@@ -322,7 +322,7 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PortfolioTable.tsx:288
+#: src/components/PortfolioTable.tsx:295
 msgid "Date"
 msgstr "Date"
 
@@ -376,8 +376,8 @@ msgstr "Enter an NYC address and find other buildings your landlord might own:"
 msgid "Enter email"
 msgstr "Enter email"
 
-#: src/components/Multiselect.tsx:444
-#: src/components/PortfolioFilters.tsx:196
+#: src/components/Multiselect.tsx:445
+#: src/components/PortfolioFilters.tsx:258
 msgid "Error"
 msgstr "Error"
 
@@ -401,7 +401,7 @@ msgstr "Evictions"
 msgid "Evictions Executed"
 msgstr "Evictions Executed"
 
-#: src/components/PortfolioTable.tsx:206
+#: src/components/PortfolioTable.tsx:207
 msgid "Evictions Since 2017"
 msgstr "Evictions Since 2017"
 
@@ -413,9 +413,13 @@ msgstr "Evictions executed by NYC Marshals since 2017. ANHD and the Housing Data
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
-#: src/components/PortfolioTable.tsx:221
+#: src/components/PortfolioTable.tsx:222
 msgid "Executed"
 msgstr "Executed"
+
+#: src/components/PortfolioFilters.tsx:188
+msgid "Expand the the Owner/Manager column in Table view to see all contacts associated with that building."
+msgstr "Expand the the Owner/Manager column in Table view to see all contacts associated with that building."
 
 #: src/components/AddressToolbar.tsx:30
 msgid "Export Data"
@@ -437,7 +441,7 @@ msgstr "FLOORING/STAIRS"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PortfolioTable.tsx:212
+#: src/components/PortfolioTable.tsx:213
 msgid "Filed"
 msgstr "Filed"
 
@@ -445,9 +449,13 @@ msgstr "Filed"
 #~ msgid "Filied"
 #~ msgstr "Filied"
 
-#: src/components/PortfolioFilters.tsx:68
+#: src/components/PortfolioFilters.tsx:168
 msgid "Filters"
 msgstr "Filters"
+
+#: src/components/PortfolioFilters.tsx:73
+msgid "Filters:"
+msgstr "Filters:"
 
 #: src/components/PortfolioFilters.tsx:60
 #~ msgid "Filter <0/>for"
@@ -461,7 +469,7 @@ msgstr "Find other buildings your landlord might own:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
-#: src/components/PortfolioTable.tsx:325
+#: src/components/PortfolioTable.tsx:332
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -478,7 +486,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:151
+#: src/components/PortfolioTable.tsx:152
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -487,7 +495,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:184
+#: src/components/PortfolioTable.tsx:185
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -503,7 +511,7 @@ msgstr "HUD Complaint Form 958"
 msgid "Head Officer"
 msgstr "Head Officer"
 
-#: src/components/PortfolioFilters.tsx:103
+#: src/components/PortfolioFilters.tsx:113
 msgid "How are the results calculated?"
 msgstr "How are the results calculated?"
 
@@ -556,7 +564,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PortfolioTable.tsx:96
+#: src/components/PortfolioTable.tsx:97
 msgid "Information"
 msgstr "Information"
 
@@ -584,8 +592,8 @@ msgstr "Known for <0>unscrupulously deregulating rent stabilized apartments</0>,
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PortfolioFilters.tsx:76
-#: src/components/PortfolioTable.tsx:230
+#: src/components/PortfolioFilters.tsx:83
+#: src/components/PortfolioTable.tsx:231
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -597,11 +605,11 @@ msgstr "Landlord name"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PortfolioTable.tsx:164
+#: src/components/PortfolioTable.tsx:165
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PortfolioTable.tsx:283
+#: src/components/PortfolioTable.tsx:290
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -631,8 +639,8 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PortfolioTable.tsx:307
-#: src/components/PortfolioTable.tsx:311
+#: src/components/PortfolioTable.tsx:314
+#: src/components/PortfolioTable.tsx:318
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -646,11 +654,11 @@ msgstr "Loading"
 msgid "Loading {0} rows"
 msgstr "Loading {0} rows"
 
-#: src/components/PortfolioTable.tsx:53
+#: src/components/PortfolioTable.tsx:54
 msgid "Location"
 msgstr "Location"
 
-#: src/components/PortfolioFilters.tsx:141
+#: src/components/PortfolioFilters.tsx:203
 msgid "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 msgstr "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 
@@ -662,11 +670,11 @@ msgstr "Looking for more information?"
 msgid "MAILBOX"
 msgstr "MAILBOX"
 
-#: src/components/PortfolioFilters.tsx:191
+#: src/components/PortfolioFilters.tsx:253
 msgid "MAX"
 msgstr "MAX"
 
-#: src/components/PortfolioFilters.tsx:188
+#: src/components/PortfolioFilters.tsx:250
 msgid "MIN"
 msgstr "MIN"
 
@@ -739,7 +747,7 @@ msgstr "NYCHA Directory"
 msgid "Network of Landlords"
 msgstr "Network of Landlords"
 
-#: src/components/PortfolioFilters.tsx:66
+#: src/components/PortfolioFilters.tsx:70
 #: src/containers/HomePage.tsx:110
 msgid "New"
 msgstr "New"
@@ -753,11 +761,11 @@ msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:476
+#: src/components/PortfolioTable.tsx:483
 msgid "Next"
 msgstr "Next"
 
-#: src/components/PortfolioTable.tsx:329
+#: src/components/PortfolioTable.tsx:336
 msgid "No"
 msgstr "No"
 
@@ -806,7 +814,7 @@ msgstr "Not found"
 #~ msgid "Notice an inaccuracy? Click here."
 #~ msgstr "Notice an inaccuracy? Click here."
 
-#: src/components/PortfolioFilters.tsx:79
+#: src/components/PortfolioFilters.tsx:86
 msgid "Number of Units"
 msgstr "Number of Units"
 
@@ -823,7 +831,7 @@ msgstr "OWNS"
 msgid "Officer"
 msgstr "Officer"
 
-#: src/components/PortfolioFilters.tsx:76
+#: src/components/PortfolioFilters.tsx:83
 msgid "Officer/Owner"
 msgstr "Officer/Owner"
 
@@ -837,7 +845,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PortfolioTable.tsx:189
+#: src/components/PortfolioTable.tsx:190
 msgid "Open"
 msgstr "Open"
 
@@ -853,7 +861,7 @@ msgstr "Overview"
 msgid "Owner Names"
 msgstr "Owner Names"
 
-#: src/components/PortfolioTable.tsx:243
+#: src/components/PortfolioTable.tsx:244
 msgid "Owner/Manager"
 msgstr "Owner/Manager"
 
@@ -877,7 +885,7 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/PortfolioTable.tsx:456
+#: src/components/PortfolioTable.tsx:463
 msgid "Page"
 msgstr "Page"
 
@@ -899,7 +907,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Portfolio Table Redesign"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:450
+#: src/components/PortfolioTable.tsx:457
 msgid "Previous"
 msgstr "Previous"
 
@@ -913,12 +921,12 @@ msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:119
+#: src/components/PortfolioTable.tsx:120
 msgid "RS Units"
 msgstr "RS Units"
 
-#: src/components/PortfolioFilters.tsx:115
-#: src/components/PortfolioFilters.tsx:135
+#: src/components/PortfolioFilters.tsx:125
+#: src/components/PortfolioFilters.tsx:145
 msgid "Read more in our Methodology section"
 msgstr "Read more in our Methodology section"
 
@@ -926,13 +934,17 @@ msgstr "Read more in our Methodology section"
 msgid "Registration expired:"
 msgstr "Registration expired:"
 
-#: src/components/PortfolioFilters.tsx:74
+#: src/components/PortfolioFilters.tsx:80
 msgid "Rent Stabilized Units"
 msgstr "Rent Stabilized Units"
 
 #: src/components/PropertiesSummary.tsx:125
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
+
+#: src/components/PortfolioFilters.tsx:194
+msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
+msgstr "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 
 #: src/components/PortfolioGraph.tsx:159
 msgid "Reset diagram"
@@ -954,8 +966,8 @@ msgstr "SIGNAGE MISSING"
 msgid "STAIRS"
 msgstr "STAIRS"
 
-#: src/components/PortfolioFilters.tsx:77
-#: src/components/PortfolioFilters.tsx:83
+#: src/components/PortfolioFilters.tsx:84
+#: src/components/PortfolioFilters.tsx:90
 #: src/containers/App.tsx:87
 msgid "Search"
 msgstr "Search"
@@ -1006,7 +1018,7 @@ msgstr "Shareholder"
 msgid "Show less"
 msgstr "Show less"
 
-#: src/components/PortfolioFilters.tsx:88
+#: src/components/PortfolioFilters.tsx:96
 msgid "Showing {0} {1, plural, one {result} other {results}}."
 msgstr "Showing {0} {1, plural, one {result} other {results}}."
 
@@ -1092,7 +1104,7 @@ msgstr "TENANT HARASSMENT"
 msgid "Take action on JustFix.org!"
 msgstr "Take action on JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:261
+#: src/components/PortfolioTable.tsx:268
 msgid "Tax Exemptions"
 msgstr "Tax Exemptions"
 
@@ -1237,19 +1249,23 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PortfolioTable.tsx:172
+#: src/components/PortfolioTable.tsx:173
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:156
-#: src/components/PortfolioTable.tsx:197
+#: src/components/PortfolioTable.tsx:157
+#: src/components/PortfolioTable.tsx:198
 msgid "Total"
 msgstr "Total"
 
 #: src/components/BuildingStatsTable.tsx:62
 msgid "Total Violations"
 msgstr "Total Violations"
+
+#: src/components/PortfolioFilters.tsx:200
+msgid "Try adjusting or clearing the filters to yield more than 0 results."
+msgstr "Try adjusting or clearing the filters to yield more than 0 results."
 
 #: src/containers/NotRegisteredPage.tsx:170
 msgid "Unable to initiate a court action for nonpayment of rent."
@@ -1260,7 +1276,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:109
+#: src/components/PortfolioTable.tsx:110
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -1286,6 +1302,10 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
+#: src/components/PortfolioFilters.tsx:175
+msgid "View Results"
+msgstr "View Results"
+
 #: src/components/Indicators.tsx:180
 #: src/components/Indicators.tsx:183
 msgid "View by:"
@@ -1295,8 +1315,8 @@ msgstr "View by:"
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PortfolioTable.tsx:338
 #: src/components/PortfolioTable.tsx:345
+#: src/components/PortfolioTable.tsx:352
 msgid "View detail"
 msgstr "View detail"
 
@@ -1355,7 +1375,7 @@ msgstr "We compare your search address with a database of over 200k buildings to
 msgid "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 msgstr "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 
-#: src/components/PortfolioFilters.tsx:106
+#: src/components/PortfolioFilters.tsx:116
 msgid "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 msgstr "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 
@@ -1388,11 +1408,11 @@ msgstr "What happens if the landlord has failed to register?"
 msgid "What's New"
 msgstr "What's New"
 
-#: src/components/PortfolioFilters.tsx:173
+#: src/components/PortfolioFilters.tsx:235
 msgid "What's this?"
 msgstr "What's this?"
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:130
 msgid "What’s the difference between a landlord, an owner, and head officer?"
 msgstr "What’s the difference between a landlord, an owner, and head officer?"
 
@@ -1400,7 +1420,7 @@ msgstr "What’s the difference between a landlord, an owner, and head officer?"
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "When two parties share the same business address, we group them as part of the same portfolio."
 
-#: src/components/PortfolioFilters.tsx:123
+#: src/components/PortfolioFilters.tsx:133
 msgid "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 msgstr "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 
@@ -1436,7 +1456,7 @@ msgstr "Why am I seeing such a big portfolio?"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PortfolioTable.tsx:328
+#: src/components/PortfolioTable.tsx:335
 msgid "Yes"
 msgstr "Yes"
 
@@ -1452,8 +1472,8 @@ msgstr "You are viewing a legacy version of Who Owns What"
 #~ msgid "You are viewing the old version of Who Owns What."
 #~ msgstr "You are viewing the old version of Who Owns What."
 
-#: src/components/PortfolioFilters.tsx:82
-#: src/components/PortfolioTable.tsx:58
+#: src/components/PortfolioFilters.tsx:89
+#: src/components/PortfolioTable.tsx:59
 msgid "Zipcode"
 msgstr "Zipcode"
 
@@ -1465,7 +1485,7 @@ msgstr "Zoom in"
 msgid "Zoom out"
 msgstr "Zoom out"
 
-#: src/components/PortfolioFilters.tsx:204
+#: src/components/PortfolioFilters.tsx:266
 #: src/components/StringifyList.tsx:18
 msgid "and"
 msgstr "and"
@@ -1482,7 +1502,7 @@ msgstr "for ${0}"
 msgid "month"
 msgstr "month"
 
-#: src/components/PortfolioTable.tsx:464
+#: src/components/PortfolioTable.tsx:471
 msgid "of"
 msgstr "of"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 31\n"
 
-#: src/components/Multiselect.tsx:513
+#: src/components/Multiselect.tsx:518
 msgid "\"No Options Available\""
 msgstr ""
 
-#: src/components/Multiselect.tsx:510
+#: src/components/Multiselect.tsx:515
 msgid "\"Select\""
 msgstr ""
 
@@ -117,7 +117,7 @@ msgstr "En todos los dueños y administradores, {0, plural, one {el nombre más 
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PortfolioTable.tsx:42
+#: src/components/PortfolioTable.tsx:43
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Dirección"
@@ -134,7 +134,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PortfolioTable.tsx:299
+#: src/components/PortfolioTable.tsx:306
 msgid "Amount"
 msgstr "Importe"
 
@@ -146,8 +146,8 @@ msgstr "Una \"demanda de desalojo\" es un caso legal de desalojo iniciado por un
 #~ msgid "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 #~ msgstr "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 
-#: src/components/Multiselect.tsx:471
-#: src/components/PortfolioFilters.tsx:220
+#: src/components/Multiselect.tsx:476
+#: src/components/PortfolioFilters.tsx:282
 msgid "Apply"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr "TIMBRE/INTERCOMUNICADOR"
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/PortfolioTable.tsx:67
+#: src/components/PortfolioTable.tsx:68
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -185,7 +185,7 @@ msgstr "Solicitudes de Permisos de Construcción"
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
 
-#: src/components/PortfolioFilters.tsx:79
+#: src/components/PortfolioFilters.tsx:86
 msgid "Building Size"
 msgstr ""
 
@@ -197,7 +197,7 @@ msgstr "Información de edificios"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PortfolioTable.tsx:101
+#: src/components/PortfolioTable.tsx:102
 msgid "Built"
 msgstr "Construido"
 
@@ -252,11 +252,11 @@ msgstr "Clase C"
 msgid "Class I"
 msgstr "Clase I"
 
-#: src/components/Multiselect.tsx:451
+#: src/components/Multiselect.tsx:455
 msgid "Clear"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:97
+#: src/components/PortfolioFilters.tsx:105
 msgid "Clear Filters"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgstr "Dueño Corporativo"
 msgid "Corporation"
 msgstr "Corporación"
 
-#: src/components/PortfolioTable.tsx:87
+#: src/components/PortfolioTable.tsx:88
 msgid "Council"
 msgstr ""
 
@@ -327,7 +327,7 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PortfolioTable.tsx:288
+#: src/components/PortfolioTable.tsx:295
 msgid "Date"
 msgstr "Fecha"
 
@@ -381,8 +381,8 @@ msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu pr
 msgid "Enter email"
 msgstr "Introducir email"
 
-#: src/components/Multiselect.tsx:444
-#: src/components/PortfolioFilters.tsx:196
+#: src/components/Multiselect.tsx:445
+#: src/components/PortfolioFilters.tsx:258
 msgid "Error"
 msgstr ""
 
@@ -406,7 +406,7 @@ msgstr "Desalojos"
 msgid "Evictions Executed"
 msgstr "Desalojos ejecutados"
 
-#: src/components/PortfolioTable.tsx:206
+#: src/components/PortfolioTable.tsx:207
 msgid "Evictions Since 2017"
 msgstr "Desalojos desde 2017"
 
@@ -418,9 +418,13 @@ msgstr "Desalojos ejecutados en este edificio por el Mariscal de NYC desde el 20
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 2017. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes del DOI."
 
-#: src/components/PortfolioTable.tsx:221
+#: src/components/PortfolioTable.tsx:222
 msgid "Executed"
 msgstr "Ejecutado"
+
+#: src/components/PortfolioFilters.tsx:188
+msgid "Expand the the Owner/Manager column in Table view to see all contacts associated with that building."
+msgstr ""
 
 #: src/components/AddressToolbar.tsx:30
 msgid "Export Data"
@@ -442,7 +446,7 @@ msgstr "PISO/ESCALERAS"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PortfolioTable.tsx:212
+#: src/components/PortfolioTable.tsx:213
 msgid "Filed"
 msgstr "Presentado"
 
@@ -450,8 +454,12 @@ msgstr "Presentado"
 #~ msgid "Filied"
 #~ msgstr "Filied"
 
-#: src/components/PortfolioFilters.tsx:68
+#: src/components/PortfolioFilters.tsx:168
 msgid "Filters"
+msgstr ""
+
+#: src/components/PortfolioFilters.tsx:73
+msgid "Filters:"
 msgstr ""
 
 #: src/components/PortfolioFilters.tsx:60
@@ -466,7 +474,7 @@ msgstr "Encuentra otros edificios que tu propietario podría poseer:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
-#: src/components/PortfolioTable.tsx:325
+#: src/components/PortfolioTable.tsx:332
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -483,7 +491,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:151
+#: src/components/PortfolioTable.tsx:152
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -492,7 +500,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontrarás más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:184
+#: src/components/PortfolioTable.tsx:185
 msgid "HPD Violations"
 msgstr "Violaciones del HPD"
 
@@ -508,7 +516,7 @@ msgstr "Formulario de queja HUD 958"
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
-#: src/components/PortfolioFilters.tsx:103
+#: src/components/PortfolioFilters.tsx:113
 msgid "How are the results calculated?"
 msgstr ""
 
@@ -561,7 +569,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
-#: src/components/PortfolioTable.tsx:96
+#: src/components/PortfolioTable.tsx:97
 msgid "Information"
 msgstr "Información"
 
@@ -589,8 +597,8 @@ msgstr "Conocido por <0>desregulando apartamentos de renta estabilizada sin escr
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PortfolioFilters.tsx:76
-#: src/components/PortfolioTable.tsx:230
+#: src/components/PortfolioFilters.tsx:83
+#: src/components/PortfolioTable.tsx:231
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -602,11 +610,11 @@ msgstr "Nombre del dueño"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PortfolioTable.tsx:164
+#: src/components/PortfolioTable.tsx:165
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PortfolioTable.tsx:283
+#: src/components/PortfolioTable.tsx:290
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -636,8 +644,8 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PortfolioTable.tsx:307
-#: src/components/PortfolioTable.tsx:311
+#: src/components/PortfolioTable.tsx:314
+#: src/components/PortfolioTable.tsx:318
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -651,11 +659,11 @@ msgstr "Cargando"
 msgid "Loading {0} rows"
 msgstr "Cargando {0} filas"
 
-#: src/components/PortfolioTable.tsx:53
+#: src/components/PortfolioTable.tsx:54
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/PortfolioFilters.tsx:141
+#: src/components/PortfolioFilters.tsx:203
 msgid "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 msgstr ""
 
@@ -667,11 +675,11 @@ msgstr "¿Buscas más información?"
 msgid "MAILBOX"
 msgstr "BUZÓN"
 
-#: src/components/PortfolioFilters.tsx:191
+#: src/components/PortfolioFilters.tsx:253
 msgid "MAX"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:188
+#: src/components/PortfolioFilters.tsx:250
 msgid "MIN"
 msgstr ""
 
@@ -744,7 +752,7 @@ msgstr "Directorio de NYCHA"
 msgid "Network of Landlords"
 msgstr "Red de Dueños"
 
-#: src/components/PortfolioFilters.tsx:66
+#: src/components/PortfolioFilters.tsx:70
 #: src/containers/HomePage.tsx:110
 msgid "New"
 msgstr "Nuevo"
@@ -758,11 +766,11 @@ msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:476
+#: src/components/PortfolioTable.tsx:483
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/components/PortfolioTable.tsx:329
+#: src/components/PortfolioTable.tsx:336
 msgid "No"
 msgstr "No"
 
@@ -811,7 +819,7 @@ msgstr "No encontrado"
 #~ msgid "Notice an inaccuracy? Click here."
 #~ msgstr ""
 
-#: src/components/PortfolioFilters.tsx:79
+#: src/components/PortfolioFilters.tsx:86
 msgid "Number of Units"
 msgstr ""
 
@@ -828,7 +836,7 @@ msgstr "POSEE"
 msgid "Officer"
 msgstr "Oficial"
 
-#: src/components/PortfolioFilters.tsx:76
+#: src/components/PortfolioFilters.tsx:83
 msgid "Officer/Owner"
 msgstr "Oficial/Propietario"
 
@@ -842,7 +850,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PortfolioTable.tsx:189
+#: src/components/PortfolioTable.tsx:190
 msgid "Open"
 msgstr "Actuales"
 
@@ -858,7 +866,7 @@ msgstr "General"
 msgid "Owner Names"
 msgstr "Dueños"
 
-#: src/components/PortfolioTable.tsx:243
+#: src/components/PortfolioTable.tsx:244
 msgid "Owner/Manager"
 msgstr ""
 
@@ -882,7 +890,7 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/PortfolioTable.tsx:456
+#: src/components/PortfolioTable.tsx:463
 msgid "Page"
 msgstr ""
 
@@ -904,7 +912,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Rediseño de la tabla del portafolio"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:450
+#: src/components/PortfolioTable.tsx:457
 msgid "Previous"
 msgstr "Anterior"
 
@@ -918,12 +926,12 @@ msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:119
+#: src/components/PortfolioTable.tsx:120
 msgid "RS Units"
 msgstr "Unidades RS"
 
-#: src/components/PortfolioFilters.tsx:115
-#: src/components/PortfolioFilters.tsx:135
+#: src/components/PortfolioFilters.tsx:125
+#: src/components/PortfolioFilters.tsx:145
 msgid "Read more in our Methodology section"
 msgstr ""
 
@@ -931,13 +939,17 @@ msgstr ""
 msgid "Registration expired:"
 msgstr "El registro ha caducado:"
 
-#: src/components/PortfolioFilters.tsx:74
+#: src/components/PortfolioFilters.tsx:80
 msgid "Rent Stabilized Units"
 msgstr ""
 
 #: src/components/PropertiesSummary.tsx:125
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
+
+#: src/components/PortfolioFilters.tsx:194
+msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
+msgstr ""
 
 #: src/components/PortfolioGraph.tsx:159
 msgid "Reset diagram"
@@ -959,8 +971,8 @@ msgstr "FALTA DE SEÑALIZACIÓN"
 msgid "STAIRS"
 msgstr "ESCALERAS"
 
-#: src/components/PortfolioFilters.tsx:77
-#: src/components/PortfolioFilters.tsx:83
+#: src/components/PortfolioFilters.tsx:84
+#: src/components/PortfolioFilters.tsx:90
 #: src/containers/App.tsx:87
 msgid "Search"
 msgstr "Buscar"
@@ -1011,7 +1023,7 @@ msgstr "Accionista"
 msgid "Show less"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:88
+#: src/components/PortfolioFilters.tsx:96
 msgid "Showing {0} {1, plural, one {result} other {results}}."
 msgstr ""
 
@@ -1097,7 +1109,7 @@ msgstr "ACOSO DE INQUILINO"
 msgid "Take action on JustFix.org!"
 msgstr "¡Toma acción en JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:261
+#: src/components/PortfolioTable.tsx:268
 msgid "Tax Exemptions"
 msgstr "Exenciones de impuestos"
 
@@ -1242,19 +1254,23 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PortfolioTable.tsx:172
+#: src/components/PortfolioTable.tsx:173
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:156
-#: src/components/PortfolioTable.tsx:197
+#: src/components/PortfolioTable.tsx:157
+#: src/components/PortfolioTable.tsx:198
 msgid "Total"
 msgstr "Total"
 
 #: src/components/BuildingStatsTable.tsx:62
 msgid "Total Violations"
 msgstr "Violaciones Totales"
+
+#: src/components/PortfolioFilters.tsx:200
+msgid "Try adjusting or clearing the filters to yield more than 0 results."
+msgstr ""
 
 #: src/containers/NotRegisteredPage.tsx:170
 msgid "Unable to initiate a court action for nonpayment of rent."
@@ -1265,7 +1281,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:109
+#: src/components/PortfolioTable.tsx:110
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades"
@@ -1291,6 +1307,10 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
+#: src/components/PortfolioFilters.tsx:175
+msgid "View Results"
+msgstr ""
+
 #: src/components/Indicators.tsx:180
 #: src/components/Indicators.tsx:183
 msgid "View by:"
@@ -1300,8 +1320,8 @@ msgstr "Visualizar por:"
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PortfolioTable.tsx:338
 #: src/components/PortfolioTable.tsx:345
+#: src/components/PortfolioTable.tsx:352
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -1360,7 +1380,7 @@ msgstr "Comparamos la dirección que buscaste con una base de datos de más de 2
 msgid "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 msgstr "Revisamos la pestaña Portafolio para ayudarle navegar por esta gran tabla de datos, especialmente para dispositivos móviles."
 
-#: src/components/PortfolioFilters.tsx:106
+#: src/components/PortfolioFilters.tsx:116
 msgid "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 msgstr ""
 
@@ -1393,11 +1413,11 @@ msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 msgid "What's New"
 msgstr "Qué hay de nuevo"
 
-#: src/components/PortfolioFilters.tsx:173
+#: src/components/PortfolioFilters.tsx:235
 msgid "What's this?"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:130
 msgid "What’s the difference between a landlord, an owner, and head officer?"
 msgstr ""
 
@@ -1405,7 +1425,7 @@ msgstr ""
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "Cuando dos partes comparten la misma dirección comercial, los agrupamos como parte del mismo portafolio."
 
-#: src/components/PortfolioFilters.tsx:123
+#: src/components/PortfolioFilters.tsx:133
 msgid "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 msgstr ""
 
@@ -1441,7 +1461,7 @@ msgstr "¿Por qué estoy viendo un portafolio tan grande?"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PortfolioTable.tsx:328
+#: src/components/PortfolioTable.tsx:335
 msgid "Yes"
 msgstr "Sí"
 
@@ -1457,8 +1477,8 @@ msgstr ""
 #~ msgid "You are viewing the old version of Who Owns What."
 #~ msgstr "You are viewing the old version of Who Owns What."
 
-#: src/components/PortfolioFilters.tsx:82
-#: src/components/PortfolioTable.tsx:58
+#: src/components/PortfolioFilters.tsx:89
+#: src/components/PortfolioTable.tsx:59
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -1470,7 +1490,7 @@ msgstr "Aumentar"
 msgid "Zoom out"
 msgstr "Alejar"
 
-#: src/components/PortfolioFilters.tsx:204
+#: src/components/PortfolioFilters.tsx:266
 #: src/components/StringifyList.tsx:18
 msgid "and"
 msgstr "y"
@@ -1487,7 +1507,7 @@ msgstr "por ${0}"
 msgid "month"
 msgstr "mes"
 
-#: src/components/PortfolioTable.tsx:464
+#: src/components/PortfolioTable.tsx:471
 msgid "of"
 msgstr ""
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -147,7 +147,7 @@ msgstr "Una \"demanda de desalojo\" es un caso legal de desalojo iniciado por un
 #~ msgstr "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 
 #: src/components/Multiselect.tsx:476
-#: src/components/PortfolioFilters.tsx:282
+#: src/components/PortfolioFilters.tsx:285
 msgid "Apply"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr "Clase I"
 msgid "Clear"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:105
+#: src/components/PortfolioFilters.tsx:106
 msgid "Clear Filters"
 msgstr ""
 
@@ -382,7 +382,7 @@ msgid "Enter email"
 msgstr "Introducir email"
 
 #: src/components/Multiselect.tsx:445
-#: src/components/PortfolioFilters.tsx:258
+#: src/components/PortfolioFilters.tsx:261
 msgid "Error"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 20
 msgid "Executed"
 msgstr "Ejecutado"
 
-#: src/components/PortfolioFilters.tsx:188
+#: src/components/PortfolioFilters.tsx:191
 msgid "Expand the the Owner/Manager column in Table view to see all contacts associated with that building."
 msgstr ""
 
@@ -454,7 +454,7 @@ msgstr "Presentado"
 #~ msgid "Filied"
 #~ msgstr "Filied"
 
-#: src/components/PortfolioFilters.tsx:168
+#: src/components/PortfolioFilters.tsx:169
 msgid "Filters"
 msgstr ""
 
@@ -516,7 +516,7 @@ msgstr "Formulario de queja HUD 958"
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
-#: src/components/PortfolioFilters.tsx:113
+#: src/components/PortfolioFilters.tsx:114
 msgid "How are the results calculated?"
 msgstr ""
 
@@ -663,7 +663,7 @@ msgstr "Cargando {0} filas"
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/PortfolioFilters.tsx:203
+#: src/components/PortfolioFilters.tsx:206
 msgid "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 msgstr ""
 
@@ -675,11 +675,11 @@ msgstr "¿Buscas más información?"
 msgid "MAILBOX"
 msgstr "BUZÓN"
 
-#: src/components/PortfolioFilters.tsx:253
+#: src/components/PortfolioFilters.tsx:256
 msgid "MAX"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:250
+#: src/components/PortfolioFilters.tsx:253
 msgid "MIN"
 msgstr ""
 
@@ -930,8 +930,8 @@ msgstr "Complejo de Vivienda Pública"
 msgid "RS Units"
 msgstr "Unidades RS"
 
-#: src/components/PortfolioFilters.tsx:125
-#: src/components/PortfolioFilters.tsx:145
+#: src/components/PortfolioFilters.tsx:126
+#: src/components/PortfolioFilters.tsx:146
 msgid "Read more in our Methodology section"
 msgstr ""
 
@@ -947,7 +947,7 @@ msgstr ""
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
-#: src/components/PortfolioFilters.tsx:194
+#: src/components/PortfolioFilters.tsx:197
 msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr "Accionista"
 msgid "Show less"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:96
+#: src/components/PortfolioFilters.tsx:97
 msgid "Showing {0} {1, plural, one {result} other {results}}."
 msgstr ""
 
@@ -1268,7 +1268,7 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Violaciones Totales"
 
-#: src/components/PortfolioFilters.tsx:200
+#: src/components/PortfolioFilters.tsx:203
 msgid "Try adjusting or clearing the filters to yield more than 0 results."
 msgstr ""
 
@@ -1307,7 +1307,7 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
-#: src/components/PortfolioFilters.tsx:175
+#: src/components/PortfolioFilters.tsx:176
 msgid "View Results"
 msgstr ""
 
@@ -1380,7 +1380,7 @@ msgstr "Comparamos la dirección que buscaste con una base de datos de más de 2
 msgid "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 msgstr "Revisamos la pestaña Portafolio para ayudarle navegar por esta gran tabla de datos, especialmente para dispositivos móviles."
 
-#: src/components/PortfolioFilters.tsx:116
+#: src/components/PortfolioFilters.tsx:117
 msgid "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 msgstr ""
 
@@ -1413,11 +1413,11 @@ msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 msgid "What's New"
 msgstr "Qué hay de nuevo"
 
-#: src/components/PortfolioFilters.tsx:235
+#: src/components/PortfolioFilters.tsx:238
 msgid "What's this?"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:130
+#: src/components/PortfolioFilters.tsx:131
 msgid "What’s the difference between a landlord, an owner, and head officer?"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "Cuando dos partes comparten la misma dirección comercial, los agrupamos como parte del mismo portafolio."
 
-#: src/components/PortfolioFilters.tsx:133
+#: src/components/PortfolioFilters.tsx:134
 msgid "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr "Aumentar"
 msgid "Zoom out"
 msgstr "Alejar"
 
-#: src/components/PortfolioFilters.tsx:266
+#: src/components/PortfolioFilters.tsx:269
 #: src/components/StringifyList.tsx:18
 msgid "and"
 msgstr "y"

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -486,76 +486,88 @@
   }
   .filter-status {
     display: flex;
-    align-items: center;
-    gap: 0.85rem;
-    text-transform: none;
-    margin-left: calc(var(--new-container-width) + var(--filter-bar-gap));
-
-    @include for-phone-only() {
-      margin-left: unset;
+    flex-direction: column;
+    width: 100%;
+    gap: 1rem;
+    @include for-tablet-portrait-up() {
+      margin-left: calc(var(--new-container-width) + var(--filter-bar-gap));
     }
 
-    .results-count {
-      font-size: 1.6rem;
-      color: $justfix-grey-600;
+    .filter-status-info {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+      text-transform: none;
+
+      .results-count {
+        font-size: 1.6rem;
+        color: $justfix-grey-600;
+      }
+      .results-info {
+        color: $justfix-grey-600;
+      }
+      .clear-filters {
+        color: $justfix-grey-700;
+      }
     }
-    .results-info {
-      color: $justfix-grey-600;
-    }
-    .clear-filters {
-      color: $justfix-grey-700;
+
+    .zero-results-alert {
+      width: fit-content;
+      outline: $justfix-grey-400 solid 1px;
+      @include for-phone-only() {
+        margin-left: unset;
+      }
     }
   }
-  .zero-results-alert {
-    width: fit-content;
-    outline: $justfix-grey-400 solid 1px;
-    margin-left: calc(var(--new-container-width) + var(--filter-bar-gap));
-    @include for-phone-only() {
-      margin-left: unset;
-    }
-  }
 
-  .filter-toast-alert {
+  .filter-toast-container {
     position: fixed;
-    right: 0;
-    bottom: -100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: fit-content;
+    bottom: 0;
     left: 50%;
     transform: translateX(-50%);
-    outline: $justfix-grey-400 solid 1px;
-    z-index: 100;
-    width: 45.4rem;
-    @include for-phone-only() {
-      width: calc(100% - 2.4rem);
+    z-index: 101;
+
+    .filter-toast-alert {
+      position: relative;
+      transform: translateY(100%);
+      outline: $justfix-grey-400 solid 1px;
+      width: 45.4rem;
+      @include for-phone-only() {
+        width: calc(100vw - 2.8rem);
+      }
+
+      @keyframes toast-up-down {
+        0% {
+          transform: translateY(100%);
+        }
+        25% {
+          transform: translateY(0%);
+        }
+        75% {
+          transform: translateY(0%);
+        }
+        100% {
+          transform: translateY(100%);
+        }
+      }
+
+      animation-name: toast-up-down;
+      animation-delay: 0.3s;
+      animation-duration: 7s;
+      animation-timing-function: ease-in-out;
+      animation-fill-mode: forwards;
+
+      &:hover {
+        animation-play-state: paused;
+      }
     }
 
-    @keyframes toast-up-down {
-      0% {
-        bottom: -100%;
-      }
-      25% {
-        bottom: 4.4rem;
-      }
-      75% {
-        bottom: 4.4rem;
-      }
-      100% {
-        bottom: -100%;
-        display: none;
-      }
-    }
-
-    animation-name: toast-up-down;
-    animation-delay: 0.3s;
-    animation-duration: 7s;
-    animation-timing-function: ease-in-out;
-    animation-fill-mode: forwards;
-
-    &:hover {
-      animation-play-state: paused;
-    }
-
-    &.rsunits-toast-alert {
-      z-index: 101;
+    :not(:first-child) {
+      display: none;
     }
   }
 }

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -275,7 +275,7 @@
               color: $justfix-grey-600;
               outline: $justfix-grey-400 solid 1px;
               margin-top: 1.2rem;
-              button {
+              button:not(:focus-visible) {
                 outline: none;
               }
             }
@@ -392,6 +392,21 @@
           background-color: $justfix-table-grey;
           border-radius: 0;
           border: none;
+
+          &.scroll-gradient {
+            // https://css-scroll-shadows.vercel.app/
+            --clear: rgba(0, 0, 0, 0);
+            --dark: rgba(140, 140, 140, 0.5);
+            background: linear-gradient($justfix-table-grey 10%, var(--clear)),
+              linear-gradient(var(--clear), $justfix-table-grey 90%) 0 100%,
+              linear-gradient(var(--dark) 10%, var(--clear)),
+              linear-gradient(var(--clear), var(--dark) 90%) 0 100%;
+            background-color: $justfix-table-grey;
+            background-repeat: no-repeat;
+            background-attachment: local, local, scroll, scroll;
+            background-size: 100% 6rem, 100% 6rem, 100% 2rem, 100% 2rem;
+          }
+
           .filter {
             height: var(--filter-bar-height);
             border-radius: 0;
@@ -460,18 +475,10 @@
             margin-left: 1em;
             @include wrap-with-parentheses();
           }
-          &.scroll-gradient {
-            // https://css-scroll-shadows.vercel.app/
-            --clear: rgba(0, 0, 0, 0);
-            --dark: rgba(140, 140, 140, 0.5);
-            background: linear-gradient($justfix-table-grey 10%, var(--clear)),
-              linear-gradient(var(--clear), $justfix-table-grey 90%) 0 100%,
-              linear-gradient(var(--dark) 10%, var(--clear)),
-              linear-gradient(var(--clear), var(--dark) 90%) 0 100%;
-            background-color: $justfix-table-grey;
-            background-repeat: no-repeat;
-            background-attachment: local, local, scroll, scroll;
-            background-size: 100% 6rem, 100% 6rem, 100% 2rem, 100% 2rem;
+          .zero-results-alert {
+            margin: 1.4rem 2.45rem 0 2.45rem;
+            width: fit-content;
+            outline: $justfix-grey-400 solid 1px;
           }
         }
       }
@@ -497,6 +504,58 @@
     }
     .clear-filters {
       color: $justfix-grey-700;
+    }
+  }
+  .zero-results-alert {
+    width: fit-content;
+    outline: $justfix-grey-400 solid 1px;
+    margin-left: calc(var(--new-container-width) + var(--filter-bar-gap));
+    @include for-phone-only() {
+      margin-left: unset;
+    }
+  }
+
+  .filter-toast-alert {
+    position: fixed;
+    right: 0;
+    bottom: -100%;
+    left: 50%;
+    transform: translateX(-50%);
+    outline: $justfix-grey-400 solid 1px;
+    z-index: 100;
+    width: 45.4rem;
+    @include for-phone-only() {
+      width: calc(100% - 2.4rem);
+    }
+
+    @keyframes toast-up-down {
+      0% {
+        bottom: -100%;
+      }
+      25% {
+        bottom: 4.4rem;
+      }
+      75% {
+        bottom: 4.4rem;
+      }
+      100% {
+        bottom: -100%;
+        display: none;
+      }
+    }
+
+    animation-name: toast-up-down;
+    animation-delay: 0.3s;
+    animation-duration: 7s;
+    animation-timing-function: ease-in-out;
+    animation-fill-mode: forwards;
+
+    &:hover {
+      animation-play-state: paused;
+    }
+
+    &.rsunits-toast-alert {
+      z-index: 101;
     }
   }
 }

--- a/client/src/styles/_alert.scss
+++ b/client/src/styles/_alert.scss
@@ -29,6 +29,9 @@
 
   button.jf-alert__close {
     align-self: flex-start;
+    &:focus-visible {
+      outline: 2px solid $focus-outline-color;
+    }
   }
 
   .closeIcon {


### PR DESCRIPTION
This PR adds the "toast" notifications that pop up when results are updated. 

[sc-11711]

They slide up from the bottom, stay for 5 seconds, then slide out. If you hover on them it pauses the animation. They have [`role="status"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) so they're read out on screen readers (after learning about this I also went through and added this role to other alerts within filters that made sense). 

<img src="https://user-images.githubusercontent.com/16906516/224454004-966d4567-6380-444d-ba70-04f1c13d4bab.png" width="400" />

![image](https://user-images.githubusercontent.com/16906516/224454045-bc178616-230d-490e-a436-133f2eb5f440.png)


In addition to the toasts, there is an in-line alert for when there are 0 results. 

<img src="https://user-images.githubusercontent.com/16906516/224453971-a4be20de-efae-4c7d-9e04-9069640985e0.png" width="400" />

<img src="https://user-images.githubusercontent.com/16906516/224453977-af604403-8af3-4572-bdd3-574e18fedda6.png" width="400" />

![image](https://user-images.githubusercontent.com/16906516/224453982-ffd40b9a-77f2-40ba-9787-88d236261c49.png)


On mobile, they only appear after you close the fullscreen filters menu, and so if you apply multiple filters within one trip into the filter menu then multiple toasts pop up at once. There is a desired priority given by Design and this is given just by the ordering of the html elements, and following Shannons comment these are now in a container and via css all but the first are not displayed. 