### PR TITLE
ios mobile menu scrolling

### DIFF
--- a/client/src/components/MinMaxSelect.tsx
+++ b/client/src/components/MinMaxSelect.tsx
@@ -32,6 +32,7 @@ type MinMaxSelectProps = {
   onError?: () => void;
   id?: string;
   onFocusInput?: () => void;
+  onBlurInput?: () => void;
 };
 
 function MinMaxSelect({
@@ -42,6 +43,7 @@ function MinMaxSelect({
   onError,
   id,
   onFocusInput,
+  onBlurInput,
 }: MinMaxSelectProps) {
   const [customRange, setCustomRange] = React.useState<FilterNumberRange>(NUMBER_RANGE_DEFAULT);
   const [customRangeErrors, setCustomRangeErrors] = React.useState<CustomRangeErrors>(
@@ -106,15 +108,6 @@ function MinMaxSelect({
       : onApply({ type: "default", values: [NUMBER_RANGE_DEFAULT] });
   };
 
-  /* iOS specific issue
-    focus inputs w/ keyboard shifts up the entire HTML tag. 
-    on keyboard close, HTML doesn't revert to previous position. 
-    this force scrolls the background to the top. */
-  const handlePageShift = () => {
-    window.scrollTo(0, 0);
-    document.body.scrollTop = 0;
-  };
-
   const commonInputProps: InputHTMLAttributes<HTMLInputElement> = {
     type: "text",
     inputMode: "numeric",
@@ -126,7 +119,7 @@ function MinMaxSelect({
     max: options.min,
     onKeyDown: helpers.preventNonNumericalInput,
     onFocus: onFocusInput,
-    onBlur: handlePageShift,
+    onBlur: onBlurInput,
   };
 
   return (

--- a/client/src/components/MinMaxSelect.tsx
+++ b/client/src/components/MinMaxSelect.tsx
@@ -31,8 +31,6 @@ type MinMaxSelectProps = {
   defaultSelections: FilterNumberRangeSelections;
   onError?: () => void;
   id?: string;
-  onFocusInput?: () => void;
-  onBlurInput?: () => void;
 };
 
 function MinMaxSelect({
@@ -42,8 +40,6 @@ function MinMaxSelect({
   defaultSelections,
   onError,
   id,
-  onFocusInput,
-  onBlurInput,
 }: MinMaxSelectProps) {
   const [customRange, setCustomRange] = React.useState<FilterNumberRange>(NUMBER_RANGE_DEFAULT);
   const [customRangeErrors, setCustomRangeErrors] = React.useState<CustomRangeErrors>(
@@ -118,8 +114,6 @@ function MinMaxSelect({
     min: options.min,
     max: options.min,
     onKeyDown: helpers.preventNonNumericalInput,
-    onFocus: onFocusInput,
-    onBlur: onBlurInput,
   };
 
   return (

--- a/client/src/components/MinMaxSelect.tsx
+++ b/client/src/components/MinMaxSelect.tsx
@@ -106,6 +106,15 @@ function MinMaxSelect({
       : onApply({ type: "default", values: [NUMBER_RANGE_DEFAULT] });
   };
 
+  /* iOS specific issue
+    focus inputs w/ keyboard shifts up the entire HTML tag. 
+    on keyboard close, HTML doesn't revert to previous position. 
+    this force scrolls the background to the top. */
+  const handlePageShift = () => {
+    window.scrollTo(0, 0);
+    document.body.scrollTop = 0;
+  };
+
   const commonInputProps: InputHTMLAttributes<HTMLInputElement> = {
     type: "text",
     inputMode: "numeric",
@@ -117,6 +126,7 @@ function MinMaxSelect({
     max: options.min,
     onKeyDown: helpers.preventNonNumericalInput,
     onFocus: onFocusInput,
+    onBlur: handlePageShift,
   };
 
   return (

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -68,7 +68,6 @@ function MultiSelect<
   onInputChange,
   onError,
   previewSelectedNum,
-  onBlur,
   ...props
 }: Props<Option, IsMulti, GroupType> & CustomMultiselectProps) {
   const [selections, setSelections] = useState<Option[]>([]);
@@ -135,7 +134,6 @@ function MultiSelect<
             options={options}
             value={selections}
             onChange={handleChange}
-            onBlur={onBlur}
             inputValue={inputValue}
             onInputChange={handleInputChange}
             placeholder={i18n._(t`Search`) + `... (${options!.length})`}

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -68,6 +68,7 @@ function MultiSelect<
   onInputChange,
   onError,
   previewSelectedNum,
+  onBlur,
   ...props
 }: Props<Option, IsMulti, GroupType> & CustomMultiselectProps) {
   const [selections, setSelections] = useState<Option[]>([]);
@@ -118,15 +119,6 @@ function MultiSelect<
     }
   };
 
-  /* iOS specific issue
-    focus inputs w/ keyboard shifts up the entire HTML tag. 
-    on keyboard close, HTML doesn't revert to previous position. 
-    this force scrolls the background to the top. */
-  const handlePageShift = () => {
-    window.scrollTo(0, 0);
-    document.body.scrollTop = 0;
-  };
-
   return (
     <I18n>
       {({ i18n }) => (
@@ -143,7 +135,7 @@ function MultiSelect<
             options={options}
             value={selections}
             onChange={handleChange}
-            onBlur={handlePageShift}
+            onBlur={onBlur}
             inputValue={inputValue}
             onInputChange={handleInputChange}
             placeholder={i18n._(t`Search`) + `... (${options!.length})`}

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -118,6 +118,15 @@ function MultiSelect<
     }
   };
 
+  /* iOS specific issue
+    focus inputs w/ keyboard shifts up the entire HTML tag. 
+    on keyboard close, HTML doesn't revert to previous position. 
+    this force scrolls the background to the top. */
+  const handlePageShift = () => {
+    window.scrollTo(0, 0);
+    document.body.scrollTop = 0;
+  };
+
   return (
     <I18n>
       {({ i18n }) => (
@@ -134,6 +143,7 @@ function MultiSelect<
             options={options}
             value={selections}
             onChange={handleChange}
+            onBlur={handlePageShift}
             inputValue={inputValue}
             onInputChange={handleInputChange}
             placeholder={i18n._(t`Search`) + `... (${options!.length})`}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -227,7 +227,8 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onApply={onUnitsresApply}
               onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
               id="filter-unitsres-minmax"
-              // onFocusInput={handlePageShift}
+              // onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
+              onFocusInput={handlePageShift}
               // onBlurInput={handlePageShift}
               isOpen={unitsresIsOpen}
               defaultSelections={unitsresSelections}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -206,6 +206,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
               options={valuesAsMultiselectOptions(ownernamesOptions)}
               onApply={onOwnernamesApply}
               onError={() => logPortfolioAnalytics("filterError", { column: "ownernames" })}
+              onBlur={handlePageShift}
               infoAlert={OwnernamesInfoAlert}
               aria-label={i18n._(t`Landlord filter`)}
               isOpen={ownernamesIsOpen}
@@ -227,6 +228,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
               id="filter-unitsres-minmax"
               onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
+              onBlurInput={handlePageShift}
               isOpen={unitsresIsOpen}
               defaultSelections={unitsresSelections}
             />
@@ -246,6 +248,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onApply={onZipApply}
               noOptionsMessage={() => i18n._(t`ZIP code is not applicable`)}
               onError={() => logPortfolioAnalytics("filterError", { column: "zip" })}
+              onBlur={handlePageShift}
               aria-label={i18n._(t`Zip code filter`)}
               onKeyDown={helpers.preventNonNumericalInput}
               isOpen={zipIsOpen}
@@ -316,15 +319,6 @@ const FiltersWrapper = (props: {
   const { isMobile, activeFilters, resultsCount, children } = props;
   const numActiveFilters = Object.values(activeFilters).filter(Boolean).length;
   const [isOpen, setIsOpen] = React.useState(false);
-
-  /* iOS specific issue
-    focus inputs w/ keyboard shifts up the entire HTML tag. 
-    on keyboard close, HTML doesn't revert to previous position. 
-    this force scrolls the background to the top. */
-  const handlePageShift = () => {
-    window.scrollTo(0, 0);
-    document.body.scrollTop = 0;
-  };
 
   return !isMobile ? (
     <div className="filters">{children}</div>
@@ -481,7 +475,6 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
   } = props;
   const [showInfoModal, setShowInfoModal] = React.useState(false);
 
-
   return (
     <>
       <FocusTrap
@@ -549,6 +542,15 @@ function valuesAsMultiselectOptions(values: string[]): Option[] {
     : [];
   return formattedOptions;
 }
+
+/* iOS specific issue
+focus inputs w/ keyboard shifts up the entire HTML tag. 
+on keyboard close, HTML doesn't revert to previous position. 
+this force scrolls the background to the top. */
+const handlePageShift = () => {
+  window.scrollTo(0, 0);
+  document.body.scrollTop = 0;
+};
 
 const PortfolioFilters = withI18n()(PortfolioFiltersWithoutI18n);
 

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -481,6 +481,16 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
   } = props;
   const [showInfoModal, setShowInfoModal] = React.useState(false);
 
+
+  /* iOS specific issue
+    focus inputs w/ keyboard shifts up the entire HTML tag. 
+    on keyboard close, HTML doesn't revert to previous position. 
+    this force scrolls the background to the top. */
+    const handlePageShift = () => {
+      window.scrollTo(0, 0);
+      document.body.scrollTop = 0;
+    };
+
   return (
     <>
       <FocusTrap
@@ -502,6 +512,7 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
               e.preventDefault();
               !isOpen && onOpen && onOpen();
               setIsOpen(!isOpen);
+              handlePageShift();
             }}
             data-selections={selectionsCount}
             aria-label={i18n._(t`Filter`)}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -206,7 +206,6 @@ const PortfolioFiltersWithoutI18n = React.memo(
               options={valuesAsMultiselectOptions(ownernamesOptions)}
               onApply={onOwnernamesApply}
               onError={() => logPortfolioAnalytics("filterError", { column: "ownernames" })}
-              // onBlur={handlePageShift}
               infoAlert={OwnernamesInfoAlert}
               aria-label={i18n._(t`Landlord filter`)}
               isOpen={ownernamesIsOpen}
@@ -227,9 +226,6 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onApply={onUnitsresApply}
               onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
               id="filter-unitsres-minmax"
-              // onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
-              // onFocusInput={handlePageShift}
-              // onBlurInput={handlePageShift}
               isOpen={unitsresIsOpen}
               defaultSelections={unitsresSelections}
             />
@@ -249,7 +245,6 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onApply={onZipApply}
               noOptionsMessage={() => i18n._(t`ZIP code is not applicable`)}
               onError={() => logPortfolioAnalytics("filterError", { column: "zip" })}
-              // onBlur={handlePageShift}
               aria-label={i18n._(t`Zip code filter`)}
               onKeyDown={helpers.preventNonNumericalInput}
               isOpen={zipIsOpen}
@@ -343,7 +338,6 @@ const FiltersWrapper = (props: {
             onClick={(e) => {
               e.preventDefault();
               setIsOpen(!isOpen);
-              // handlePageShift();
             }}
           >
             <Trans>Filters</Trans>
@@ -359,7 +353,6 @@ const FiltersWrapper = (props: {
                 className="button is-primary"
                 onClick={() => {
                   setIsOpen(!isOpen);
-                  // handlePageShift();
                 }}
               >
                 <Trans>View Results</Trans>
@@ -543,15 +536,6 @@ function valuesAsMultiselectOptions(values: string[]): Option[] {
     : [];
   return formattedOptions;
 }
-
-/* iOS specific issue
-focus inputs w/ keyboard shifts up the entire HTML tag. 
-on keyboard close, HTML doesn't revert to previous position. 
-this force scrolls the background to the top. */
-// const handlePageShift = () => {
-//   window.scrollTo(0, 0);
-//   document.body.scrollTop = 0;
-// };
 
 const PortfolioFilters = withI18n()(PortfolioFiltersWithoutI18n);
 

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -481,15 +481,14 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
   } = props;
   const [showInfoModal, setShowInfoModal] = React.useState(false);
 
-
   /* iOS specific issue
     focus inputs w/ keyboard shifts up the entire HTML tag. 
     on keyboard close, HTML doesn't revert to previous position. 
     this force scrolls the background to the top. */
-    const handlePageShift = () => {
-      window.scrollTo(0, 0);
-      document.body.scrollTop = 0;
-    };
+  const handlePageShift = () => {
+    window.scrollTo(0, 0);
+    document.body.scrollTop = 0;
+  };
 
   return (
     <>

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -227,6 +227,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onApply={onUnitsresApply}
               onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
               id="filter-unitsres-minmax"
+              onFocusInput={handlePageShift}
               onBlurInput={handlePageShift}
               isOpen={unitsresIsOpen}
               defaultSelections={unitsresSelections}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -206,7 +206,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
               options={valuesAsMultiselectOptions(ownernamesOptions)}
               onApply={onOwnernamesApply}
               onError={() => logPortfolioAnalytics("filterError", { column: "ownernames" })}
-              onBlur={handlePageShift}
+              // onBlur={handlePageShift}
               infoAlert={OwnernamesInfoAlert}
               aria-label={i18n._(t`Landlord filter`)}
               isOpen={ownernamesIsOpen}
@@ -228,8 +228,8 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
               id="filter-unitsres-minmax"
               // onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
-              onFocusInput={handlePageShift}
-              onBlurInput={handlePageShift}
+              // onFocusInput={handlePageShift}
+              // onBlurInput={handlePageShift}
               isOpen={unitsresIsOpen}
               defaultSelections={unitsresSelections}
             />
@@ -249,7 +249,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onApply={onZipApply}
               noOptionsMessage={() => i18n._(t`ZIP code is not applicable`)}
               onError={() => logPortfolioAnalytics("filterError", { column: "zip" })}
-              onBlur={handlePageShift}
+              // onBlur={handlePageShift}
               aria-label={i18n._(t`Zip code filter`)}
               onKeyDown={helpers.preventNonNumericalInput}
               isOpen={zipIsOpen}
@@ -343,7 +343,7 @@ const FiltersWrapper = (props: {
             onClick={(e) => {
               e.preventDefault();
               setIsOpen(!isOpen);
-              handlePageShift();
+              // handlePageShift();
             }}
           >
             <Trans>Filters</Trans>
@@ -359,7 +359,7 @@ const FiltersWrapper = (props: {
                 className="button is-primary"
                 onClick={() => {
                   setIsOpen(!isOpen);
-                  handlePageShift();
+                  // handlePageShift();
                 }}
               >
                 <Trans>View Results</Trans>

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -229,7 +229,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
               id="filter-unitsres-minmax"
               // onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
               onFocusInput={handlePageShift}
-              // onBlurInput={handlePageShift}
+              onBlurInput={handlePageShift}
               isOpen={unitsresIsOpen}
               defaultSelections={unitsresSelections}
             />

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -227,8 +227,8 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onApply={onUnitsresApply}
               onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
               id="filter-unitsres-minmax"
-              onFocusInput={handlePageShift}
-              onBlurInput={handlePageShift}
+              // onFocusInput={handlePageShift}
+              // onBlurInput={handlePageShift}
               isOpen={unitsresIsOpen}
               defaultSelections={unitsresSelections}
             />

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -481,14 +481,6 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
   } = props;
   const [showInfoModal, setShowInfoModal] = React.useState(false);
 
-  /* iOS specific issue
-    focus inputs w/ keyboard shifts up the entire HTML tag. 
-    on keyboard close, HTML doesn't revert to previous position. 
-    this force scrolls the background to the top. */
-  const handlePageShift = () => {
-    window.scrollTo(0, 0);
-    document.body.scrollTop = 0;
-  };
 
   return (
     <>
@@ -511,7 +503,6 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
               e.preventDefault();
               !isOpen && onOpen && onOpen();
               setIsOpen(!isOpen);
-              handlePageShift();
             }}
             data-selections={selectionsCount}
             aria-label={i18n._(t`Filter`)}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -548,10 +548,10 @@ function valuesAsMultiselectOptions(values: string[]): Option[] {
 focus inputs w/ keyboard shifts up the entire HTML tag. 
 on keyboard close, HTML doesn't revert to previous position. 
 this force scrolls the background to the top. */
-const handlePageShift = () => {
-  window.scrollTo(0, 0);
-  document.body.scrollTop = 0;
-};
+// const handlePageShift = () => {
+//   window.scrollTo(0, 0);
+//   document.body.scrollTop = 0;
+// };
 
 const PortfolioFilters = withI18n()(PortfolioFiltersWithoutI18n);
 

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -227,7 +227,6 @@ const PortfolioFiltersWithoutI18n = React.memo(
               onApply={onUnitsresApply}
               onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
               id="filter-unitsres-minmax"
-              onFocusInput={() => helpers.scrollToBottom(".mobile-wrapper-dropdown")}
               onBlurInput={handlePageShift}
               isOpen={unitsresIsOpen}
               defaultSelections={unitsresSelections}

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -230,7 +230,7 @@
           position: absolute;
           top: 5rem;
           left: -0.1rem;
-          z-index: 100;
+          z-index: 10;
           overflow-y: scroll;
           background-color: $justfix-table-grey;
           box-sizing: border-box;
@@ -359,7 +359,7 @@
         top: 0;
         left: 0;
         right: 0;
-        z-index: 101;
+        z-index: 11;
         height: 100%;
         background-color: $justfix-table-grey;
         border-radius: 0.8rem 0.8rem 0 0;
@@ -417,12 +417,8 @@
           border-bottom: 0.2rem solid $justfix-grey-700;
         }
         & > .dropdown-container {
-          // position: absolute;
-          // top: var(--filter-bar-top-height);
-          // left: 0;
-          // max-height: none;
           height: calc(100% - var(--filter-bar-top-height));
-          z-index: 102;
+          z-index: 12;
           padding: 0;
           overflow: auto;
 

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -365,7 +365,6 @@
         border-radius: 0.8rem 0.8rem 0 0;
         box-sizing: border-box;
         border: none;
-        border-bottom: 0.2rem solid $justfix-grey-700;
 
         @keyframes slide-up {
           0% {

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -382,35 +382,35 @@
 
         // Hide page from showing through around rounded corners
         // Sadly outline+offset doesn't work since in safari is doesn't follow border-radius
-        // &::before {
-        //   --border-size: 0.5rem;
-        //   content: "";
-        //   position: absolute;
-        //   top: calc(0rem - var(--border-size));
-        //   right: calc(0rem - var(--border-size));
-        //   bottom: calc(0rem - var(--border-size));
-        //   left: calc(0rem - var(--border-size));
-        //   border: var(--border-size) solid $justfix-black;
-        //   border-bottom: none;
-        //   border-radius: 1.25rem 1.25rem 0 0;
+        &::before {
+          --border-size: 0.5rem;
+          content: "";
+          position: absolute;
+          top: calc(0rem - var(--border-size));
+          right: calc(0rem - var(--border-size));
+          bottom: calc(0rem - var(--border-size));
+          left: calc(0rem - var(--border-size));
+          border: var(--border-size) solid $justfix-black;
+          border-bottom: none;
+          border-radius: 1.25rem 1.25rem 0 0;
 
-        //   @keyframes fade-in {
-        //     0% {
-        //       opacity: 0;
-        //     }
-        //     90% {
-        //       opacity: 0;
-        //     }
-        //     100% {
-        //       opacity: 1;
-        //     }
-        //   }
+          @keyframes fade-in {
+            0% {
+              opacity: 0;
+            }
+            90% {
+              opacity: 0;
+            }
+            100% {
+              opacity: 1;
+            }
+          }
 
-        //   animation-name: fade-in;
-        //   animation-duration: 0.5s;
-        //   animation-timing-function: ease-in-out;
-        //   animation-fill-mode: forwards;
-        // }
+          animation-name: fade-in;
+          animation-duration: 0.5s;
+          animation-timing-function: ease-in-out;
+          animation-fill-mode: forwards;
+        }
 
         & > summary {
           padding: 0 2.4rem;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -355,6 +355,7 @@
       &[open] {
         --filter-bar-top-height: 4.6rem;
         --filter-bar-height: 6.6rem;
+        overflow: auto;
         position: absolute;
         top: 0;
         left: 0;
@@ -383,46 +384,46 @@
 
         // Hide page from showing through around rounded corners
         // Sadly outline+offset doesn't work since in safari is doesn't follow border-radius
-        &::before {
-          --border-size: 0.5rem;
-          content: "";
-          position: absolute;
-          top: calc(0rem - var(--border-size));
-          right: calc(0rem - var(--border-size));
-          bottom: calc(0rem - var(--border-size));
-          left: calc(0rem - var(--border-size));
-          border: var(--border-size) solid $justfix-black;
-          border-bottom: none;
-          border-radius: 1.25rem 1.25rem 0 0;
+        // &::before {
+        //   --border-size: 0.5rem;
+        //   content: "";
+        //   position: absolute;
+        //   top: calc(0rem - var(--border-size));
+        //   right: calc(0rem - var(--border-size));
+        //   bottom: calc(0rem - var(--border-size));
+        //   left: calc(0rem - var(--border-size));
+        //   border: var(--border-size) solid $justfix-black;
+        //   border-bottom: none;
+        //   border-radius: 1.25rem 1.25rem 0 0;
 
-          @keyframes fade-in {
-            0% {
-              opacity: 0;
-            }
-            90% {
-              opacity: 0;
-            }
-            100% {
-              opacity: 1;
-            }
-          }
+        //   @keyframes fade-in {
+        //     0% {
+        //       opacity: 0;
+        //     }
+        //     90% {
+        //       opacity: 0;
+        //     }
+        //     100% {
+        //       opacity: 1;
+        //     }
+        //   }
 
-          animation-name: fade-in;
-          animation-duration: 0.5s;
-          animation-timing-function: ease-in-out;
-          animation-fill-mode: forwards;
-        }
+        //   animation-name: fade-in;
+        //   animation-duration: 0.5s;
+        //   animation-timing-function: ease-in-out;
+        //   animation-fill-mode: forwards;
+        // }
 
         & > summary {
           padding: 0 2.4rem;
           border-bottom: 0.2rem solid $justfix-grey-700;
         }
         & > .dropdown-container {
-          position: absolute;
-          top: var(--filter-bar-top-height);
-          left: 0;
-          max-height: none;
-          height: calc(100vh - var(--filter-bar-top-height));
+          // position: absolute;
+          // top: var(--filter-bar-top-height);
+          // left: 0;
+          // max-height: none;
+          // height: calc(100vh - var(--filter-bar-top-height));
           z-index: 102;
           padding: 0;
 

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -355,7 +355,6 @@
       &[open] {
         --filter-bar-top-height: 4.6rem;
         --filter-bar-height: 6.6rem;
-        overflow: auto;
         position: absolute;
         top: 0;
         left: 0;
@@ -423,9 +422,10 @@
           // top: var(--filter-bar-top-height);
           // left: 0;
           // max-height: none;
-          // height: calc(100vh - var(--filter-bar-top-height));
+          height: calc(100% - var(--filter-bar-top-height));
           z-index: 102;
           padding: 0;
+          overflow: auto;
 
           &.scroll-gradient {
             // https://css-scroll-shadows.vercel.app/

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -415,6 +415,7 @@
 
         & > summary {
           padding: 0 2.4rem;
+          border-bottom: 0.2rem solid $justfix-grey-700;
         }
         & > .dropdown-container {
           position: absolute;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -355,12 +355,12 @@
       &[open] {
         --filter-bar-top-height: 4.6rem;
         --filter-bar-height: 6.6rem;
-        position: fixed;
+        position: absolute;
         top: 0;
         left: 0;
         right: 0;
         z-index: 101;
-        height: var(--filter-bar-top-height);
+        height: 100%;
         background-color: $justfix-table-grey;
         border-radius: 0.8rem 0.8rem 0 0;
         box-sizing: border-box;

--- a/client/src/styles/index.scss
+++ b/client/src/styles/index.scss
@@ -8,6 +8,7 @@ body {
 }
 
 body {
+  position: relative;
   margin: 0;
   padding: 0;
   color: $dark !important;


### PR DESCRIPTION
We have been having problems with the mobile filter menu on IOS cause by layout shifts when the virtual keyboard appears. The way IOS (Chrome and Safari) handles the changing space is to keep the page the same size, but push it up and off screen at the top. 

This is their intended bahavior, but it has been causing some bugs as well. First, it would cause a permeant shift of the page that would persist even after closing the keyboard and exiting the mobile filter menu - leaving the whole portfolio table page with a black/white section at the bottom of the page. We found a workaround for this in #769, using JS to scroll the page once the filter menu is closed, and this fixed the layout back on the portoflio table page. 

Another problem we were having is that on the menu when the keyboard is active, you couldn't scroll all the way down - it would just get stuck. This meant that you couldn't make some selections from the multiselect dropdown then scroll down to click apply, without first exiting the keyboard. 

This PR makes some CSS changes for the mobile filter menu that solves both of these problems (so we can remove the JS scroll functions), for IOS Safari and Chrome (and it all still works properly, the same as before, for the other browsers/devices). We change the heights of the `<details/>` and the `<div/>` within it so that they use 100% instead of 100vh, use absolute instead of fixed positioning for details, and use default positioning for the inside div. Finally, for all this to work properly we need to make the parent of the absolute positioned `details`, which is the `body`, positioned relative.

https://github.com/JustFixNYC/who-owns-what/assets/16906516/ac9fabd5-f063-4b1e-b38a-0e79d752df0d

This leaves just one remaining issue for IOS Safari. Because when the keyboard it up and the page is intentionally pushed off screen, a new level of scrolling is added so you can scroll the full page to see the areas pushed off screen. Since we already have scrolling on the filter menu, once this extra level is added it means that you have the keyboard up and first scroll the menu normally to the bottom, then if you try to scroll down more it actives the extra page scrolling and you can pull up this weird empty black bar. If you close the keyboard, every thing goes back to normal for scrolling and the black bar disappears. 

https://github.com/JustFixNYC/who-owns-what/assets/16906516/10a524ae-4231-42a2-ab81-2a3c89e9e5f8

I've found a ton of different questions about this online (going back years) but no solutions. 

Since this is still an improvement over what we had, I'm going to merge this in so we can move ahead with other design review, and will continue looking into this black bar issue separately. 

Also in this PR, I change the z-indexes on the mobile menu for fore sensible values, remove a callbacks for the min-max select on focus of the inputs since now the OS handles the scroll to keep them in view as the keyboard appears. 

[sc-12263]