### PR TITLE
remove auto focus of inputs on opening accordions (desktop)

### DIFF
--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -176,7 +176,6 @@ export const PortfolioFilters = React.memo(
             isActive={ownernamesActive}
             isOpen={ownernamesIsOpen}
             setIsOpen={setOwnernamesIsOpen}
-            initialFocus={isMobile ? undefined : "#filter-ownernames-multiselect input"}
             selectionsCount={filterContext.filterSelections.ownernames.length}
             className="ownernames-accordion"
           >
@@ -194,7 +193,6 @@ export const PortfolioFilters = React.memo(
             isMobile={isMobile}
             isActive={unitsresActive}
             isOpen={unitsresIsOpen}
-            initialFocus={isMobile ? undefined : "#filter-unitsres-minmax_min-input"}
             setIsOpen={setUnitsresIsOpen}
             className="unitsres-accordion"
           >
@@ -211,7 +209,6 @@ export const PortfolioFilters = React.memo(
             isActive={zipActive}
             isOpen={zipIsOpen}
             setIsOpen={setZipIsOpen}
-            initialFocus={isMobile ? undefined : "#filter-zip-multiselect input"}
             selectionsCount={filterContext.filterSelections.zip.length}
             className="zip-accordion"
           >


### PR DESCRIPTION
We've gone back and forth on this a few times. Most recently, on desktop only, when you opened the filter accordions it would automatically focus the inputs. This had already been disabled for mobile, and now this behavior has been removed from desktop as well. (Though the optional prop is retained in FilterAccordion in case we change our minds again later)
[sc-12270]