### PR TITLE
use same style for "new search" button as for "export"

### DIFF
--- a/client/src/components/AddressToolbar.tsx
+++ b/client/src/components/AddressToolbar.tsx
@@ -28,7 +28,7 @@ const AddressToolbar: React.FC<AddressToolbarProps> = ({ searchAddr, assocAddrs 
     <div className="AddressToolbar">
       <div className="btn-group float-right">
         <Link
-          className="btn btn-primary"
+          className="btn"
           onClick={() => {
             logAmplitudeEvent("newSearch");
             window.gtag("event", "new-search");


### PR DESCRIPTION
Anticipating the "map/table" toggle design wanted to change these button styles so it doesn't look like the same sort of thing. 

before
![image](https://user-images.githubusercontent.com/16906516/225767183-e80d5f3b-595d-41d0-a29e-fa300555b87a.png)

after
![image](https://user-images.githubusercontent.com/16906516/225767197-fe22ecf3-f645-417b-9fd9-f725eb94fc05.png)

[sc-11499]