### PR TITLE
fix hidden underline on IOS

### DIFF
--- a/client/src/styles/_button.scss
+++ b/client/src/styles/_button.scss
@@ -222,6 +222,7 @@
 .button.is-text {
   padding: 0;
   color: $justfix-black;
+  display: flex; // needed for IOS issue with hidden underline position under
   text-decoration: underline;
   text-underline-position: under;
   &:focus,


### PR DESCRIPTION
For the design system we use `text-underline-position: under` for everything so that the underline never crosses descenders in the text. This has caused some issues (on IOS only it seems) because the auto height of the element content doesn't account this lower underline, it just uses the line-height as normal, and there are inconsistencies with whether the underline shows above other content. On IOS if `display` is `block` or `inline-block` it doesn't show through, but it does if it's `flex`. And it just seems to work regardless on other browser/devices. 

You can kinda see what's happening here:
![image](https://user-images.githubusercontent.com/16906516/235545256-08cbeb78-6b76-4e95-b803-f8123f090ea3.png)

I documented this issue for the design system in shortcut as well [sc-12324]

[sc-12267]