### PR TITLE
prevent over-scroll on portfolio table

### DIFF
--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -13,6 +13,8 @@ $table-border-dark: 1px solid $dark;
   // controls
   overflow: auto;
 
+  overscroll-behavior: none;
+
   // Add right-side fade out when list is scrollable:
   &::before {
     content: "";


### PR DESCRIPTION
On mobile scrolling past the end of the content would drag the whole table out of place before snapping back on release. This disables that over-scrollig behaviour

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/6b48f55a-6e5d-4356-ac41-6021b511ad5b)

[sc-11855]