### PR TITLE
Fix mobile multiselect searchbar width 

### DIFF
--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -284,6 +284,12 @@
             @include for-phone-only {
               padding: 0;
 
+              .multiselect__menu,
+              .multiselect__control,
+              .multiselect__selected-value-control-container {
+                width: 75%;
+              }
+
               .multiselect__input-container,
               .multiselect__placeholder {
                 height: 5rem;
@@ -292,7 +298,6 @@
               .multiselect__input-container,
               .multiselect__placeholder,
               .multiselect__menu {
-                width: 75%;
                 font-size: 1.8rem;
                 line-height: 100%;
               }


### PR DESCRIPTION
On mobile our multiselect searchbar/options list is only 75% width. There was an invisible div that was missed in setting that width, so it extended out of the intended width and clicking in this area was focusing the search bar and opening the options dropdown. 
![image](https://user-images.githubusercontent.com/16906516/235741211-73b7dac3-bec9-42da-8e27-3cfa0ee8b0d0.png)
Now everything is the correct width, and also the "clear" selections button is aligned with the search bar. 
![image](https://user-images.githubusercontent.com/16906516/235741354-52aa3427-23dd-439c-b013-f9312bfa1424.png)
