### PR TITLE
fix broken column sorting in portfolio table

### DIFF
--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -580,8 +580,8 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
                               className: header.column.getCanSort()
                                 ? "cursor-pointer select-none"
                                 : "",
-                              onClick: () => {
-                                header.column.getToggleSortingHandler();
+                              onClick: (e) => {
+                                header.column.getToggleSortingHandler()?.(e);
                                 logPortfolioAnalytics("portfolioColumnSort", {
                                   column: header.column.id,
                                 });


### PR DESCRIPTION
When adding a analytics event on the column sort click in #752  I accidentally broke the table sorting. There is a method from the react-table that handles the sorting - but it actually returns a handler function rather than actually handling it. So I just needed to actually call it after getting the handler.

[sc-12405]