### PR TITLE
multiselect dropdown - add checkboxes, keep searchbar text, keep selected options in list

### DIFF
--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -343,13 +343,7 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
   }
 
   renderOptionList() {
-    const {
-      id,
-      style,
-      emptyRecordMsg,
-      loading,
-      loadingMessage = "loading...",
-    } = this.props;
+    const { id, style, emptyRecordMsg, loading, loadingMessage = "loading..." } = this.props;
     const { options, highlightOption } = this.state;
     if (loading) {
       return (

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -20,7 +20,6 @@ export interface IMultiselectProps {
   showCheckbox?: boolean;
   selectionLimit?: any;
   placeholder?: string;
-  groupBy?: string;
   loading?: boolean;
   style?: object;
   emptyRecordMsg?: string;
@@ -66,7 +65,6 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
       highlightOption: props.avoidHighlightFirstOption ? -1 : 0,
       showCheckbox: props.showCheckbox,
       keepSearchTerm: props.keepSearchTerm,
-      groupedObject: [],
       hasError: false,
     };
     // @ts-ignore
@@ -91,7 +89,6 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
     this.isSelectedValue = this.isSelectedValue.bind(this);
     this.fadeOutSelection = this.fadeOutSelection.bind(this);
     this.isDisablePreSelectedValues = this.isDisablePreSelectedValues.bind(this);
-    this.renderGroupByOptions = this.renderGroupByOptions.bind(this);
     this.renderNormalOption = this.renderNormalOption.bind(this);
     this.listenerCallback = this.listenerCallback.bind(this);
     this.resetSelectedValues = this.resetSelectedValues.bind(this);
@@ -103,13 +100,9 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
   }
 
   initialSetValue() {
-    const { showCheckbox, groupBy } = this.props;
-    const { options } = this.state;
+    const { showCheckbox } = this.props;
     if (!showCheckbox) {
       this.removeSelectedValuesFromOptions(false);
-    }
-    if (groupBy) {
-      this.groupByOptions(options);
     }
   }
 
@@ -183,11 +176,8 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
 
   // Skipcheck flag - value will be true when the func called from on deselect anything.
   removeSelectedValuesFromOptions(skipCheck) {
-    const { isObject, displayValue, groupBy } = this.props;
-    const { selectedValues = [], unfilteredOptions, options } = this.state;
-    if (!skipCheck && groupBy) {
-      this.groupByOptions(options);
-    }
+    const { isObject, displayValue } = this.props;
+    const { selectedValues = [], unfilteredOptions } = this.state;
     if (!selectedValues.length && !skipCheck) {
       return;
     }
@@ -197,9 +187,6 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
           ? true
           : false;
       });
-      if (groupBy) {
-        this.groupByOptions(optionList);
-      }
       this.setState(
         { options: optionList, filteredOptions: optionList },
         this.filterOptionsByInput
@@ -209,18 +196,6 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
     let optionList = unfilteredOptions.filter((item) => selectedValues.indexOf(item) === -1);
 
     this.setState({ options: optionList, filteredOptions: optionList }, this.filterOptionsByInput);
-  }
-
-  groupByOptions(options) {
-    const { groupBy } = this.props;
-    const groupedObject = options.reduce(function (r, a) {
-      const key = a[groupBy] || "Others";
-      r[key] = r[key] || [];
-      r[key].push(a);
-      return r;
-    }, Object.create({}));
-
-    this.setState({ groupedObject });
   }
 
   onChange(event) {
@@ -252,7 +227,6 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
     } else {
       options = filteredOptions.filter((i) => this.matchValues(i, inputValue));
     }
-    this.groupByOptions(options);
     this.setState({ options });
   }
 
@@ -371,7 +345,6 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
   renderOptionList() {
     const {
       id,
-      groupBy,
       style,
       emptyRecordMsg,
       loading,
@@ -403,53 +376,9 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
             {emptyRecordMsg}
           </span>
         )}
-        {!groupBy ? this.renderNormalOption() : this.renderGroupByOptions()}
+        {this.renderNormalOption()}
       </ul>
     );
