### PR TITLE
ZIP Code filter QA fixes

### DIFF
--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -8,6 +8,7 @@ import { CloseButton } from "./CloseButton";
 import { Trans } from "@lingui/macro";
 import { Alert } from "./Alert";
 import classnames from "classnames";
+import helpers from "util/helpers";
 
 const KEY_ESC = 27;
 
@@ -31,6 +32,7 @@ export interface IMultiselectProps {
   onFocusInput?: () => void;
   infoAlert?: React.ReactNode;
   caseSensitiveSearch?: boolean;
+  preventNonNumericalInput?: boolean;
   id?: string;
   closeOnSelect?: boolean;
   avoidHighlightFirstOption?: boolean;
@@ -558,6 +560,7 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
       hideSelectedList,
       onApply,
       infoAlert,
+      preventNonNumericalInput,
     } = this.props;
     return (
       <div
@@ -606,7 +609,12 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
             value={inputValue}
             onFocus={this.onFocus}
             placeholder={hidePlaceholder && selectedValues.length ? "" : placeholder}
-            onKeyDown={this.onArrowKeyNavigation}
+            onKeyDown={(e) => {
+              if (preventNonNumericalInput) {
+                helpers.preventNonNumericalInput(e);
+              }
+              this.onArrowKeyNavigation(e);
+            }}
             style={style["inputField"]}
             autoComplete="off"
             disabled={disable}
@@ -688,6 +696,7 @@ Multiselect.defaultProps = {
   onKeyPressFn: () => {},
   onFocusInput: () => {},
   caseSensitiveSearch: false,
+  preventNonNumericalInput: false,
   id: "",
   name: "",
   closeOnSelect: true,

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -198,7 +198,7 @@ export const PortfolioFilters = React.memo(
               avoidHighlightFirstOption={true}
               showCheckbox={true}
               keepSearchTerm={true}
-              emptyRecordMsg={i18n._(t`Enter NYC zip code`)}
+              emptyRecordMsg={i18n._(t`Enter NYC Zip Code`)}
               preventNonNumericalInput={true}
             />
           </FilterAccordion>

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -178,7 +178,7 @@ export const PortfolioFilters = React.memo(
             />
           </FilterAccordion>
           <FilterAccordion
-            title={i18n._(t`Zipcode`)}
+            title={i18n._(t`ZIP CODE`)}
             isMobile={isMobile}
             isActive={zipActive}
             isOpen={zipIsOpen}
@@ -198,7 +198,7 @@ export const PortfolioFilters = React.memo(
               avoidHighlightFirstOption={true}
               showCheckbox={true}
               keepSearchTerm={true}
-              emptyRecordMsg={i18n._(t`Enter NYC Zip Code`)}
+              emptyRecordMsg={i18n._(t`Enter NYC ZIP CODE`)}
               preventNonNumericalInput={true}
             />
           </FilterAccordion>

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -198,6 +198,8 @@ export const PortfolioFilters = React.memo(
               avoidHighlightFirstOption={true}
               showCheckbox={true}
               keepSearchTerm={true}
+              emptyRecordMsg={i18n._(t`Enter NYC zip code`)}
+              preventNonNumericalInput={true}
             />
           </FilterAccordion>
         </FiltersWrapper>
@@ -527,7 +529,7 @@ function MinMaxSelect(props: {
             min={options[0]}
             max={options[1]}
             value={minMax[0] == null ? "" : minMax[0]}
-            onKeyDown={preventNonNumericalInput}
+            onKeyDown={helpers.preventNonNumericalInput}
             onChange={(e) => {
               setMinMaxErrors([false, false, undefined]);
               setMinMax([cleanNumberInput(e.target.value), minMax[1]]);
@@ -542,7 +544,7 @@ function MinMaxSelect(props: {
             min={options[0]}
             max={options[1]}
             value={minMax[1] == null ? "" : minMax[1]}
-            onKeyDown={preventNonNumericalInput}
+            onKeyDown={helpers.preventNonNumericalInput}
             onChange={(e) => {
               setMinMaxErrors([false, false, undefined]);
               setMinMax([minMax[0], cleanNumberInput(e.target.value)]);
@@ -606,11 +608,4 @@ function minMaxHasError(values: FilterNumberRange, options: FilterNumberRange): 
   }
 
   return [minHasError, maxHasError, errorMessage];
-}
-
-// Firefox doesn't prevent typing non-numeric characters
-// https://stackoverflow.com/a/49924215/7051239
-function preventNonNumericalInput(e: React.KeyboardEvent) {
-  e = e || window.event;
-  if (!/^\d*$/.test(e.key) && e.key in ["Enter", "Delete"]) e.preventDefault();
 }

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -129,7 +129,7 @@ export const PortfolioTable = React.memo((props: PortfolioTableProps) => {
         columns: [
           {
             accessorKey: "zip",
-            header: i18n._(t`Zipcode`),
+            header: i18n._(t`Zip Code`),
             cell: (info) => info.getValue(),
             footer: (props) => props.column.id,
             enableColumnFilter: false,

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -129,7 +129,7 @@ export const PortfolioTable = React.memo((props: PortfolioTableProps) => {
         columns: [
           {
             accessorKey: "zip",
-            header: i18n._(t`Zip Code`),
+            header: i18n._(t`ZIP CODE`),
             cell: (info) => info.getValue(),
             footer: (props) => props.column.id,
             enableColumnFilter: false,

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -369,8 +369,12 @@ msgid "Emergency"
 msgstr "Emergency"
 
 #: src/components/PortfolioFilters.tsx:90
-msgid "Enter NYC Zip Code"
-msgstr "Enter NYC Zip Code"
+msgid "Enter NYC ZIP CODE"
+msgstr "Enter NYC ZIP CODE"
+
+#: src/components/PortfolioFilters.tsx:90
+#~ msgid "Enter NYC Zip Code"
+#~ msgstr "Enter NYC Zip Code"
 
 #: src/components/PortfolioFilters.tsx:90
 #~ msgid "Enter NYC zip code"
@@ -1509,13 +1513,18 @@ msgstr "You are viewing a legacy version of Who Owns What"
 #~ msgid "You are viewing the old version of Who Owns What."
 #~ msgstr "You are viewing the old version of Who Owns What."
 
+#: src/components/PortfolioFilters.tsx:89
 #: src/components/PortfolioTable.tsx:76
-msgid "Zip Code"
-msgstr "Zip Code"
+msgid "ZIP CODE"
+msgstr "ZIP CODE"
+
+#: src/components/PortfolioTable.tsx:76
+#~ msgid "Zip Code"
+#~ msgstr "Zip Code"
 
 #: src/components/PortfolioFilters.tsx:89
-msgid "Zipcode"
-msgstr "Zipcode"
+#~ msgid "Zipcode"
+#~ msgstr "Zipcode"
 
 #: src/components/PortfolioGraph.tsx:133
 msgid "Zoom in"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -1509,8 +1509,11 @@ msgstr "You are viewing a legacy version of Who Owns What"
 #~ msgid "You are viewing the old version of Who Owns What."
 #~ msgstr "You are viewing the old version of Who Owns What."
 
-#: src/components/PortfolioFilters.tsx:89
 #: src/components/PortfolioTable.tsx:76
+msgid "Zip Code"
+msgstr "Zip Code"
+
+#: src/components/PortfolioFilters.tsx:89
 msgid "Zipcode"
 msgstr "Zipcode"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -369,8 +369,12 @@ msgid "Emergency"
 msgstr "Emergency"
 
 #: src/components/PortfolioFilters.tsx:90
-msgid "Enter NYC zip code"
-msgstr "Enter NYC zip code"
+msgid "Enter NYC Zip Code"
+msgstr "Enter NYC Zip Code"
+
+#: src/components/PortfolioFilters.tsx:90
+#~ msgid "Enter NYC zip code"
+#~ msgstr "Enter NYC zip code"
 
 #: src/containers/HomePage.tsx:89
 msgid "Enter an NYC address and find other buildings your landlord might own:"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Multiselect.tsx:518
+#: src/components/Multiselect.tsx:478
 msgid "\"No Options Available\""
 msgstr "\"No Options Available\""
 
-#: src/components/Multiselect.tsx:515
+#: src/components/Multiselect.tsx:476
 msgid "\"Select\""
 msgstr "\"Select\""
 
@@ -46,7 +46,7 @@ msgstr "(expires {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
-#: src/components/PropertiesList.tsx:79
+#: src/components/PropertiesList.tsx:80
 msgid "(this may take a while)"
 msgstr "(this may take a while)"
 
@@ -112,7 +112,7 @@ msgstr "Across owners and management staff, the most common {0, plural, one {nam
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PortfolioTable.tsx:58
+#: src/components/PortfolioTable.tsx:60
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Address"
@@ -129,7 +129,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PortfolioTable.tsx:319
+#: src/components/PortfolioTable.tsx:323
 msgid "Amount"
 msgstr "Amount"
 
@@ -141,8 +141,8 @@ msgstr "An “eviction filing” is a legal case for eviction commenced by a lan
 #~ msgid "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 #~ msgstr "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 
-#: src/components/Multiselect.tsx:476
-#: src/components/PortfolioFilters.tsx:288
+#: src/components/Multiselect.tsx:437
+#: src/components/PortfolioFilters.tsx:289
 msgid "Apply"
 msgstr "Apply"
 
@@ -162,7 +162,7 @@ msgstr "BELL/BUZZER/INTERCOM"
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/PortfolioTable.tsx:83
+#: src/components/PortfolioTable.tsx:85
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -192,7 +192,7 @@ msgstr "Building info"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PortfolioTable.tsx:115
+#: src/components/PortfolioTable.tsx:119
 msgid "Built"
 msgstr "Built"
 
@@ -247,7 +247,7 @@ msgstr "Class C"
 msgid "Class I"
 msgstr "Class I"
 
-#: src/components/Multiselect.tsx:455
+#: src/components/Multiselect.tsx:411
 msgid "Clear"
 msgstr "Clear"
 
@@ -298,7 +298,7 @@ msgstr "Corporate Owner"
 msgid "Corporation"
 msgstr "Corporation"
 
-#: src/components/PortfolioTable.tsx:101
+#: src/components/PortfolioTable.tsx:105
 msgid "Council"
 msgstr "Council"
 
@@ -322,7 +322,7 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PortfolioTable.tsx:308
+#: src/components/PortfolioTable.tsx:312
 msgid "Date"
 msgstr "Date"
 
@@ -368,6 +368,10 @@ msgstr "Email"
 msgid "Emergency"
 msgstr "Emergency"
 
+#: src/components/PortfolioFilters.tsx:90
+msgid "Enter NYC zip code"
+msgstr "Enter NYC zip code"
+
 #: src/containers/HomePage.tsx:89
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Enter an NYC address and find other buildings your landlord might own:"
@@ -401,7 +405,7 @@ msgstr "Evictions"
 msgid "Evictions Executed"
 msgstr "Evictions Executed"
 
-#: src/components/PortfolioTable.tsx:220
+#: src/components/PortfolioTable.tsx:224
 msgid "Evictions Since 2017"
 msgstr "Evictions Since 2017"
 
@@ -413,7 +417,7 @@ msgstr "Evictions executed by NYC Marshals since 2017. ANHD and the Housing Data
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
-#: src/components/PortfolioTable.tsx:235
+#: src/components/PortfolioTable.tsx:239
 msgid "Executed"
 msgstr "Executed"
 
@@ -441,7 +445,7 @@ msgstr "FLOORING/STAIRS"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PortfolioTable.tsx:226
+#: src/components/PortfolioTable.tsx:230
 msgid "Filed"
 msgstr "Filed"
 
@@ -469,7 +473,7 @@ msgstr "Find other buildings your landlord might own:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
-#: src/components/PortfolioTable.tsx:345
+#: src/components/PortfolioTable.tsx:349
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -486,7 +490,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:165
+#: src/components/PortfolioTable.tsx:169
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -495,7 +499,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:198
+#: src/components/PortfolioTable.tsx:202
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -564,7 +568,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PortfolioTable.tsx:110
+#: src/components/PortfolioTable.tsx:114
 msgid "Information"
 msgstr "Information"
 
@@ -593,7 +597,7 @@ msgid "LOCKS"
 msgstr "LOCKS"
 
 #: src/components/PortfolioFilters.tsx:83
-#: src/components/PortfolioTable.tsx:244
+#: src/components/PortfolioTable.tsx:248
 msgid "Landlord"
 msgstr "Landlord"
 
@@ -605,11 +609,11 @@ msgstr "Landlord name"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PortfolioTable.tsx:178
+#: src/components/PortfolioTable.tsx:182
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PortfolioTable.tsx:303
+#: src/components/PortfolioTable.tsx:307
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -639,22 +643,22 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PortfolioTable.tsx:327
 #: src/components/PortfolioTable.tsx:331
+#: src/components/PortfolioTable.tsx:335
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:80
+#: src/components/PropertiesList.tsx:81
 #: src/components/PropertiesMap.tsx:158
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:77
+#: src/components/PropertiesList.tsx:78
 msgid "Loading {0} rows"
 msgstr "Loading {0} rows"
 
-#: src/components/PortfolioTable.tsx:69
+#: src/components/PortfolioTable.tsx:71
 msgid "Location"
 msgstr "Location"
 
@@ -670,11 +674,11 @@ msgstr "Looking for more information?"
 msgid "MAILBOX"
 msgstr "MAILBOX"
 
-#: src/components/PortfolioFilters.tsx:263
+#: src/components/PortfolioFilters.tsx:264
 msgid "MAX"
 msgstr "MAX"
 
-#: src/components/PortfolioFilters.tsx:260
+#: src/components/PortfolioFilters.tsx:261
 msgid "MIN"
 msgstr "MIN"
 
@@ -690,7 +694,7 @@ msgstr "Made with NYC ♥ by the team at <0>JustFix.org</0>"
 msgid "Maintenance code violations"
 msgstr "Maintenance code violations"
 
-#: src/components/Multiselect.tsx:445
+#: src/components/Multiselect.tsx:401
 msgid "Make a selection from the list or clear search text"
 msgstr "Make a selection from the list or clear search text"
 
@@ -698,11 +702,11 @@ msgstr "Make a selection from the list or clear search text"
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
 
-#: src/components/PortfolioFilters.tsx:314
+#: src/components/PortfolioFilters.tsx:315
 msgid "Max must be greater than 0"
 msgstr "Max must be greater than 0"
 
-#: src/components/PortfolioFilters.tsx:318
+#: src/components/PortfolioFilters.tsx:319
 msgid "Max must be greater than {minOption}"
 msgstr "Max must be greater than {minOption}"
 
@@ -723,15 +727,15 @@ msgstr "Menu"
 msgid "Methodology"
 msgstr "Methodology"
 
-#: src/components/PortfolioFilters.tsx:310
+#: src/components/PortfolioFilters.tsx:311
 msgid "Min must be greater than 0"
 msgstr "Min must be greater than 0"
 
-#: src/components/PortfolioFilters.tsx:306
+#: src/components/PortfolioFilters.tsx:307
 msgid "Min must be less than or equal to Max"
 msgstr "Min must be less than or equal to Max"
 
-#: src/components/PortfolioFilters.tsx:322
+#: src/components/PortfolioFilters.tsx:323
 msgid "Min must be less than {maxOption}"
 msgstr "Min must be less than {maxOption}"
 
@@ -785,11 +789,11 @@ msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:501
+#: src/components/PortfolioTable.tsx:505
 msgid "Next"
 msgstr "Next"
 
-#: src/components/PortfolioTable.tsx:349
+#: src/components/PortfolioTable.tsx:353
 msgid "No"
 msgstr "No"
 
@@ -869,7 +873,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PortfolioTable.tsx:203
+#: src/components/PortfolioTable.tsx:207
 msgid "Open"
 msgstr "Open"
 
@@ -877,7 +881,7 @@ msgstr "Open"
 msgid "Open Violations"
 msgstr "Open Violations"
 
-#: src/containers/AddressPage.tsx:134
+#: src/containers/AddressPage.tsx:133
 msgid "Overview"
 msgstr "Overview"
 
@@ -885,7 +889,7 @@ msgstr "Overview"
 msgid "Owner Names"
 msgstr "Owner Names"
 
-#: src/components/PortfolioTable.tsx:257
+#: src/components/PortfolioTable.tsx:261
 msgid "Owner/Manager"
 msgstr "Owner/Manager"
 
@@ -905,11 +909,11 @@ msgstr "PESTS"
 msgid "PLUMBING"
 msgstr "PLUMBING"
 
-#: src/containers/AddressPage.tsx:120
+#: src/containers/AddressPage.tsx:119
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/PortfolioTable.tsx:481
+#: src/components/PortfolioTable.tsx:485
 msgid "Page"
 msgstr "Page"
 
@@ -922,7 +926,7 @@ msgstr "People"
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/containers/AddressPage.tsx:150
+#: src/containers/AddressPage.tsx:149
 msgid "Portfolio"
 msgstr "Portfolio"
 
@@ -931,7 +935,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Portfolio Table Redesign"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:475
+#: src/components/PortfolioTable.tsx:479
 msgid "Previous"
 msgstr "Previous"
 
@@ -945,7 +949,7 @@ msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:133
+#: src/components/PortfolioTable.tsx:137
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -1038,7 +1042,7 @@ msgstr "Share this page with your neighbors"
 msgid "Shareholder"
 msgstr "Shareholder"
 
-#: src/components/Multiselect.tsx:359
+#: src/components/Multiselect.tsx:320
 msgid "Show less"
 msgstr "Show less"
 
@@ -1071,7 +1075,7 @@ msgstr "Sign up for email updates"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/components/PortfolioTable.tsx:528
+#: src/components/PortfolioTable.tsx:532
 msgid "Since {year}"
 msgstr "Since {year}"
 
@@ -1103,11 +1107,11 @@ msgstr "Source code"
 msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:528
+#: src/components/PortfolioTable.tsx:532
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
-#: src/containers/AddressPage.tsx:158
+#: src/containers/AddressPage.tsx:157
 msgid "Summary"
 msgstr "Summary"
 
@@ -1128,7 +1132,7 @@ msgstr "TENANT HARASSMENT"
 msgid "Take action on JustFix.org!"
 msgstr "Take action on JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:281
+#: src/components/PortfolioTable.tsx:285
 msgid "Tax Exemptions"
 msgstr "Tax Exemptions"
 
@@ -1269,17 +1273,17 @@ msgstr "This tracks how rent stabilized units in the building have changed (i.e.
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:142
+#: src/containers/AddressPage.tsx:141
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PortfolioTable.tsx:186
+#: src/components/PortfolioTable.tsx:190
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:170
-#: src/components/PortfolioTable.tsx:211
+#: src/components/PortfolioTable.tsx:174
+#: src/components/PortfolioTable.tsx:215
 msgid "Total"
 msgstr "Total"
 
@@ -1300,7 +1304,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:123
+#: src/components/PortfolioTable.tsx:127
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -1326,8 +1330,8 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
-#: src/components/PortfolioTable.tsx:358
-#: src/components/PortfolioTable.tsx:365
+#: src/components/PortfolioTable.tsx:362
+#: src/components/PortfolioTable.tsx:369
 msgid "View Detail"
 msgstr "View Detail"
 
@@ -1437,7 +1441,7 @@ msgstr "What happens if the landlord has failed to register?"
 msgid "What's New"
 msgstr "What's New"
 
-#: src/components/PortfolioFilters.tsx:239
+#: src/components/PortfolioFilters.tsx:240
 msgid "What's this?"
 msgstr "What's this?"
 
@@ -1485,7 +1489,7 @@ msgstr "Why am I seeing such a big portfolio?"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PortfolioTable.tsx:348
+#: src/components/PortfolioTable.tsx:352
 msgid "Yes"
 msgstr "Yes"
 
@@ -1502,7 +1506,7 @@ msgstr "You are viewing a legacy version of Who Owns What"
 #~ msgstr "You are viewing the old version of Who Owns What."
 
 #: src/components/PortfolioFilters.tsx:89
-#: src/components/PortfolioTable.tsx:74
+#: src/components/PortfolioTable.tsx:76
 msgid "Zipcode"
 msgstr "Zipcode"
 
@@ -1530,7 +1534,7 @@ msgstr "for ${0}"
 msgid "month"
 msgstr "month"
 
-#: src/components/PortfolioTable.tsx:489
+#: src/components/PortfolioTable.tsx:493
 msgid "of"
 msgstr "of"
 
@@ -1542,7 +1546,7 @@ msgstr "quarter"
 msgid "search address"
 msgstr "search address"
 
-#: src/components/PortfolioFilters.tsx:271
+#: src/components/PortfolioFilters.tsx:272
 msgid "to"
 msgstr "to"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -374,8 +374,12 @@ msgid "Emergency"
 msgstr "Emergencia"
 
 #: src/components/PortfolioFilters.tsx:90
-msgid "Enter NYC Zip Code"
+msgid "Enter NYC ZIP CODE"
 msgstr ""
+
+#: src/components/PortfolioFilters.tsx:90
+#~ msgid "Enter NYC Zip Code"
+#~ msgstr ""
 
 #: src/components/PortfolioFilters.tsx:90
 #~ msgid "Enter NYC zip code"
@@ -1514,13 +1518,18 @@ msgstr ""
 #~ msgid "You are viewing the old version of Who Owns What."
 #~ msgstr "You are viewing the old version of Who Owns What."
 
+#: src/components/PortfolioFilters.tsx:89
 #: src/components/PortfolioTable.tsx:76
-msgid "Zip Code"
+msgid "ZIP CODE"
 msgstr ""
 
+#: src/components/PortfolioTable.tsx:76
+#~ msgid "Zip Code"
+#~ msgstr ""
+
 #: src/components/PortfolioFilters.tsx:89
-msgid "Zipcode"
-msgstr "Código postal"
+#~ msgid "Zipcode"
+#~ msgstr "Código postal"
 
 #: src/components/PortfolioGraph.tsx:133
 msgid "Zoom in"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -1514,8 +1514,11 @@ msgstr ""
 #~ msgid "You are viewing the old version of Who Owns What."
 #~ msgstr "You are viewing the old version of Who Owns What."
 
-#: src/components/PortfolioFilters.tsx:89
 #: src/components/PortfolioTable.tsx:76
+msgid "Zip Code"
+msgstr ""
+
+#: src/components/PortfolioFilters.tsx:89
 msgid "Zipcode"
 msgstr "Código postal"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: /master/client/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 31\n"
 
-#: src/components/Multiselect.tsx:518
+#: src/components/Multiselect.tsx:478
 msgid "\"No Options Available\""
 msgstr ""
 
-#: src/components/Multiselect.tsx:515
+#: src/components/Multiselect.tsx:476
 msgid "\"Select\""
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr "(caduca {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
-#: src/components/PropertiesList.tsx:79
+#: src/components/PropertiesList.tsx:80
 msgid "(this may take a while)"
 msgstr "(esto puede tardar un rato)"
 
@@ -117,7 +117,7 @@ msgstr "En todos los dueños y administradores, {0, plural, one {el nombre más 
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PortfolioTable.tsx:58
+#: src/components/PortfolioTable.tsx:60
 #: src/containers/HomePage.tsx:104
 msgid "Address"
 msgstr "Dirección"
@@ -134,7 +134,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PortfolioTable.tsx:319
+#: src/components/PortfolioTable.tsx:323
 msgid "Amount"
 msgstr "Importe"
 
@@ -146,8 +146,8 @@ msgstr "Una \"demanda de desalojo\" es un caso legal de desalojo iniciado por un
 #~ msgid "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 #~ msgstr "An “eviction filing” is a legal case for eviction commenced by a landlord against a tenant in Housing Court. Such a case can be commenced for nonpayment of rent (most commonly) or for a violation of the lease (such as a nuisance). The eviction filings number only represents cases filed in Housing Court (data from the New York State Office of Court Administration<0>via the Housing Data Coalition</0> in collaboration with the <1>Right to Counsel Coalition</1>) and not evictions carried out by NYC Marshals.<2/>If you or someone you know is facing eviction and want to learn more about your rights, head over to <3>Housing Court Answers for more information</3>.<4/>Due to privacy restrictions on the use of these data, eviction filings cannot be shown for buildings with fewer than 11 units."
 
-#: src/components/Multiselect.tsx:476
-#: src/components/PortfolioFilters.tsx:288
+#: src/components/Multiselect.tsx:437
+#: src/components/PortfolioFilters.tsx:289
 msgid "Apply"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr "TIMBRE/INTERCOMUNICADOR"
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/PortfolioTable.tsx:83
+#: src/components/PortfolioTable.tsx:85
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -197,7 +197,7 @@ msgstr "Información de edificios"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PortfolioTable.tsx:115
+#: src/components/PortfolioTable.tsx:119
 msgid "Built"
 msgstr "Construido"
 
@@ -252,7 +252,7 @@ msgstr "Clase C"
 msgid "Class I"
 msgstr "Clase I"
 
-#: src/components/Multiselect.tsx:455
+#: src/components/Multiselect.tsx:411
 msgid "Clear"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgstr "Dueño Corporativo"
 msgid "Corporation"
 msgstr "Corporación"
 
-#: src/components/PortfolioTable.tsx:101
+#: src/components/PortfolioTable.tsx:105
 msgid "Council"
 msgstr ""
 
@@ -327,7 +327,7 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PortfolioTable.tsx:308
+#: src/components/PortfolioTable.tsx:312
 msgid "Date"
 msgstr "Fecha"
 
@@ -373,6 +373,10 @@ msgstr "Email"
 msgid "Emergency"
 msgstr "Emergencia"
 
+#: src/components/PortfolioFilters.tsx:90
+msgid "Enter NYC zip code"
+msgstr ""
+
 #: src/containers/HomePage.tsx:89
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
@@ -406,7 +410,7 @@ msgstr "Desalojos"
 msgid "Evictions Executed"
 msgstr "Desalojos ejecutados"
 
-#: src/components/PortfolioTable.tsx:220
+#: src/components/PortfolioTable.tsx:224
 msgid "Evictions Since 2017"
 msgstr "Desalojos desde 2017"
 
@@ -418,7 +422,7 @@ msgstr "Desalojos ejecutados en este edificio por el Mariscal de NYC desde el 20
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 2017. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes del DOI."
 
-#: src/components/PortfolioTable.tsx:235
+#: src/components/PortfolioTable.tsx:239
 msgid "Executed"
 msgstr "Ejecutado"
 
@@ -446,7 +450,7 @@ msgstr "PISO/ESCALERAS"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PortfolioTable.tsx:226
+#: src/components/PortfolioTable.tsx:230
 msgid "Filed"
 msgstr "Presentado"
 
@@ -474,7 +478,7 @@ msgstr "Encuentra otros edificios que tu propietario podría poseer:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
-#: src/components/PortfolioTable.tsx:345
+#: src/components/PortfolioTable.tsx:349
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -491,7 +495,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:165
+#: src/components/PortfolioTable.tsx:169
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -500,7 +504,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontrarás más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:198
+#: src/components/PortfolioTable.tsx:202
 msgid "HPD Violations"
 msgstr "Violaciones del HPD"
 
@@ -569,7 +573,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
-#: src/components/PortfolioTable.tsx:110
+#: src/components/PortfolioTable.tsx:114
 msgid "Information"
 msgstr "Información"
 
@@ -598,7 +602,7 @@ msgid "LOCKS"
 msgstr "CERRADURAS"
 
 #: src/components/PortfolioFilters.tsx:83
-#: src/components/PortfolioTable.tsx:244
+#: src/components/PortfolioTable.tsx:248
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
@@ -610,11 +614,11 @@ msgstr "Nombre del dueño"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PortfolioTable.tsx:178
+#: src/components/PortfolioTable.tsx:182
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PortfolioTable.tsx:303
+#: src/components/PortfolioTable.tsx:307
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -644,22 +648,22 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PortfolioTable.tsx:327
 #: src/components/PortfolioTable.tsx:331
+#: src/components/PortfolioTable.tsx:335
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:80
+#: src/components/PropertiesList.tsx:81
 #: src/components/PropertiesMap.tsx:158
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:77
+#: src/components/PropertiesList.tsx:78
 msgid "Loading {0} rows"
 msgstr "Cargando {0} filas"
 
-#: src/components/PortfolioTable.tsx:69
+#: src/components/PortfolioTable.tsx:71
 msgid "Location"
 msgstr "Ubicación"
 
@@ -675,11 +679,11 @@ msgstr "¿Buscas más información?"
 msgid "MAILBOX"
 msgstr "BUZÓN"
 
-#: src/components/PortfolioFilters.tsx:263
+#: src/components/PortfolioFilters.tsx:264
 msgid "MAX"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:260
+#: src/components/PortfolioFilters.tsx:261
 msgid "MIN"
 msgstr ""
 
@@ -695,7 +699,7 @@ msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.org</0>"
 msgid "Maintenance code violations"
 msgstr "Violaciones del código de mantenimiento"
 
-#: src/components/Multiselect.tsx:445
+#: src/components/Multiselect.tsx:401
 msgid "Make a selection from the list or clear search text"
 msgstr ""
 
@@ -703,11 +707,11 @@ msgstr ""
 #~ msgid "Make a selection."
 #~ msgstr ""
 
-#: src/components/PortfolioFilters.tsx:314
+#: src/components/PortfolioFilters.tsx:315
 msgid "Max must be greater than 0"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:318
+#: src/components/PortfolioFilters.tsx:319
 msgid "Max must be greater than {minOption}"
 msgstr ""
 
@@ -728,15 +732,15 @@ msgstr "Menu"
 msgid "Methodology"
 msgstr "Metodología"
 
-#: src/components/PortfolioFilters.tsx:310
+#: src/components/PortfolioFilters.tsx:311
 msgid "Min must be greater than 0"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:306
+#: src/components/PortfolioFilters.tsx:307
 msgid "Min must be less than or equal to Max"
 msgstr ""
 
-#: src/components/PortfolioFilters.tsx:322
+#: src/components/PortfolioFilters.tsx:323
 msgid "Min must be less than {maxOption}"
 msgstr ""
 
@@ -790,11 +794,11 @@ msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:501
+#: src/components/PortfolioTable.tsx:505
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/components/PortfolioTable.tsx:349
+#: src/components/PortfolioTable.tsx:353
 msgid "No"
 msgstr "No"
 
@@ -874,7 +878,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PortfolioTable.tsx:203
+#: src/components/PortfolioTable.tsx:207
 msgid "Open"
 msgstr "Actuales"
 
@@ -882,7 +886,7 @@ msgstr "Actuales"
 msgid "Open Violations"
 msgstr "Violaciones Actuales"
 
-#: src/containers/AddressPage.tsx:134
+#: src/containers/AddressPage.tsx:133
 msgid "Overview"
 msgstr "General"
 
@@ -890,7 +894,7 @@ msgstr "General"
 msgid "Owner Names"
 msgstr "Dueños"
 
-#: src/components/PortfolioTable.tsx:257
+#: src/components/PortfolioTable.tsx:261
 msgid "Owner/Manager"
 msgstr ""
 
@@ -910,11 +914,11 @@ msgstr "PLAGAS"
 msgid "PLUMBING"
 msgstr "PLOMERÍA"
 
-#: src/containers/AddressPage.tsx:120
+#: src/containers/AddressPage.tsx:119
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/PortfolioTable.tsx:481
+#: src/components/PortfolioTable.tsx:485
 msgid "Page"
 msgstr ""
 
@@ -927,7 +931,7 @@ msgstr "Personas"
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/containers/AddressPage.tsx:150
+#: src/containers/AddressPage.tsx:149
 msgid "Portfolio"
 msgstr "Portafolio"
 
@@ -936,7 +940,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Rediseño de la tabla del portafolio"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:475
+#: src/components/PortfolioTable.tsx:479
 msgid "Previous"
 msgstr "Anterior"
 
@@ -950,7 +954,7 @@ msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:133
+#: src/components/PortfolioTable.tsx:137
 msgid "RS Units"
 msgstr "Unidades RS"
 
@@ -1043,7 +1047,7 @@ msgstr "Comparte esta página con tus vecinos"
 msgid "Shareholder"
 msgstr "Accionista"
 
-#: src/components/Multiselect.tsx:359
+#: src/components/Multiselect.tsx:320
 msgid "Show less"
 msgstr ""
 
@@ -1076,7 +1080,7 @@ msgstr "Regístrate para recibir noticias por email"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde 2017, los dueños presentaron {totalEvictionFilings, plural, one {un caso de desalojo} other {# casos de desalojo}} y los alguaciles de la ciudad de Nueva York ejecutaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en toda esta cartera."
 
-#: src/components/PortfolioTable.tsx:528
+#: src/components/PortfolioTable.tsx:532
 msgid "Since {year}"
 msgstr "Desde {year}"
 
@@ -1108,11 +1112,11 @@ msgstr "Código fuente"
 msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 msgstr ""
 
-#: src/components/PortfolioTable.tsx:528
+#: src/components/PortfolioTable.tsx:532
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
-#: src/containers/AddressPage.tsx:158
+#: src/containers/AddressPage.tsx:157
 msgid "Summary"
 msgstr "Resúmen"
 
@@ -1133,7 +1137,7 @@ msgstr "ACOSO DE INQUILINO"
 msgid "Take action on JustFix.org!"
 msgstr "¡Toma acción en JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:281
+#: src/components/PortfolioTable.tsx:285
 msgid "Tax Exemptions"
 msgstr "Exenciones de impuestos"
 
@@ -1274,17 +1278,17 @@ msgstr "El cambio en apartamentos de renta estabilizada que hay en el edificio (
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:142
+#: src/containers/AddressPage.tsx:141
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PortfolioTable.tsx:186
+#: src/components/PortfolioTable.tsx:190
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:170
-#: src/components/PortfolioTable.tsx:211
+#: src/components/PortfolioTable.tsx:174
+#: src/components/PortfolioTable.tsx:215
 msgid "Total"
 msgstr "Total"
 
@@ -1305,7 +1309,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:123
+#: src/components/PortfolioTable.tsx:127
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades"
@@ -1331,8 +1335,8 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
-#: src/components/PortfolioTable.tsx:358
-#: src/components/PortfolioTable.tsx:365
+#: src/components/PortfolioTable.tsx:362
+#: src/components/PortfolioTable.tsx:369
 msgid "View Detail"
 msgstr ""
 
@@ -1442,7 +1446,7 @@ msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 msgid "What's New"
 msgstr "Qué hay de nuevo"
 
-#: src/components/PortfolioFilters.tsx:239
+#: src/components/PortfolioFilters.tsx:240
 msgid "What's this?"
 msgstr ""
 
@@ -1490,7 +1494,7 @@ msgstr "¿Por qué estoy viendo un portafolio tan grande?"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PortfolioTable.tsx:348
+#: src/components/PortfolioTable.tsx:352
 msgid "Yes"
 msgstr "Sí"
 
@@ -1507,7 +1511,7 @@ msgstr ""
 #~ msgstr "You are viewing the old version of Who Owns What."
 
 #: src/components/PortfolioFilters.tsx:89
-#: src/components/PortfolioTable.tsx:74
+#: src/components/PortfolioTable.tsx:76
 msgid "Zipcode"
 msgstr "Código postal"
 
@@ -1535,7 +1539,7 @@ msgstr "por ${0}"
 msgid "month"
 msgstr "mes"
 
-#: src/components/PortfolioTable.tsx:489
+#: src/components/PortfolioTable.tsx:493
 msgid "of"
 msgstr ""
 
@@ -1547,7 +1551,7 @@ msgstr "trimestre"
 msgid "search address"
 msgstr "dirección de búsqueda"
 
-#: src/components/PortfolioFilters.tsx:271
+#: src/components/PortfolioFilters.tsx:272
 msgid "to"
 msgstr ""
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -374,8 +374,12 @@ msgid "Emergency"
 msgstr "Emergencia"
 
 #: src/components/PortfolioFilters.tsx:90
-msgid "Enter NYC zip code"
+msgid "Enter NYC Zip Code"
 msgstr ""
+
+#: src/components/PortfolioFilters.tsx:90
+#~ msgid "Enter NYC zip code"
+#~ msgstr ""
 
 #: src/containers/HomePage.tsx:89
 msgid "Enter an NYC address and find other buildings your landlord might own:"

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -416,6 +416,17 @@ const helpers = {
     const elem = document.querySelector(selectors);
     elem?.scroll(0, elem?.scrollHeight);
   },
+
+  /**
+   * Prevents user from typing non-numeric characters in an input field. Necessary
+   * because Firefox doesn't do this by default with type="numeric" inputs.
+   * See https://stackoverflow.com/a/49924215/7051239
+   */
+  preventNonNumericalInput(e: React.KeyboardEvent) {
+    e = e || window.event;
+    // Control keys (tab, delete, arrows, etc.) are length > 1
+    if (!/^\d$/.test(e.key) && e.key.length === 1) e.preventDefault();
+  },
 };
 
 export default helpers;


### PR DESCRIPTION
- [x] prevent users from typing non-numeric inputs
- [x] update copy for "no records found" in filter options to "Enter NYC ZIP CODE"
- [x] update column headers to "ZIP CODE" 

[sc-11869]
[sc-12042]