### PR TITLE
add space between filter accordion subtitle and filter ui (mobile)

### DIFF
--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -532,6 +532,7 @@
                 width: 100%;
                 padding: 0 2.4rem;
                 .filter-subtitle-container {
+                  margin-bottom: 1.2rem;
                   .filter-subtitle {
                     font-size: 1.6rem;
                   }


### PR DESCRIPTION
adds back some space between filter accordion subtitle and filter ui, on Mobile only.
(I think this got messed up in a merge conflict before) 

![image](https://user-images.githubusercontent.com/16906516/229606428-219d0a0f-5453-445e-b17a-aaeb259d3378.png)