-  }
-
-  renderGroupByOptions() {
-    const { isObject = false, displayValue, showCheckbox, style } = this.props;
-    const { groupedObject } = this.state;
-    return Object.keys(groupedObject).map((obj) => {
-      return (
-        <React.Fragment key={obj}>
-          <li className="groupHeading" style={style["groupHeading"]}>
-            {obj}
-          </li>
-          {groupedObject[obj].map((option, i) => {
-            const isSelected = this.isSelectedValue(option);
-            return (
-              <li
-                key={`option${i}`}
-                style={style["option"]}
-                className={`groupChildEle option ${isSelected ? "selected" : ""} ${
-                  this.fadeOutSelection(option) ? "disableSelection" : ""
-                } ${this.isDisablePreSelectedValues(option) ? "disableSelection" : ""}`}
-                onClick={() => this.onSelectItem(option)}
-                onKeyDown={this.onEscKeyCloseOptionList}
-              >
-                {showCheckbox && (
-                  <input
-                    type="checkbox"
-                    className={"checkbox"}
-                    readOnly
-                    checked={isSelected}
-                    onKeyDown={this.onEscKeyCloseOptionList}
-                  />
-                )}
-                <span>
-                  {this.props.optionValueDecorator(
-                    isObject ? option[displayValue] : (option || "").toString(),
-                    option
-                  )}
-                </span>
-              </li>
-            );
-          })}
-        </React.Fragment>
-      );
-    });
   }
 
   renderNormalOption() {
@@ -756,7 +685,6 @@ Multiselect.defaultProps = {
   showCheckbox: false,
   selectionLimit: -1,
   placeholder: <Trans>"Select"</Trans>,
-  groupBy: "",
   style: {},
   emptyRecordMsg: <Trans>"No Options Available"</Trans>,
   onApply: () => {},

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -399,6 +399,7 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
           {showCheckbox && (
             <input
               id={`option-check-${i}`}
+              aria-labelledby={`option-label-${i}`}
               type="checkbox"
               readOnly
               className="checkbox"
@@ -406,12 +407,12 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
               onKeyDown={this.onEscKeyCloseOptionList}
             />
           )}
-          <span>
+          <label id={`option-label-${i}`} htmlFor={`option-check-${i}`}>
             {this.props.optionValueDecorator(
               isObject ? option[displayValue] : (option || "").toString(),
               option
             )}
-          </span>
+          </label>
         </li>
       );
     });

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -156,6 +156,8 @@ export const PortfolioFilters = React.memo(
               id="filter-ownernames-multiselect"
               infoAlert={OwnernamesInfoAlert}
               avoidHighlightFirstOption={true}
+              showCheckbox={true}
+              keepSearchTerm={true}
             />
           </FilterAccordion>
           <FilterAccordion
@@ -194,6 +196,8 @@ export const PortfolioFilters = React.memo(
               id="filter-zip-multiselect"
               onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
               avoidHighlightFirstOption={true}
+              showCheckbox={true}
+              keepSearchTerm={true}
             />
           </FilterAccordion>
         </FiltersWrapper>
@@ -450,6 +454,7 @@ function FilterAccordion(props: {
         returnFocusOnDeactivate: false,
         onDeactivate: () => setIsOpen(false),
         initialFocus: initialFocus,
+        escapeDeactivates: false,
       }}
     >
       <details

--- a/client/src/styles/Multiselect.scss
+++ b/client/src/styles/Multiselect.scss
@@ -126,7 +126,7 @@
               transform: rotate(45deg);
             }
           }
-          span {
+          label {
             align-self: center;
           }
         }

--- a/client/src/styles/Multiselect.scss
+++ b/client/src/styles/Multiselect.scss
@@ -1,128 +1,169 @@
 @import "./vars";
 
