### PR TITLE
Reduce negative space between "new" label and "filters" label.

### DIFF
--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -54,7 +54,7 @@
       padding: 0.5rem 1rem;
       border-radius: 1.6rem;
       width: fit-content;
-      margin-bottom: auto;
+      margin-bottom: 0.26rem;
     }
 
     @include for-phone-only() {


### PR DESCRIPTION
Reduce negative space between "new" label and "filters" label.

[sc-11593]

before: 
![image](https://user-images.githubusercontent.com/16906516/229608800-87b891ff-a585-4168-a640-d2b78729dbfc.png)


after:
![image](https://user-images.githubusercontent.com/16906516/229608723-e9302c58-b417-456d-adba-216925877d80.png)
