### PR TITLE
fix import of algolia logo svg for img src

### DIFF
--- a/client/src/components/LandlordSearch.tsx
+++ b/client/src/components/LandlordSearch.tsx
@@ -12,6 +12,7 @@ import { I18n } from "@lingui/react";
 import { t, Trans, Plural } from "@lingui/macro";
 import { Link } from "react-router-dom";
 import { createRouteForFullBbl } from "routes";
+import algoliaIcon from "../assets/img/algolia.svg";
 
 import "../styles/LandlordSearch.css";
 import FocusTrap from "focus-trap-react";
@@ -87,12 +88,7 @@ const SearchBox = ({ currentRefinement, refine }: SearchBoxProvided) => {
               <CustomHits />
             </div>
             <div className="search-by is-pulled-right">
-              <img
-                width="140"
-                height="20"
-                alt="Algolia"
-                src={require("../assets/img/algolia.svg")}
-              />
+              <img width="140" height="20" alt="Algolia" src={algoliaIcon} />
             </div>
           </>
         )}


### PR DESCRIPTION
We show the Algolia logo for our search by landlord dropdown, and the svg import was not working (not sure how/when this changed). This PR just fixes the method of importing the file to use for the `<img>` `src`
![Screenshot 2023-05-02 at 1 22 48 PM](https://user-images.githubusercontent.com/16906516/235744145-811be56e-4c65-445f-baf9-ce1e4675c210.png)
