### PR TITLE
add extra params for GTM on portfolio events

### DIFF
--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -175,18 +175,20 @@ const TableOfData = React.memo(
     const { addrs, headerTopSpacing, i18n, locale, rsunitslatestyear, analyticsEventData } = props;
 
     const logAnalyticsColumnSort = (columnName: string) => {
-      logAmplitudeEvent("portfolioColumnSort", {
+      const extraParams = {
         ...analyticsEventData,
         portfolioColumn: columnName,
-      });
-      window.gtag("event", "portfolio-column-sort");
+      };
+      logAmplitudeEvent("portfolioColumnSort", extraParams);
+      window.gtag("event", "portfolio-column-sort", extraParams);
     };
     const logAnalyticsAddressClick = (columnName: string) => {
-      logAmplitudeEvent("addressChangePortfolio", {
+      const extraParams = {
         ...analyticsEventData,
         portfolioColumn: columnName,
-      });
-      window.gtag("event", "address-change-portfolio");
+      };
+      logAmplitudeEvent("addressChangePortfolio", extraParams);
+      window.gtag("event", "address-change-portfolio", extraParams);
     };
 
     return (


### PR DESCRIPTION
Previously we weren't sending any extra data along with our google analytics events in WOW, we only did for Amplitude. This PR adds the same extra properties along with our events for portfolio table column sorts and address clicks. I'm doing just these two now so they can go to prod and I can make sure everything works correctly on GTM for updating the custom variables/tags for the events. After that there is another filters-specific PR to follow that sets up all the new events for filters. 