### PR TITLE
add analytics events for filters

### DIFF
--- a/client/src/components/Amplitude.ts
+++ b/client/src/components/Amplitude.ts
@@ -66,7 +66,13 @@ export type AmplitudeEvent =
   | "addressChangeMap"
   | "addressChangePortfolio"
   | "portfolioColumnSort"
-  | "alertToFilterPortfolio";
+  | "portfolioPagination"
+  | "portfolioRowExpanded"
+  | "alertToFilterPortfolio"
+  | "filterOpened"
+  | "filterError"
+  | "filterApplied"
+  | "filterCleared";
 
 export type EventProperties = {
   [x: string]: unknown;

--- a/client/src/components/MinMaxSelect.tsx
+++ b/client/src/components/MinMaxSelect.tsx
@@ -22,10 +22,11 @@ const PRESETS_DEFAULT = [
 function MinMaxSelect(props: {
   options: FilterNumberRange;
   onApply: (selections: FilterNumberRange[]) => void;
+  onError?: () => void;
   id?: string;
   onFocusInput?: () => void;
 }) {
-  const { options, onApply, id, onFocusInput } = props;
+  const { options, onApply, onError, id, onFocusInput } = props;
   const [customRange, setCustomRange] = React.useState<FilterNumberRange>(NUMBER_RANGE_DEFAULT);
   const [customRangeErrors, setCustomRangeErrors] = React.useState<CustomRangeErrors>(
     CUSTOM_RANGE_ERRORS_DEFAULT
@@ -46,6 +47,7 @@ function MinMaxSelect(props: {
     if (isFinite(customRange.min) || isFinite(customRange.max)) {
       const errors = minMaxHasError(customRange, options);
       if (errors.min || errors.max) {
+        onError && onError();
         setCustomRangeErrors(errors);
         return;
       }

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -25,6 +25,7 @@ export type Option = {
 
 interface CustomMultiselectProps {
   onApply: (selectedList: any) => void;
+  onError?: () => void;
   previewSelectedNum?: number;
   infoAlert?: JSX.Element;
 }
@@ -61,6 +62,7 @@ function MultiSelect<
   infoAlert,
   onChange,
   onInputChange,
+  onError,
   previewSelectedNum,
   ...props
 }: Props<Option, IsMulti, GroupType> & CustomMultiselectProps) {
@@ -99,6 +101,7 @@ function MultiSelect<
     // @ts-ignore (value isn't recognizing the available properties of Option type)
     const selectedValues = selections.map((v) => ({ name: v.value || "", id: v.label }));
     if (!selectedValues.length && !!inputValue) {
+      onError && onError();
       setHasError(true);
     } else {
       onApply(selectedValues);

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -3,7 +3,12 @@ import { t, Trans, Plural } from "@lingui/macro";
 import classnames from "classnames";
 import React from "react";
 import { CheckIcon, ChevronIcon, CloseIcon, InfoIcon } from "./Icons";
-import { FilterContext, FilterNumberRange, NUMBER_RANGE_DEFAULT } from "./PropertiesList";
+import {
+  FilterContext,
+  FilterNumberRange,
+  LogPortfolioAnalytics,
+  NUMBER_RANGE_DEFAULT,
+} from "./PropertiesList";
 import FocusTrap from "focus-trap-react";
 import { FocusTarget } from "focus-trap";
 import { Alert } from "./Alert";
@@ -19,8 +24,12 @@ import MinMaxSelect from "./MinMaxSelect";
 
 import "styles/PortfolioFilters.scss";
 
+type PortfolioFilterProps = {
+  logPortfolioAnalytics: LogPortfolioAnalytics;
+};
+
 export const PortfolioFilters = React.memo(
-  React.forwardRef<HTMLDivElement>((props, ref) => {
+  React.forwardRef<HTMLDivElement, PortfolioFilterProps>((props, ref) => {
     const isMobile = Browser.isMobile();
 
     const [showInfoModal, setShowInfoModal] = React.useState(false);
@@ -32,8 +41,13 @@ export const PortfolioFilters = React.memo(
     const { filteredBuildings } = filterContext;
     const { ownernames: ownernamesOptions, zip: zipOptions } = filterContext.filterOptions;
 
+    const { logPortfolioAnalytics } = props;
+
     const [rsunitslatestActive, setRsunitslatestActive] = React.useState(false);
     const updateRsunitslatest = () => {
+      logPortfolioAnalytics(rsunitslatestActive ? "filterCleared" : "filterApplied", {
+        column: "rsunitslatest",
+      });
       setRsunitslatestActive(!rsunitslatestActive);
       setFilterContext({
         ...filterContext,
@@ -47,6 +61,9 @@ export const PortfolioFilters = React.memo(
     const [ownernamesActive, setOwnernamesActive] = React.useState(false);
     const [ownernamesIsOpen, setOwnernamesIsOpen] = React.useState(false);
     const onOwnernamesApply = (selectedList: any) => {
+      logPortfolioAnalytics(!selectedList.length ? "filterCleared" : "filterApplied", {
+        column: "ownernames",
+      });
       setOwnernamesActive(!!selectedList.length);
       setOwnernamesIsOpen(false);
       setFilterContext({
@@ -61,7 +78,11 @@ export const PortfolioFilters = React.memo(
     const [unitsresActive, setUnitsresActive] = React.useState(false);
     const [unitsresIsOpen, setUnitsresIsOpen] = React.useState(false);
     const onUnitsresApply = (selections: FilterNumberRange[]) => {
-      setUnitsresActive(isFinite(selections[0].min) || isFinite(selections[0].max));
+      const updatedIsActive = isFinite(selections[0].min) || isFinite(selections[0].max);
+      logPortfolioAnalytics(!updatedIsActive ? "filterCleared" : "filterApplied", {
+        column: "unitsres",
+      });
+      setUnitsresActive(updatedIsActive);
       setUnitsresIsOpen(false);
       setFilterContext({
         ...filterContext,
@@ -75,6 +96,9 @@ export const PortfolioFilters = React.memo(
     const [zipActive, setZipActive] = React.useState(false);
     const [zipIsOpen, setZipIsOpen] = React.useState(false);
     const onZipApply = (selectedList: any) => {
+      logPortfolioAnalytics(!selectedList.length ? "filterCleared" : "filterApplied", {
+        column: "zip",
+      });
       setZipActive(!!selectedList.length);
       setZipIsOpen(false);
       setFilterContext({
@@ -87,6 +111,7 @@ export const PortfolioFilters = React.memo(
     };
 
     const clearFilters = () => {
+      logPortfolioAnalytics("filterCleared", { column: "_all" });
       setRsunitslatestActive(false);
       setOwnernamesActive(false);
       setUnitsresActive(false);
@@ -176,6 +201,7 @@ export const PortfolioFilters = React.memo(
             isActive={ownernamesActive}
             isOpen={ownernamesIsOpen}
             setIsOpen={setOwnernamesIsOpen}
+            onOpen={() => logPortfolioAnalytics("filterOpened", { column: "ownernames" })}
             initialFocus={isMobile ? undefined : "#filter-ownernames-multiselect input"}
             selectionsCount={filterContext.filterSelections.ownernames.length}
             className="ownernames-accordion"
@@ -184,6 +210,7 @@ export const PortfolioFilters = React.memo(
               id="filter-ownernames-multiselect"
               options={ownernamesOptionsSelect}
               onApply={onOwnernamesApply}
+              onError={() => logPortfolioAnalytics("filterError", { column: "ownernames" })}
               infoAlert={OwnernamesInfoAlert}
               aria-label={i18n._(t`Landlord filter`)}
             />
@@ -194,6 +221,7 @@ export const PortfolioFilters = React.memo(
             isMobile={isMobile}
             isActive={unitsresActive}
             isOpen={unitsresIsOpen}
+            onOpen={() => logPortfolioAnalytics("filterOpened", { column: "unitsres" })}
             initialFocus={isMobile ? undefined : "#filter-unitsres-minmax_min-input"}
             setIsOpen={setUnitsresIsOpen}
             className="unitsres-accordion"
@@ -201,6 +229,7 @@ export const PortfolioFilters = React.memo(
             <MinMaxSelect
               options={filterContext.filterOptions.unitsres}
               onApply={onUnitsresApply}
+              onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
               id="filter-unitsres-minmax"
               onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
             />
@@ -211,6 +240,7 @@ export const PortfolioFilters = React.memo(
             isActive={zipActive}
             isOpen={zipIsOpen}
             setIsOpen={setZipIsOpen}
+            onOpen={() => logPortfolioAnalytics("filterOpened", { column: "zip" })}
             initialFocus={isMobile ? undefined : "#filter-zip-multiselect input"}
             selectionsCount={filterContext.filterSelections.zip.length}
             className="zip-accordion"
@@ -220,6 +250,7 @@ export const PortfolioFilters = React.memo(
               options={zipOptionsSelect}
               onApply={onZipApply}
               noOptionsMessage={() => i18n._(t`ZIP code is not applicable`)}
+              onError={() => logPortfolioAnalytics("filterError", { column: "zip" })}
               aria-label={i18n._(t`Zip code filter`)}
               onKeyDown={helpers.preventNonNumericalInput}
             />
@@ -409,6 +440,7 @@ function FilterAccordion(props: {
   isActive: boolean;
   isOpen: boolean;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onOpen?: () => void;
   initialFocus?: FocusTarget;
   selectionsCount?: number;
   className?: string;
@@ -424,6 +456,7 @@ function FilterAccordion(props: {
     isActive,
     isOpen,
     setIsOpen,
+    onOpen,
     initialFocus,
     selectionsCount,
     className,
@@ -449,6 +482,7 @@ function FilterAccordion(props: {
           <summary
             onClick={(e) => {
               e.preventDefault();
+              !isOpen && onOpen && onOpen();
               setIsOpen(!isOpen);
             }}
             data-selections={selectionsCount}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -6,7 +6,7 @@ import { CheckIcon, ChevronIcon, CloseIcon, InfoIcon } from "./Icons";
 import {
   FilterContext,
   FilterNumberRange,
-  LogPortfolioAnalytics,
+  PortfolioAnalyticsEvent,
   NUMBER_RANGE_DEFAULT,
 } from "./PropertiesList";
 import FocusTrap from "focus-trap-react";
@@ -25,7 +25,7 @@ import MinMaxSelect from "./MinMaxSelect";
 import "styles/PortfolioFilters.scss";
 
 type PortfolioFilterProps = {
-  logPortfolioAnalytics: LogPortfolioAnalytics;
+  logPortfolioAnalytics: PortfolioAnalyticsEvent;
 };
 
 export const PortfolioFilters = React.memo(

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -663,7 +663,9 @@ export const PortfolioTable = React.memo((props: PortfolioTableProps) => {
             className="page-btn"
             onClick={() => {
               table.previousPage();
-              logPortfolioAnalytics("portfolioPagination", { extraParams: { type: "previous" } });
+              logPortfolioAnalytics("portfolioPagination", {
+                extraParams: { paginationType: "previous" },
+              });
             }}
             disabled={!table.getCanPreviousPage()}
           >
@@ -682,7 +684,9 @@ export const PortfolioTable = React.memo((props: PortfolioTableProps) => {
                 onChange={(e) => {
                   const page = e.target.value ? Number(e.target.value) - 1 : 0;
                   table.setPageIndex(page);
-                  logPortfolioAnalytics("portfolioPagination", { extraParams: { type: "custom" } });
+                  logPortfolioAnalytics("portfolioPagination", {
+                    extraParams: { paginationType: "custom" },
+                  });
                 }}
               />
             </div>
@@ -692,7 +696,9 @@ export const PortfolioTable = React.memo((props: PortfolioTableProps) => {
             value={table.getState().pagination.pageSize}
             onChange={(e) => {
               table.setPageSize(Number(e.target.value));
-              logPortfolioAnalytics("portfolioPagination", { extraParams: { type: "size" } });
+              logPortfolioAnalytics("portfolioPagination", {
+                extraParams: { paginationType: "size" },
+              });
             }}
           >
             {[10, 20, 50, 100, 500].map((pageSize) => (
@@ -707,7 +713,9 @@ export const PortfolioTable = React.memo((props: PortfolioTableProps) => {
             className="page-btn"
             onClick={() => {
               table.nextPage();
-              logPortfolioAnalytics("portfolioPagination", { extraParams: { type: "next" } });
+              logPortfolioAnalytics("portfolioPagination", {
+                extraParams: { paginationType: "next" },
+              });
             }}
             disabled={!table.getCanNextPage()}
           >

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -31,7 +31,7 @@ import {
   FilterContext,
   FilterNumberRange,
   IFilterContext,
-  LogPortfolioAnalytics,
+  PortfolioAnalyticsEvent,
   NUMBER_RANGE_DEFAULT,
 } from "./PropertiesList";
 import "styles/PortfolioTable.scss";
@@ -81,7 +81,7 @@ type PortfolioTableProps = {
   locale: SupportedLocale;
   rsunitslatestyear: number;
   getRowCanExpand: (row: Row<AddressRecord>) => boolean;
-  logPortfolioAnalytics: LogPortfolioAnalytics;
+  logPortfolioAnalytics: PortfolioAnalyticsEvent;
 };
 
 /**

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -606,7 +606,7 @@ export const PortfolioTable = React.memo((props: PortfolioTableProps) => {
             ))}
           </thead>
           <tbody>
-            {table.getRowModel().rows.length ? (
+            {!!table.getRowModel().rows.length &&
               (activeFilters.rsunitslatestActive || activeFilters.ownernamesActive) && (
                 <tr>
                   <td
@@ -617,10 +617,7 @@ export const PortfolioTable = React.memo((props: PortfolioTableProps) => {
                     {activeFilters.ownernamesActive && OwnernamesResultAlert}
                   </td>
                 </tr>
-              )
-            ) : (
-              <></>
-            )}
+              )}
             {table.getRowModel().rows.map((row, i) => {
               return (
                 <Fragment key={row.id}>

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -62,7 +62,7 @@ const FilterContextProvider: React.FC<{}> = (props) => {
   return <FilterContext.Provider value={useValue()}>{props.children}</FilterContext.Provider>;
 };
 
-export type LogPortfolioAnalytics = (
+export type PortfolioAnalyticsEvent = (
   event: AmplitudeEvent,
   extraProps: {
     column?: string;
@@ -83,7 +83,7 @@ const PropertiesListWithoutI18n: React.FC<
   const addrs = props.state.context.portfolioData.assocAddrs;
   const rsunitslatestyear = props.state.context.portfolioData.searchAddr.rsunitslatestyear;
 
-  const logPortfolioAnalytics: LogPortfolioAnalytics = (event, extraProps) => {
+  const logPortfolioAnalytics: PortfolioAnalyticsEvent = (event, extraProps) => {
     const { column, extraParams, gtmEvent } = extraProps;
     const portfolioColumn = !!column && { portfolioColumn: column };
     const eventParams = {
@@ -129,7 +129,8 @@ const PropertiesListWithoutI18n: React.FC<
       {isTableVisible ? (
         <FilterContextProvider>
           {useNewPortfolioMethod && (
-            <PortfolioFilters logPortfolioAnalytics={logPortfolioAnalytics} /> )} 
+            <PortfolioFilters logPortfolioAnalytics={logPortfolioAnalytics} />
+          )}
           <PortfolioTable
             data={addrs}
             headerTopSpacing={headerTopSpacing}

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -128,11 +128,8 @@ const PropertiesListWithoutI18n: React.FC<
     <div className="PropertiesList" ref={tableRef}>
       {isTableVisible ? (
         <FilterContextProvider>
-          {useNewPortfolioMethod ? (
-            <PortfolioFilters logPortfolioAnalytics={logPortfolioAnalytics} />
-          ) : (
-            <></>
-          )}
+          {useNewPortfolioMethod && (
+            <PortfolioFilters logPortfolioAnalytics={logPortfolioAnalytics} /> )} 
           <PortfolioTable
             data={addrs}
             headerTopSpacing={headerTopSpacing}

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -8,6 +8,7 @@ import Helpers from "../util/helpers";
 import Loader from "./Loader";
 import { PortfolioFilters } from "./PortfolioFilters";
 import { MAX_TABLE_ROWS_PER_PAGE, PortfolioTable } from "./PortfolioTable";
+import { EventProperties } from "./Amplitude";
 
 // Pattern for context provider to update context from child components
 // https://stackoverflow.com/a/67710693/7051239
@@ -72,6 +73,11 @@ const PropertiesListWithoutI18n: React.FC<
   const addrs = props.state.context.portfolioData.assocAddrs;
   const rsunitslatestyear = props.state.context.portfolioData.searchAddr.rsunitslatestyear;
 
+  const analyticsEventData: EventProperties = {
+    portfolioSize: addrs.length,
+    portfolioMappingMethod: useNewPortfolioMethod ? "wowza" : "legacy",
+  };
+
   /**
    * For older browsers that do not support the `useOnScreen` hook,
    * let's hide the dynamic scroll fade by default.
@@ -110,6 +116,7 @@ const PropertiesListWithoutI18n: React.FC<
             locale={locale}
             rsunitslatestyear={rsunitslatestyear}
             getRowCanExpand={() => true}
+            analyticsEventData={analyticsEventData}
           />
         </FilterContextProvider>
       ) : (

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -8,7 +8,7 @@ import Helpers from "../util/helpers";
 import Loader from "./Loader";
 import { PortfolioFilters } from "./PortfolioFilters";
 import { MAX_TABLE_ROWS_PER_PAGE, PortfolioTable } from "./PortfolioTable";
-import { EventProperties } from "./Amplitude";
+import { AmplitudeEvent, EventProperties, logAmplitudeEvent } from "./Amplitude";
 
 // Pattern for context provider to update context from child components
 // https://stackoverflow.com/a/67710693/7051239
@@ -62,6 +62,16 @@ const FilterContextProvider: React.FC<{}> = (props) => {
   return <FilterContext.Provider value={useValue()}>{props.children}</FilterContext.Provider>;
 };
 
+export type LogPortfolioAnalytics = (
+  event: AmplitudeEvent,
+  extraProps: {
+    column?: string;
+    extraParams?: EventProperties;
+    /** In case the corresponding event name for google isn't a straight case change from amplitude */
+    gtmEvent?: string;
+  }
+) => void;
+
 const PropertiesListWithoutI18n: React.FC<
   withMachineInStateProps<"portfolioFound"> & withI18nProps
 > = (props) => {
@@ -73,9 +83,18 @@ const PropertiesListWithoutI18n: React.FC<
   const addrs = props.state.context.portfolioData.assocAddrs;
   const rsunitslatestyear = props.state.context.portfolioData.searchAddr.rsunitslatestyear;
 
-  const analyticsEventData: EventProperties = {
-    portfolioSize: addrs.length,
-    portfolioMappingMethod: useNewPortfolioMethod ? "wowza" : "legacy",
+  const logPortfolioAnalytics: LogPortfolioAnalytics = (event, extraProps) => {
+    const { column, extraParams, gtmEvent } = extraProps;
+    const portfolioColumn = !!column && { portfolioColumn: column };
+    const eventParams = {
+      portfolioSize: addrs.length,
+      portfolioMappingMethod: useNewPortfolioMethod ? "wowza" : "legacy",
+      ...portfolioColumn,
+      ...extraParams,
+    };
+    logAmplitudeEvent(event, eventParams);
+    const gtagEvent = gtmEvent || event.replace(/([a-zA-Z])(?=[A-Z])/g, "$1-").toLowerCase();
+    window.gtag("event", gtagEvent, eventParams);
   };
 
   /**
@@ -109,14 +128,18 @@ const PropertiesListWithoutI18n: React.FC<
     <div className="PropertiesList" ref={tableRef}>
       {isTableVisible ? (
         <FilterContextProvider>
-          {useNewPortfolioMethod ? <PortfolioFilters /> : <></>}
+          {useNewPortfolioMethod ? (
+            <PortfolioFilters logPortfolioAnalytics={logPortfolioAnalytics} />
+          ) : (
+            <></>
+          )}
           <PortfolioTable
             data={addrs}
             headerTopSpacing={headerTopSpacing}
             locale={locale}
             rsunitslatestyear={rsunitslatestyear}
             getRowCanExpand={() => true}
-            analyticsEventData={analyticsEventData}
+            logPortfolioAnalytics={logPortfolioAnalytics}
           />
         </FilterContextProvider>
       ) : (


### PR DESCRIPTION
This PR adds a collection of analytics events - some are already in wow but needed to be added back after the table was completely rewritten for filters, and others are brand new to cover the filters interactions. All of the events have parity between Google and Amplitude, including the custom properties we send along with each (eg. portfolioSize, portfolioColumn, etc.). [sc-10784]

The way I'm actually logging the events in kind of awkward, because we have some common extra properties to send with them all, I tried to make them not too clunky when actually doing the logging, and we also have some frustrating inconsistencies between amplitude and google. Once we have everything up for filters, and can spend a bit of time getting settled into the new Google ecosystem of analytics tools, we'll have a better idea of what to change (eg. maybe we can drop amplitude all together?). These things should be addressed in a update of all the analytics event setup for WOW - I've started adding some thoughts on that in shortcut [sc-12296]

There is also a small bug that I noticed while testing - when there are 0 records for the table (from filtering) it showed up as `0` so now it returns a react fragment. 