### PR TITLE
Filters mobile menu

### DIFF
--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -218,7 +218,7 @@
           .minmax-container {
             display: flex;
             flex-direction: column;
-            margin-top: 0.8rem;
+            margin: 0.8rem 0;
           }
           .minmax-container {
             padding: 1.2rem;
@@ -381,6 +381,9 @@
         border: none;
         border-bottom: 0.2rem solid $justfix-grey-700;
         outline: 1rem solid $justfix-grey-700;
+        & > summary {
+          padding: 0 2.4rem;
+        }
         .dropdown-container {
           display: flex;
           flex-direction: column;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -79,8 +79,6 @@
       text-transform: uppercase;
       display: flex;
       align-items: center;
-      // height based on toggle toggle checkbox plus 1rem padding
-      height: calc(var(--checkbox-height) + 1rem * 2);
 
       &.active:not([open]),
       &[aria-pressed="true"] {
@@ -127,7 +125,8 @@
       position: relative;
 
       summary {
-        height: 100%;
+        // height based on toggle toggle checkbox plus 1rem padding
+        height: calc(var(--checkbox-height) + 1rem * 2);
         padding: 0 1rem 0 1rem;
         display: flex;
         align-items: center;
@@ -293,6 +292,9 @@
               outline: 2px $justfix-orange solid;
               outline-offset: -2px;
             }
+            input {
+              width: -webkit-fill-available;
+            }
           }
 
           .optionsContainer,
@@ -380,18 +382,21 @@
         border-bottom: 0.2rem solid $justfix-grey-700;
         outline: 1rem solid $justfix-grey-700;
         .dropdown-container {
-          position: absolute;
           display: flex;
           flex-direction: column;
-          top: calc(var(--filter-bar-top-height)); // borders
-          left: 0;
-          max-height: none;
-          height: calc(100vh - var(--filter-bar-top-height));
           width: 100%;
           padding: 0;
           background-color: $justfix-table-grey;
           border-radius: 0;
           border: none;
+          top: unset;
+        }
+        & > .dropdown-container {
+          position: absolute;
+          top: calc(var(--filter-bar-top-height)); // borders
+          left: 0;
+          max-height: none;
+          height: calc(100vh - var(--filter-bar-top-height));
 
           &.scroll-gradient {
             // https://css-scroll-shadows.vercel.app/
@@ -408,11 +413,18 @@
           }
 
           .filter {
-            height: var(--filter-bar-height);
             border-radius: 0;
             box-sizing: border-box;
             border: none;
             border-bottom: 0.1rem solid $justfix-grey-400;
+            &.filter-toggle {
+              height: var(--filter-bar-height);
+              padding: 0 2.4rem;
+            }
+            &.filter-accordion > summary {
+              height: var(--filter-bar-height);
+              padding: 0 2.4rem;
+            }
             &.active:not(.filter-toggle) {
               background-color: $justfix-table-grey;
               color: $justfix-black;
@@ -429,7 +441,7 @@
               .dropdown-container {
                 align-items: flex-start;
                 width: 100%;
-                padding: 2.4rem;
+                padding: 0 2.4rem;
                 .filter-subtitle-container {
                   padding: 0;
                   .filter-subtitle {

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -77,7 +77,6 @@
       border: 0.1rem solid $justfix-black;
       border-radius: 0.8rem;
       text-transform: uppercase;
-      padding: 1rem;
       display: flex;
       align-items: center;
       // height based on toggle toggle checkbox plus 1rem padding
@@ -101,6 +100,7 @@
 
     .filter-toggle {
       gap: 1rem;
+      padding: 1rem;
       .checkbox {
         box-sizing: border-box;
         border: 0.1rem solid $justfix-black;
@@ -127,8 +127,8 @@
       position: relative;
 
       summary {
-        // typical flex stretch doesn't seem to work in summary/details
         height: 100%;
+        padding: 0 1rem 0 1rem;
         display: flex;
         align-items: center;
         position: relative;
@@ -446,12 +446,18 @@
               }
             }
           }
-          .filter-accordion summary {
-            position: relative;
-            .chevronIcon {
-              @include for-phone-only() {
-                margin-left: auto;
+
+          .filter-accordion {
+            summary {
+              position: relative;
+              .chevronIcon {
+                @include for-phone-only() {
+                  margin-left: auto;
+                }
               }
+            }
+            .dropdown-container {
+              position: relative;
             }
           }
           .zip-accordion {


### PR DESCRIPTION
Adjust the styles for the mobile filter menu to make sure all of the individual filter dropdowns stay stacked together (previously everything below the active one was hidden).

![image](https://user-images.githubusercontent.com/16906516/225760920-70e42c29-3bc4-43ff-b0f2-ac24b03dbd7b.png)

This also make a small fix to the zipcode input that was causing horizontal scroll

[sc-11884]

[sc-11809]