### PR TITLE
Clear unapplied filter selections

### DIFF
--- a/client/src/components/MinMaxSelect.tsx
+++ b/client/src/components/MinMaxSelect.tsx
@@ -62,7 +62,6 @@ function MinMaxSelect({
           return { ...preset, checked: selectionMinValues.includes(preset.min) };
         });
         setPresets(presetSelections);
-        console.log({ defaultSelections, selectionMinValues, presetSelections });
       } else {
         setCustomRange(NUMBER_RANGE_DEFAULT);
         setPresets((prev) => prev.map((preset) => ({ ...preset, checked: false })));
@@ -122,7 +121,6 @@ function MinMaxSelect({
         tabIndex={hasCustomInputs ? 0 : -1}
       >
         {presets.map((preset, i) => {
-          console.log({ presets });
           return (
             <div className="minmaxselect__preset-value" key={i}>
               <input

--- a/client/src/components/MinMaxSelect.tsx
+++ b/client/src/components/MinMaxSelect.tsx
@@ -52,19 +52,23 @@ function MinMaxSelect({
 
   React.useEffect(() => {
     if (!isOpen) {
-      if (defaultSelections.type === "custom") {
-        setCustomRange(defaultSelections.values[0]);
-        setPresets((prev) => prev.map((preset) => ({ ...preset, checked: false })));
-      } else if (defaultSelections.type === "presets") {
-        setCustomRange(NUMBER_RANGE_DEFAULT);
-        const selectionMinValues = defaultSelections.values.map((rng) => rng.min);
-        const presetSelections = PRESETS_DEFAULT.map((preset) => {
-          return { ...preset, checked: selectionMinValues.includes(preset.min) };
-        });
-        setPresets(presetSelections);
-      } else {
-        setCustomRange(NUMBER_RANGE_DEFAULT);
-        setPresets((prev) => prev.map((preset) => ({ ...preset, checked: false })));
+      switch (defaultSelections.type) {
+        case "custom":
+          setCustomRange(defaultSelections.values[0]);
+          setPresets((prev) => prev.map((preset) => ({ ...preset, checked: false })));
+          break;
+        case "presets":
+          setCustomRange(NUMBER_RANGE_DEFAULT);
+          const selectionMinValues = defaultSelections.values.map((rng) => rng.min);
+          const presetSelections = PRESETS_DEFAULT.map((preset) => {
+            return { ...preset, checked: selectionMinValues.includes(preset.min) };
+          });
+          setPresets(presetSelections);
+          break;
+        default:
+          setCustomRange(NUMBER_RANGE_DEFAULT);
+          setPresets((prev) => prev.map((preset) => ({ ...preset, checked: false })));
+          break;
       }
     }
   }, [isOpen, defaultSelections]);

--- a/client/src/components/MinMaxSelect.tsx
+++ b/client/src/components/MinMaxSelect.tsx
@@ -50,23 +50,25 @@ function MinMaxSelect({
 
   const hasCustomInputs = isFinite(customRange.min) || isFinite(customRange.max);
 
-  // React.useEffect(() => {
-  //   if (!isOpen) {
-  //     console.log({defaultSelections})
-  //     if (defaultSelections[0].min !== -Infinity) {
-  //       setCustomRange(defaultSelections[0]);
-  //       setPresets(PRESETS_DEFAULT);
-  //     } else if (defaultSelections.length > 1) {
-  //       setCustomRange(NUMBER_RANGE_DEFAULT);
-  //       const selectionMinValues = defaultSelections.map((rng) => rng.min);
-  //       const presetSelections = PRESETS_DEFAULT.map((preset) => {
-  //         return { ...preset, checked: selectionMinValues.includes(preset.min) };
-  //       });
-  //       console.log({selectionMinValues, presetSelections})
-  //       setPresets(presetSelections);
-  //     }
-  //   }
-  // }, [isOpen, defaultSelections]); // eslint-disable-line react-hooks/exhaustive-deps
+  React.useEffect(() => {
+    if (!isOpen) {
+      if (defaultSelections.type === "custom") {
+        setCustomRange(defaultSelections.values[0]);
+        setPresets((prev) => prev.map((preset) => ({ ...preset, checked: false })));
+      } else if (defaultSelections.type === "presets") {
+        setCustomRange(NUMBER_RANGE_DEFAULT);
+        const selectionMinValues = defaultSelections.values.map((rng) => rng.min);
+        const presetSelections = PRESETS_DEFAULT.map((preset) => {
+          return { ...preset, checked: selectionMinValues.includes(preset.min) };
+        });
+        setPresets(presetSelections);
+        console.log({ defaultSelections, selectionMinValues, presetSelections });
+      } else {
+        setCustomRange(NUMBER_RANGE_DEFAULT);
+        setPresets((prev) => prev.map((preset) => ({ ...preset, checked: false })));
+      }
+    }
+  }, [isOpen, defaultSelections]);
 
   const handlePresetChange = (preset: Preset, i: number) => {
     setPresets((prev) => {
@@ -119,25 +121,28 @@ function MinMaxSelect({
         aria-labelledby={`${id || "minmax-select"}__preset-a11y-text`}
         tabIndex={hasCustomInputs ? 0 : -1}
       >
-        {presets.map((preset, i) => (
-          <div className="minmaxselect__preset-value" key={i}>
-            <input
-              type="checkbox"
-              id={`minmaxselect__preset-${i}`}
-              name={`minmaxselect__preset-${i}`}
-              className={classnames({ checked: preset.checked })}
-              aria-describedby={`${id || "minmax-select"}__preset-a11y-text`}
-              onChange={() => handlePresetChange(preset, i)}
-              disabled={hasCustomInputs}
-              aria-hidden={hasCustomInputs}
-              checked={preset.checked}
-            />
-            <label htmlFor={`minmaxselect__preset-${i}`}>
-              {preset.min}
-              {isFinite(preset.max) ? `-${preset.max}` : "+"}
-            </label>
-          </div>
-        ))}
+        {presets.map((preset, i) => {
+          console.log({ presets });
+          return (
+            <div className="minmaxselect__preset-value" key={i}>
+              <input
+                type="checkbox"
+                id={`minmaxselect__preset-${i}`}
+                name={`minmaxselect__preset-${i}`}
+                className={classnames({ checked: preset.checked })}
+                aria-describedby={`${id || "minmax-select"}__preset-a11y-text`}
+                onChange={() => handlePresetChange(preset, i)}
+                disabled={hasCustomInputs}
+                aria-hidden={hasCustomInputs}
+                checked={preset.checked}
+              />
+              <label htmlFor={`minmaxselect__preset-${i}`}>
+                {preset.min}
+                {isFinite(preset.max) ? `-${preset.max}` : "+"}
+              </label>
+            </div>
+          );
+        })}
         <span
           id={`${id || "minmax-select"}__preset-a11y-text`}
           className="minmaxselect__a11y-text"

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -25,6 +25,8 @@ export type Option = {
 
 interface CustomMultiselectProps {
   onApply: (selectedList: any) => void;
+  defaultSelections?: Option[];
+  isOpen: boolean;
   onError?: () => void;
   previewSelectedNum?: number;
   infoAlert?: JSX.Element;
@@ -58,6 +60,8 @@ function MultiSelect<
   GroupType extends GroupBase<Option> = GroupBase<Option>
 >({
   options,
+  defaultSelections,
+  isOpen,
   onApply,
   infoAlert,
   onChange,
@@ -70,6 +74,12 @@ function MultiSelect<
   const [hasError, setHasError] = useState(false);
   const [showAllSelections, setShowAllSelections] = useState(false);
   const [inputValue, setInputValue] = useState<string | undefined>(undefined);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      setSelections(defaultSelections as Option[]);
+    }
+  }, [isOpen, defaultSelections]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleChange = useCallback(
     (newValue, actionMeta) => {
@@ -99,7 +109,7 @@ function MultiSelect<
 
   const handleApply = () => {
     // @ts-ignore (value isn't recognizing the available properties of Option type)
-    const selectedValues = selections.map((v) => ({ name: v.value || "", id: v.label }));
+    const selectedValues: string[] = selections.map((v) => (v.value || v.label).toString());
     if (!selectedValues.length && !!inputValue) {
       onError && onError();
       setHasError(true);

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -5,9 +5,9 @@ import React from "react";
 import { CheckIcon, ChevronIcon, CloseIcon, InfoIcon } from "./Icons";
 import {
   FilterContext,
-  FilterNumberRange,
   PortfolioAnalyticsEvent,
   NUMBER_RANGE_DEFAULT,
+  FilterNumberRangeSelections,
 } from "./PropertiesList";
 import FocusTrap from "focus-trap-react";
 import { FocusTarget } from "focus-trap";
@@ -40,7 +40,11 @@ const PortfolioFiltersWithoutI18n = React.memo(
     const { filterContext, setFilterContext } = React.useContext(FilterContext);
     const { filteredBuildings } = filterContext;
     const { ownernames: ownernamesOptions, zip: zipOptions } = filterContext.filterOptions;
-    const { ownernames: ownernamesSelections, zip: zipSelections } = filterContext.filterSelections;
+    const {
+      ownernames: ownernamesSelections,
+      unitsres: unitsresSelections,
+      zip: zipSelections,
+    } = filterContext.filterSelections;
 
     const { i18n, logPortfolioAnalytics } = props;
 
@@ -66,6 +70,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
         column: "ownernames",
       });
       setOwnernamesActive(!!selectedList.length);
+      setOwnernamesIsOpen(false);
       setFilterContext({
         ...filterContext,
         filterSelections: {
@@ -73,13 +78,12 @@ const PortfolioFiltersWithoutI18n = React.memo(
           ownernames: selectedList,
         },
       });
-      setOwnernamesIsOpen(false);
     };
 
     const [unitsresActive, setUnitsresActive] = React.useState(false);
     const [unitsresIsOpen, setUnitsresIsOpen] = React.useState(false);
-    const onUnitsresApply = (selections: FilterNumberRange[]) => {
-      const updatedIsActive = isFinite(selections[0].min) || isFinite(selections[0].max);
+    const onUnitsresApply = (selections: FilterNumberRangeSelections) => {
+      const updatedIsActive = selections.type !== "default";
       logPortfolioAnalytics(!updatedIsActive ? "filterCleared" : "filterApplied", {
         column: "unitsres",
       });
@@ -122,7 +126,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
         filterSelections: {
           rsunitslatest: false,
           ownernames: [],
-          unitsres: [NUMBER_RANGE_DEFAULT],
+          unitsres: { type: "default", values: [NUMBER_RANGE_DEFAULT] },
           zip: [],
         },
       });
@@ -225,6 +229,8 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
               id="filter-unitsres-minmax"
               onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
+              isOpen={unitsresIsOpen}
+              defaultSelections={unitsresSelections}
             />
           </FilterAccordion>
           <FilterAccordion

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -40,6 +40,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
     const { filterContext, setFilterContext } = React.useContext(FilterContext);
     const { filteredBuildings } = filterContext;
     const { ownernames: ownernamesOptions, zip: zipOptions } = filterContext.filterOptions;
+    const { ownernames: ownernamesSelections, zip: zipSelections } = filterContext.filterSelections;
 
     const { i18n, logPortfolioAnalytics } = props;
 
@@ -60,12 +61,11 @@ const PortfolioFiltersWithoutI18n = React.memo(
 
     const [ownernamesActive, setOwnernamesActive] = React.useState(false);
     const [ownernamesIsOpen, setOwnernamesIsOpen] = React.useState(false);
-    const onOwnernamesApply = (selectedList: any) => {
+    const onOwnernamesApply = (selectedList: string[]) => {
       logPortfolioAnalytics(!selectedList.length ? "filterCleared" : "filterApplied", {
         column: "ownernames",
       });
       setOwnernamesActive(!!selectedList.length);
-      setOwnernamesIsOpen(false);
       setFilterContext({
         ...filterContext,
         filterSelections: {
@@ -73,6 +73,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
           ownernames: selectedList,
         },
       });
+      setOwnernamesIsOpen(false);
     };
 
     const [unitsresActive, setUnitsresActive] = React.useState(false);
@@ -95,7 +96,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
 
     const [zipActive, setZipActive] = React.useState(false);
     const [zipIsOpen, setZipIsOpen] = React.useState(false);
-    const onZipApply = (selectedList: any) => {
+    const onZipApply = (selectedList: string[]) => {
       logPortfolioAnalytics(!selectedList.length ? "filterCleared" : "filterApplied", {
         column: "zip",
       });
@@ -126,14 +127,6 @@ const PortfolioFiltersWithoutI18n = React.memo(
         },
       });
     };
-
-    const zipOptionsSelect: Option[] = zipOptions
-      ? zipOptions.map((val: string) => ({ value: val, label: val }))
-      : [];
-
-    const ownernamesOptionsSelect: Option[] = ownernamesOptions
-      ? ownernamesOptions.map((val: string) => ({ value: val, label: val }))
-      : [];
 
     const activeFilters = { rsunitslatestActive, ownernamesActive, unitsresActive, zipActive };
 
@@ -207,11 +200,13 @@ const PortfolioFiltersWithoutI18n = React.memo(
           >
             <MultiSelect
               id="filter-ownernames-multiselect"
-              options={ownernamesOptionsSelect}
+              options={valuesAsMultiselectOptions(ownernamesOptions)}
               onApply={onOwnernamesApply}
               onError={() => logPortfolioAnalytics("filterError", { column: "ownernames" })}
               infoAlert={OwnernamesInfoAlert}
               aria-label={i18n._(t`Landlord filter`)}
+              isOpen={ownernamesIsOpen}
+              defaultSelections={valuesAsMultiselectOptions(ownernamesSelections)}
             />
           </FilterAccordion>
           <FilterAccordion
@@ -244,12 +239,14 @@ const PortfolioFiltersWithoutI18n = React.memo(
           >
             <MultiSelect
               id="filter-zip-multiselect"
-              options={zipOptionsSelect}
+              options={valuesAsMultiselectOptions(zipOptions)}
               onApply={onZipApply}
               noOptionsMessage={() => i18n._(t`ZIP code is not applicable`)}
               onError={() => logPortfolioAnalytics("filterError", { column: "zip" })}
               aria-label={i18n._(t`Zip code filter`)}
               onKeyDown={helpers.preventNonNumericalInput}
+              isOpen={zipIsOpen}
+              defaultSelections={valuesAsMultiselectOptions(zipSelections)}
             />
           </FilterAccordion>
         </FiltersWrapper>
@@ -523,6 +520,13 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
     </>
   );
 });
+
+function valuesAsMultiselectOptions(values: string[]): Option[] {
+  const formattedOptions: Option[] = values
+    ? values.map((val: string) => ({ value: val, label: val }))
+    : [];
+  return formattedOptions;
+}
 
 const PortfolioFilters = withI18n()(PortfolioFiltersWithoutI18n);
 

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -792,9 +792,9 @@ function useFilterSelectionsUpdater(filterContext: IFilterContext, table: Table<
   React.useEffect(() => {
     const { rsunitslatest, ownernames, unitsres, zip } = filterContext.filterSelections;
     table.getColumn("rsunitslatest").setFilterValue(rsunitslatest);
-    table.getColumn("ownernames").setFilterValue(ownernames!.map((item: any) => item.name));
+    table.getColumn("ownernames").setFilterValue(ownernames);
     table.getColumn("unitsres").setFilterValue(unitsres);
-    table.getColumn("zip").setFilterValue(zip!.map((item: any) => item.name));
+    table.getColumn("zip").setFilterValue(zip);
   }, [filterContext.filterSelections]);
 }
 

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -100,8 +100,7 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
   const activeFilters = {
     rsunitslatestActive: filterSelections.rsunitslatest,
     ownernamesActive: !!filterSelections.ownernames.length,
-    unitsresActive:
-      isFinite(filterSelections.unitsres[0].min) || isFinite(filterSelections.unitsres[0].max),
+    unitsresActive: filterSelections.unitsres.type !== "default",
     zipActive: !!filterSelections.zip.length,
   };
 
@@ -793,7 +792,7 @@ function useFilterSelectionsUpdater(filterContext: IFilterContext, table: Table<
     const { rsunitslatest, ownernames, unitsres, zip } = filterContext.filterSelections;
     table.getColumn("rsunitslatest").setFilterValue(rsunitslatest);
     table.getColumn("ownernames").setFilterValue(ownernames);
-    table.getColumn("unitsres").setFilterValue(unitsres);
+    table.getColumn("unitsres").setFilterValue(unitsres.values);
     table.getColumn("zip").setFilterValue(zip);
   }, [filterContext.filterSelections]);
 }

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -15,13 +15,17 @@ import { AmplitudeEvent, EventProperties, logAmplitudeEvent } from "./Amplitude"
 
 export type FilterNumberRange = { min: number; max: number };
 export const NUMBER_RANGE_DEFAULT = { min: -Infinity, max: Infinity };
+export type FilterNumberRangeSelections = {
+  type: "default" | "presets" | "custom";
+  values: FilterNumberRange[];
+};
 
 export type IFilterContext = {
   totalBuildings?: number | undefined;
   filteredBuildings?: number | undefined;
   filterSelections: {
     ownernames: string[];
-    unitsres: FilterNumberRange[];
+    unitsres: FilterNumberRangeSelections;
     zip: string[];
     rsunitslatest?: boolean;
   };
@@ -33,13 +37,13 @@ export type IFilterContext = {
 };
 
 const useValue = () => {
-  const defaultContext = {
+  const defaultContext: IFilterContext = {
     totalBuildings: undefined,
     filteredBuildings: undefined,
     filterSelections: {
       rsunitslatest: false,
       ownernames: [],
-      unitsres: [NUMBER_RANGE_DEFAULT],
+      unitsres: { type: "default", values: [NUMBER_RANGE_DEFAULT] },
       zip: [],
     },
     filterOptions: {
@@ -48,7 +52,7 @@ const useValue = () => {
       zip: [],
     },
   };
-  const [filterContext, setFilterContext] = React.useState<IFilterContext>(defaultContext);
+  const [filterContext, setFilterContext] = React.useState(defaultContext);
 
   return {
     filterContext,


### PR DESCRIPTION
For our multiselect filters all selections made from the options dropdown are saved in the multiselect component state as "pending" selections, then once "apply" is clicked that are confirmed and passed into the main filters context/state. We want to make sure things match user expectations, so this PR changes so that:

any selections that are not applied are cleared when the filter dropdown is closed
any applied selections persist in the filter when opened/closed
when all applied filter selections are cleared with the "clear all" button the "pending" selections should also be cleared from the multiselect component. 

Also, in doing this I realized there was some inconsistency with the types of the multiselect filter selections that needed to be fixed. No more `any` used in those!

For the MinMax select filter we do the same thing. However, to be able to show the applied selections in the component based on the applied filter selections (since they are cleared from the internal minmax select state on every close) we needed to change the data structure of those applied selections to know whether the selection is from the custom range or the presets (or if it just the default -Infinity/Infinity min max values). 

Here's how that all looks for both kinds of filters:

https://user-images.githubusercontent.com/16906516/236201775-f2250916-b1aa-460d-aef8-2d941f23aeae.mov

[sc-12346]
[sc-11789]
[sc-12329]