### PR TITLE
fix RS units toggle height and hover on mobile

### DIFF
--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -422,7 +422,12 @@
             border-bottom: 0.1rem solid $justfix-grey-400;
             &.filter-toggle {
               height: var(--filter-bar-height);
+              min-height: var(--filter-bar-height);
               padding: 0 2.4rem;
+              &[aria-pressed="false"]:hover,
+              &[aria-pressed="true"] {
+                text-decoration: none;
+              }
             }
             &.filter-accordion > summary {
               height: var(--filter-bar-height);
@@ -431,9 +436,6 @@
             &.active:not(.filter-toggle) {
               background-color: $justfix-table-grey;
               color: $justfix-black;
-              text-decoration: none;
-            }
-            &.filter-toggle[aria-pressed="true"] {
               text-decoration: none;
             }
             &[open] {


### PR DESCRIPTION
Fixes a couple small bugs for the RS units toggle on mobile:
* It was getting squished when the other filter accordions were expanded
* It was staying underlined after toggling it off (mobile hover state)

[sc-11939]
[sc-11926]