-// Styles copied from 'multiselect-react-dropdown' (and a few edits)
-.multiSelectContainer,
-.multiSelectContainer *,
-.multiSelectContainer ::after,
-.multiSelectContainer ::before {
-  box-sizing: border-box;
-}
-
+// Styles adapted from 'multiselect-react-dropdown'
 .multiSelectContainer {
   position: relative;
   text-align: left;
-}
-.disable_ms {
-  pointer-events: none;
-  opacity: 0.5;
-}
-.display-none {
-  display: none;
-}
-.searchWrapper {
-  border: 1px solid #cccccc;
-  border-radius: 4px;
-  padding: 5px;
-  min-height: 22px;
-  position: relative;
-  &.hasError {
-    outline: 2px $justfix-orange solid;
-    outline-offset: -2px;
+
+  &,
+  & *,
+  & ::after,
+  & ::before {
+    box-sizing: border-box;
+  }
+
+  &.disable_ms,
+  .disable_ms {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+  &.display-none,
+  .display-none {
+    display: none;
+  }
+  .searchWrapper {
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+    padding: 5px;
+    min-height: 22px;
+    position: relative;
+    &.hasError {
+      outline: 2px $justfix-orange solid;
+      outline-offset: -2px;
+    }
+  }
+  input {
+    border: none;
+    margin-top: 3px;
+    background: transparent;
+    &:focus {
+      outline: none;
+    }
+  }
+  .chip {
+    padding: 4px 10px;
+    background: #0096fb;
+    margin-right: 5px;
+    margin-bottom: 5px;
+    border-radius: 11px;
+    display: inline-flex;
+    align-items: center;
+    font-size: 1.4rem;
+    line-height: 100%;
+    color: #fff;
+    white-space: nowrap;
+  }
+  .singleChip {
+    background: none;
+    border-radius: none;
+    color: inherit;
+    white-space: nowrap;
+    i {
+      display: none;
+    }
+  }
+  .optionListContainer {
+    position: absolute;
+    width: 100%;
+    background: #fff;
+    border-radius: 4px;
+    z-index: 2;
+    ul {
+      display: block;
+      padding: 0;
+      margin: 0;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      max-height: 250px;
+      overflow-y: auto;
+      li {
+        display: flex;
+        font-size: 1.6rem;
+        gap: 1.6rem;
+        padding: 0.6rem 1.2rem;
+        &:hover {
+          cursor: pointer;
+          text-decoration: underline;
+        }
+        &.groupHeading {
+          color: #908e8e;
+          pointer-events: none;
+          padding: 5px 15px;
+        }
+        &.groupChildEle {
+          padding-left: 30px;
+        }
+        input {
+          --box-size: 1.8rem;
+
+          -webkit-appearance: none;
+          -moz-appearance: none;
+          -o-appearance: none;
+          appearance: none;
+
+          position: relative;
+          border: 0.1rem solid $justfix-black;
+          min-height: calc(var(--box-size));
+          min-width: calc(var(--box-size));
+          height: calc(var(--box-size));
+          width: calc(var(--box-size));
+          border-radius: 0.4rem;
+          margin: 0;
+
+          &:checked {
+            background-color: $justfix-black;
+            color: $justfix-white;
+            border-color: $justfix-black;
+            &:checked:before {
+              content: "";
+              position: absolute;
+              left: 0.6rem;
+              top: 0.2rem;
+              width: 0.5rem;
+              height: 1rem;
+              border: solid $justfix-white;
+              border-width: 0 0.2rem 0.2rem 0;
+              transform: rotate(45deg);
+            }
+          }
+          span {
+            align-self: center;
+          }
+        }
+      }
+    }
+  }
+  .disableSelection {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+  .highlightOption {
+    text-decoration: underline;
+  }
+  .displayBlock {
+    display: block;
+  }
+  .displayNone {
+    display: none;
+  }
+  .notFound {
+    padding: 10px;
+    display: block;
+  }
+  .singleSelect {
+    padding-right: 20px;
+  }
+  .icon_down_dir {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 14px;
+    &:before {
+      content: "\e803";
+    }
+  }
+  .custom-close {
+    display: flex;
   }
 }
-.multiSelectContainer input {
-  border: none;
-  margin-top: 3px;
-  background: transparent;
-}
-.multiSelectContainer input:focus {
-  outline: none;
-}
-.chip {
-  padding: 4px 10px;
-  background: #0096fb;
-  margin-right: 5px;
-  margin-bottom: 5px;
-  border-radius: 11px;
-  display: inline-flex;
-  align-items: center;
-  font-size: 1.4rem;
-  line-height: 100%;
-  color: #fff;
-  white-space: nowrap;
-}
-.singleChip {
-  background: none;
-  border-radius: none;
-  color: inherit;
-  white-space: nowrap;
-}
-.singleChip i {
-  display: none;
-}
-.optionListContainer {
-  position: absolute;
-  width: 100%;
-  background: #fff;
-  border-radius: 4px;
-  z-index: 2;
-}
-.multiSelectContainer ul {
-  display: block;
-  padding: 0;
-  margin: 0;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  max-height: 250px;
-  overflow-y: auto;
-}
-.multiSelectContainer li {
-  padding: 0.6rem 1.2rem;
-}
-.multiSelectContainer li:hover {
-  cursor: pointer;
-  text-decoration: underline;
-}
-.disableSelection {
-  pointer-events: none;
-  opacity: 0.5;
-}
-.highlightOption {
-  text-decoration: underline;
-}
-.displayBlock {
-  display: block;
-}
-.displayNone {
-  display: none;
-}
-.notFound {
-  padding: 10px;
-  display: block;
-}
-.singleSelect {
-  padding-right: 20px;
-}
-li.groupHeading {
-  color: #908e8e;
-  pointer-events: none;
-  padding: 5px 15px;
-}
-li.groupChildEle {
-  padding-left: 30px;
-}
-.icon_down_dir {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 14px;
-}
-.icon_down_dir:before {
-  content: "\e803";
-}
-.custom-close {
-  display: flex;
-}
-
-// JF custom styles

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -219,6 +219,9 @@
             display: flex;
             flex-direction: column;
             margin: 0.8rem 0;
+            input {
+              font-size: 1.6rem;
+            }
           }
           .minmax-container {
             padding: 1.2rem;
@@ -422,6 +425,7 @@
             border-bottom: 0.1rem solid $justfix-grey-400;
             &.filter-toggle {
               height: var(--filter-bar-height);
+              min-height: var(--filter-bar-height);
               padding: 0 2.4rem;
             }
             &.filter-accordion > summary {

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -297,6 +297,7 @@
             }
             input {
               width: -webkit-fill-available;
+              height: -webkit-fill-available;
             }
           }
 
@@ -425,7 +426,6 @@
             border-bottom: 0.1rem solid $justfix-grey-400;
             &.filter-toggle {
               height: var(--filter-bar-height);
-              min-height: var(--filter-bar-height);
               padding: 0 2.4rem;
             }
             &.filter-accordion > summary {
@@ -478,6 +478,9 @@
             .dropdown-container {
               position: relative;
             }
+          }
+          .search-wrapper {
+            height: 5rem;
           }
           .zip-accordion {
             .clear-all-container,


### PR DESCRIPTION
A few changes related to the multiselect component:

* The dropdown options are changed so that selected options aren't removed from the list. Instead they have a checkbox to show if they are selected. And for keyboard navigation/hover they are still underlined. 
* The component is improved for tab navigation/screen readers, but it's still not working on all platforms, and a follow up PR will address that. For now this makes sure that escape closes the option list returning to the searchbar (so you don't get cught in the often super long lists). The screen reader experience is working mostly in Chrome/OSX, but not on Windows. 
* The Multiselect component styles are cleaned up so that it's all nested under the component class
* The font size for the searchbar input is increased to 16px to prevent auto-zoom on focus for mobile
* Search bar height increased for mobile
* Search bar inputs are no longer cleared when an option is selected
* I've also cut the "grouby" option for multiselect, which we aren't using just to simplify that component a bit.

![image](https://user-images.githubusercontent.com/16906516/228067514-58c5d427-be75-40cb-91d4-54fc86ceec51.png)
![image](https://user-images.githubusercontent.com/16906516/228067752-b50b65c3-02c2-48c8-b85b-2c923e17f408.png)

[sc-11701]
[sc-11808]
[sc-11864]
[sc-11946]
[sc-11687]