### PR TITLE
style expanded owner contact row for mvp

### DIFF
--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -32,6 +32,7 @@ import { FilterContext, IFilterContext, MINMAX_DEFAULT } from "./PropertiesList"
 import "styles/PortfolioTable.scss";
 import { sortContactsByImportance } from "./DetailView";
 import { ArrowIcon } from "./Icons";
+import classNames from "classnames";
 
 const FIRST_COLUMN_WIDTH = 130;
 export const MAX_TABLE_ROWS_PER_PAGE = 100;
@@ -568,7 +569,9 @@ export const PortfolioTable = React.memo(
                   {row.getIsExpanded() && (
                     <tr>
                       {/* 2nd row is a custom 1 cell row */}
-                      <td colSpan={row.getVisibleCells().length}>{renderContacts({ row })}</td>
+                      <td colSpan={row.getVisibleCells().length}>
+                        {renderContacts({ row, i18n })}
+                      </td>
                     </tr>
                   )}
                 </Fragment>
@@ -631,15 +634,15 @@ export const PortfolioTable = React.memo(
   })
 );
 
-const renderContacts = ({ row }: { row: Row<AddressRecord> }) => {
+const renderContacts = ({ row, i18n }: { row: Row<AddressRecord>; i18n: I18n }) => {
   return (
-    <ul className="contacts-list">
+    <ul className={classNames("contacts-list", `lang-${i18n.language}`)}>
       {Object.entries(_groupBy(row.original.allcontacts, "value"))
         .sort(sortContactsByImportance)
         .map((group) => group[1][0])
         .map((contact, i) => (
           <li key={i}>
-            {contact.title}: {contact.value}
+            {Helpers.translateContactTitleAndIncludeEnglish(contact.title, i18n)}: {contact.value}
           </li>
         ))}
     </ul>

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -112,7 +112,7 @@ msgstr "Across owners and management staff, the most common {0, plural, one {nam
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PortfolioTable.tsx:43
+#: src/components/PortfolioTable.tsx:44
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Address"
@@ -129,7 +129,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PortfolioTable.tsx:306
+#: src/components/PortfolioTable.tsx:307
 msgid "Amount"
 msgstr "Amount"
 
@@ -162,7 +162,7 @@ msgstr "BELL/BUZZER/INTERCOM"
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/PortfolioTable.tsx:68
+#: src/components/PortfolioTable.tsx:69
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -192,7 +192,7 @@ msgstr "Building info"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PortfolioTable.tsx:102
+#: src/components/PortfolioTable.tsx:103
 msgid "Built"
 msgstr "Built"
 
@@ -298,7 +298,7 @@ msgstr "Corporate Owner"
 msgid "Corporation"
 msgstr "Corporation"
 
-#: src/components/PortfolioTable.tsx:88
+#: src/components/PortfolioTable.tsx:89
 msgid "Council"
 msgstr "Council"
 
@@ -322,7 +322,7 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PortfolioTable.tsx:295
+#: src/components/PortfolioTable.tsx:296
 msgid "Date"
 msgstr "Date"
 
@@ -401,7 +401,7 @@ msgstr "Evictions"
 msgid "Evictions Executed"
 msgstr "Evictions Executed"
 
-#: src/components/PortfolioTable.tsx:207
+#: src/components/PortfolioTable.tsx:208
 msgid "Evictions Since 2017"
 msgstr "Evictions Since 2017"
 
@@ -413,7 +413,7 @@ msgstr "Evictions executed by NYC Marshals since 2017. ANHD and the Housing Data
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
-#: src/components/PortfolioTable.tsx:222
+#: src/components/PortfolioTable.tsx:223
 msgid "Executed"
 msgstr "Executed"
 
@@ -441,7 +441,7 @@ msgstr "FLOORING/STAIRS"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PortfolioTable.tsx:213
+#: src/components/PortfolioTable.tsx:214
 msgid "Filed"
 msgstr "Filed"
 
@@ -469,7 +469,7 @@ msgstr "Find other buildings your landlord might own:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
-#: src/components/PortfolioTable.tsx:332
+#: src/components/PortfolioTable.tsx:333
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -486,7 +486,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:152
+#: src/components/PortfolioTable.tsx:153
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -495,7 +495,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:185
+#: src/components/PortfolioTable.tsx:186
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -564,7 +564,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PortfolioTable.tsx:97
+#: src/components/PortfolioTable.tsx:98
 msgid "Information"
 msgstr "Information"
 
@@ -593,7 +593,7 @@ msgid "LOCKS"
 msgstr "LOCKS"
 
 #: src/components/PortfolioFilters.tsx:83
-#: src/components/PortfolioTable.tsx:231
+#: src/components/PortfolioTable.tsx:232
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -605,11 +605,11 @@ msgstr "Landlord name"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PortfolioTable.tsx:165
+#: src/components/PortfolioTable.tsx:166
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PortfolioTable.tsx:290
+#: src/components/PortfolioTable.tsx:291
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -639,8 +639,8 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PortfolioTable.tsx:314
-#: src/components/PortfolioTable.tsx:318
+#: src/components/PortfolioTable.tsx:315
+#: src/components/PortfolioTable.tsx:319
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
@@ -654,7 +654,7 @@ msgstr "Loading"
 msgid "Loading {0} rows"
 msgstr "Loading {0} rows"
 
-#: src/components/PortfolioTable.tsx:54
+#: src/components/PortfolioTable.tsx:55
 msgid "Location"
 msgstr "Location"
 
@@ -761,11 +761,11 @@ msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:483
+#: src/components/PortfolioTable.tsx:486
 msgid "Next"
 msgstr "Next"
 
-#: src/components/PortfolioTable.tsx:336
+#: src/components/PortfolioTable.tsx:337
 msgid "No"
 msgstr "No"
 
@@ -845,7 +845,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PortfolioTable.tsx:190
+#: src/components/PortfolioTable.tsx:191
 msgid "Open"
 msgstr "Open"
 
@@ -861,7 +861,7 @@ msgstr "Overview"
 msgid "Owner Names"
 msgstr "Owner Names"
 
-#: src/components/PortfolioTable.tsx:244
+#: src/components/PortfolioTable.tsx:245
 msgid "Owner/Manager"
 msgstr "Owner/Manager"
 
@@ -885,7 +885,7 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/PortfolioTable.tsx:463
+#: src/components/PortfolioTable.tsx:466
 msgid "Page"
 msgstr "Page"
 
@@ -907,7 +907,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Portfolio Table Redesign"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:457
+#: src/components/PortfolioTable.tsx:460
 msgid "Previous"
 msgstr "Previous"
 
@@ -921,7 +921,7 @@ msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:120
+#: src/components/PortfolioTable.tsx:121
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -1047,7 +1047,7 @@ msgstr "Sign up for email updates"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/components/PortfolioTable.tsx:510
+#: src/components/PortfolioTable.tsx:513
 msgid "Since {year}"
 msgstr "Since {year}"
 
@@ -1079,7 +1079,7 @@ msgstr "Source code"
 msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:510
+#: src/components/PortfolioTable.tsx:513
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
@@ -1104,7 +1104,7 @@ msgstr "TENANT HARASSMENT"
 msgid "Take action on JustFix.org!"
 msgstr "Take action on JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:268
+#: src/components/PortfolioTable.tsx:269
 msgid "Tax Exemptions"
 msgstr "Tax Exemptions"
 
@@ -1249,13 +1249,13 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PortfolioTable.tsx:173
+#: src/components/PortfolioTable.tsx:174
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:157
-#: src/components/PortfolioTable.tsx:198
+#: src/components/PortfolioTable.tsx:158
+#: src/components/PortfolioTable.tsx:199
 msgid "Total"
 msgstr "Total"
 
@@ -1276,7 +1276,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:110
+#: src/components/PortfolioTable.tsx:111
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -1315,8 +1315,8 @@ msgstr "View by:"
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
-#: src/components/PortfolioTable.tsx:345
-#: src/components/PortfolioTable.tsx:352
+#: src/components/PortfolioTable.tsx:346
+#: src/components/PortfolioTable.tsx:353
 msgid "View detail"
 msgstr "View detail"
 
@@ -1456,7 +1456,7 @@ msgstr "Why am I seeing such a big portfolio?"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PortfolioTable.tsx:335
+#: src/components/PortfolioTable.tsx:336
 msgid "Yes"
 msgstr "Yes"
 
@@ -1473,7 +1473,7 @@ msgstr "You are viewing a legacy version of Who Owns What"
 #~ msgstr "You are viewing the old version of Who Owns What."
 
 #: src/components/PortfolioFilters.tsx:89
-#: src/components/PortfolioTable.tsx:59
+#: src/components/PortfolioTable.tsx:60
 msgid "Zipcode"
 msgstr "Zipcode"
 
@@ -1502,7 +1502,7 @@ msgstr "for ${0}"
 msgid "month"
 msgstr "month"
 
-#: src/components/PortfolioTable.tsx:471
+#: src/components/PortfolioTable.tsx:474
 msgid "of"
 msgstr "of"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -117,7 +117,7 @@ msgstr "En todos los dueños y administradores, {0, plural, one {el nombre más 
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PortfolioTable.tsx:43
+#: src/components/PortfolioTable.tsx:44
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Dirección"
@@ -134,7 +134,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PortfolioTable.tsx:306
+#: src/components/PortfolioTable.tsx:307
 msgid "Amount"
 msgstr "Importe"
 
@@ -167,7 +167,7 @@ msgstr "TIMBRE/INTERCOMUNICADOR"
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/PortfolioTable.tsx:68
+#: src/components/PortfolioTable.tsx:69
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -197,7 +197,7 @@ msgstr "Información de edificios"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PortfolioTable.tsx:102
+#: src/components/PortfolioTable.tsx:103
 msgid "Built"
 msgstr "Construido"
 
@@ -303,7 +303,7 @@ msgstr "Dueño Corporativo"
 msgid "Corporation"
 msgstr "Corporación"
 
-#: src/components/PortfolioTable.tsx:88
+#: src/components/PortfolioTable.tsx:89
 msgid "Council"
 msgstr ""
 
@@ -327,7 +327,7 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PortfolioTable.tsx:295
+#: src/components/PortfolioTable.tsx:296
 msgid "Date"
 msgstr "Fecha"
 
@@ -406,7 +406,7 @@ msgstr "Desalojos"
 msgid "Evictions Executed"
 msgstr "Desalojos ejecutados"
 
-#: src/components/PortfolioTable.tsx:207
+#: src/components/PortfolioTable.tsx:208
 msgid "Evictions Since 2017"
 msgstr "Desalojos desde 2017"
 
@@ -418,7 +418,7 @@ msgstr "Desalojos ejecutados en este edificio por el Mariscal de NYC desde el 20
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 2017. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes del DOI."
 
-#: src/components/PortfolioTable.tsx:222
+#: src/components/PortfolioTable.tsx:223
 msgid "Executed"
 msgstr "Ejecutado"
 
@@ -446,7 +446,7 @@ msgstr "PISO/ESCALERAS"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PortfolioTable.tsx:213
+#: src/components/PortfolioTable.tsx:214
 msgid "Filed"
 msgstr "Presentado"
 
@@ -474,7 +474,7 @@ msgstr "Encuentra otros edificios que tu propietario podría poseer:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
-#: src/components/PortfolioTable.tsx:332
+#: src/components/PortfolioTable.tsx:333
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -491,7 +491,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:152
+#: src/components/PortfolioTable.tsx:153
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -500,7 +500,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontrarás más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:185
+#: src/components/PortfolioTable.tsx:186
 msgid "HPD Violations"
 msgstr "Violaciones del HPD"
 
@@ -569,7 +569,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
-#: src/components/PortfolioTable.tsx:97
+#: src/components/PortfolioTable.tsx:98
 msgid "Information"
 msgstr "Información"
 
@@ -598,7 +598,7 @@ msgid "LOCKS"
 msgstr "CERRADURAS"
 
 #: src/components/PortfolioFilters.tsx:83
-#: src/components/PortfolioTable.tsx:231
+#: src/components/PortfolioTable.tsx:232
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -610,11 +610,11 @@ msgstr "Nombre del dueño"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PortfolioTable.tsx:165
+#: src/components/PortfolioTable.tsx:166
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PortfolioTable.tsx:290
+#: src/components/PortfolioTable.tsx:291
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -644,8 +644,8 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PortfolioTable.tsx:314
-#: src/components/PortfolioTable.tsx:318
+#: src/components/PortfolioTable.tsx:315
+#: src/components/PortfolioTable.tsx:319
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
@@ -659,7 +659,7 @@ msgstr "Cargando"
 msgid "Loading {0} rows"
 msgstr "Cargando {0} filas"
 
-#: src/components/PortfolioTable.tsx:54
+#: src/components/PortfolioTable.tsx:55
 msgid "Location"
 msgstr "Ubicación"
 
@@ -766,11 +766,11 @@ msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:483
+#: src/components/PortfolioTable.tsx:486
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/components/PortfolioTable.tsx:336
+#: src/components/PortfolioTable.tsx:337
 msgid "No"
 msgstr "No"
 
@@ -850,7 +850,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PortfolioTable.tsx:190
+#: src/components/PortfolioTable.tsx:191
 msgid "Open"
 msgstr "Actuales"
 
@@ -866,7 +866,7 @@ msgstr "General"
 msgid "Owner Names"
 msgstr "Dueños"
 
-#: src/components/PortfolioTable.tsx:244
+#: src/components/PortfolioTable.tsx:245
 msgid "Owner/Manager"
 msgstr ""
 
@@ -890,7 +890,7 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/PortfolioTable.tsx:463
+#: src/components/PortfolioTable.tsx:466
 msgid "Page"
 msgstr ""
 
@@ -912,7 +912,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Rediseño de la tabla del portafolio"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:457
+#: src/components/PortfolioTable.tsx:460
 msgid "Previous"
 msgstr "Anterior"
 
@@ -926,7 +926,7 @@ msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:120
+#: src/components/PortfolioTable.tsx:121
 msgid "RS Units"
 msgstr "Unidades RS"
 
@@ -1052,7 +1052,7 @@ msgstr "Regístrate para recibir noticias por email"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde 2017, los dueños presentaron {totalEvictionFilings, plural, one {un caso de desalojo} other {# casos de desalojo}} y los alguaciles de la ciudad de Nueva York ejecutaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en toda esta cartera."
 
-#: src/components/PortfolioTable.tsx:510
+#: src/components/PortfolioTable.tsx:513
 msgid "Since {year}"
 msgstr "Desde {year}"
 
@@ -1084,7 +1084,7 @@ msgstr "Código fuente"
 msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 msgstr ""
 
-#: src/components/PortfolioTable.tsx:510
+#: src/components/PortfolioTable.tsx:513
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
@@ -1109,7 +1109,7 @@ msgstr "ACOSO DE INQUILINO"
 msgid "Take action on JustFix.org!"
 msgstr "¡Toma acción en JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:268
+#: src/components/PortfolioTable.tsx:269
 msgid "Tax Exemptions"
 msgstr "Exenciones de impuestos"
 
@@ -1254,13 +1254,13 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PortfolioTable.tsx:173
+#: src/components/PortfolioTable.tsx:174
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:157
-#: src/components/PortfolioTable.tsx:198
+#: src/components/PortfolioTable.tsx:158
+#: src/components/PortfolioTable.tsx:199
 msgid "Total"
 msgstr "Total"
 
@@ -1281,7 +1281,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:110
+#: src/components/PortfolioTable.tsx:111
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades"
@@ -1320,8 +1320,8 @@ msgstr "Visualizar por:"
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
-#: src/components/PortfolioTable.tsx:345
-#: src/components/PortfolioTable.tsx:352
+#: src/components/PortfolioTable.tsx:346
+#: src/components/PortfolioTable.tsx:353
 msgid "View detail"
 msgstr "Ver detalles"
 
@@ -1461,7 +1461,7 @@ msgstr "¿Por qué estoy viendo un portafolio tan grande?"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PortfolioTable.tsx:335
+#: src/components/PortfolioTable.tsx:336
 msgid "Yes"
 msgstr "Sí"
 
@@ -1478,7 +1478,7 @@ msgstr ""
 #~ msgstr "You are viewing the old version of Who Owns What."
 
 #: src/components/PortfolioFilters.tsx:89
-#: src/components/PortfolioTable.tsx:59
+#: src/components/PortfolioTable.tsx:60
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -1507,7 +1507,7 @@ msgstr "por ${0}"
 msgid "month"
 msgstr "mes"
 
-#: src/components/PortfolioTable.tsx:471
+#: src/components/PortfolioTable.tsx:474
 msgid "of"
 msgstr ""
 

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -79,6 +79,8 @@
       text-transform: uppercase;
       display: flex;
       align-items: center;
+      // height based on toggle toggle checkbox plus 1rem padding
+      height: calc(var(--checkbox-height) + 1rem * 2);
 
       &.active:not([open]),
       &[aria-pressed="true"] {
@@ -125,8 +127,7 @@
       position: relative;
 
       summary {
-        // height based on toggle toggle checkbox plus 1rem padding
-        height: calc(var(--checkbox-height) + 1rem * 2);
+        height: 100%;
         padding: 0 1rem 0 1rem;
         display: flex;
         align-items: center;
@@ -292,9 +293,6 @@
               outline: 2px $justfix-orange solid;
               outline-offset: -2px;
             }
-            input {
-              width: -webkit-fill-available;
-            }
           }
 
           .optionsContainer,
@@ -382,21 +380,18 @@
         border-bottom: 0.2rem solid $justfix-grey-700;
         outline: 1rem solid $justfix-grey-700;
         .dropdown-container {
+          position: absolute;
           display: flex;
           flex-direction: column;
+          top: calc(var(--filter-bar-top-height)); // borders
+          left: 0;
+          max-height: none;
+          height: calc(100vh - var(--filter-bar-top-height));
           width: 100%;
           padding: 0;
           background-color: $justfix-table-grey;
           border-radius: 0;
           border: none;
-          top: unset;
-        }
-        & > .dropdown-container {
-          position: absolute;
-          top: calc(var(--filter-bar-top-height)); // borders
-          left: 0;
-          max-height: none;
-          height: calc(100vh - var(--filter-bar-top-height));
 
           &.scroll-gradient {
             // https://css-scroll-shadows.vercel.app/
@@ -413,18 +408,11 @@
           }
 
           .filter {
+            height: var(--filter-bar-height);
             border-radius: 0;
             box-sizing: border-box;
             border: none;
             border-bottom: 0.1rem solid $justfix-grey-400;
-            &.filter-toggle {
-              height: var(--filter-bar-height);
-              padding: 0 2.4rem;
-            }
-            &.filter-accordion > summary {
-              height: var(--filter-bar-height);
-              padding: 0 2.4rem;
-            }
             &.active:not(.filter-toggle) {
               background-color: $justfix-table-grey;
               color: $justfix-black;
@@ -441,7 +429,7 @@
               .dropdown-container {
                 align-items: flex-start;
                 width: 100%;
-                padding: 0 2.4rem;
+                padding: 2.4rem;
                 .filter-subtitle-container {
                   padding: 0;
                   .filter-subtitle {

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -79,8 +79,6 @@
       text-transform: uppercase;
       display: flex;
       align-items: center;
-      // height based on toggle toggle checkbox plus 1rem padding
-      height: calc(var(--checkbox-height) + 1rem * 2);
 
       &.active:not([open]),
       &[aria-pressed="true"] {
@@ -127,7 +125,8 @@
       position: relative;
 
       summary {
-        height: 100%;
+        // height based on toggle toggle checkbox plus 1rem padding
+        height: calc(var(--checkbox-height) + 1rem * 2);
         padding: 0 1rem 0 1rem;
         display: flex;
         align-items: center;
@@ -293,6 +292,9 @@
               outline: 2px $justfix-orange solid;
               outline-offset: -2px;
             }
+            input {
+              width: -webkit-fill-available;
+            }
           }
 
           .optionsContainer,
@@ -380,18 +382,21 @@
         border-bottom: 0.2rem solid $justfix-grey-700;
         outline: 1rem solid $justfix-grey-700;
         .dropdown-container {
-          position: absolute;
           display: flex;
           flex-direction: column;
-          top: calc(var(--filter-bar-top-height)); // borders
-          left: 0;
-          max-height: none;
-          height: calc(100vh - var(--filter-bar-top-height));
           width: 100%;
           padding: 0;
           background-color: $justfix-table-grey;
           border-radius: 0;
           border: none;
+          top: unset;
+        }
+        & > .dropdown-container {
+          position: absolute;
+          top: calc(var(--filter-bar-top-height)); // borders
+          left: 0;
+          max-height: none;
+          height: calc(100vh - var(--filter-bar-top-height));
 
           &.scroll-gradient {
             // https://css-scroll-shadows.vercel.app/
@@ -408,11 +413,18 @@
           }
 
           .filter {
-            height: var(--filter-bar-height);
             border-radius: 0;
             box-sizing: border-box;
             border: none;
             border-bottom: 0.1rem solid $justfix-grey-400;
+            &.filter-toggle {
+              height: var(--filter-bar-height);
+              padding: 0 2.4rem;
+            }
+            &.filter-accordion > summary {
+              height: var(--filter-bar-height);
+              padding: 0 2.4rem;
+            }
             &.active:not(.filter-toggle) {
               background-color: $justfix-table-grey;
               color: $justfix-black;
@@ -429,7 +441,7 @@
               .dropdown-container {
                 align-items: flex-start;
                 width: 100%;
-                padding: 2.4rem;
+                padding: 0 2.4rem;
                 .filter-subtitle-container {
                   padding: 0;
                   .filter-subtitle {

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -77,7 +77,6 @@
       border: 0.1rem solid $justfix-black;
       border-radius: 0.8rem;
       text-transform: uppercase;
-      padding: 1rem;
       display: flex;
       align-items: center;
       // height based on toggle toggle checkbox plus 1rem padding
@@ -101,6 +100,7 @@
 
     .filter-toggle {
       gap: 1rem;
+      padding: 1rem;
       .checkbox {
         box-sizing: border-box;
         border: 0.1rem solid $justfix-black;
@@ -127,8 +127,8 @@
       position: relative;
 
       summary {
-        // typical flex stretch doesn't seem to work in summary/details
         height: 100%;
+        padding: 0 1rem 0 1rem;
         display: flex;
         align-items: center;
         position: relative;
@@ -446,12 +446,18 @@
               }
             }
           }
-          .filter-accordion summary {
-            position: relative;
-            .chevronIcon {
-              @include for-phone-only() {
-                margin-left: auto;
+
+          .filter-accordion {
+            summary {
+              position: relative;
+              .chevronIcon {
+                @include for-phone-only() {
+                  margin-left: auto;
+                }
               }
+            }
+            .dropdown-container {
+              position: relative;
             }
           }
           .zip-accordion {

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -77,6 +77,7 @@
       border: 0.1rem solid $justfix-black;
       border-radius: 0.8rem;
       text-transform: uppercase;
+      padding: 1rem;
       display: flex;
       align-items: center;
       // height based on toggle toggle checkbox plus 1rem padding
@@ -100,7 +101,6 @@
 
     .filter-toggle {
       gap: 1rem;
-      padding: 1rem;
       .checkbox {
         box-sizing: border-box;
         border: 0.1rem solid $justfix-black;
@@ -127,8 +127,8 @@
       position: relative;
 
       summary {
+        // typical flex stretch doesn't seem to work in summary/details
         height: 100%;
-        padding: 0 1rem 0 1rem;
         display: flex;
         align-items: center;
         position: relative;
@@ -446,18 +446,12 @@
               }
             }
           }
-
-          .filter-accordion {
-            summary {
-              position: relative;
-              .chevronIcon {
-                @include for-phone-only() {
-                  margin-left: auto;
-                }
+          .filter-accordion summary {
+            position: relative;
+            .chevronIcon {
+              @include for-phone-only() {
+                margin-left: auto;
               }
-            }
-            .dropdown-container {
-              position: relative;
             }
           }
           .zip-accordion {

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -107,7 +107,13 @@ $table-border-dark: 1px solid $dark;
           border: 1px solid $justfix-grey-700;
         }
         .contacts-list {
-          color: $justfix-green;
+          text-align: left;
+          position: relative;
+          list-style-type: none;
+          left: 130.5rem;
+          &.lang-es {
+            left: 152.5rem;
+          }
         }
       }
 


### PR DESCRIPTION
Apply styles for expanded row of owner contacts for MVP. Design will provide final styles later, but for MVP they just wanted something basic. This PR just adds proper internationalization following what we do on overview page, and adjusts the positioning so the names always appear directly under the owner name. It's a bit awkward on mobile since there is just so little horizontal space, but with scrolling it can work.

![image](https://user-images.githubusercontent.com/16906516/225514185-f94b6ef2-1cb1-4539-aaab-de9f60396610.png)
![image](https://user-images.githubusercontent.com/16906516/225514202-2966e865-0121-4033-97c5-48a9c7dc7af3.png)
![image](https://user-images.githubusercontent.com/16906516/225514207-e56991bf-d94f-43ba-ab66-42a6731d2209.png)

[sc-11715]