### PR TITLE
fix min-max errors and units filter styles

### DIFF
--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -611,7 +611,7 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
       >
         {hasError && (
           <Alert type="error" variant="primary" closeType="none" role="status">
-            <Trans>Error</Trans>
+            <Trans>Make a selection from the list or clear search text</Trans>
           </Alert>
         )}
         <div className="selectedListContainer">

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -493,55 +493,59 @@ function MinMaxSelect(props: {
 }) {
   const { options, onApply, id, onFocusInput } = props;
   const [minMax, setMinMax] = React.useState<FilterNumberRange>(MINMAX_DEFAULT);
-  const [minMaxErrors, setMinMaxErrors] = React.useState([false, false]);
+  const [minMaxErrors, setMinMaxErrors] = React.useState<MinMaxErrors>([false, false, undefined]);
 
   return (
     <form id={id} className="minmax-container">
-      <div className="labels-container">
-        <label htmlFor="min-input">
-          <Trans>MIN</Trans>
-        </label>
-        <label htmlFor="max-input">
-          <Trans>MAX</Trans>
-        </label>
-      </div>
       {minMaxErrors[0] || minMaxErrors[1] ? (
         <div className="alerts-container">
           <Alert type="error" variant="primary" closeType="none" role="status">
-            <Trans>Error</Trans>
+            {minMaxErrors[2]}
           </Alert>
         </div>
       ) : (
         <></>
       )}
-      <div className="inputs-container">
-        <input
-          id={`${id || "minmax-select"}_min-input`}
-          type="number"
-          min={options[0]}
-          max={options[1]}
-          value={minMax[0] == null ? "" : minMax[0]}
-          onChange={(e) => {
-            setMinMaxErrors([false, false]);
-            setMinMax([cleanNumberInput(e.target.value), minMax[1]]);
-          }}
-          onFocus={onFocusInput}
-          className={classnames("min-input", { hasError: minMaxErrors[0] })}
-        />
-        <Trans>and</Trans>
-        <input
-          id={`${id || "minmax-select"}_max-input`}
-          type="number"
-          min={options[0]}
-          max={options[1]}
-          value={minMax[1] == null ? "" : minMax[1]}
-          onChange={(e) => {
-            setMinMaxErrors([false, false]);
-            setMinMax([minMax[0], cleanNumberInput(e.target.value)]);
-          }}
-          onFocus={onFocusInput}
-          className={classnames("max-input", { hasError: minMaxErrors[1] })}
-        />
+      <div className="label-input-container">
+        <div className="labels-container">
+          <label htmlFor="min-input">
+            <Trans>MIN</Trans>
+          </label>
+          <label htmlFor="max-input">
+            <Trans>MAX</Trans>
+          </label>
+        </div>
+        <div className="inputs-container">
+          <input
+            id={`${id || "minmax-select"}_min-input`}
+            type="number"
+            min={options[0]}
+            max={options[1]}
+            value={minMax[0] == null ? "" : minMax[0]}
+            onKeyDown={preventNonNumericalInput}
+            onChange={(e) => {
+              setMinMaxErrors([false, false, undefined]);
+              setMinMax([cleanNumberInput(e.target.value), minMax[1]]);
+            }}
+            onFocus={onFocusInput}
+            className={classnames("min-input", { hasError: minMaxErrors[0] })}
+          />
+          <Trans>to</Trans>
+          <input
+            id={`${id || "minmax-select"}_max-input`}
+            type="number"
+            min={options[0]}
+            max={options[1]}
+            value={minMax[1] == null ? "" : minMax[1]}
+            onKeyDown={preventNonNumericalInput}
+            onChange={(e) => {
+              setMinMaxErrors([false, false, undefined]);
+              setMinMax([minMax[0], cleanNumberInput(e.target.value)]);
+            }}
+            onFocus={onFocusInput}
+            className={classnames("max-input", { hasError: minMaxErrors[1] })}
+          />
+        </div>
       </div>
       <button
         onClick={(e) => {
@@ -566,13 +570,42 @@ function cleanNumberInput(value: string): number | undefined {
   return Number(value);
 }
 
-function minMaxHasError(values: FilterNumberRange, options: FilterNumberRange): [boolean, boolean] {
-  const minHasError =
-    values[0] == null
-      ? false
-      : values[0] < 0 || (options[1] == null ? false : values[0] >= options[1]);
+type MinMaxErrors = [boolean, boolean, JSX.Element | undefined];
+function minMaxHasError(values: FilterNumberRange, options: FilterNumberRange): MinMaxErrors {
+  const [minValue, maxValue] = values;
+  const [minOption, maxOption] = options;
+  let minHasError = false;
+  let maxHasError = false;
+  let errorMessage: JSX.Element | undefined;
 
-  const maxHasError = values[1] == null || options[0] == null ? false : values[1] <= options[0];
+  if (minValue != null && maxValue != null && minValue > maxValue) {
+    minHasError = true;
+    maxHasError = true;
+    errorMessage = <Trans>Min must be less than or equal to Max</Trans>;
+  }
+  if (minValue != null && minValue < 0) {
+    minHasError = true;
+    errorMessage = <Trans>Min must be greater than 0</Trans>;
+  }
+  if (maxValue != null && maxValue < 0) {
+    minHasError = true;
+    errorMessage = <Trans>Max must be greater than 0</Trans>;
+  }
+  if (maxValue != null && minOption != null && maxValue < minOption) {
+    maxHasError = true;
+    errorMessage = <Trans>Max must be greater than {minOption}</Trans>;
+  }
+  if (minValue != null && maxOption != null && minValue > maxOption) {
+    minHasError = true;
+    errorMessage = <Trans>Min must be less than {maxOption}</Trans>;
+  }
 
-  return [minHasError, maxHasError];
+  return [minHasError, maxHasError, errorMessage];
+}
+
+// Firefox doesn't prevent typing non-numeric characters
+// https://stackoverflow.com/a/49924215/7051239
+function preventNonNumericalInput(e: React.KeyboardEvent) {
+  e = e || window.event;
+  if (!/^\d*$/.test(e.key) && e.key in ["Enter", "Delete"]) e.preventDefault();
 }

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -46,7 +46,7 @@ msgstr "(expires {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
-#: src/components/PropertiesList.tsx:88
+#: src/components/PropertiesList.tsx:79
 msgid "(this may take a while)"
 msgstr "(this may take a while)"
 
@@ -112,7 +112,7 @@ msgstr "Across owners and management staff, the most common {0, plural, one {nam
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PortfolioTable.tsx:44
+#: src/components/PortfolioTable.tsx:58
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Address"
@@ -129,7 +129,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PortfolioTable.tsx:307
+#: src/components/PortfolioTable.tsx:319
 msgid "Amount"
 msgstr "Amount"
 
@@ -142,7 +142,7 @@ msgstr "An “eviction filing” is a legal case for eviction commenced by a lan
 #~ msgstr "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 
 #: src/components/Multiselect.tsx:476
-#: src/components/PortfolioFilters.tsx:285
+#: src/components/PortfolioFilters.tsx:288
 msgid "Apply"
 msgstr "Apply"
 
@@ -162,7 +162,7 @@ msgstr "BELL/BUZZER/INTERCOM"
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/PortfolioTable.tsx:69
+#: src/components/PortfolioTable.tsx:83
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -192,7 +192,7 @@ msgstr "Building info"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PortfolioTable.tsx:103
+#: src/components/PortfolioTable.tsx:115
 msgid "Built"
 msgstr "Built"
 
@@ -298,7 +298,7 @@ msgstr "Corporate Owner"
 msgid "Corporation"
 msgstr "Corporation"
 
-#: src/components/PortfolioTable.tsx:89
+#: src/components/PortfolioTable.tsx:101
 msgid "Council"
 msgstr "Council"
 
@@ -322,7 +322,7 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PortfolioTable.tsx:296
+#: src/components/PortfolioTable.tsx:308
 msgid "Date"
 msgstr "Date"
 
@@ -378,8 +378,8 @@ msgstr "Enter email"
 
 #: src/components/Multiselect.tsx:445
 #: src/components/PortfolioFilters.tsx:261
-msgid "Error"
-msgstr "Error"
+#~ msgid "Error"
+#~ msgstr "Error"
 
 #: src/components/BuildingStatsTable.tsx:80
 #: src/components/IndicatorsDatasets.tsx:126
@@ -401,7 +401,7 @@ msgstr "Evictions"
 msgid "Evictions Executed"
 msgstr "Evictions Executed"
 
-#: src/components/PortfolioTable.tsx:208
+#: src/components/PortfolioTable.tsx:220
 msgid "Evictions Since 2017"
 msgstr "Evictions Since 2017"
 
@@ -413,7 +413,7 @@ msgstr "Evictions executed by NYC Marshals since 2017. ANHD and the Housing Data
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
-#: src/components/PortfolioTable.tsx:223
+#: src/components/PortfolioTable.tsx:235
 msgid "Executed"
 msgstr "Executed"
 
@@ -441,7 +441,7 @@ msgstr "FLOORING/STAIRS"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PortfolioTable.tsx:214
+#: src/components/PortfolioTable.tsx:226
 msgid "Filed"
 msgstr "Filed"
 
@@ -469,7 +469,7 @@ msgstr "Find other buildings your landlord might own:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
-#: src/components/PortfolioTable.tsx:333
+#: src/components/PortfolioTable.tsx:345
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -486,7 +486,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:153
+#: src/components/PortfolioTable.tsx:165
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -495,7 +495,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:186
+#: src/components/PortfolioTable.tsx:198
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -564,7 +564,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PortfolioTable.tsx:98
+#: src/components/PortfolioTable.tsx:110
 msgid "Information"
 msgstr "Information"
 
@@ -593,7 +593,7 @@ msgid "LOCKS"
 msgstr "LOCKS"
 
 #: src/components/PortfolioFilters.tsx:83
-#: src/components/PortfolioTable.tsx:232
+#: src/components/PortfolioTable.tsx:244
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -605,11 +605,11 @@ msgstr "Landlord name"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PortfolioTable.tsx:166
+#: src/components/PortfolioTable.tsx:178
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PortfolioTable.tsx:291
+#: src/components/PortfolioTable.tsx:303
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -639,22 +639,22 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PortfolioTable.tsx:315
-#: src/components/PortfolioTable.tsx:319
+#: src/components/PortfolioTable.tsx:327
+#: src/components/PortfolioTable.tsx:331
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:89
+#: src/components/PropertiesList.tsx:80
 #: src/components/PropertiesMap.tsx:158
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:86
+#: src/components/PropertiesList.tsx:77
 msgid "Loading {0} rows"
 msgstr "Loading {0} rows"
 
-#: src/components/PortfolioTable.tsx:55
+#: src/components/PortfolioTable.tsx:69
 msgid "Location"
 msgstr "Location"
 
@@ -670,11 +670,11 @@ msgstr "Looking for more information?"
 msgid "MAILBOX"
 msgstr "MAILBOX"
 
-#: src/components/PortfolioFilters.tsx:256
+#: src/components/PortfolioFilters.tsx:263
 msgid "MAX"
 msgstr "MAX"
 
-#: src/components/PortfolioFilters.tsx:253
+#: src/components/PortfolioFilters.tsx:260
 msgid "MIN"
 msgstr "MIN"
 
@@ -690,9 +690,21 @@ msgstr "Made with NYC ♥ by the team at <0>JustFix.org</0>"
 msgid "Maintenance code violations"
 msgstr "Maintenance code violations"
 
+#: src/components/Multiselect.tsx:445
+msgid "Make a selection from the list or clear search text"
+msgstr "Make a selection from the list or clear search text"
+
 #: src/components/Multiselect.tsx:450
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
+
+#: src/components/PortfolioFilters.tsx:314
+msgid "Max must be greater than 0"
+msgstr "Max must be greater than 0"
+
+#: src/components/PortfolioFilters.tsx:318
+msgid "Max must be greater than {minOption}"
+msgstr "Max must be greater than {minOption}"
 
 #: src/components/PortfolioFilters.tsx:145
 #~ msgid "Maximum"
@@ -710,6 +722,18 @@ msgstr "Menu"
 #: src/containers/Methodology.tsx:14
 msgid "Methodology"
 msgstr "Methodology"
+
+#: src/components/PortfolioFilters.tsx:310
+msgid "Min must be greater than 0"
+msgstr "Min must be greater than 0"
+
+#: src/components/PortfolioFilters.tsx:306
+msgid "Min must be less than or equal to Max"
+msgstr "Min must be less than or equal to Max"
+
+#: src/components/PortfolioFilters.tsx:322
+msgid "Min must be less than {maxOption}"
+msgstr "Min must be less than {maxOption}"
 
 #: src/components/PortfolioFilters.tsx:140
 #~ msgid "Minimum"
@@ -761,11 +785,11 @@ msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:486
+#: src/components/PortfolioTable.tsx:501
 msgid "Next"
 msgstr "Next"
 
-#: src/components/PortfolioTable.tsx:337
+#: src/components/PortfolioTable.tsx:349
 msgid "No"
 msgstr "No"
 
@@ -845,7 +869,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PortfolioTable.tsx:191
+#: src/components/PortfolioTable.tsx:203
 msgid "Open"
 msgstr "Open"
 
@@ -861,7 +885,7 @@ msgstr "Overview"
 msgid "Owner Names"
 msgstr "Owner Names"
 
-#: src/components/PortfolioTable.tsx:245
+#: src/components/PortfolioTable.tsx:257
 msgid "Owner/Manager"
 msgstr "Owner/Manager"
 
@@ -885,7 +909,7 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/PortfolioTable.tsx:466
+#: src/components/PortfolioTable.tsx:481
 msgid "Page"
 msgstr "Page"
 
@@ -907,7 +931,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Portfolio Table Redesign"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:460
+#: src/components/PortfolioTable.tsx:475
 msgid "Previous"
 msgstr "Previous"
 
@@ -921,7 +945,7 @@ msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:121
+#: src/components/PortfolioTable.tsx:133
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -1047,7 +1071,7 @@ msgstr "Sign up for email updates"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/components/PortfolioTable.tsx:513
+#: src/components/PortfolioTable.tsx:528
 msgid "Since {year}"
 msgstr "Since {year}"
 
@@ -1079,7 +1103,7 @@ msgstr "Source code"
 msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:513
+#: src/components/PortfolioTable.tsx:528
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
@@ -1104,7 +1128,7 @@ msgstr "TENANT HARASSMENT"
 msgid "Take action on JustFix.org!"
 msgstr "Take action on JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:269
+#: src/components/PortfolioTable.tsx:281
 msgid "Tax Exemptions"
 msgstr "Tax Exemptions"
 
@@ -1249,13 +1273,13 @@ msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PortfolioTable.tsx:174
+#: src/components/PortfolioTable.tsx:186
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:158
-#: src/components/PortfolioTable.tsx:199
+#: src/components/PortfolioTable.tsx:170
+#: src/components/PortfolioTable.tsx:211
 msgid "Total"
 msgstr "Total"
 
@@ -1276,7 +1300,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:111
+#: src/components/PortfolioTable.tsx:123
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -1302,6 +1326,11 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
+#: src/components/PortfolioTable.tsx:358
+#: src/components/PortfolioTable.tsx:365
+msgid "View Detail"
+msgstr "View Detail"
+
 #: src/components/PortfolioFilters.tsx:176
 msgid "View Results"
 msgstr "View Results"
@@ -1317,8 +1346,8 @@ msgstr "View data over time ↗︎"
 
 #: src/components/PortfolioTable.tsx:346
 #: src/components/PortfolioTable.tsx:353
-msgid "View detail"
-msgstr "View detail"
+#~ msgid "View detail"
+#~ msgstr "View detail"
 
 #: src/components/UsefulLinks.tsx:12
 msgid "View documents on <0>ACRIS</0>"
@@ -1408,7 +1437,7 @@ msgstr "What happens if the landlord has failed to register?"
 msgid "What's New"
 msgstr "What's New"
 
-#: src/components/PortfolioFilters.tsx:238
+#: src/components/PortfolioFilters.tsx:239
 msgid "What's this?"
 msgstr "What's this?"
 
@@ -1456,7 +1485,7 @@ msgstr "Why am I seeing such a big portfolio?"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PortfolioTable.tsx:336
+#: src/components/PortfolioTable.tsx:348
 msgid "Yes"
 msgstr "Yes"
 
@@ -1473,7 +1502,7 @@ msgstr "You are viewing a legacy version of Who Owns What"
 #~ msgstr "You are viewing the old version of Who Owns What."
 
 #: src/components/PortfolioFilters.tsx:89
-#: src/components/PortfolioTable.tsx:60
+#: src/components/PortfolioTable.tsx:74
 msgid "Zipcode"
 msgstr "Zipcode"
 
@@ -1485,7 +1514,6 @@ msgstr "Zoom in"
 msgid "Zoom out"
 msgstr "Zoom out"
 
-#: src/components/PortfolioFilters.tsx:269
 #: src/components/StringifyList.tsx:18
 msgid "and"
 msgstr "and"
@@ -1502,7 +1530,7 @@ msgstr "for ${0}"
 msgid "month"
 msgstr "month"
 
-#: src/components/PortfolioTable.tsx:474
+#: src/components/PortfolioTable.tsx:489
 msgid "of"
 msgstr "of"
 
@@ -1513,6 +1541,10 @@ msgstr "quarter"
 #: src/components/PropertiesMap.tsx:212
 msgid "search address"
 msgstr "search address"
+
+#: src/components/PortfolioFilters.tsx:271
+msgid "to"
+msgstr "to"
 
 #: src/components/Indicators.tsx:18
 msgid "year"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -51,7 +51,7 @@ msgstr "(caduca {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
-#: src/components/PropertiesList.tsx:88
+#: src/components/PropertiesList.tsx:79
 msgid "(this may take a while)"
 msgstr "(esto puede tardar un rato)"
 
@@ -117,7 +117,7 @@ msgstr "En todos los dueños y administradores, {0, plural, one {el nombre más 
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PortfolioTable.tsx:44
+#: src/components/PortfolioTable.tsx:58
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Dirección"
@@ -134,7 +134,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PortfolioTable.tsx:307
+#: src/components/PortfolioTable.tsx:319
 msgid "Amount"
 msgstr "Importe"
 
@@ -147,7 +147,7 @@ msgstr "Una \"demanda de desalojo\" es un caso legal de desalojo iniciado por un
 #~ msgstr "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 
 #: src/components/Multiselect.tsx:476
-#: src/components/PortfolioFilters.tsx:285
+#: src/components/PortfolioFilters.tsx:288
 msgid "Apply"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr "TIMBRE/INTERCOMUNICADOR"
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/PortfolioTable.tsx:69
+#: src/components/PortfolioTable.tsx:83
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -197,7 +197,7 @@ msgstr "Información de edificios"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PortfolioTable.tsx:103
+#: src/components/PortfolioTable.tsx:115
 msgid "Built"
 msgstr "Construido"
 
@@ -303,7 +303,7 @@ msgstr "Dueño Corporativo"
 msgid "Corporation"
 msgstr "Corporación"
 
-#: src/components/PortfolioTable.tsx:89
+#: src/components/PortfolioTable.tsx:101
 msgid "Council"
 msgstr ""
 
@@ -327,7 +327,7 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PortfolioTable.tsx:296
+#: src/components/PortfolioTable.tsx:308
 msgid "Date"
 msgstr "Fecha"
 
@@ -383,8 +383,8 @@ msgstr "Introducir email"
 
 #: src/components/Multiselect.tsx:445
 #: src/components/PortfolioFilters.tsx:261
-msgid "Error"
-msgstr ""
+#~ msgid "Error"
+#~ msgstr ""
 
 #: src/components/BuildingStatsTable.tsx:80
 #: src/components/IndicatorsDatasets.tsx:126
@@ -406,7 +406,7 @@ msgstr "Desalojos"
 msgid "Evictions Executed"
 msgstr "Desalojos ejecutados"
 
-#: src/components/PortfolioTable.tsx:208
+#: src/components/PortfolioTable.tsx:220
 msgid "Evictions Since 2017"
 msgstr "Desalojos desde 2017"
 
@@ -418,7 +418,7 @@ msgstr "Desalojos ejecutados en este edificio por el Mariscal de NYC desde el 20
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 2017. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes del DOI."
 
-#: src/components/PortfolioTable.tsx:223
+#: src/components/PortfolioTable.tsx:235
 msgid "Executed"
 msgstr "Ejecutado"
 
@@ -446,7 +446,7 @@ msgstr "PISO/ESCALERAS"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PortfolioTable.tsx:214
+#: src/components/PortfolioTable.tsx:226
 msgid "Filed"
 msgstr "Presentado"
 
@@ -474,7 +474,7 @@ msgstr "Encuentra otros edificios que tu propietario podría poseer:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
-#: src/components/PortfolioTable.tsx:333
+#: src/components/PortfolioTable.tsx:345
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -491,7 +491,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:153
+#: src/components/PortfolioTable.tsx:165
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -500,7 +500,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontrarás más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:186
+#: src/components/PortfolioTable.tsx:198
 msgid "HPD Violations"
 msgstr "Violaciones del HPD"
 
@@ -569,7 +569,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
-#: src/components/PortfolioTable.tsx:98
+#: src/components/PortfolioTable.tsx:110
 msgid "Information"
 msgstr "Información"
 
@@ -598,7 +598,7 @@ msgid "LOCKS"
 msgstr "CERRADURAS"
 
 #: src/components/PortfolioFilters.tsx:83
-#: src/components/PortfolioTable.tsx:232
+#: src/components/PortfolioTable.tsx:244
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -610,11 +610,11 @@ msgstr "Nombre del dueño"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PortfolioTable.tsx:166
+#: src/components/PortfolioTable.tsx:178
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PortfolioTable.tsx:291
+#: src/components/PortfolioTable.tsx:303
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -644,22 +644,22 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PortfolioTable.tsx:315
-#: src/components/PortfolioTable.tsx:319
+#: src/components/PortfolioTable.tsx:327
+#: src/components/PortfolioTable.tsx:331
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:89
+#: src/components/PropertiesList.tsx:80
 #: src/components/PropertiesMap.tsx:158
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:86
+#: src/components/PropertiesList.tsx:77
 msgid "Loading {0} rows"
 msgstr "Cargando {0} filas"
 
-#: src/components/PortfolioTable.tsx:55
+#: src/components/PortfolioTable.tsx:69
 msgid "Location"
 msgstr "Ubicación"
 
@@ -675,11 +675,11 @@ msgstr "¿Buscas más información?"
 msgid "MAILBOX"
 msgstr "BUZÓN"
 
-#: src/components/PortfolioFilters.tsx:256
+#: src/components/PortfolioFilters.tsx:263
 msgid "MAX"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:253
+#: src/components/PortfolioFilters.tsx:260
 msgid "MIN"
 msgstr ""
 
@@ -695,9 +695,21 @@ msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.org</0>"
 msgid "Maintenance code violations"
 msgstr "Violaciones del código de mantenimiento"
 
+#: src/components/Multiselect.tsx:445
+msgid "Make a selection from the list or clear search text"
+msgstr ""
+
 #: src/components/Multiselect.tsx:450
 #~ msgid "Make a selection."
 #~ msgstr ""
+
+#: src/components/PortfolioFilters.tsx:314
+msgid "Max must be greater than 0"
+msgstr ""
+
+#: src/components/PortfolioFilters.tsx:318
+msgid "Max must be greater than {minOption}"
+msgstr ""
 
 #: src/components/PortfolioFilters.tsx:145
 #~ msgid "Maximum"
@@ -715,6 +727,18 @@ msgstr "Menu"
 #: src/containers/Methodology.tsx:14
 msgid "Methodology"
 msgstr "Metodología"
+
+#: src/components/PortfolioFilters.tsx:310
+msgid "Min must be greater than 0"
+msgstr ""
+
+#: src/components/PortfolioFilters.tsx:306
+msgid "Min must be less than or equal to Max"
+msgstr ""
+
+#: src/components/PortfolioFilters.tsx:322
+msgid "Min must be less than {maxOption}"
+msgstr ""
 
 #: src/components/PortfolioFilters.tsx:140
 #~ msgid "Minimum"
@@ -766,11 +790,11 @@ msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:486
+#: src/components/PortfolioTable.tsx:501
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/components/PortfolioTable.tsx:337
+#: src/components/PortfolioTable.tsx:349
 msgid "No"
 msgstr "No"
 
@@ -850,7 +874,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PortfolioTable.tsx:191
+#: src/components/PortfolioTable.tsx:203
 msgid "Open"
 msgstr "Actuales"
 
@@ -866,7 +890,7 @@ msgstr "General"
 msgid "Owner Names"
 msgstr "Dueños"
 
-#: src/components/PortfolioTable.tsx:245
+#: src/components/PortfolioTable.tsx:257
 msgid "Owner/Manager"
 msgstr ""
 
@@ -890,7 +914,7 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/PortfolioTable.tsx:466
+#: src/components/PortfolioTable.tsx:481
 msgid "Page"
 msgstr ""
 
@@ -912,7 +936,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Rediseño de la tabla del portafolio"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:460
+#: src/components/PortfolioTable.tsx:475
 msgid "Previous"
 msgstr "Anterior"
 
@@ -926,7 +950,7 @@ msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:121
+#: src/components/PortfolioTable.tsx:133
 msgid "RS Units"
 msgstr "Unidades RS"
 
@@ -1052,7 +1076,7 @@ msgstr "Regístrate para recibir noticias por email"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde 2017, los dueños presentaron {totalEvictionFilings, plural, one {un caso de desalojo} other {# casos de desalojo}} y los alguaciles de la ciudad de Nueva York ejecutaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en toda esta cartera."
 
-#: src/components/PortfolioTable.tsx:513
+#: src/components/PortfolioTable.tsx:528
 msgid "Since {year}"
 msgstr "Desde {year}"
 
@@ -1084,7 +1108,7 @@ msgstr "Código fuente"
 msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 msgstr ""
 
-#: src/components/PortfolioTable.tsx:513
+#: src/components/PortfolioTable.tsx:528
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
@@ -1109,7 +1133,7 @@ msgstr "ACOSO DE INQUILINO"
 msgid "Take action on JustFix.org!"
 msgstr "¡Toma acción en JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:269
+#: src/components/PortfolioTable.tsx:281
 msgid "Tax Exemptions"
 msgstr "Exenciones de impuestos"
 
@@ -1254,13 +1278,13 @@ msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PortfolioTable.tsx:174
+#: src/components/PortfolioTable.tsx:186
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:158
-#: src/components/PortfolioTable.tsx:199
+#: src/components/PortfolioTable.tsx:170
+#: src/components/PortfolioTable.tsx:211
 msgid "Total"
 msgstr "Total"
 
@@ -1281,7 +1305,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:111
+#: src/components/PortfolioTable.tsx:123
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades"
@@ -1307,6 +1331,11 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
+#: src/components/PortfolioTable.tsx:358
+#: src/components/PortfolioTable.tsx:365
+msgid "View Detail"
+msgstr ""
+
 #: src/components/PortfolioFilters.tsx:176
 msgid "View Results"
 msgstr ""
@@ -1322,8 +1351,8 @@ msgstr "Ver datos a lo largo del tiempo ↗︎"
 
 #: src/components/PortfolioTable.tsx:346
 #: src/components/PortfolioTable.tsx:353
-msgid "View detail"
-msgstr "Ver detalles"
+#~ msgid "View detail"
+#~ msgstr "Ver detalles"
 
 #: src/components/UsefulLinks.tsx:12
 msgid "View documents on <0>ACRIS</0>"
@@ -1413,7 +1442,7 @@ msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 msgid "What's New"
 msgstr "Qué hay de nuevo"
 
-#: src/components/PortfolioFilters.tsx:238
+#: src/components/PortfolioFilters.tsx:239
 msgid "What's this?"
 msgstr ""
 
@@ -1461,7 +1490,7 @@ msgstr "¿Por qué estoy viendo un portafolio tan grande?"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PortfolioTable.tsx:336
+#: src/components/PortfolioTable.tsx:348
 msgid "Yes"
 msgstr "Sí"
 
@@ -1478,7 +1507,7 @@ msgstr ""
 #~ msgstr "You are viewing the old version of Who Owns What."
 
 #: src/components/PortfolioFilters.tsx:89
-#: src/components/PortfolioTable.tsx:60
+#: src/components/PortfolioTable.tsx:74
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -1490,7 +1519,6 @@ msgstr "Aumentar"
 msgid "Zoom out"
 msgstr "Alejar"
 
-#: src/components/PortfolioFilters.tsx:269
 #: src/components/StringifyList.tsx:18
 msgid "and"
 msgstr "y"
@@ -1507,7 +1535,7 @@ msgstr "por ${0}"
 msgid "month"
 msgstr "mes"
 
-#: src/components/PortfolioTable.tsx:474
+#: src/components/PortfolioTable.tsx:489
 msgid "of"
 msgstr ""
 
@@ -1518,6 +1546,10 @@ msgstr "trimestre"
 #: src/components/PropertiesMap.tsx:212
 msgid "search address"
 msgstr "dirección de búsqueda"
+
+#: src/components/PortfolioFilters.tsx:271
+msgid "to"
+msgstr ""
 
 #: src/components/Indicators.tsx:18
 msgid "year"

--- a/client/src/styles/Multiselect.scss
+++ b/client/src/styles/Multiselect.scss
@@ -21,7 +21,6 @@
 }
 .searchWrapper {
   border: 1px solid #cccccc;
-  border-radius: 4px;
   padding: 5px;
   min-height: 22px;
   position: relative;
@@ -62,9 +61,7 @@
 }
 .optionListContainer {
   position: absolute;
-  width: 100%;
   background: #fff;
-  border-radius: 4px;
   z-index: 2;
 }
 .multiSelectContainer ul {

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -84,10 +84,12 @@
       &[aria-pressed="true"] {
         @include white-on-black();
       }
-      &:not([open]):hover,
-      [open] summary {
-        text-decoration: underline;
-        text-underline-position: under;
+      @include for-tablet-portrait-up() {
+        &:not([open]):hover,
+        [open] summary {
+          text-decoration: underline;
+          text-underline-position: under;
+        }
       }
       &:focus-visible {
         box-shadow: none;
@@ -188,7 +190,6 @@
           z-index: 100;
           overflow-y: scroll;
           max-height: calc(100vh - 25rem);
-          padding: 0.6rem 1.2rem 1.2rem 1.2rem;
           background-color: $justfix-table-grey;
           box-sizing: border-box;
           border: 0.1rem solid $justfix-black;
@@ -201,16 +202,26 @@
           .filter-subtitle-container {
             font-size: 1.2rem;
             color: $justfix-grey-700;
+            @include for-tablet-portrait-up {
+              padding: 1.2rem;
+              margin-bottom: 1.2rem;
+            }
             display: flex;
             width: 100%;
+            @include for-tablet-portrait-up() {
+              border-bottom: 0.1rem solid $justfix-grey;
+            }
             .filter-subtitle {
               margin-right: auto;
             }
 
-            .filter-info:focus-visible {
-              box-shadow: none;
-              outline: 2px solid $focus-outline-color;
-              outline-offset: 2px;
+            .filter-info {
+              color: $justfix-grey-700;
+              &:focus-visible {
+                box-shadow: none;
+                outline: 2px solid $focus-outline-color;
+                outline-offset: 2px;
+              }
             }
           }
 
@@ -218,50 +229,61 @@
           .minmax-container {
             display: flex;
             flex-direction: column;
-            margin: 0.8rem 0;
+            .jf-alert {
+              margin-top: 0.6rem;
+              margin-bottom: 0.4rem;
+            }
           }
           .minmax-container {
-            padding: 1.2rem;
-            border-top: 1px solid $justfix-grey;
             @include for-phone-only {
               border-top: none;
-              padding-left: 0;
             }
 
-            .labels-container {
-              display: flex;
-              color: $justfix-grey-700;
-              margin-bottom: 0.4rem;
-              label:first-child {
-                margin-right: auto;
+            .label-input-container {
+              width: fit-content;
+              padding: 0 1.2rem 1.2rem 1.2rem;
+              @include for-phone-only {
+                padding: 1.2rem 0;
               }
-            }
-            .inputs-container {
-              display: flex;
-              gap: 1rem;
-              align-items: center;
-              justify-content: center;
-              input {
-                background-color: $justfix-white;
-                width: 4.4rem;
-                height: 4.4rem;
-                border: 0.1rem solid $justfix-black;
-                border-radius: 0.2rem;
-                padding: 0.5rem;
-                // remove increment arrows
-                &::-webkit-outer-spin-button,
-                &::-webkit-inner-spin-button {
-                  -webkit-appearance: none;
-                  margin: 0;
+              @include for-tablet-portrait-up() {
+                border-bottom: 0.1rem solid $justfix-grey;
+              }
+              .labels-container {
+                display: flex;
+                color: $justfix-grey-600;
+                font-size: 1.2rem;
+                margin-bottom: 0.4rem;
+                label:first-child {
+                  margin-right: auto;
                 }
-                -moz-appearance: textfield;
+              }
+              .inputs-container {
+                display: flex;
+                gap: 1rem;
+                align-items: center;
+                color: $justfix-grey-600;
+                input {
+                  background-color: $justfix-white;
+                  width: 4.4rem;
+                  height: 4.4rem;
+                  border: 0.1rem solid $justfix-grey-600;
+                  border-radius: 0.2rem;
+                  padding: 0.5rem;
+                  // remove increment arrows
+                  &::-webkit-outer-spin-button,
+                  &::-webkit-inner-spin-button {
+                    -webkit-appearance: none;
+                    margin: 0;
+                  }
+                  -moz-appearance: textfield;
 
-                &:focus-visible {
-                  outline: none;
-                }
-                &.hasError {
-                  outline: 2px $justfix-orange solid;
-                  outline-offset: -2px;
+                  &:focus-visible {
+                    outline: none;
+                  }
+                  &.hasError {
+                    outline: 3px $justfix-orange solid;
+                    outline-offset: -3px;
+                  }
                 }
               }
             }
@@ -280,11 +302,21 @@
             }
           }
 
+          @include for-tablet-portrait-up() {
+            .selectedListContainer,
+            .clear-all-container {
+              padding: 0 1.2rem;
+            }
+            .search-wrapper,
+            .optionListContainer,
+            .jf-alert {
+              margin: 0 1.2rem;
+            }
+          }
           .search-wrapper,
           .optionListContainer {
             background-color: $justfix-white;
             outline: 1px solid $justfix-grey;
-            border-radius: unset;
             border: none;
           }
           .search-wrapper {
@@ -424,6 +456,7 @@
               height: var(--filter-bar-height);
               min-height: var(--filter-bar-height);
               padding: 0 2.4rem;
+              font-size: 1.8rem;
               &[aria-pressed="false"]:hover,
               &[aria-pressed="true"] {
                 text-decoration: none;
@@ -432,6 +465,7 @@
             &.filter-accordion > summary {
               height: var(--filter-bar-height);
               padding: 0 2.4rem;
+              font-size: 1.8rem;
             }
             &.active:not(.filter-toggle) {
               background-color: $justfix-table-grey;
@@ -448,7 +482,6 @@
                 width: 100%;
                 padding: 0 2.4rem;
                 .filter-subtitle-container {
-                  padding: 0;
                   .filter-subtitle {
                     font-size: 1.6rem;
                   }
@@ -475,6 +508,15 @@
             }
             .dropdown-container {
               position: relative;
+              padding-bottom: 1.2rem;
+              .labels-container {
+                font-size: 1.6rem;
+              }
+              .labels-container,
+              .inputs-container {
+                padding-right: 0;
+                padding-left: 0;
+              }
             }
           }
           .zip-accordion {


### PR DESCRIPTION
Fixes to the handling of errors in Min/Max building size inputs, and the styling of the binding size filter on desktop/mobile

For the errors:

* Apparently some browsers still allow characters in numeric inputs, so I found a work around to prevent that.
* I've fixed the validation so errors are raised when:
  * min or max is a negative value,
  * min input > max input
  * min input > max range
  * max input < min range
* The error alerts will now have explanations for all these cases

For styles, there were a bunch of little changes, but here's what it looks like now:

![image](https://user-images.githubusercontent.com/16906516/228986108-bcbf6eb4-8bb0-4b9c-ad49-2daab91504d4.png)
![image](https://user-images.githubusercontent.com/16906516/228986114-a41341ad-d495-4e55-b8e2-9fa2a70dd62a.png)
![image](https://user-images.githubusercontent.com/16906516/228986126-643c03d9-01a3-4194-ba6d-17a6ce3f059e.png)
![image](https://user-images.githubusercontent.com/16906516/228986137-7b89cae5-85d1-4c08-9b3f-00d1e6c22e17.png)


[sc-11953]
[sc-11638]
