### PR TITLE
GTM event name typo fix

### DIFF
--- a/client/src/components/PortfolioAlerts.tsx
+++ b/client/src/components/PortfolioAlerts.tsx
@@ -110,7 +110,7 @@ export const FilterPortfolioAlert = ({
           to={addressPageRoutes.portfolio}
           onClick={() => {
             logAmplitudeEvent("alertToFilterPortfolio", { portfolioSize });
-            window.gtag("event", "alert-topfilter-portfolio", { portfolioSize });
+            window.gtag("event", "alert-to-filter-portfolio", { portfolioSize });
           }}
         >
           the Portfolio tab.


### PR DESCRIPTION
I just noticed a typo in the event name for the GTM event tracking clicks on the overview page alert on the map directing users to use filters on the portfolio tab. 