### PR TITLE
widen zip filter for desktop, chips flex direction row

### DIFF
--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -214,7 +214,7 @@
             width: 25.2rem;
           }
           &.zip-accordion .dropdown-container {
-            width: 16.5rem;
+            width: 24rem;
           }
         }
 
@@ -298,11 +298,6 @@
               }
               .multiselect__menu {
                 font-size: 1.6rem;
-              }
-            }
-            .multiselect__selected-value-container {
-              @include for-tablet-portrait-up {
-                flex-direction: column;
               }
             }
           }


### PR DESCRIPTION
We changed the language for the multiselect filters from "clear" to "clear selections", and on desktop we ran out of room. So we are widening the filter dropdown. And now that there is more room, we decided to change the selected chips to be `flex-direction: row` so the spacing looks better. 

![image](https://user-images.githubusercontent.com/16906516/236507033-913c978d-170d-43f1-a5b1-e37e0e48e84f.png) ![image](https://user-images.githubusercontent.com/16906516/236507016-f013e230-f0e0-4c4f-a872-b5ec2ba1a97a.png)
