### PR TITLE
add map view for portfolio filters

### DIFF
--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -61,7 +61,7 @@ export type AddressRecord = {
   lat: number | null;
   lng: number | null;
   /** This property gets assigned in the PropertiesMap component, not from our API */
-  mapType?: "base" | "search" | "filter";
+  mapType?: "base" | "search";
   openviolations: number;
   ownernames: HpdOwnerContact[] | null;
   recentcomplaints: number;

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -61,7 +61,7 @@ export type AddressRecord = {
   lat: number | null;
   lng: number | null;
   /** This property gets assigned in the PropertiesMap component, not from our API */
-  mapType?: "base" | "search";
+  mapType?: "base" | "search" | "filter";
   openviolations: number;
   ownernames: HpdOwnerContact[] | null;
   recentcomplaints: number;

--- a/client/src/components/Alert.tsx
+++ b/client/src/components/Alert.tsx
@@ -11,11 +11,12 @@ export interface AlertProps extends React.ComponentPropsWithoutRef<"div"> {
   variant?: "primary" | "secondary";
   closeType?: "none" | "state" | "session" | "local";
   storageId?: string;
+  onClose?: () => void;
   className?: string;
 }
 
 export const Alert = forwardRef<HTMLDivElement, AlertProps>(
-  ({ type, variant, closeType, storageId, className, children, ...props }, ref) => {
+  ({ type, variant, closeType, storageId, onClose, className, children, ...props }, ref) => {
     const usingStorage = closeType && ["session", "local"].includes(closeType);
 
     // TODO: see if there's a way to do this that works with intellisense.
@@ -42,6 +43,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
         store.setItem(storageId!, "true");
       }
       setClosed(true);
+      !!onClose && onClose();
     };
 
     const alertClassNames = classNames("jf-alert", `is-${variant}`, `is-${type}`, className);
@@ -68,6 +70,7 @@ Alert.propTypes = {
   variant: PropTypes.oneOf(["primary", "secondary"]),
   closeType: PropTypes.oneOf(["none", "state", "session", "local"]),
   storageId: PropTypes.string,
+  onClose: PropTypes.func,
   className: PropTypes.string,
 };
 

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -230,7 +230,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
               <div className="DetailView__card card">
                 <div className="DetailView__mobilePortfolioView">
                   <button onClick={() => this.props.onCloseDetail()}>
-                    <Trans render="span">View portfolio map</Trans>
+                    <Trans render="span">View map</Trans>
                   </button>
                 </div>
                 <div className="card-image show-lg">{streetView}</div>

--- a/client/src/components/Multiselect.tsx
+++ b/client/src/components/Multiselect.tsx
@@ -334,7 +334,7 @@ function CustomInput<
   IsMulti extends boolean = true,
   GroupType extends GroupBase<Option> = GroupBase<Option>
 >(props: InputProps<Option, IsMulti, GroupType>) {
-  const id = "test-123456789";
+  const id = `aria-label-${Math.floor(Math.random() * 100)}`;
   return (
     <>
       <components.Input

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -8,7 +8,7 @@ import {
   PortfolioAnalyticsEvent,
   NUMBER_RANGE_DEFAULT,
   FilterNumberRangeSelections,
-  filterAddrs,
+  filterAddresses,
 } from "./PropertiesList";
 import FocusTrap from "focus-trap-react";
 import { FocusTarget } from "focus-trap";
@@ -64,23 +64,20 @@ const PortfolioFiltersWithoutI18n = React.memo(
       setFilterContext({
         ...filterContext,
         filterOptions: {
-          // put corporations like "123 Fake St, LLC" at the end so real names are shown first
           ownernames: getOwnernamesOptions(assocAddrs),
           unitsres: getUnitsresOptions(assocAddrs),
           zip: getZipOptions(assocAddrs),
         },
       });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [assocAddrs]);
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     React.useEffect(() => {
       setFilterContext((prevContext) => ({
         ...prevContext,
         totalBuildings: assocAddrs.length,
-        filteredBuildings: filterAddrs(assocAddrs, filterSelections).length,
+        filteredBuildings: filterAddresses(assocAddrs, filterSelections).length,
       }));
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [assocAddrs, filterSelections]);
+    }, [filterSelections]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const [rsunitslatestActive, setRsunitslatestActive] = React.useState(false);
     const updateRsunitslatest = () => {
@@ -243,7 +240,7 @@ const PortfolioFiltersWithoutI18n = React.memo(
             <FilterAccordion
               title={i18n._(t`Landlord`)}
               subtitle={i18n._(t`Person/Entity`)}
-              infoIconAria={i18n._(
+              infoIconAriaLabel={i18n._(
                 t`Learn more about what it means for someone to be listed as a landlord`
               )}
               infoModalContents={ownernamesInfoModalContents}
@@ -486,7 +483,7 @@ const OwnernamesInfoAlert = (
 type FilterAccordionProps = withI18nProps & {
   title: string;
   subtitle?: string;
-  infoIconAria?: string;
+  infoIconAriaLabel?: string;
   onInfoClick?: () => void;
   infoModalContents?: JSX.Element;
   children: React.ReactNode;
@@ -510,7 +507,7 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
   const {
     title,
     subtitle,
-    infoIconAria,
+    infoIconAriaLabel,
     onInfoClick,
     infoModalContents,
     children,
@@ -563,7 +560,7 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
                 {infoModalContents && (
                   <button
                     className="filter-info"
-                    aria-label={infoIconAria}
+                    aria-label={infoIconAriaLabel}
                     onClick={() => {
                       setShowInfoModal(true);
                       onInfoClick && onInfoClick();

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -207,27 +207,27 @@ const PortfolioFiltersWithoutI18n = React.memo(
             </span>
           )}
         </div>
+        <div className="view-type-toggle-container">
+          <button
+            aria-pressed={viewType === "table"}
+            className="view-type-toggle"
+            onClick={() => setFilterContext((prev) => ({ ...prev, viewType: "table" }))}
+          >
+            <Trans>Table</Trans>
+          </button>
+          <button
+            aria-pressed={viewType === "map"}
+            className="view-type-toggle"
+            onClick={() => setFilterContext((prev) => ({ ...prev, viewType: "map" }))}
+          >
+            <Trans>Map</Trans>
+          </button>
+        </div>
         <FiltersWrapper
           isMobile={isMobile}
           activeFilters={activeFilters}
           resultsCount={filteredBuildings}
         >
-          <div className="view-type-toggle-container">
-            <button
-              aria-pressed={viewType === "table"}
-              className="view-type-toggle"
-              onClick={() => setFilterContext((prev) => ({ ...prev, viewType: "table" }))}
-            >
-              <Trans>Table</Trans>
-            </button>
-            <button
-              aria-pressed={viewType === "map"}
-              className="view-type-toggle"
-              onClick={() => setFilterContext((prev) => ({ ...prev, viewType: "map" }))}
-            >
-              <Trans>Map</Trans>
-            </button>
-          </div>
           <button
             aria-pressed={rsunitslatestActive}
             onClick={updateRsunitslatest}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -324,8 +324,11 @@ const PortfolioFiltersWithoutI18n = React.memo(
               </button>
             </div>
             {filteredBuildings === 0 && ZeroResultsAlert}
-            {!!filteredBuildings && RsUnitsResultAlert}
-            {!!filteredBuildings && viewType === "table" && OwnernamesResultAlert}
+            {!!filteredBuildings && rsunitslatestActive && RsUnitsResultAlert}
+            {!!filteredBuildings &&
+              ownernamesActive &&
+              viewType === "table" &&
+              OwnernamesResultAlert}
           </div>
         )}
 

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -12,7 +12,7 @@ import {
 } from "./PropertiesList";
 import FocusTrap from "focus-trap-react";
 import { FocusTarget } from "focus-trap";
-import { Alert, AlertProps } from "./Alert";
+import { Alert } from "./Alert";
 import Modal from "./Modal";
 import { LocaleLink } from "i18n";
 import { createWhoOwnsWhatRoutePaths } from "routes";
@@ -323,7 +323,9 @@ const PortfolioFiltersWithoutI18n = React.memo(
                 <Trans>Clear Filters</Trans>
               </button>
             </div>
-            {filteredBuildings === 0 ? <ZeroResultsAlert /> : <></>}
+            {filteredBuildings === 0 && ZeroResultsAlert}
+            {!!filteredBuildings && RsUnitsResultAlert}
+            {!!filteredBuildings && viewType === "table" && OwnernamesResultAlert}
           </div>
         )}
 
@@ -409,7 +411,7 @@ const FiltersWrapper = (props: {
                 {resultsCount != null && <span className="view-results-count">{resultsCount}</span>}
               </button>
             )}
-            {resultsCount === 0 ? <ZeroResultsAlert /> : <></>}
+            {resultsCount === 0 && ZeroResultsAlert}
           </div>
         </details>
       </div>
@@ -417,9 +419,9 @@ const FiltersWrapper = (props: {
   );
 };
 
-export const OwnernamesResultAlert = () => (
+const OwnernamesResultAlert = (
   <Alert
-    className="filter-result-alert"
+    className="filter-results-alert"
     type="info"
     variant="secondary"
     closeType="session"
@@ -433,15 +435,14 @@ export const OwnernamesResultAlert = () => (
   </Alert>
 );
 
-export const RsUnitsResultAlert = (props: Omit<AlertProps, "children">) => (
+const RsUnitsResultAlert = (
   <Alert
-    className="filter-result-alert"
+    className="filter-results-alert"
     type="info"
     variant="secondary"
     closeType="session"
     storageId="filter-rsunits-results-alert"
     role="status"
-    {...props}
   >
     <Trans>
       Rent stabilized units are self-reported in yearly tax statements by building owners. As a
@@ -450,7 +451,7 @@ export const RsUnitsResultAlert = (props: Omit<AlertProps, "children">) => (
   </Alert>
 );
 
-export const ZeroResultsAlert = (props: Omit<AlertProps, "children">) => (
+const ZeroResultsAlert = (
   <Alert
     className="zero-results-alert"
     type="info"

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -207,134 +207,136 @@ const PortfolioFiltersWithoutI18n = React.memo(
             </span>
           )}
         </div>
-        <div className="view-type-toggle-container">
-          <button
-            aria-pressed={viewType === "table"}
-            className="view-type-toggle"
-            onClick={() => setFilterContext((prev) => ({ ...prev, viewType: "table" }))}
-          >
-            <Trans>Table</Trans>
-          </button>
-          <button
-            aria-pressed={viewType === "map"}
-            className="view-type-toggle"
-            onClick={() => setFilterContext((prev) => ({ ...prev, viewType: "map" }))}
-          >
-            <Trans>Map</Trans>
-          </button>
-        </div>
-        <FiltersWrapper
-          isMobile={isMobile}
-          activeFilters={activeFilters}
-          resultsCount={filteredBuildings}
-        >
-          <button
-            aria-pressed={rsunitslatestActive}
-            onClick={updateRsunitslatest}
-            className="filter filter-toggle"
-            aria-label={i18n._(t`Rent Stabilized Units filter`)}
-          >
-            <div className="checkbox">{rsunitslatestActive && <CheckIcon />}</div>
-            <span>
-              <Trans>Rent Stabilized Units</Trans>
-            </span>
-          </button>
-          <FilterAccordion
-            title={i18n._(t`Landlord`)}
-            subtitle={i18n._(t`Person/Entity`)}
-            infoIconAria={i18n._(
-              t`Learn more about what it means for someone to be listed as a landlord`
-            )}
-            infoModalContents={ownernamesInfoModalContents}
-            isActive={ownernamesActive}
-            isOpen={ownernamesIsOpen}
-            setIsOpen={setOwnernamesIsOpen}
-            onOpen={() => logPortfolioAnalytics("filterOpened", { column: "ownernames" })}
-            selectionsCount={filterContext.filterSelections.ownernames.length}
-            className="ownernames-accordion"
-          >
-            <MultiSelect
-              id="filter-ownernames-multiselect"
-              options={valuesAsMultiselectOptions(ownernamesOptions)}
-              onApply={onOwnernamesApply}
-              onError={() => logPortfolioAnalytics("filterError", { column: "ownernames" })}
-              infoAlert={OwnernamesInfoAlert}
-              aria-label={i18n._(t`Landlord filter`)}
-              isOpen={ownernamesIsOpen}
-              defaultSelections={valuesAsMultiselectOptions(ownernamesSelections)}
-            />
-          </FilterAccordion>
-          <FilterAccordion
-            title={i18n._(t`Building Size`)}
-            subtitle={i18n._(t`Number of Units`)}
-            isActive={unitsresActive}
-            isOpen={unitsresIsOpen}
-            onOpen={() => logPortfolioAnalytics("filterOpened", { column: "unitsres" })}
-            setIsOpen={setUnitsresIsOpen}
-            className="unitsres-accordion"
-          >
-            <MinMaxSelect
-              options={unitsresOptions}
-              onApply={onUnitsresApply}
-              onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
-              id="filter-unitsres-minmax"
-              isOpen={unitsresIsOpen}
-              defaultSelections={unitsresSelections}
-            />
-          </FilterAccordion>
-          <FilterAccordion
-            title={i18n._(t`Zip Code`)}
-            isActive={zipActive}
-            isOpen={zipIsOpen}
-            setIsOpen={setZipIsOpen}
-            onOpen={() => logPortfolioAnalytics("filterOpened", { column: "zip" })}
-            selectionsCount={filterContext.filterSelections.zip.length}
-            className="zip-accordion"
-          >
-            <MultiSelect
-              id="filter-zip-multiselect"
-              options={valuesAsMultiselectOptions(zipOptions)}
-              onApply={onZipApply}
-              noOptionsMessage={() => i18n._(t`ZIP code is not applicable`)}
-              onError={() => logPortfolioAnalytics("filterError", { column: "zip" })}
-              aria-label={i18n._(t`Zip code filter`)}
-              onKeyDown={helpers.preventNonNumericalInput}
-              isOpen={zipIsOpen}
-              defaultSelections={valuesAsMultiselectOptions(zipSelections)}
-            />
-          </FilterAccordion>
-        </FiltersWrapper>
-
-        {(rsunitslatestActive || ownernamesActive || unitsresActive || zipActive) && (
-          <div className="filter-status">
-            <div className="filter-status-info">
-              <span className="results-count" role="status">
-                <Trans>
-                  Showing {filteredBuildings || 0}{" "}
-                  <Plural value={filteredBuildings || 0} one="result" other="results" />
-                </Trans>
-              </span>
-              <button
-                className="results-info"
-                onClick={() => setShowInfoModal(true)}
-                aria-label={i18n._(t`Learn more about how the results are calculated`)}
-              >
-                <InfoIcon />
-              </button>
-              <button className="clear-filters button is-text" onClick={clearFilters}>
-                <Trans>Clear Filters</Trans>
-              </button>
-            </div>
-            {filteredBuildings === 0 && ZeroResultsAlert}
-            {!!filteredBuildings && rsunitslatestActive && RsUnitsResultAlert}
-            {!!filteredBuildings &&
-              ownernamesActive &&
-              viewType === "table" &&
-              OwnernamesResultAlert}
+        <div className="filters-container">
+          <div className="view-type-toggle-container">
+            <button
+              aria-pressed={viewType === "table"}
+              className="view-type-toggle"
+              onClick={() => setFilterContext((prev) => ({ ...prev, viewType: "table" }))}
+            >
+              <Trans>Table</Trans>
+            </button>
+            <button
+              aria-pressed={viewType === "map"}
+              className="view-type-toggle"
+              onClick={() => setFilterContext((prev) => ({ ...prev, viewType: "map" }))}
+            >
+              <Trans>Map</Trans>
+            </button>
           </div>
-        )}
+          <FiltersWrapper
+            isMobile={isMobile}
+            activeFilters={activeFilters}
+            resultsCount={filteredBuildings}
+          >
+            <button
+              aria-pressed={rsunitslatestActive}
+              onClick={updateRsunitslatest}
+              className="filter filter-toggle"
+              aria-label={i18n._(t`Rent Stabilized Units filter`)}
+            >
+              <div className="checkbox">{rsunitslatestActive && <CheckIcon />}</div>
+              <span>
+                <Trans>Rent Stabilized Units</Trans>
+              </span>
+            </button>
+            <FilterAccordion
+              title={i18n._(t`Landlord`)}
+              subtitle={i18n._(t`Person/Entity`)}
+              infoIconAria={i18n._(
+                t`Learn more about what it means for someone to be listed as a landlord`
+              )}
+              infoModalContents={ownernamesInfoModalContents}
+              isActive={ownernamesActive}
+              isOpen={ownernamesIsOpen}
+              setIsOpen={setOwnernamesIsOpen}
+              onOpen={() => logPortfolioAnalytics("filterOpened", { column: "ownernames" })}
+              selectionsCount={filterContext.filterSelections.ownernames.length}
+              className="ownernames-accordion"
+            >
+              <MultiSelect
+                id="filter-ownernames-multiselect"
+                options={valuesAsMultiselectOptions(ownernamesOptions)}
+                onApply={onOwnernamesApply}
+                onError={() => logPortfolioAnalytics("filterError", { column: "ownernames" })}
+                infoAlert={OwnernamesInfoAlert}
+                aria-label={i18n._(t`Landlord filter`)}
+                isOpen={ownernamesIsOpen}
+                defaultSelections={valuesAsMultiselectOptions(ownernamesSelections)}
+              />
+            </FilterAccordion>
+            <FilterAccordion
+              title={i18n._(t`Building Size`)}
+              subtitle={i18n._(t`Number of Units`)}
+              isActive={unitsresActive}
+              isOpen={unitsresIsOpen}
+              onOpen={() => logPortfolioAnalytics("filterOpened", { column: "unitsres" })}
+              setIsOpen={setUnitsresIsOpen}
+              className="unitsres-accordion"
+            >
+              <MinMaxSelect
+                options={unitsresOptions}
+                onApply={onUnitsresApply}
+                onError={() => logPortfolioAnalytics("filterError", { column: "unitsres" })}
+                id="filter-unitsres-minmax"
+                isOpen={unitsresIsOpen}
+                defaultSelections={unitsresSelections}
+              />
+            </FilterAccordion>
+            <FilterAccordion
+              title={i18n._(t`Zip Code`)}
+              isActive={zipActive}
+              isOpen={zipIsOpen}
+              setIsOpen={setZipIsOpen}
+              onOpen={() => logPortfolioAnalytics("filterOpened", { column: "zip" })}
+              selectionsCount={filterContext.filterSelections.zip.length}
+              className="zip-accordion"
+            >
+              <MultiSelect
+                id="filter-zip-multiselect"
+                options={valuesAsMultiselectOptions(zipOptions)}
+                onApply={onZipApply}
+                noOptionsMessage={() => i18n._(t`ZIP code is not applicable`)}
+                onError={() => logPortfolioAnalytics("filterError", { column: "zip" })}
+                aria-label={i18n._(t`Zip code filter`)}
+                onKeyDown={helpers.preventNonNumericalInput}
+                isOpen={zipIsOpen}
+                defaultSelections={valuesAsMultiselectOptions(zipSelections)}
+              />
+            </FilterAccordion>
+          </FiltersWrapper>
 
-        <Modal key={1} showModal={showInfoModal} width={20} onClose={() => setShowInfoModal(false)}>
+          {(rsunitslatestActive || ownernamesActive || unitsresActive || zipActive) && (
+            <div className="filter-status">
+              <div className="filter-status-info">
+                <span className="results-count" role="status">
+                  <Trans>
+                    Showing {filteredBuildings || 0}{" "}
+                    <Plural value={filteredBuildings || 0} one="result" other="results" />
+                  </Trans>
+                </span>
+                <button
+                  className="results-info"
+                  onClick={() => setShowInfoModal(true)}
+                  aria-label={i18n._(t`Learn more about how the results are calculated`)}
+                >
+                  <InfoIcon />
+                </button>
+                <button className="clear-filters button is-text" onClick={clearFilters}>
+                  <Trans>Clear Filters</Trans>
+                </button>
+              </div>
+              {filteredBuildings === 0 && ZeroResultsAlert}
+              {!!filteredBuildings && rsunitslatestActive && RsUnitsResultAlert}
+              {!!filteredBuildings &&
+                ownernamesActive &&
+                viewType === "table" &&
+                OwnernamesResultAlert}
+            </div>
+          )}
+        </div>
+
+        <Modal key={1} showModal={showInfoModal} width={40} onClose={() => setShowInfoModal(false)}>
           <h4>
             <Trans>How are the results calculated?</Trans>
           </h4>
@@ -477,10 +479,7 @@ const OwnernamesInfoAlert = (
     storageId="owner-info-alert-close"
     role="status"
   >
-    <Trans>
-      Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways
-      in official documents.
-    </Trans>
+    <Trans>The same owner may have spelled their name several ways in official documents.</Trans>
   </Alert>
 );
 
@@ -580,7 +579,7 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
         </details>
       </FocusTrap>
       {infoModalContents && (
-        <Modal showModal={showInfoModal} width={20} onClose={() => setShowInfoModal(false)}>
+        <Modal showModal={showInfoModal} width={40} onClose={() => setShowInfoModal(false)}>
           {infoModalContents}
         </Modal>
       )}

--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -242,7 +242,9 @@ const PortfolioFiltersWithoutI18n = React.memo(
           <FilterAccordion
             title={i18n._(t`Landlord`)}
             subtitle={i18n._(t`Person/Entity`)}
-            infoLabel={i18n._(t`Who are they?`)}
+            infoIconAria={i18n._(
+              t`Learn more about what it means for someone to be listed as a landlord`
+            )}
             infoModalContents={ownernamesInfoModalContents}
             isActive={ownernamesActive}
             isOpen={ownernamesIsOpen}
@@ -485,7 +487,7 @@ const OwnernamesInfoAlert = (
 type FilterAccordionProps = withI18nProps & {
   title: string;
   subtitle?: string;
-  infoLabel?: string;
+  infoIconAria?: string;
   onInfoClick?: () => void;
   infoModalContents?: JSX.Element;
   children: React.ReactNode;
@@ -509,7 +511,7 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
   const {
     title,
     subtitle,
-    infoLabel,
+    infoIconAria,
     onInfoClick,
     infoModalContents,
     children,
@@ -559,15 +561,16 @@ const FilterAccordion = withI18n()((props: FilterAccordionProps) => {
             {subtitle && (
               <div className="filter-subtitle-container">
                 {subtitle && <span className="filter-subtitle">{subtitle}</span>}
-                {infoLabel && (
+                {infoModalContents && (
                   <button
-                    className="filter-info button is-text"
+                    className="filter-info"
+                    aria-label={infoIconAria}
                     onClick={() => {
                       setShowInfoModal(true);
                       onInfoClick && onInfoClick();
                     }}
                   >
-                    {infoLabel}
+                    <InfoIcon />
                   </button>
                 )}
               </div>

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -33,7 +33,6 @@ import { sortContactsByImportance } from "./DetailView";
 import { ArrowIcon } from "./Icons";
 import classnames from "classnames";
 import { isLegacyPath } from "./WowzaToggle";
-import { OwnernamesResultAlert, RsUnitsResultAlert } from "./PortfolioFilters";
 
 const FIRST_COLUMN_WIDTH = 130;
 export const MAX_TABLE_ROWS_PER_PAGE = 100;
@@ -99,12 +98,6 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
   const { filterContext } = React.useContext(FilterContext);
 
   const { filterSelections } = filterContext;
-  const activeFilters = {
-    rsunitslatestActive: filterSelections.rsunitslatest,
-    ownernamesActive: !!filterSelections.ownernames.length,
-    unitsresActive: filterSelections.unitsres.type !== "default",
-    zipActive: !!filterSelections.zip.length,
-  };
 
   const lastColumnRef = React.useRef<HTMLDivElement>(null);
   const isLastColumnVisible = Helpers.useOnScreen(lastColumnRef);
@@ -615,18 +608,6 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
             ))}
           </thead>
           <tbody>
-            {!!table.getRowModel().rows.length &&
-              (activeFilters.rsunitslatestActive || activeFilters.ownernamesActive) && (
-                <tr>
-                  <td
-                    className="filter-table-alert-container"
-                    colSpan={table.getVisibleFlatColumns().length}
-                  >
-                    {activeFilters.rsunitslatestActive && <RsUnitsResultAlert />}
-                    {activeFilters.ownernamesActive && <OwnernamesResultAlert />}
-                  </td>
-                </tr>
-              )}
             {table.getRowModel().rows.map((row, i) => {
               return (
                 <Fragment key={row.id}>

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -64,7 +64,7 @@ const inNumberRanges: FilterFn<any> = (
 ) => {
   const rowValue = row.getValue<number>(columnId);
   return filterValue.reduce(
-    (acc, rng) => acc || (rowValue >= rng.min && rowValue <= rng.max),
+    (acc, range) => acc || (rowValue >= range.min && rowValue <= range.max),
     false
   );
 };
@@ -547,14 +547,12 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
     table.getColumn("zip").setFilterValue(zip);
   }, [filterSelections]);
 
-  // TODO: is this necessary?
   React.useEffect(() => {
     if (table.getState().columnFilters[0]?.id === "ownernames") {
       if (table.getState().sorting[0]?.id !== "ownernames") {
         table.setSorting([{ id: "ownernames", desc: false }]);
       }
     }
-    //   eslint-disable-next-line
   }, [table.getState().columnFilters[0]?.id]);
 
   const tableRef = React.useRef<HTMLDivElement>(null);
@@ -596,16 +594,14 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
                           {header.isPlaceholder ? null : (
                             <>
                               <div
-                                {...{
-                                  className: header.column.getCanSort()
-                                    ? "cursor-pointer select-none"
-                                    : "",
-                                  onClick: (e) => {
-                                    header.column.getToggleSortingHandler()?.(e);
-                                    logPortfolioAnalytics("portfolioColumnSort", {
-                                      column: header.column.id,
-                                    });
-                                  },
+                                className={classnames(
+                                  !header.column.getCanSort() ?? "cursor-pointer select-none"
+                                )}
+                                onClick={(e) => {
+                                  header.column.getToggleSortingHandler()?.(e);
+                                  logPortfolioAnalytics("portfolioColumnSort", {
+                                    column: header.column.id,
+                                  });
                                 }}
                                 ref={header.column.id === "detail" ? lastColumnRef : undefined}
                               >

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -687,6 +687,7 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
                 <div>
                   <input
                     type="number"
+                    aria-label={i18n._(t`page number`)}
                     value={String(table.getState().pagination.pageIndex + 1)}
                     onChange={(e) => {
                       const page = e.target.value ? Number(e.target.value) - 1 : 0;
@@ -701,6 +702,7 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
               </span>
               <select
                 value={table.getState().pagination.pageSize}
+                aria-label={i18n._(t`number of records per page`)}
                 onChange={(e) => {
                   table.setPageSize(Number(e.target.value));
                   logPortfolioAnalytics("portfolioPagination", {

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -44,7 +44,7 @@ export type IFilterContext = {
 };
 
 export const defaultFilterContext: IFilterContext = {
-  viewType: "map",
+  viewType: "table",
   totalBuildings: undefined,
   filteredBuildings: undefined,
   filterSelections: {

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -44,7 +44,7 @@ export type IFilterContext = {
 };
 
 export const defaultFilterContext: IFilterContext = {
-  viewType: "table",
+  viewType: "map",
   totalBuildings: undefined,
   filteredBuildings: undefined,
   filterSelections: {

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -69,7 +69,7 @@ const useValue = () => {
 
 export const FilterContext = React.createContext({} as ReturnType<typeof useValue>);
 
-export const filterAddrs = (addrs: AddressRecord[], filterSelections: FilterSelections) => {
+export const filterAddresses = (addrs: AddressRecord[], filterSelections: FilterSelections) => {
   const {
     rsunitslatest: filterRsunitslatest,
     ownernames: filterOwnernames,
@@ -96,8 +96,9 @@ export const filterAddrs = (addrs: AddressRecord[], filterSelections: FilterSele
 
     if (keepAddr && filterUnitsres.type !== "default") {
       keepAddr = filterUnitsres.values.reduce(
-        (acc, rng) =>
-          acc || (addr.unitsres != null && addr.unitsres >= rng.min && addr.unitsres <= rng.max),
+        (acc, range) =>
+          acc ||
+          (addr.unitsres != null && addr.unitsres >= range.min && addr.unitsres <= range.max),
         false
       );
     }

--- a/client/src/components/PropertiesList.tsx
+++ b/client/src/components/PropertiesList.tsx
@@ -153,7 +153,14 @@ const PropertiesListWithoutI18n: React.FC<
     map: viewType === "map",
   });
 
+  // We keep trak of this since mapbox loads on render of the Map component (not
+  // instantiation of the Map object) and we're charged for each load, so we
+  // want to only render it when necessary and then not unmount when switching
+  // views back and forth
   React.useEffect(() => {
+    // Currently table will alsways be true, and map always start as false, but
+    // we have talked about adding the ability to link to the portfolio tab with
+    // the view type (map/table) specified, so this will help if/when we do that
     setViewsEverVisible((prev) => ({
       table: prev.table || viewType === "table",
       map: prev.map || viewType === "map",

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -3,7 +3,6 @@ import ReactMapboxGl, { Layer, Feature, ZoomControl } from "react-mapbox-gl";
 import Helpers from "../util/helpers";
 import Browser from "../util/browser";
 import MapHelpers, { LatLng, BoundingBox } from "../util/mapping";
-
 import Loader from "../components/Loader";
 
 import "styles/PropertiesMap.css";
@@ -93,7 +92,6 @@ const DYNAMIC_ASSOC_PAINT = {
     stops: [
       ["base", "#FF9800"],
       ["search", "#FF5722"],
-      ["filter", "#5188FF"],
     ],
   },
 };
@@ -119,6 +117,18 @@ const DYNAMIC_SELECTED_PAINT = {
   "circle-stroke-width": 5,
   "circle-stroke-color": "#F2F2F2",
   "circle-color": "#5188FF",
+};
+
+const ASSOC_LAYOUT = {
+  "circle-sort-key": {
+    property: "mapType",
+    type: "categorical",
+    default: 0,
+    stops: [
+      ["base", 0],
+      ["search", 1],
+    ],
+  },
 };
 
 // due to the wonky way react-mapboxgl works, we can't just specify a center/zoom combo
@@ -273,8 +283,6 @@ export default class PropertiesMap extends Component<Props, State> {
         // presuming that nextProps.userAddr is in sync with nextProps.addrs
         if (Helpers.addrsAreEqual(addr, searchAddr)) {
           addr.mapType = "search";
-        } else if (this.filtersAreActive()) {
-          addr.mapType = "filter";
         } else {
           addr.mapType = "base";
         }
@@ -406,6 +414,7 @@ export default class PropertiesMap extends Component<Props, State> {
               <Layer
                 id="assoc"
                 type="circle"
+                layout={ASSOC_LAYOUT}
                 paint={this.filtersAreActive() ? DYNAMIC_FILTER_PAINT : DYNAMIC_ASSOC_PAINT}
               >
                 {this.state.addrsPoints}

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -468,18 +468,18 @@ export default class PropertiesMap extends Component<Props, State> {
         )}
 
         <div
-          className={`PropertiesMap__legend ${
-            this.state.mobileLegendSlide ? "PropertiesMap__legend--slide" : ""
-          }`}
+          className={classnames("PropertiesMap__legend", {
+            "PropertiesMap__legend--slide": this.state.mobileLegendSlide,
+          })}
           onClick={() => this.setState({ mobileLegendSlide: !this.state.mobileLegendSlide })}
         >
           <p>
             <span>
               {Browser.isMobile() ? (
                 this.state.mobileLegendSlide ? (
-                  <Trans>Close legend</Trans>
+                  <Trans>Hide legend</Trans>
                 ) : (
-                  <Trans>View legend</Trans>
+                  <Trans>Show legend</Trans>
                 )
               ) : (
                 <Trans>Legend</Trans>

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -109,8 +109,17 @@ const DYNAMIC_FILTER_PAINT = {
     type: "categorical",
     default: "#acb3c2",
     stops: [
-      ["base", "#5188FF"],
+      ["base", "#d6d6d6"],
       ["search", "#FF5722"],
+    ],
+  },
+  "circle-stroke-color": {
+    property: "mapType",
+    type: "categorical",
+    default: "#000000",
+    stops: [
+      ["base", "#5188FF"],
+      ["search", "#000000"],
     ],
   },
 };
@@ -120,7 +129,15 @@ const DYNAMIC_SELECTED_PAINT = {
   "circle-opacity": 1,
   "circle-stroke-opacity": 1,
   "circle-stroke-width": 2,
-  "circle-stroke-color": "#d6d6d6",
+  "circle-stroke-color": {
+    property: "mapType",
+    type: "categorical",
+    default: "#000000",
+    stops: [
+      ["base", "#000000"],
+      ["search", "#d6d6d6"],
+    ],
+  },
 };
 
 const ASSOC_LAYOUT = {

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -521,8 +521,14 @@ const SelectedAddrAlert = ({
   const numberFormatter = new Intl.NumberFormat(locale || defaultLocale);
 
   return (
-    <Alert closeType="state" variant="secondary" type="info" onClose={onClose}>
-      <p>{`${addr.housenumber} ${addr.streetname}`}</p>
+    <Alert
+      closeType="state"
+      variant="secondary"
+      type="info"
+      onClose={onClose}
+      className="selected-addr-alert"
+    >
+      <p className="selected-addr-alert__address">{`${addr.housenumber} ${addr.streetname}`}</p>
 
       {!isMobile && (
         <>

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -19,7 +19,7 @@ import {
   IFilterContext,
   PortfolioAnalyticsEvent,
   defaultFilterContext,
-  filterAddrs,
+  filterAddresses,
 } from "./PropertiesList";
 import { isEqual } from "lodash";
 import { Alert } from "./Alert";
@@ -218,8 +218,6 @@ export default class PropertiesMap extends Component<Props, State> {
   componentDidUpdate(prevProps: Props, prevState: State) {
     this.state.mapRef?.resize();
 
-    // this.isOnOverview() && this.zoomToNewDetailAddr(prevProps);
-
     const { filterContext } = this.context;
 
     if (typeof filterContext === "undefined") return;
@@ -247,7 +245,6 @@ export default class PropertiesMap extends Component<Props, State> {
     // On Overview page, this updates global context/state with new detail address. On Portfolio this just has telemetry.
     this.props.onAddrChange(addr.bbl);
 
-    // TODO: when on portfolio page, update state for selected address
     if (!this.isOnOverview()) {
       this.setState({ selectedAddr: addr });
     }
@@ -274,7 +271,7 @@ export default class PropertiesMap extends Component<Props, State> {
     const { assocAddrs, searchAddr } = this.getPortfolioData();
 
     // cycle through addrs, adding them to the set and categorizing them
-    this.filterAddrs(assocAddrs, searchAddr).forEach((addr, i) => {
+    this.filterAddresses(assocAddrs, searchAddr).forEach((addr, i) => {
       const pos: LatLng = [addr.lng || NaN, addr.lat || NaN];
 
       if (!MapHelpers.latLngIsNull(pos)) {
@@ -305,12 +302,12 @@ export default class PropertiesMap extends Component<Props, State> {
     return { newAssocAddrs, newAddrsBounds };
   };
 
-  filterAddrs(addrs: AddressRecord[], searchAddr: AddressRecord) {
+  filterAddresses(addrs: AddressRecord[], searchAddr: AddressRecord) {
     const { filterContext } = this.context;
 
     if (typeof filterContext === "undefined") return addrs;
 
-    const filteredAddrs = filterAddrs(addrs, filterContext.filterSelections).filter(
+    const filteredAddrs = filterAddresses(addrs, filterContext.filterSelections).filter(
       (addr) => addr.bbl !== searchAddr.bbl
     );
 

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -162,8 +162,6 @@ const ASSOC_LAYOUT = {
 
 // due to the wonky way react-mapboxgl works, we can't just specify a center/zoom combo
 // instead we use this offset value to create a fake bounding box around the detail center point
-// TODO: probably a non-hack way to do this?
-// const DETAIL_OFFSET = 0.0007;
 const DETAIL_OFFSET = 0.0015;
 
 export default class PropertiesMap extends Component<Props, State> {

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -474,16 +474,16 @@ export default class PropertiesMap extends Component<Props, State> {
             <i>{this.state.mobileLegendSlide ? "\u2b07\uFE0E" : "\u2b06\uFE0E"}</i>
           </p>
 
-          <ul>
-            <Trans render="li" className="addr-search">
+          <div className="legend-entry-container">
+            <Trans render="div" className="addr-search">
               search address
             </Trans>
-            <Trans render="li" className={`addr-${this.filtersAreActive() ? "filter" : "assoc"}`}>
+            <Trans render="div" className={`addr-${this.filtersAreActive() ? "filter" : "assoc"}`}>
               {this.filtersAreActive()
                 ? "building associated with selected filter(s)"
                 : "associated building"}
             </Trans>
-          </ul>
+          </div>
         </div>
       </div>
     );

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -207,7 +207,6 @@ export default class PropertiesMap extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-
     this.state.mapRef?.resize();
 
     // this.isOnOverview() && this.zoomToNewDetailAddr(prevProps);

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -493,9 +493,7 @@ export default class PropertiesMap extends Component<Props, State> {
               search address
             </Trans>
             <Trans render="div" className={`addr-${this.filtersAreActive() ? "filter" : "assoc"}`}>
-              {this.filtersAreActive()
-                ? "building associated with selected filter(s)"
-                : "associated building"}
+              associated building
             </Trans>
           </div>
         </div>

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -128,7 +128,6 @@ const DYNAMIC_SELECTED_PAINT = {
   ...DYNAMIC_FILTER_PAINT,
   "circle-opacity": 1,
   "circle-stroke-opacity": 1,
-  "circle-stroke-width": 2,
   "circle-stroke-color": {
     property: "mapType",
     type: "categorical",

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -29,7 +29,6 @@ import { SupportedLocale, defaultLocale } from "i18n-base";
 import { isLegacyPath } from "./WowzaToggle";
 import { sortContactsByImportance } from "./DetailView";
 import _groupBy from "lodash/groupBy";
-import { RsUnitsResultAlert, ZeroResultsAlert } from "./PortfolioFilters";
 import classnames from "classnames";
 
 type Props = withMachineInStateProps<"portfolioFound"> & {
@@ -327,20 +326,6 @@ export default class PropertiesMap extends Component<Props, State> {
     return !isEqual(filterSelections, defaultfilterSelections);
   }
 
-  toastAlert(): JSX.Element | undefined {
-    if (this.isOnOverview()) return undefined;
-
-    const { filterSelections, filteredBuildings } = this.context.filterContext;
-
-    if (filteredBuildings === 0) {
-      return <ZeroResultsAlert variant="primary" />;
-    } else if (filterSelections.rsunitslatest) {
-      return <RsUnitsResultAlert variant="primary" />;
-    }
-
-    return undefined;
-  }
-
   render() {
     const { useNewPortfolioMethod } = this.props.state.context;
     const portfolioFiltersEnabled = process.env.REACT_APP_PORTFOLIO_FILTERS_ENABLED === "1" || true;
@@ -486,7 +471,6 @@ export default class PropertiesMap extends Component<Props, State> {
             </Trans>
           </ul>
         </div>
-        <div className="filter-toast-container">{this.toastAlert()}</div>
       </div>
     );
   }

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -542,7 +542,7 @@ const SelectedAddrAlert = ({
       onClose={onClose}
       className="selected-addr-alert"
     >
-      <p className="selected-addr-alert__address">{`${addr.housenumber} ${addr.streetname}`}</p>
+      <p className="selected-addr-alert__address">{`${addr.housenumber} ${addr.streetname}, ${addr.boro}`}</p>
 
       {!isMobile && (
         <>

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -285,7 +285,7 @@ export default class PropertiesMap extends Component<Props, State> {
         <Feature
           key={i}
           coordinates={pos}
-          properties={{ mapType: addr.mapType}}
+          properties={{ mapType: addr.mapType }}
           onClick={(e) => this.handleAddrSelect(addr, e)}
         />
       );

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -197,32 +197,7 @@ export default class PropertiesMap extends Component<Props, State> {
       this.state.mapRef.resize();
     }
 
-    /**
-     * Either we are receiving detailAddr for the first time, or it has been updated to a new address.
-     */
-    const didDetailAddrUpdate =
-      (!prevProps.state.context.portfolioData && this.props.state.context.portfolioData) ||
-      prevProps.state.context.portfolioData.detailAddr.bbl !==
-        this.getPortfolioData().detailAddr.bbl;
-
-    if (this.isOnOverview() && didDetailAddrUpdate) {
-      const { detailAddr } = this.getPortfolioData();
-      const { lat, lng } = detailAddr;
-
-      // build a bounding box around our new detail addr
-      const newBounds = !!(lat && lng)
-        ? ([
-            [lng - DETAIL_OFFSET, lat - DETAIL_OFFSET],
-            [lng + DETAIL_OFFSET, lat + DETAIL_OFFSET],
-          ] as FitBounds)
-        : this.state.mapProps.fitBounds;
-      this.setState({
-        mapProps: {
-          ...this.state.mapProps,
-          fitBounds: newBounds,
-        },
-      });
-    }
+    // this.isOnOverview() && this.zoomToNewDetailAddr(prevProps);
 
     const { filterContext } = this.context;
 
@@ -343,6 +318,35 @@ export default class PropertiesMap extends Component<Props, State> {
     const { filterSelections: defaultfilterSelections } = defaultFilterContext;
 
     return !isEqual(filterSelections, defaultfilterSelections);
+  }
+
+  zoomToNewDetailAddr(prevProps: Props) {
+    /**
+     * Either we are receiving detailAddr for the first time, or it has been updated to a new address.
+     */
+    const didDetailAddrUpdate =
+      (!prevProps.state.context.portfolioData && this.props.state.context.portfolioData) ||
+      prevProps.state.context.portfolioData.detailAddr.bbl !==
+        this.getPortfolioData().detailAddr.bbl;
+
+    if (this.isOnOverview() && didDetailAddrUpdate) {
+      const { detailAddr } = this.getPortfolioData();
+      const { lat, lng } = detailAddr;
+
+      // build a bounding box around our new detail addr
+      const newBounds = !!(lat && lng)
+        ? ([
+            [lng - DETAIL_OFFSET, lat - DETAIL_OFFSET],
+            [lng + DETAIL_OFFSET, lat + DETAIL_OFFSET],
+          ] as FitBounds)
+        : this.state.mapProps.fitBounds;
+      this.setState({
+        mapProps: {
+          ...this.state.mapProps,
+          fitBounds: newBounds,
+        },
+      });
+    }
   }
 
   render() {

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -207,11 +207,8 @@ export default class PropertiesMap extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    // is this necessary?
-    // meant to reconfigure after bring the tab back in focus
-    if (!prevProps.isVisible && this.props.isVisible && this.state.mapRef) {
-      this.state.mapRef.resize();
-    }
+
+    this.state.mapRef?.resize();
 
     // this.isOnOverview() && this.zoomToNewDetailAddr(prevProps);
 

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -115,7 +115,8 @@ const DYNAMIC_FILTER_PAINT = {
 const DYNAMIC_SELECTED_PAINT = {
   ...DYNAMIC_FILTER_PAINT,
   "circle-stroke-opacity": 1,
-  "circle-stroke-width": 3,
+  "circle-radius": 5,
+  "circle-stroke-width": 5,
   "circle-stroke-color": "#F2F2F2",
   "circle-color": "#5188FF",
 };
@@ -426,7 +427,11 @@ export default class PropertiesMap extends Component<Props, State> {
                 />
               )}
             </Layer>
-            <Layer id="detail" type="circle" paint={DYNAMIC_SELECTED_PAINT}>
+            <Layer
+              id="selected"
+              type="circle"
+              paint={this.filtersAreActive() ? DYNAMIC_SELECTED_PAINT : DYNAMIC_DETAIL_PAINT}
+            >
               {!this.isOnOverview() && !!selectedAddr && selectedAddr.lng && selectedAddr.lat && (
                 <Feature
                   properties={{

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -128,6 +128,15 @@ const DYNAMIC_SELECTED_PAINT = {
   ...DYNAMIC_FILTER_PAINT,
   "circle-opacity": 1,
   "circle-stroke-opacity": 1,
+  "circle-color": {
+    property: "mapType",
+    type: "categorical",
+    default: "#5188FF",
+    stops: [
+      ["base", "#5188FF"],
+      ["search", "#FF5722"],
+    ],
+  },
   "circle-stroke-color": {
     property: "mapType",
     type: "categorical",

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -94,7 +94,7 @@ const DYNAMIC_ASSOC_PAINT = {
     stops: [
       ["base", "#FF9800"],
       ["search", "#FF5722"],
-      ["filter", "#5188FF"]
+      ["filter", "#5188FF"],
     ],
   },
 };
@@ -285,7 +285,7 @@ export default class PropertiesMap extends Component<Props, State> {
         <Feature
           key={i}
           coordinates={pos}
-          properties={{ mapType: addr.mapType }}
+          properties={{ mapType: addr.mapType}}
           onClick={(e) => this.handleAddrSelect(addr, e)}
         />
       );
@@ -441,7 +441,7 @@ export default class PropertiesMap extends Component<Props, State> {
                 />
               )}
             </Layer>
-            <Layer id="selected" type="marker" paint={DYNAMIC_SELECTED_PAINT}>
+            <Layer id="detail" type="circle" paint={DYNAMIC_SELECTED_PAINT}>
               {!this.isOnOverview() && !!selectedAddr && selectedAddr.lng && selectedAddr.lat && (
                 <Feature
                   properties={{

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -191,26 +191,26 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                   </li>
                   <li className={`tab-item ${this.props.currentTab === 1 ? "active" : ""}`}>
                     <Link
-                      to={routes.timeline}
-                      tabIndex={this.props.currentTab === 1 ? -1 : 0}
-                      onClick={() => {
-                        logAmplitudeEvent("timelineTab");
-                        window.gtag("event", "timeline-tab");
-                      }}
-                    >
-                      <Trans>Timeline</Trans>
-                    </Link>
-                  </li>
-                  <li className={`tab-item ${this.props.currentTab === 2 ? "active" : ""}`}>
-                    <Link
                       to={routes.portfolio}
-                      tabIndex={this.props.currentTab === 2 ? -1 : 0}
+                      tabIndex={this.props.currentTab === 1 ? -1 : 0}
                       onClick={() => {
                         logAmplitudeEvent("portfolioTab");
                         window.gtag("event", "portfolio-tab");
                       }}
                     >
                       <Trans>Portfolio</Trans>
+                    </Link>
+                  </li>
+                  <li className={`tab-item ${this.props.currentTab === 2 ? "active" : ""}`}>
+                    <Link
+                      to={routes.timeline}
+                      tabIndex={this.props.currentTab === 2 ? -1 : 0}
+                      onClick={() => {
+                        logAmplitudeEvent("timelineTab");
+                        window.gtag("event", "timeline-tab");
+                      }}
+                    >
+                      <Trans>Timeline</Trans>
                     </Link>
                   </li>
                   <li className={`tab-item ${this.props.currentTab === 3 ? "active" : ""}`}>
@@ -258,21 +258,8 @@ export default class AddressPage extends Component<AddressPageProps, State> {
               />
             </div>
             <div
-              className={`AddressPage__content AddressPage__summary ${
-                this.props.currentTab === 1 ? "AddressPage__content-active" : ""
-              }`}
-            >
-              <Indicators
-                isVisible={this.props.currentTab === 1}
-                state={state}
-                send={send}
-                onBackToOverview={this.handleAddrChange}
-                addressPageRoutes={routes}
-              />
-            </div>
-            <div
               className={`AddressPage__content AddressPage__table ${
-                this.props.currentTab === 2 ? "AddressPage__content-active" : ""
+                this.props.currentTab === 1 ? "AddressPage__content-active" : ""
               }`}
             >
               <FilterContextProvider>
@@ -280,9 +267,22 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                   state={state}
                   send={send}
                   addressPageRoutes={routes}
-                  isVisible={this.props.currentTab === 2}
+                  isVisible={this.props.currentTab === 1}
                 />
               </FilterContextProvider>
+            </div>
+            <div
+              className={`AddressPage__content AddressPage__summary ${
+                this.props.currentTab === 2 ? "AddressPage__content-active" : ""
+              }`}
+            >
+              <Indicators
+                isVisible={this.props.currentTab === 2}
+                state={state}
+                send={send}
+                onBackToOverview={this.handleAddrChange}
+                addressPageRoutes={routes}
+              />
             </div>
             <div
               className={`AddressPage__content AddressPage__summary ${

--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -234,6 +234,8 @@ export default class AddressPage extends Component<AddressPageProps, State> {
                 this.props.currentTab === 0 ? "AddressPage__content-active" : ""
               }`}
             >
+              {/* We are changed for each map load, which happens on render, so we want to
+              avoid rendering when it's not in view or rerendering which switching between tabs */}
               {this.state.overviewEverVisible && (
                 <PropertiesMap
                   location="overview"

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -94,11 +94,11 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
         exact
       />
       <Route
-        path={paths.legacy.addressPage.timeline}
+        path={paths.legacy.addressPage.portfolio}
         render={(props) => <AddressPage currentTab={1} {...machineProps} {...props} />}
       />
       <Route
-        path={paths.legacy.addressPage.portfolio}
+        path={paths.legacy.addressPage.timeline}
         render={(props) => <AddressPage currentTab={2} {...machineProps} {...props} />}
       />
       <Route
@@ -118,7 +118,7 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
         exact
       />
       <Route
-        path={paths.addressPage.timeline}
+        path={paths.addressPage.portfolio}
         render={(props) => (
           <AddressPage
             currentTab={1}
@@ -129,7 +129,7 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
         )}
       />
       <Route
-        path={paths.addressPage.portfolio}
+        path={paths.addressPage.timeline}
         render={(props) => (
           <AddressPage
             currentTab={2}

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -6,7 +6,6 @@ import LegalFooter from "../components/LegalFooter";
 import "styles/HomePage.css";
 
 import { LocaleLink as Link } from "../i18n";
-import westminsterLogo from "../assets/img/westminster.svg";
 import stellarLogo from "../assets/img/stellar.png";
 import aeLogo from "../assets/img/aande.svg";
 import AddressSearch, { SearchAddress } from "../components/AddressSearch";
@@ -196,60 +195,7 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
             </h5>
             <div className="container">
               <div className="columns">
-                <div className="column col-4 col-sm-12">
-                  <div className="HomePage__sample">
-                    <h6>
-                      <Link
-                        to={getSampleUrls()[0]}
-                        onClick={() => {
-                          window.gtag("event", "example-portfolio-1-homepage");
-                        }}
-                      >
-                        Kushner Companies / Westminster Management
-                      </Link>
-                    </h6>
-                    <Link
-                      className="image"
-                      tabIndex={-1} // Since link is not necessary navigation, removing tab focus
-                      to={getSampleUrls()[0]}
-                      onClick={() => {
-                        window.gtag("event", "example-portfolio-1-homepage");
-                      }}
-                    >
-                      <img className="img-responsive" src={westminsterLogo} alt="Westminster" />
-                    </Link>
-                    <Trans render="p">
-                      This property management company owned by the Kushner family is notorious for{" "}
-                      <a
-                        href="https://www.nytimes.com/2017/08/15/business/tenants-sue-kushner-companies-claiming-rent-rule-violations.html"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        violating rent regulations
-                      </a>{" "}
-                      and{" "}
-                      <a
-                        href="https://www.villagevoice.com/2017/01/12/jared-kushners-east-village-tenants-horrified-their-landlord-will-be-working-in-the-white-house/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        harassing tenants
-                      </a>
-                      . The stake currently held by Jared Kushner and Ivanka Trump is worth as much
-                      as $761 million.
-                    </Trans>
-                    <Link
-                      className="btn block text-center"
-                      to={getSampleUrls()[0]}
-                      onClick={() => {
-                        window.gtag("event", "example-portfolio-1-homepage");
-                      }}
-                    >
-                      <Trans>View portfolio</Trans> &#10230;
-                    </Link>
-                  </div>
-                </div>
-                <div className="column col-4 col-sm-12">
+                <div className="column col-6 col-sm-12">
                   <div className="HomePage__sample">
                     <h6>
                       <Link
@@ -322,7 +268,7 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
                     </Link>
                   </div>
                 </div>
-                <div className="column col-4 col-sm-12">
+                <div className="column col-6 col-sm-12">
                   <div className="HomePage__sample">
                     <h6>
                       <Link

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -6,8 +6,6 @@ import LegalFooter from "../components/LegalFooter";
 import "styles/HomePage.css";
 
 import { LocaleLink as Link } from "../i18n";
-import stellarLogo from "../assets/img/stellar.png";
-import aeLogo from "../assets/img/aande.svg";
 import AddressSearch, { SearchAddress } from "../components/AddressSearch";
 import { Trans } from "@lingui/macro";
 import Page from "../components/Page";
@@ -207,20 +205,6 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
                         A&amp;E Real Estate
                       </Link>
                     </h6>
-                    <Link
-                      className="image"
-                      tabIndex={-1} // Since link is not necessary navigation, removing tab focus
-                      to={getSampleUrls()[1]}
-                      onClick={() => {
-                        window.gtag("event", "example-portfolio-2-homepage");
-                      }}
-                    >
-                      <img
-                        className="emassoc img-responsive"
-                        src={aeLogo}
-                        alt="A&amp;E Real Estate"
-                      />
-                    </Link>
                     <Trans render="p">
                       The city’s fifth{" "}
                       <a
@@ -280,16 +264,6 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
                         Stellar Management
                       </Link>
                     </h6>
-                    <Link
-                      className="image"
-                      tabIndex={-1} // Since link is not necessary navigation, removing tab focus
-                      to={getSampleUrls()[2]}
-                      onClick={() => {
-                        window.gtag("event", "example-portfolio-3-homepage");
-                      }}
-                    >
-                      <img className="img-responsive" src={stellarLogo} alt="Stellar Management" />
-                    </Link>
                     <Trans render="p">
                       Known for{" "}
                       <a
@@ -297,21 +271,19 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        unscrupulously deregulating rent stabilized apartments
+                        deregulating rent stabilized apartments
                       </a>
-                      , Larry Gluck’s Stellar Management has also secured a prominent place as one
-                      of{" "}
+                      , Stellar Management is also one of the city’s of{" "}
                       <a
                         href="https://www.worstevictorsnyc.org/"
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        New York City’s Worst Evictors
+                        Worst Evictors
                       </a>
-                      . Stellar is a gentrifying force, particularly in upper Manhattan where Gluck
-                      operates the majority of his properties. Stellar has a reputation for
-                      displacing long-term tenants, renovating their units while vacant, and
-                      skyrocketing rents to market rate.
+                      . Stellar is a gentrifying force, particularly in upper Manhattan where they
+                      have a reputation for displacing long-term tenants, renovating their units
+                      while vacant, and skyrocketing rents to market rate.
                     </Trans>
                     <Link
                       className="btn block text-center"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -46,7 +46,7 @@ msgstr "(expires {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
-#: src/components/PropertiesList.tsx:87
+#: src/components/PropertiesList.tsx:125
 msgid "(this may take a while)"
 msgstr "(this may take a while)"
 
@@ -159,6 +159,10 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
+#: src/components/PropertiesMap.tsx:322
+msgid "Associated names/entities: {0}"
+msgstr "Associated names/entities: {0}"
+
 #: src/util/helpers.ts:13
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
@@ -185,13 +189,17 @@ msgstr "Building Permit Applications"
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
-#: src/components/PortfolioFilters.tsx:123
+#: src/components/PortfolioFilters.tsx:147
 msgid "Building Size"
 msgstr "Building Size"
 
 #: src/components/PropertiesSummary.tsx:101
 msgid "Building info"
 msgstr "Building info"
+
+#: src/components/PropertiesMap.tsx:330
+msgid "Building size: {0}"
+msgstr "Building size: {0}"
 
 #: src/containers/NotRegisteredPage.tsx:162
 msgid "Buildings without valid property registration are subject to the following:"
@@ -256,7 +264,7 @@ msgstr "Class I"
 #~ msgid "Clear"
 #~ msgstr "Clear"
 
-#: src/components/PortfolioFilters.tsx:143
+#: src/components/PortfolioFilters.tsx:167
 msgid "Clear Filters"
 msgstr "Clear Filters"
 
@@ -293,7 +301,7 @@ msgstr "Click here to learn more."
 msgid "Close"
 msgstr "Close"
 
-#: src/components/PropertiesMap.tsx:207
+#: src/components/PropertiesMap.tsx:290
 msgid "Close legend"
 msgstr "Close legend"
 
@@ -452,7 +460,7 @@ msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD 
 msgid "Executed"
 msgstr "Executed"
 
-#: src/components/PortfolioFilters.tsx:204
+#: src/components/PortfolioFilters.tsx:228
 msgid "Expand the Person/ Entity column in the Table to see all contacts associated with that building."
 msgstr "Expand the Person/ Entity column in the Table to see all contacts associated with that building."
 
@@ -488,7 +496,7 @@ msgstr "Filed"
 #~ msgid "Filied"
 #~ msgstr "Filied"
 
-#: src/components/PortfolioFilters.tsx:246
+#: src/components/PortfolioFilters.tsx:270
 msgid "Filter"
 msgstr "Filter"
 
@@ -496,11 +504,11 @@ msgstr "Filter"
 #~ msgid "Filter through this portfolio in <0>the Portfolio tab.</0>"
 #~ msgstr "Filter through this portfolio in <0>the Portfolio tab.</0>"
 
-#: src/components/PortfolioFilters.tsx:185
+#: src/components/PortfolioFilters.tsx:209
 msgid "Filters"
 msgstr "Filters"
 
-#: src/components/PortfolioFilters.tsx:110
+#: src/components/PortfolioFilters.tsx:126
 msgid "Filters:"
 msgstr "Filters:"
 
@@ -558,7 +566,7 @@ msgstr "HUD Complaint Form 958"
 msgid "Head Officer"
 msgstr "Head Officer"
 
-#: src/components/PortfolioFilters.tsx:151
+#: src/components/PortfolioFilters.tsx:175
 msgid "How are the results calculated?"
 msgstr "How are the results calculated?"
 
@@ -651,12 +659,12 @@ msgstr "Known for <0>unscrupulously deregulating rent stabilized apartments</0>,
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:144
 #: src/components/PortfolioTable.tsx:260
 msgid "Landlord"
 msgstr "Landlord"
 
-#: src/components/PortfolioFilters.tsx:121
+#: src/components/PortfolioFilters.tsx:145
 msgid "Landlord filter"
 msgstr "Landlord filter"
 
@@ -693,7 +701,7 @@ msgstr "Last sold:"
 msgid "Learn more"
 msgstr "Learn more"
 
-#: src/components/PortfolioFilters.tsx:139
+#: src/components/PortfolioFilters.tsx:163
 msgid "Learn more about how the results are calculated"
 msgstr "Learn more about how the results are calculated"
 
@@ -701,7 +709,7 @@ msgstr "Learn more about how the results are calculated"
 msgid "Learn more."
 msgstr "Learn more."
 
-#: src/components/PropertiesMap.tsx:207
+#: src/components/PropertiesMap.tsx:290
 msgid "Legend"
 msgstr "Legend"
 
@@ -715,12 +723,12 @@ msgid "Link to Deed"
 msgstr "Link to Deed"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:88
-#: src/components/PropertiesMap.tsx:158
+#: src/components/PropertiesList.tsx:126
+#: src/components/PropertiesMap.tsx:233
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:85
+#: src/components/PropertiesList.tsx:123
 msgid "Loading {0} rows"
 msgstr "Loading {0} rows"
 
@@ -732,7 +740,7 @@ msgstr "Location"
 #~ msgid "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 #~ msgstr "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 
-#: src/components/PortfolioFilters.tsx:219
+#: src/components/PortfolioFilters.tsx:243
 msgid "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
 msgstr "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
 
@@ -771,6 +779,10 @@ msgstr "Make a selection from the list or clear search text"
 #: src/components/Multiselect.tsx:450
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
+
+#: src/components/PortfolioFilters.tsx:135
+msgid "Map"
+msgstr "Map"
 
 #: src/components/MinMaxSelect.tsx:207
 msgid "Max must be greater than 0"
@@ -849,7 +861,7 @@ msgstr "Narrow down this portfolio using filters in <0>the Portfolio tab.</0>"
 msgid "Network of Landlords"
 msgstr "Network of Landlords"
 
-#: src/components/PortfolioFilters.tsx:107
+#: src/components/PortfolioFilters.tsx:123
 msgid "New"
 msgstr "New"
 
@@ -862,7 +874,7 @@ msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:548
+#: src/components/PortfolioTable.tsx:552
 msgid "Next"
 msgstr "Next"
 
@@ -915,7 +927,7 @@ msgstr "Not found"
 #~ msgid "Notice an inaccuracy? Click here."
 #~ msgstr "Notice an inaccuracy? Click here."
 
-#: src/components/PortfolioFilters.tsx:123
+#: src/components/PortfolioFilters.tsx:147
 msgid "Number of Units"
 msgstr "Number of Units"
 
@@ -954,7 +966,7 @@ msgstr "Open"
 msgid "Open Violations"
 msgstr "Open Violations"
 
-#: src/containers/AddressPage.tsx:133
+#: src/containers/AddressPage.tsx:140
 msgid "Overview"
 msgstr "Overview"
 
@@ -982,11 +994,11 @@ msgstr "PESTS"
 msgid "PLUMBING"
 msgstr "PLUMBING"
 
-#: src/containers/AddressPage.tsx:119
+#: src/containers/AddressPage.tsx:126
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/PortfolioTable.tsx:517
+#: src/components/PortfolioTable.tsx:521
 msgid "Page"
 msgstr "Page"
 
@@ -995,7 +1007,7 @@ msgstr "Page"
 msgid "People"
 msgstr "People"
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:144
 #: src/components/PortfolioTable.tsx:273
 msgid "Person/Entity"
 msgstr "Person/Entity"
@@ -1004,7 +1016,7 @@ msgstr "Person/Entity"
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/containers/AddressPage.tsx:149
+#: src/containers/AddressPage.tsx:156
 msgid "Portfolio"
 msgstr "Portfolio"
 
@@ -1013,7 +1025,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Portfolio Table Redesign"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:511
+#: src/components/PortfolioTable.tsx:515
 msgid "Previous"
 msgstr "Previous"
 
@@ -1036,8 +1048,8 @@ msgstr "RS Units"
 #~ msgid "Read more about our Methodology"
 #~ msgstr "Read more about our Methodology"
 
-#: src/components/PortfolioFilters.tsx:100
-#: src/components/PortfolioFilters.tsx:163
+#: src/components/PortfolioFilters.tsx:116
+#: src/components/PortfolioFilters.tsx:187
 msgid "Read more in our Methodology section"
 msgstr "Read more in our Methodology section"
 
@@ -1045,11 +1057,11 @@ msgstr "Read more in our Methodology section"
 msgid "Registration expired:"
 msgstr "Registration expired:"
 
-#: src/components/PortfolioFilters.tsx:117
+#: src/components/PortfolioFilters.tsx:141
 msgid "Rent Stabilized Units"
 msgstr "Rent Stabilized Units"
 
-#: src/components/PortfolioFilters.tsx:114
+#: src/components/PortfolioFilters.tsx:138
 msgid "Rent Stabilized Units filter"
 msgstr "Rent Stabilized Units filter"
 
@@ -1057,11 +1069,15 @@ msgstr "Rent Stabilized Units filter"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
+#: src/components/PropertiesMap.tsx:318
+msgid "Rent stabilized units ({0}): {1}"
+msgstr "Rent stabilized units ({0}): {1}"
+
 #: src/components/PortfolioFilters.tsx:210
 #~ msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may appear to be deregulated."
 #~ msgstr "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may appear to be deregulated."
 
-#: src/components/PortfolioFilters.tsx:210
+#: src/components/PortfolioFilters.tsx:234
 msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 msgstr "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 
@@ -1107,6 +1123,10 @@ msgstr "Search for a different address"
 msgid "Search landlords"
 msgstr "Search landlords"
 
+#: src/components/PropertiesMap.tsx:342
+msgid "See Building Profile"
+msgstr "See Building Profile"
+
 #: src/components/FeatureCalloutContent.ts:9
 msgid "See the most common complaints reported by tenants to 311, now on the Overview and Portfolio tabs."
 msgstr "See the most common complaints reported by tenants to 311, now on the Overview and Portfolio tabs."
@@ -1148,7 +1168,7 @@ msgstr "Show less"
 msgid "Show only {previewSelectedNum} selections"
 msgstr "Show only {previewSelectedNum} selections"
 
-#: src/components/PortfolioFilters.tsx:134
+#: src/components/PortfolioFilters.tsx:158
 msgid "Showing {0} {1, plural, one {result} other {results}}"
 msgstr "Showing {0} {1, plural, one {result} other {results}}"
 
@@ -1181,7 +1201,7 @@ msgstr "Sign up for email updates"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/components/PortfolioTable.tsx:575
+#: src/components/PortfolioTable.tsx:579
 msgid "Since {year}"
 msgstr "Since {year}"
 
@@ -1197,7 +1217,7 @@ msgstr "Sold to Current Owner"
 msgid "Some large corporations, however, are a bit more complicated and may share personnel and financial stake with other related companies, which all will show up on Who Owns What as one large portfolio."
 msgstr "Some large corporations, however, are a bit more complicated and may share personnel and financial stake with other related companies, which all will show up on Who Owns What as one large portfolio."
 
-#: src/components/PropertiesMap.tsx:168
+#: src/components/PropertiesMap.tsx:243
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 
@@ -1217,11 +1237,11 @@ msgstr "Source code"
 #~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:575
+#: src/components/PortfolioTable.tsx:579
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
-#: src/containers/AddressPage.tsx:157
+#: src/containers/AddressPage.tsx:164
 msgid "Summary"
 msgstr "Summary"
 
@@ -1236,6 +1256,10 @@ msgstr "Summary"
 #: src/util/helpers.ts:23
 msgid "TENANT HARASSMENT"
 msgstr "TENANT HARASSMENT"
+
+#: src/components/PortfolioFilters.tsx:132
+msgid "Table"
+msgstr "Table"
 
 #: src/components/DetailView.tsx:264
 #: src/containers/NychaPage.tsx:179
@@ -1383,7 +1407,7 @@ msgstr "This tracks how rent stabilized units in the building have changed (i.e.
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:141
+#: src/containers/AddressPage.tsx:148
 msgid "Timeline"
 msgstr "Timeline"
 
@@ -1401,7 +1425,7 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Total Violations"
 
-#: src/components/PortfolioFilters.tsx:216
+#: src/components/PortfolioFilters.tsx:240
 msgid "Try adjusting or clearing the filters to show more than 0 results."
 msgstr "Try adjusting or clearing the filters to show more than 0 results."
 
@@ -1449,7 +1473,7 @@ msgstr "VENTILATION SYSTEM"
 msgid "View Detail"
 msgstr "View Detail"
 
-#: src/components/PortfolioFilters.tsx:194
+#: src/components/PortfolioFilters.tsx:218
 msgid "View Results"
 msgstr "View Results"
 
@@ -1471,7 +1495,7 @@ msgstr "View data over time ↗︎"
 msgid "View documents on <0>ACRIS</0>"
 msgstr "View documents on <0>ACRIS</0>"
 
-#: src/components/PropertiesMap.tsx:207
+#: src/components/PropertiesMap.tsx:290
 msgid "View legend"
 msgstr "View legend"
 
@@ -1522,7 +1546,7 @@ msgstr "We compare your search address with a database of over 200k buildings to
 msgid "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 msgstr "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 
-#: src/components/PortfolioFilters.tsx:154
+#: src/components/PortfolioFilters.tsx:178
 msgid "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 msgstr "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 
@@ -1559,7 +1583,7 @@ msgstr "What's New"
 #~ msgid "What's this?"
 #~ msgstr "What's this?"
 
-#: src/components/PortfolioFilters.tsx:84
+#: src/components/PortfolioFilters.tsx:100
 msgid "What’s the difference between a landlord, an owner, and head officer?"
 msgstr "What’s the difference between a landlord, an owner, and head officer?"
 
@@ -1575,7 +1599,7 @@ msgstr "When two parties share the same business address, we group them as part 
 #~ msgid "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with the Department of Housing Preservation (“HPD”) offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 #~ msgstr "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with the Department of Housing Preservation (“HPD”) offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 
-#: src/components/PortfolioFilters.tsx:87
+#: src/components/PortfolioFilters.tsx:103
 msgid "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with the Department of Housing Preservation and Development (“HPD”) offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 msgstr "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with the Department of Housing Preservation and Development (“HPD”) offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 
@@ -1583,7 +1607,7 @@ msgstr "While the legal owner of a building is often a company (usually called a
 msgid "Who Owns What is a free tool built by JustFix to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Who Owns What is a free tool built by JustFix to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:144
 msgid "Who are they?"
 msgstr "Who are they?"
 
@@ -1644,16 +1668,16 @@ msgstr "You are viewing the old version of Who Owns What. <0>Switch to the new v
 #~ msgid "ZIP CODE is not applicable"
 #~ msgstr "ZIP CODE is not applicable"
 
-#: src/components/PortfolioFilters.tsx:127
+#: src/components/PortfolioFilters.tsx:151
 msgid "ZIP code is not applicable"
 msgstr "ZIP code is not applicable"
 
-#: src/components/PortfolioFilters.tsx:126
+#: src/components/PortfolioFilters.tsx:150
 #: src/components/PortfolioTable.tsx:88
 msgid "Zip Code"
 msgstr "Zip Code"
 
-#: src/components/PortfolioFilters.tsx:127
+#: src/components/PortfolioFilters.tsx:151
 msgid "Zip code filter"
 msgstr "Zip code filter"
 
@@ -1675,8 +1699,8 @@ msgid "and"
 msgstr "and"
 
 #: src/components/PropertiesMap.tsx:214
-msgid "associated building"
-msgstr "associated building"
+#~ msgid "associated building"
+#~ msgstr "associated building"
 
 #: src/components/DetailView.tsx:242
 msgid "for ${0}"
@@ -1686,7 +1710,7 @@ msgstr "for ${0}"
 msgid "month"
 msgstr "month"
 
-#: src/components/PortfolioTable.tsx:528
+#: src/components/PortfolioTable.tsx:532
 msgid "of"
 msgstr "of"
 
@@ -1694,7 +1718,7 @@ msgstr "of"
 msgid "quarter"
 msgstr "quarter"
 
-#: src/components/PropertiesMap.tsx:213
+#: src/components/PropertiesMap.tsx:296
 msgid "search address"
 msgstr "search address"
 
@@ -1705,6 +1729,14 @@ msgstr "search address"
 #: src/components/Indicators.tsx:18
 msgid "year"
 msgstr "year"
+
+#: src/components/PropertiesMap.tsx:333
+msgid "{0, plural, one {unit} other {units}}"
+msgstr "{0, plural, one {unit} other {units}}"
+
+#: src/components/PropertiesMap.tsx:299
+msgid "{0}"
+msgstr "{0}"
 
 #: src/components/FeatureCalloutWidget.tsx:26
 msgid "{0} of {numberOfEntries}"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -159,7 +159,7 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/components/PropertiesMap.tsx:344
+#: src/components/PropertiesMap.tsx:345
 msgid "Associated names/entities: {0}"
 msgstr "Associated names/entities: {0}"
 
@@ -197,7 +197,7 @@ msgstr "Building Size"
 msgid "Building info"
 msgstr "Building info"
 
-#: src/components/PropertiesMap.tsx:352
+#: src/components/PropertiesMap.tsx:353
 msgid "Building size: {0}"
 msgstr "Building size: {0}"
 
@@ -508,7 +508,7 @@ msgstr "Filter"
 msgid "Filters"
 msgstr "Filters"
 
-#: src/components/PortfolioFilters.tsx:123
+#: src/components/PortfolioFilters.tsx:124
 msgid "Filters:"
 msgstr "Filters:"
 
@@ -566,7 +566,7 @@ msgstr "HUD Complaint Form 958"
 msgid "Head Officer"
 msgstr "Head Officer"
 
-#: src/components/PropertiesMap.tsx:315
+#: src/components/PropertiesMap.tsx:316
 msgid "Hide legend"
 msgstr "Hide legend"
 
@@ -721,7 +721,7 @@ msgstr "Learn more about what it means for someone to be listed as a landlord"
 msgid "Learn more."
 msgstr "Learn more."
 
-#: src/components/PropertiesMap.tsx:315
+#: src/components/PropertiesMap.tsx:316
 msgid "Legend"
 msgstr "Legend"
 
@@ -736,7 +736,7 @@ msgstr "Link to Deed"
 
 #: src/components/Loader.tsx:19
 #: src/components/PortfolioTable.tsx:440
-#: src/components/PropertiesMap.tsx:256
+#: src/components/PropertiesMap.tsx:257
 msgid "Loading"
 msgstr "Loading"
 
@@ -873,7 +873,7 @@ msgstr "Narrow down this portfolio using filters in <0>the Portfolio tab.</0>"
 msgid "Network of Landlords"
 msgstr "Network of Landlords"
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:121
 msgid "New"
 msgstr "New"
 
@@ -1081,7 +1081,7 @@ msgstr "Rent Stabilized Units filter"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/components/PropertiesMap.tsx:340
+#: src/components/PropertiesMap.tsx:341
 msgid "Rent stabilized units ({0}): {1}"
 msgstr "Rent stabilized units ({0}): {1}"
 
@@ -1135,7 +1135,7 @@ msgstr "Search for a different address"
 msgid "Search landlords"
 msgstr "Search landlords"
 
-#: src/components/PropertiesMap.tsx:364
+#: src/components/PropertiesMap.tsx:363
 msgid "See Building Profile"
 msgstr "See Building Profile"
 
@@ -1172,7 +1172,7 @@ msgstr "Shareholder"
 msgid "Show all {numSelections} selections"
 msgstr "Show all {numSelections} selections"
 
-#: src/components/PropertiesMap.tsx:315
+#: src/components/PropertiesMap.tsx:316
 msgid "Show legend"
 msgstr "Show legend"
 
@@ -1233,7 +1233,7 @@ msgstr "Sold to Current Owner"
 msgid "Some large corporations, however, are a bit more complicated and may share personnel and financial stake with other related companies, which all will show up on Who Owns What as one large portfolio."
 msgstr "Some large corporations, however, are a bit more complicated and may share personnel and financial stake with other related companies, which all will show up on Who Owns What as one large portfolio."
 
-#: src/components/PropertiesMap.tsx:266
+#: src/components/PropertiesMap.tsx:267
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 
@@ -1721,7 +1721,7 @@ msgstr "Zoom out"
 msgid "and"
 msgstr "and"
 
-#: src/components/PropertiesMap.tsx:324
+#: src/components/PropertiesMap.tsx:325
 msgid "associated building"
 msgstr "associated building"
 
@@ -1749,7 +1749,7 @@ msgstr "page number"
 msgid "quarter"
 msgstr "quarter"
 
-#: src/components/PropertiesMap.tsx:321
+#: src/components/PropertiesMap.tsx:322
 msgid "search address"
 msgstr "search address"
 
@@ -1761,7 +1761,7 @@ msgstr "search address"
 msgid "year"
 msgstr "year"
 
-#: src/components/PropertiesMap.tsx:355
+#: src/components/PropertiesMap.tsx:356
 msgid "{0, plural, one {unit} other {units}}"
 msgstr "{0, plural, one {unit} other {units}}"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -46,7 +46,7 @@ msgstr "(expires {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(hover over a box to learn more)"
 
-#: src/components/PropertiesList.tsx:125
+#: src/components/PortfolioTable.tsx:441
 msgid "(this may take a while)"
 msgstr "(this may take a while)"
 
@@ -54,7 +54,7 @@ msgstr "(this may take a while)"
 #~ msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 #~ msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 
-#: src/containers/HomePage.tsx:120
+#: src/containers/HomePage.tsx:117
 msgid "... or view some sample portfolios:"
 msgstr "... or view some sample portfolios:"
 
@@ -112,8 +112,8 @@ msgstr "Across owners and management staff, the most common {0, plural, one {nam
 msgid "Additional links"
 msgstr "Additional links"
 
-#: src/components/PortfolioTable.tsx:72
-#: src/containers/HomePage.tsx:104
+#: src/components/PortfolioTable.tsx:66
+#: src/containers/HomePage.tsx:101
 msgid "Address"
 msgstr "Address"
 
@@ -129,7 +129,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "All the public info on your landlord"
 msgstr "All the public info on your landlord"
 
-#: src/components/PortfolioTable.tsx:339
+#: src/components/PortfolioTable.tsx:333
 msgid "Amount"
 msgstr "Amount"
 
@@ -159,7 +159,7 @@ msgstr "Are you having issues in this building?"
 msgid "Are you having issues in this development?"
 msgstr "Are you having issues in this development?"
 
-#: src/components/PropertiesMap.tsx:322
+#: src/components/PropertiesMap.tsx:348
 msgid "Associated names/entities: {0}"
 msgstr "Associated names/entities: {0}"
 
@@ -171,7 +171,7 @@ msgstr "BELL/BUZZER/INTERCOM"
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
-#: src/components/PortfolioTable.tsx:97
+#: src/components/PortfolioTable.tsx:91
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Borough"
@@ -189,7 +189,7 @@ msgstr "Building Permit Applications"
 msgid "Building Permits Applied For"
 msgstr "Building Permits Applied For"
 
-#: src/components/PortfolioFilters.tsx:147
+#: src/components/PortfolioFilters.tsx:148
 msgid "Building Size"
 msgstr "Building Size"
 
@@ -197,7 +197,7 @@ msgstr "Building Size"
 msgid "Building info"
 msgstr "Building info"
 
-#: src/components/PropertiesMap.tsx:330
+#: src/components/PropertiesMap.tsx:356
 msgid "Building size: {0}"
 msgstr "Building size: {0}"
 
@@ -205,7 +205,7 @@ msgstr "Building size: {0}"
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
-#: src/components/PortfolioTable.tsx:131
+#: src/components/PortfolioTable.tsx:125
 msgid "Built"
 msgstr "Built"
 
@@ -264,7 +264,7 @@ msgstr "Class I"
 #~ msgid "Clear"
 #~ msgstr "Clear"
 
-#: src/components/PortfolioFilters.tsx:167
+#: src/components/PortfolioFilters.tsx:168
 msgid "Clear Filters"
 msgstr "Clear Filters"
 
@@ -302,8 +302,8 @@ msgid "Close"
 msgstr "Close"
 
 #: src/components/PropertiesMap.tsx:290
-msgid "Close legend"
-msgstr "Close legend"
+#~ msgid "Close legend"
+#~ msgstr "Close legend"
 
 #: src/components/IndicatorsDatasets.tsx:14
 msgid "Complaints Issued"
@@ -325,7 +325,7 @@ msgstr "Corporate Owner"
 msgid "Corporation"
 msgstr "Corporation"
 
-#: src/components/PortfolioTable.tsx:117
+#: src/components/PortfolioTable.tsx:111
 msgid "Council"
 msgstr "Council"
 
@@ -353,7 +353,7 @@ msgstr "DOOR/WINDOW"
 msgid "DOORS"
 msgstr "DOORS"
 
-#: src/components/PortfolioTable.tsx:328
+#: src/components/PortfolioTable.tsx:322
 msgid "Date"
 msgstr "Date"
 
@@ -403,7 +403,7 @@ msgstr "Emergency"
 #~ msgid "Enter NYC ZIP CODE"
 #~ msgstr "Enter NYC ZIP CODE"
 
-#: src/containers/HomePage.tsx:89
+#: src/containers/HomePage.tsx:86
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Enter an NYC address and find other buildings your landlord might own:"
 
@@ -444,7 +444,7 @@ msgstr "Evictions"
 msgid "Evictions Executed"
 msgstr "Evictions Executed"
 
-#: src/components/PortfolioTable.tsx:236
+#: src/components/PortfolioTable.tsx:230
 msgid "Evictions Since 2017"
 msgstr "Evictions Since 2017"
 
@@ -456,11 +456,11 @@ msgstr "Evictions executed by NYC Marshals since 2017. ANHD and the Housing Data
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 
-#: src/components/PortfolioTable.tsx:251
+#: src/components/PortfolioTable.tsx:245
 msgid "Executed"
 msgstr "Executed"
 
-#: src/components/PortfolioFilters.tsx:228
+#: src/components/PortfolioFilters.tsx:235
 msgid "Expand the Person/ Entity column in the Table to see all contacts associated with that building."
 msgstr "Expand the Person/ Entity column in the Table to see all contacts associated with that building."
 
@@ -488,7 +488,7 @@ msgstr "FLOORING/STAIRS"
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
-#: src/components/PortfolioTable.tsx:242
+#: src/components/PortfolioTable.tsx:236
 msgid "Filed"
 msgstr "Filed"
 
@@ -496,7 +496,7 @@ msgstr "Filed"
 #~ msgid "Filied"
 #~ msgstr "Filied"
 
-#: src/components/PortfolioFilters.tsx:270
+#: src/components/PortfolioFilters.tsx:274
 msgid "Filter"
 msgstr "Filter"
 
@@ -504,7 +504,7 @@ msgstr "Filter"
 #~ msgid "Filter through this portfolio in <0>the Portfolio tab.</0>"
 #~ msgstr "Filter through this portfolio in <0>the Portfolio tab.</0>"
 
-#: src/components/PortfolioFilters.tsx:209
+#: src/components/PortfolioFilters.tsx:216
 msgid "Filters"
 msgstr "Filters"
 
@@ -516,7 +516,7 @@ msgstr "Filters:"
 #~ msgid "Filter <0/>for"
 #~ msgstr "Filter <0/>for"
 
-#: src/containers/HomePage.tsx:90
+#: src/containers/HomePage.tsx:87
 msgid "Find other buildings your landlord might own:"
 msgstr "Find other buildings your landlord might own:"
 
@@ -524,7 +524,7 @@ msgstr "Find other buildings your landlord might own:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "GARBAGE/RECYCLING STORAGE"
 
-#: src/components/PortfolioTable.tsx:366
+#: src/components/PortfolioTable.tsx:360
 msgid "Group Sale?"
 msgstr "Group Sale?"
 
@@ -541,7 +541,7 @@ msgid "HPD Building Profile"
 msgstr "HPD Building Profile"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:181
+#: src/components/PortfolioTable.tsx:175
 msgid "HPD Complaints"
 msgstr "HPD Complaints"
 
@@ -550,7 +550,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "HPD Complaints are housing issues reported to the City <0>by a tenant calling 311</0>. When someone issues a complaint, the Department of Housing Preservation and Development begins a process of investigation that may lead to an official violation from the City. Complaints can be identified as:<1/><2/><3>Emergency</3> — reported to be hazardous/dire<4/><5>Non-Emergency</5> — all others<6/><7/>Read more about HPD Complaints and how to file them at the <8>official HPD page</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:214
+#: src/components/PortfolioTable.tsx:208
 msgid "HPD Violations"
 msgstr "HPD Violations"
 
@@ -566,7 +566,11 @@ msgstr "HUD Complaint Form 958"
 msgid "Head Officer"
 msgstr "Head Officer"
 
-#: src/components/PortfolioFilters.tsx:175
+#: src/components/PropertiesMap.tsx:319
+msgid "Hide legend"
+msgstr "Hide legend"
+
+#: src/components/PortfolioFilters.tsx:182
 msgid "How are the results calculated?"
 msgstr "How are the results calculated?"
 
@@ -631,7 +635,7 @@ msgstr "Individual Owner"
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
-#: src/components/PortfolioTable.tsx:126
+#: src/components/PortfolioTable.tsx:120
 msgid "Information"
 msgstr "Information"
 
@@ -651,24 +655,28 @@ msgstr "Joint Owner"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
+#: src/containers/HomePage.tsx:166
+msgid "Known for <0>deregulating rent stabilized apartments</0>, Stellar Management is also one of the city’s of <1>Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where they have a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
+msgstr "Known for <0>deregulating rent stabilized apartments</0>, Stellar Management is also one of the city’s of <1>Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where they have a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
+
 #: src/containers/HomePage.tsx:215
-msgid "Known for <0>unscrupulously deregulating rent stabilized apartments</0>, Larry Gluck’s Stellar Management has also secured a prominent place as one of <1>New York City’s Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where Gluck operates the majority of his properties. Stellar has a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
-msgstr "Known for <0>unscrupulously deregulating rent stabilized apartments</0>, Larry Gluck’s Stellar Management has also secured a prominent place as one of <1>New York City’s Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where Gluck operates the majority of his properties. Stellar has a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
+#~ msgid "Known for <0>unscrupulously deregulating rent stabilized apartments</0>, Larry Gluck’s Stellar Management has also secured a prominent place as one of <1>New York City’s Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where Gluck operates the majority of his properties. Stellar has a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
+#~ msgstr "Known for <0>unscrupulously deregulating rent stabilized apartments</0>, Larry Gluck’s Stellar Management has also secured a prominent place as one of <1>New York City’s Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where Gluck operates the majority of his properties. Stellar has a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
 
 #: src/util/helpers.ts:40
 msgid "LOCKS"
 msgstr "LOCKS"
 
-#: src/components/PortfolioFilters.tsx:144
-#: src/components/PortfolioTable.tsx:260
+#: src/components/PortfolioFilters.tsx:145
+#: src/components/PortfolioTable.tsx:254
 msgid "Landlord"
 msgstr "Landlord"
 
-#: src/components/PortfolioFilters.tsx:145
+#: src/components/PortfolioFilters.tsx:146
 msgid "Landlord filter"
 msgstr "Landlord filter"
 
-#: src/containers/HomePage.tsx:108
+#: src/containers/HomePage.tsx:105
 msgid "Landlord name"
 msgstr "Landlord name"
 
@@ -676,11 +684,11 @@ msgstr "Landlord name"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 
-#: src/components/PortfolioTable.tsx:194
+#: src/components/PortfolioTable.tsx:188
 msgid "Last 3 Years"
 msgstr "Last 3 Years"
 
-#: src/components/PortfolioTable.tsx:323
+#: src/components/PortfolioTable.tsx:317
 msgid "Last Sale"
 msgstr "Last Sale"
 
@@ -701,15 +709,19 @@ msgstr "Last sold:"
 msgid "Learn more"
 msgstr "Learn more"
 
-#: src/components/PortfolioFilters.tsx:163
+#: src/components/PortfolioFilters.tsx:164
 msgid "Learn more about how the results are calculated"
 msgstr "Learn more about how the results are calculated"
+
+#: src/components/PortfolioFilters.tsx:145
+msgid "Learn more about what it means for someone to be listed as a landlord"
+msgstr "Learn more about what it means for someone to be listed as a landlord"
 
 #: src/components/PortfolioAlerts.tsx:39
 msgid "Learn more."
 msgstr "Learn more."
 
-#: src/components/PropertiesMap.tsx:290
+#: src/components/PropertiesMap.tsx:319
 msgid "Legend"
 msgstr "Legend"
 
@@ -717,22 +729,22 @@ msgstr "Legend"
 msgid "Lessee"
 msgstr "Lessee"
 
-#: src/components/PortfolioTable.tsx:347
-#: src/components/PortfolioTable.tsx:352
+#: src/components/PortfolioTable.tsx:341
+#: src/components/PortfolioTable.tsx:346
 msgid "Link to Deed"
 msgstr "Link to Deed"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:126
-#: src/components/PropertiesMap.tsx:233
+#: src/components/PortfolioTable.tsx:442
+#: src/components/PropertiesMap.tsx:260
 msgid "Loading"
 msgstr "Loading"
 
-#: src/components/PropertiesList.tsx:123
+#: src/components/PortfolioTable.tsx:439
 msgid "Loading {0} rows"
 msgstr "Loading {0} rows"
 
-#: src/components/PortfolioTable.tsx:83
+#: src/components/PortfolioTable.tsx:77
 msgid "Location"
 msgstr "Location"
 
@@ -741,8 +753,8 @@ msgstr "Location"
 #~ msgstr "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 
 #: src/components/PortfolioFilters.tsx:243
-msgid "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
-msgstr "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
+#~ msgid "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
+#~ msgstr "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
 
 #: src/components/PropertiesSummary.tsx:134
 msgid "Looking for more information?"
@@ -874,11 +886,11 @@ msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:552
+#: src/components/PortfolioTable.tsx:548
 msgid "Next"
 msgstr "Next"
 
-#: src/components/PortfolioTable.tsx:370
+#: src/components/PortfolioTable.tsx:364
 msgid "No"
 msgstr "No"
 
@@ -927,7 +939,7 @@ msgstr "Not found"
 #~ msgid "Notice an inaccuracy? Click here."
 #~ msgstr "Notice an inaccuracy? Click here."
 
-#: src/components/PortfolioFilters.tsx:147
+#: src/components/PortfolioFilters.tsx:148
 msgid "Number of Units"
 msgstr "Number of Units"
 
@@ -958,7 +970,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/PortfolioTable.tsx:219
+#: src/components/PortfolioTable.tsx:213
 msgid "Open"
 msgstr "Open"
 
@@ -998,7 +1010,7 @@ msgstr "PLUMBING"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
-#: src/components/PortfolioTable.tsx:521
+#: src/components/PortfolioTable.tsx:517
 msgid "Page"
 msgstr "Page"
 
@@ -1007,8 +1019,8 @@ msgstr "Page"
 msgid "People"
 msgstr "People"
 
-#: src/components/PortfolioFilters.tsx:144
-#: src/components/PortfolioTable.tsx:273
+#: src/components/PortfolioFilters.tsx:145
+#: src/components/PortfolioTable.tsx:267
 msgid "Person/Entity"
 msgstr "Person/Entity"
 
@@ -1016,7 +1028,7 @@ msgstr "Person/Entity"
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/containers/AddressPage.tsx:156
+#: src/containers/AddressPage.tsx:148
 msgid "Portfolio"
 msgstr "Portfolio"
 
@@ -1025,7 +1037,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Portfolio Table Redesign"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:515
+#: src/components/PortfolioTable.tsx:511
 msgid "Previous"
 msgstr "Previous"
 
@@ -1039,7 +1051,7 @@ msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:149
+#: src/components/PortfolioTable.tsx:143
 msgid "RS Units"
 msgstr "RS Units"
 
@@ -1049,7 +1061,7 @@ msgstr "RS Units"
 #~ msgstr "Read more about our Methodology"
 
 #: src/components/PortfolioFilters.tsx:116
-#: src/components/PortfolioFilters.tsx:187
+#: src/components/PortfolioFilters.tsx:194
 msgid "Read more in our Methodology section"
 msgstr "Read more in our Methodology section"
 
@@ -1057,11 +1069,11 @@ msgstr "Read more in our Methodology section"
 msgid "Registration expired:"
 msgstr "Registration expired:"
 
-#: src/components/PortfolioFilters.tsx:141
+#: src/components/PortfolioFilters.tsx:142
 msgid "Rent Stabilized Units"
 msgstr "Rent Stabilized Units"
 
-#: src/components/PortfolioFilters.tsx:138
+#: src/components/PortfolioFilters.tsx:139
 msgid "Rent Stabilized Units filter"
 msgstr "Rent Stabilized Units filter"
 
@@ -1069,7 +1081,7 @@ msgstr "Rent Stabilized Units filter"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/components/PropertiesMap.tsx:318
+#: src/components/PropertiesMap.tsx:344
 msgid "Rent stabilized units ({0}): {1}"
 msgstr "Rent stabilized units ({0}): {1}"
 
@@ -1077,7 +1089,7 @@ msgstr "Rent stabilized units ({0}): {1}"
 #~ msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may appear to be deregulated."
 #~ msgstr "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may appear to be deregulated."
 
-#: src/components/PortfolioFilters.tsx:234
+#: src/components/PortfolioFilters.tsx:241
 msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 msgstr "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 
@@ -1110,7 +1122,7 @@ msgstr "Search"
 msgid "Search by your landlord's name"
 msgstr "Search by your landlord's name"
 
-#: src/containers/HomePage.tsx:100
+#: src/containers/HomePage.tsx:97
 msgid "Search by:"
 msgstr "Search by:"
 
@@ -1123,7 +1135,7 @@ msgstr "Search for a different address"
 msgid "Search landlords"
 msgstr "Search landlords"
 
-#: src/components/PropertiesMap.tsx:342
+#: src/components/PropertiesMap.tsx:368
 msgid "See Building Profile"
 msgstr "See Building Profile"
 
@@ -1160,6 +1172,10 @@ msgstr "Shareholder"
 msgid "Show all {numSelections} selections"
 msgstr "Show all {numSelections} selections"
 
+#: src/components/PropertiesMap.tsx:319
+msgid "Show legend"
+msgstr "Show legend"
+
 #: src/components/Multiselect.tsx:140
 msgid "Show less"
 msgstr "Show less"
@@ -1168,7 +1184,7 @@ msgstr "Show less"
 msgid "Show only {previewSelectedNum} selections"
 msgstr "Show only {previewSelectedNum} selections"
 
-#: src/components/PortfolioFilters.tsx:158
+#: src/components/PortfolioFilters.tsx:159
 msgid "Showing {0} {1, plural, one {result} other {results}}"
 msgstr "Showing {0} {1, plural, one {result} other {results}}"
 
@@ -1201,7 +1217,7 @@ msgstr "Sign up for email updates"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/components/PortfolioTable.tsx:579
+#: src/components/PortfolioTable.tsx:576
 msgid "Since {year}"
 msgstr "Since {year}"
 
@@ -1217,7 +1233,7 @@ msgstr "Sold to Current Owner"
 msgid "Some large corporations, however, are a bit more complicated and may share personnel and financial stake with other related companies, which all will show up on Who Owns What as one large portfolio."
 msgstr "Some large corporations, however, are a bit more complicated and may share personnel and financial stake with other related companies, which all will show up on Who Owns What as one large portfolio."
 
-#: src/components/PropertiesMap.tsx:243
+#: src/components/PropertiesMap.tsx:270
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 
@@ -1237,7 +1253,7 @@ msgstr "Source code"
 #~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:579
+#: src/components/PortfolioTable.tsx:576
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
@@ -1266,7 +1282,7 @@ msgstr "Table"
 msgid "Take action on JustFix.org!"
 msgstr "Take action on JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:301
+#: src/components/PortfolioTable.tsx:295
 msgid "Tax Exemptions"
 msgstr "Tax Exemptions"
 
@@ -1303,7 +1319,7 @@ msgstr "The building with the most executed evictions is <0>{0} {1}, {2}</0> wit
 msgid "The city borough where your search address is located"
 msgstr "The city borough where your search address is located"
 
-#: src/containers/HomePage.tsx:173
+#: src/containers/HomePage.tsx:130
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
@@ -1330,6 +1346,10 @@ msgstr "The number of residential units in this building, according to the Dept.
 #: src/containers/NotRegisteredPage.tsx:123
 msgid "The registration for this property is missing details for owner name or businesses address, which are required to link the property to a portfolio."
 msgstr "The registration for this property is missing details for owner name or businesses address, which are required to link the property to a portfolio."
+
+#: src/components/PortfolioFilters.tsx:250
+msgid "The same owner may have spelled their name several ways in official documents."
+msgstr "The same owner may have spelled their name several ways in official documents."
 
 #: src/components/BuildingStatsTable.tsx:34
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
@@ -1384,8 +1404,8 @@ msgid "This portfolio has an average of <0>{0}</0> open HPD violations per resid
 msgstr "This portfolio has an average of <0>{0}</0> open HPD violations per residential unit."
 
 #: src/containers/HomePage.tsx:139
-msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
-msgstr "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
+#~ msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
+#~ msgstr "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
 
 #: src/components/RentstabSummary.tsx:23
 msgid "This represents <0>{0}%</0> of the total size of this portfolio."
@@ -1407,17 +1427,17 @@ msgstr "This tracks how rent stabilized units in the building have changed (i.e.
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:148
+#: src/containers/AddressPage.tsx:156
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/PortfolioTable.tsx:202
+#: src/components/PortfolioTable.tsx:196
 msgid "Top Complaint"
 msgstr "Top Complaint"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:186
-#: src/components/PortfolioTable.tsx:227
+#: src/components/PortfolioTable.tsx:180
+#: src/components/PortfolioTable.tsx:221
 msgid "Total"
 msgstr "Total"
 
@@ -1425,7 +1445,7 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Total Violations"
 
-#: src/components/PortfolioFilters.tsx:240
+#: src/components/PortfolioFilters.tsx:247
 msgid "Try adjusting or clearing the filters to show more than 0 results."
 msgstr "Try adjusting or clearing the filters to show more than 0 results."
 
@@ -1442,7 +1462,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:139
+#: src/components/PortfolioTable.tsx:133
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Units"
@@ -1468,12 +1488,12 @@ msgstr "Useful links"
 msgid "VENTILATION SYSTEM"
 msgstr "VENTILATION SYSTEM"
 
-#: src/components/PortfolioTable.tsx:379
-#: src/components/PortfolioTable.tsx:386
+#: src/components/PortfolioTable.tsx:373
+#: src/components/PortfolioTable.tsx:380
 msgid "View Detail"
 msgstr "View Detail"
 
-#: src/components/PortfolioFilters.tsx:218
+#: src/components/PortfolioFilters.tsx:225
 msgid "View Results"
 msgstr "View Results"
 
@@ -1496,18 +1516,21 @@ msgid "View documents on <0>ACRIS</0>"
 msgstr "View documents on <0>ACRIS</0>"
 
 #: src/components/PropertiesMap.tsx:290
-msgid "View legend"
-msgstr "View legend"
+#~ msgid "View legend"
+#~ msgstr "View legend"
 
-#: src/containers/HomePage.tsx:154
-#: src/containers/HomePage.tsx:196
-#: src/containers/HomePage.tsx:233
+#: src/components/DetailView.tsx:146
+msgid "View map"
+msgstr "View map"
+
+#: src/containers/HomePage.tsx:153
+#: src/containers/HomePage.tsx:182
 msgid "View portfolio"
 msgstr "View portfolio"
 
 #: src/components/DetailView.tsx:146
-msgid "View portfolio map"
-msgstr "View portfolio map"
+#~ msgid "View portfolio map"
+#~ msgstr "View portfolio map"
 
 #: src/components/IndicatorsDatasets.tsx:42
 #: src/components/IndicatorsDatasets.tsx:97
@@ -1546,7 +1569,7 @@ msgstr "We compare your search address with a database of over 200k buildings to
 msgid "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 msgstr "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 
-#: src/components/PortfolioFilters.tsx:178
+#: src/components/PortfolioFilters.tsx:185
 msgid "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 msgstr "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 
@@ -1608,8 +1631,8 @@ msgid "Who Owns What is a free tool built by JustFix to research property owners
 msgstr "Who Owns What is a free tool built by JustFix to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 
 #: src/components/PortfolioFilters.tsx:144
-msgid "Who are they?"
-msgstr "Who are they?"
+#~ msgid "Who are they?"
+#~ msgstr "Who are they?"
 
 #: src/containers/App.tsx:42
 msgid "Who owns what in n y c?"
@@ -1639,7 +1662,7 @@ msgstr "Why am I seeing such a big portfolio?"
 msgid "Year Built"
 msgstr "Year Built"
 
-#: src/components/PortfolioTable.tsx:369
+#: src/components/PortfolioTable.tsx:363
 msgid "Yes"
 msgstr "Yes"
 
@@ -1668,16 +1691,16 @@ msgstr "You are viewing the old version of Who Owns What. <0>Switch to the new v
 #~ msgid "ZIP CODE is not applicable"
 #~ msgstr "ZIP CODE is not applicable"
 
-#: src/components/PortfolioFilters.tsx:151
+#: src/components/PortfolioFilters.tsx:152
 msgid "ZIP code is not applicable"
 msgstr "ZIP code is not applicable"
 
-#: src/components/PortfolioFilters.tsx:150
-#: src/components/PortfolioTable.tsx:88
+#: src/components/PortfolioFilters.tsx:151
+#: src/components/PortfolioTable.tsx:82
 msgid "Zip Code"
 msgstr "Zip Code"
 
-#: src/components/PortfolioFilters.tsx:151
+#: src/components/PortfolioFilters.tsx:152
 msgid "Zip code filter"
 msgstr "Zip code filter"
 
@@ -1698,9 +1721,9 @@ msgstr "Zoom out"
 msgid "and"
 msgstr "and"
 
-#: src/components/PropertiesMap.tsx:214
-#~ msgid "associated building"
-#~ msgstr "associated building"
+#: src/components/PropertiesMap.tsx:328
+msgid "associated building"
+msgstr "associated building"
 
 #: src/components/DetailView.tsx:242
 msgid "for ${0}"
@@ -1710,15 +1733,23 @@ msgstr "for ${0}"
 msgid "month"
 msgstr "month"
 
-#: src/components/PortfolioTable.tsx:532
+#: src/components/PortfolioTable.tsx:530
+msgid "number of records per page"
+msgstr "number of records per page"
+
+#: src/components/PortfolioTable.tsx:528
 msgid "of"
 msgstr "of"
+
+#: src/components/PortfolioTable.tsx:520
+msgid "page number"
+msgstr "page number"
 
 #: src/components/Indicators.tsx:17
 msgid "quarter"
 msgstr "quarter"
 
-#: src/components/PropertiesMap.tsx:296
+#: src/components/PropertiesMap.tsx:325
 msgid "search address"
 msgstr "search address"
 
@@ -1730,13 +1761,13 @@ msgstr "search address"
 msgid "year"
 msgstr "year"
 
-#: src/components/PropertiesMap.tsx:333
+#: src/components/PropertiesMap.tsx:359
 msgid "{0, plural, one {unit} other {units}}"
 msgstr "{0, plural, one {unit} other {units}}"
 
 #: src/components/PropertiesMap.tsx:299
-msgid "{0}"
-msgstr "{0}"
+#~ msgid "{0}"
+#~ msgstr "{0}"
 
 #: src/components/FeatureCalloutWidget.tsx:26
 msgid "{0} of {numberOfEntries}"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -164,7 +164,7 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
-#: src/components/PropertiesMap.tsx:344
+#: src/components/PropertiesMap.tsx:345
 msgid "Associated names/entities: {0}"
 msgstr ""
 
@@ -202,7 +202,7 @@ msgstr "Tamaño del Edificio"
 msgid "Building info"
 msgstr "Información de edificios"
 
-#: src/components/PropertiesMap.tsx:352
+#: src/components/PropertiesMap.tsx:353
 msgid "Building size: {0}"
 msgstr ""
 
@@ -513,7 +513,7 @@ msgstr "Filtro"
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/components/PortfolioFilters.tsx:123
+#: src/components/PortfolioFilters.tsx:124
 msgid "Filters:"
 msgstr "Filtros:"
 
@@ -571,7 +571,7 @@ msgstr "Formulario de queja HUD 958"
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
-#: src/components/PropertiesMap.tsx:315
+#: src/components/PropertiesMap.tsx:316
 msgid "Hide legend"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr ""
 msgid "Learn more."
 msgstr "Aprende más."
 
-#: src/components/PropertiesMap.tsx:315
+#: src/components/PropertiesMap.tsx:316
 msgid "Legend"
 msgstr "Leyenda"
 
@@ -741,7 +741,7 @@ msgstr "Enlace a la Escritura"
 
 #: src/components/Loader.tsx:19
 #: src/components/PortfolioTable.tsx:440
-#: src/components/PropertiesMap.tsx:256
+#: src/components/PropertiesMap.tsx:257
 msgid "Loading"
 msgstr "Cargando"
 
@@ -878,7 +878,7 @@ msgstr "Restrinja esta cartera utilizando los filtros de la <0>pestaña Cartera.
 msgid "Network of Landlords"
 msgstr "Red de Dueños"
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:121
 msgid "New"
 msgstr "Nuevo"
 
@@ -1086,7 +1086,7 @@ msgstr "Filtro de Unidades con renta estabilizada"
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
-#: src/components/PropertiesMap.tsx:340
+#: src/components/PropertiesMap.tsx:341
 msgid "Rent stabilized units ({0}): {1}"
 msgstr ""
 
@@ -1140,7 +1140,7 @@ msgstr "Buscar otra dirección"
 msgid "Search landlords"
 msgstr "Buscar dueños"
 
-#: src/components/PropertiesMap.tsx:364
+#: src/components/PropertiesMap.tsx:363
 msgid "See Building Profile"
 msgstr ""
 
@@ -1177,7 +1177,7 @@ msgstr "Accionista"
 msgid "Show all {numSelections} selections"
 msgstr "Mostrar todas las {numSelections} selecciones"
 
-#: src/components/PropertiesMap.tsx:315
+#: src/components/PropertiesMap.tsx:316
 msgid "Show legend"
 msgstr ""
 
@@ -1238,7 +1238,7 @@ msgstr "Vendido al Propietario Actual"
 msgid "Some large corporations, however, are a bit more complicated and may share personnel and financial stake with other related companies, which all will show up on Who Owns What as one large portfolio."
 msgstr "Sin embargo, algunas grandes corporaciones son un poco más complicadas y pueden compartir personal y participación financiera con otras compañías relacionadas, que todos se mostrarán en Quién es el Dueño como un gran portafolio."
 
-#: src/components/PropertiesMap.tsx:266
+#: src/components/PropertiesMap.tsx:267
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Lo sentimos, parece que hay un error en el mapa. Inténtalo de nuevo con un navegador diferente o <0>habilita WebGL</0>."
 
@@ -1726,7 +1726,7 @@ msgstr "Alejar"
 msgid "and"
 msgstr "y"
 
-#: src/components/PropertiesMap.tsx:324
+#: src/components/PropertiesMap.tsx:325
 msgid "associated building"
 msgstr "edificio asociado"
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "quarter"
 msgstr "trimestre"
 
-#: src/components/PropertiesMap.tsx:321
+#: src/components/PropertiesMap.tsx:322
 msgid "search address"
 msgstr "dirección de búsqueda"
 
@@ -1766,7 +1766,7 @@ msgstr "dirección de búsqueda"
 msgid "year"
 msgstr "año"
 
-#: src/components/PropertiesMap.tsx:355
+#: src/components/PropertiesMap.tsx:356
 msgid "{0, plural, one {unit} other {units}}"
 msgstr ""
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -51,7 +51,7 @@ msgstr "(caduca {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
-#: src/components/PropertiesList.tsx:87
+#: src/components/PropertiesList.tsx:125
 msgid "(this may take a while)"
 msgstr "(esto puede tardar un rato)"
 
@@ -164,6 +164,10 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
+#: src/components/PropertiesMap.tsx:322
+msgid "Associated names/entities: {0}"
+msgstr ""
+
 #: src/util/helpers.ts:13
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
@@ -190,13 +194,17 @@ msgstr "Solicitudes de Permisos de Construcción"
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
 
-#: src/components/PortfolioFilters.tsx:123
+#: src/components/PortfolioFilters.tsx:147
 msgid "Building Size"
 msgstr "Tamaño del Edificio"
 
 #: src/components/PropertiesSummary.tsx:101
 msgid "Building info"
 msgstr "Información de edificios"
+
+#: src/components/PropertiesMap.tsx:330
+msgid "Building size: {0}"
+msgstr ""
 
 #: src/containers/NotRegisteredPage.tsx:162
 msgid "Buildings without valid property registration are subject to the following:"
@@ -261,7 +269,7 @@ msgstr "Clase I"
 #~ msgid "Clear"
 #~ msgstr "Clear"
 
-#: src/components/PortfolioFilters.tsx:143
+#: src/components/PortfolioFilters.tsx:167
 msgid "Clear Filters"
 msgstr "Borrar filtros"
 
@@ -298,7 +306,7 @@ msgstr "HaZ clic aquí para obtener más información."
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/components/PropertiesMap.tsx:207
+#: src/components/PropertiesMap.tsx:290
 msgid "Close legend"
 msgstr "Cerrar leyenda"
 
@@ -457,7 +465,7 @@ msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 20
 msgid "Executed"
 msgstr "Ejecutado"
 
-#: src/components/PortfolioFilters.tsx:204
+#: src/components/PortfolioFilters.tsx:228
 msgid "Expand the Person/ Entity column in the Table to see all contacts associated with that building."
 msgstr "Expanda la columna Persona/Entidad en la Tabla para ver todos los contactos asociados a ese edificio."
 
@@ -493,7 +501,7 @@ msgstr "Presentado"
 #~ msgid "Filied"
 #~ msgstr "Filied"
 
-#: src/components/PortfolioFilters.tsx:246
+#: src/components/PortfolioFilters.tsx:270
 msgid "Filter"
 msgstr "Filtro"
 
@@ -501,11 +509,11 @@ msgstr "Filtro"
 #~ msgid "Filter through this portfolio in <0>the Portfolio tab.</0>"
 #~ msgstr "Filter through this portfolio in <0>the Portfolio tab.</0>"
 
-#: src/components/PortfolioFilters.tsx:185
+#: src/components/PortfolioFilters.tsx:209
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/components/PortfolioFilters.tsx:110
+#: src/components/PortfolioFilters.tsx:126
 msgid "Filters:"
 msgstr "Filtros:"
 
@@ -563,7 +571,7 @@ msgstr "Formulario de queja HUD 958"
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
-#: src/components/PortfolioFilters.tsx:151
+#: src/components/PortfolioFilters.tsx:175
 msgid "How are the results calculated?"
 msgstr "¿Cómo se calculan los resultados?"
 
@@ -656,12 +664,12 @@ msgstr "Conocido por <0>desregulando apartamentos de renta estabilizada sin escr
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:144
 #: src/components/PortfolioTable.tsx:260
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
-#: src/components/PortfolioFilters.tsx:121
+#: src/components/PortfolioFilters.tsx:145
 msgid "Landlord filter"
 msgstr "Filtro de dueño"
 
@@ -698,7 +706,7 @@ msgstr "Vendido por última vez:"
 msgid "Learn more"
 msgstr "Aprende más"
 
-#: src/components/PortfolioFilters.tsx:139
+#: src/components/PortfolioFilters.tsx:163
 msgid "Learn more about how the results are calculated"
 msgstr "Más información sobre cómo se calculan los resultados"
 
@@ -706,7 +714,7 @@ msgstr "Más información sobre cómo se calculan los resultados"
 msgid "Learn more."
 msgstr "Aprende más."
 
-#: src/components/PropertiesMap.tsx:207
+#: src/components/PropertiesMap.tsx:290
 msgid "Legend"
 msgstr "Leyenda"
 
@@ -720,12 +728,12 @@ msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:88
-#: src/components/PropertiesMap.tsx:158
+#: src/components/PropertiesList.tsx:126
+#: src/components/PropertiesMap.tsx:233
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:85
+#: src/components/PropertiesList.tsx:123
 msgid "Loading {0} rows"
 msgstr "Cargando {0} filas"
 
@@ -737,7 +745,7 @@ msgstr "Ubicación"
 #~ msgid "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 #~ msgstr "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 
-#: src/components/PortfolioFilters.tsx:219
+#: src/components/PortfolioFilters.tsx:243
 msgid "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
 msgstr "Preste atención a las múltiples formas de escribir una misma persona o entidad. Los nombres pueden escribirse de varias maneras en los documentos oficiales."
 
@@ -776,6 +784,10 @@ msgstr "Hacer una selección de la lista o borrar el texto de búsqueda"
 #: src/components/Multiselect.tsx:450
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
+
+#: src/components/PortfolioFilters.tsx:135
+msgid "Map"
+msgstr ""
 
 #: src/components/MinMaxSelect.tsx:207
 msgid "Max must be greater than 0"
@@ -854,7 +866,7 @@ msgstr "Restrinja esta cartera utilizando los filtros de la <0>pestaña Cartera.
 msgid "Network of Landlords"
 msgstr "Red de Dueños"
 
-#: src/components/PortfolioFilters.tsx:107
+#: src/components/PortfolioFilters.tsx:123
 msgid "New"
 msgstr "Nuevo"
 
@@ -867,7 +879,7 @@ msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:548
+#: src/components/PortfolioTable.tsx:552
 msgid "Next"
 msgstr "Siguiente"
 
@@ -920,7 +932,7 @@ msgstr "No encontrado"
 #~ msgid "Notice an inaccuracy? Click here."
 #~ msgstr "Notice an inaccuracy? Click here."
 
-#: src/components/PortfolioFilters.tsx:123
+#: src/components/PortfolioFilters.tsx:147
 msgid "Number of Units"
 msgstr "Número de unidades"
 
@@ -959,7 +971,7 @@ msgstr "Actuales"
 msgid "Open Violations"
 msgstr "Violaciones Actuales"
 
-#: src/containers/AddressPage.tsx:133
+#: src/containers/AddressPage.tsx:140
 msgid "Overview"
 msgstr "General"
 
@@ -987,11 +999,11 @@ msgstr "PLAGAS"
 msgid "PLUMBING"
 msgstr "PLOMERÍA"
 
-#: src/containers/AddressPage.tsx:119
+#: src/containers/AddressPage.tsx:126
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/PortfolioTable.tsx:517
+#: src/components/PortfolioTable.tsx:521
 msgid "Page"
 msgstr "Página"
 
@@ -1000,7 +1012,7 @@ msgstr "Página"
 msgid "People"
 msgstr "Personas"
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:144
 #: src/components/PortfolioTable.tsx:273
 msgid "Person/Entity"
 msgstr "Persona/Entidad"
@@ -1009,7 +1021,7 @@ msgstr "Persona/Entidad"
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/containers/AddressPage.tsx:149
+#: src/containers/AddressPage.tsx:156
 msgid "Portfolio"
 msgstr "Portafolio"
 
@@ -1018,7 +1030,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Rediseño de la tabla del portafolio"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:511
+#: src/components/PortfolioTable.tsx:515
 msgid "Previous"
 msgstr "Anterior"
 
@@ -1041,8 +1053,8 @@ msgstr "Unidades RS"
 #~ msgid "Read more about our Methodology"
 #~ msgstr "Read more about our Methodology"
 
-#: src/components/PortfolioFilters.tsx:100
-#: src/components/PortfolioFilters.tsx:163
+#: src/components/PortfolioFilters.tsx:116
+#: src/components/PortfolioFilters.tsx:187
 msgid "Read more in our Methodology section"
 msgstr "Más información sobre nuestra metodología"
 
@@ -1050,11 +1062,11 @@ msgstr "Más información sobre nuestra metodología"
 msgid "Registration expired:"
 msgstr "El registro ha caducado:"
 
-#: src/components/PortfolioFilters.tsx:117
+#: src/components/PortfolioFilters.tsx:141
 msgid "Rent Stabilized Units"
 msgstr "Unidades con renta estabilizada"
 
-#: src/components/PortfolioFilters.tsx:114
+#: src/components/PortfolioFilters.tsx:138
 msgid "Rent Stabilized Units filter"
 msgstr "Filtro de Unidades con renta estabilizada"
 
@@ -1062,11 +1074,15 @@ msgstr "Filtro de Unidades con renta estabilizada"
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
+#: src/components/PropertiesMap.tsx:318
+msgid "Rent stabilized units ({0}): {1}"
+msgstr ""
+
 #: src/components/PortfolioFilters.tsx:210
 #~ msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may appear to be deregulated."
 #~ msgstr "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may appear to be deregulated."
 
-#: src/components/PortfolioFilters.tsx:210
+#: src/components/PortfolioFilters.tsx:234
 msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 msgstr "Las unidades de renta estabilizada son declaradas por los dueños de los edificios en sus declaraciones fiscales anuales. Como resultado, muchos edificios con unidades de renta estabilizada pueden parecer desregulados."
 
@@ -1112,6 +1128,10 @@ msgstr "Buscar otra dirección"
 msgid "Search landlords"
 msgstr "Buscar dueños"
 
+#: src/components/PropertiesMap.tsx:342
+msgid "See Building Profile"
+msgstr ""
+
 #: src/components/FeatureCalloutContent.ts:9
 msgid "See the most common complaints reported by tenants to 311, now on the Overview and Portfolio tabs."
 msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en las pestañas General y Portafolio."
@@ -1153,7 +1173,7 @@ msgstr "Mostrar menos"
 msgid "Show only {previewSelectedNum} selections"
 msgstr "Mostrar sólo {previewSelectedNum} selecciones"
 
-#: src/components/PortfolioFilters.tsx:134
+#: src/components/PortfolioFilters.tsx:158
 msgid "Showing {0} {1, plural, one {result} other {results}}"
 msgstr "Mostrar {0} {1, plural, one {resultado} other {resultados}}"
 
@@ -1186,7 +1206,7 @@ msgstr "Regístrate para recibir noticias por email"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde 2017, los dueños presentaron {totalEvictionFilings, plural, one {un caso de desalojo} other {# casos de desalojo}} y los alguaciles de la ciudad de Nueva York ejecutaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en toda esta cartera."
 
-#: src/components/PortfolioTable.tsx:575
+#: src/components/PortfolioTable.tsx:579
 msgid "Since {year}"
 msgstr "Desde {year}"
 
@@ -1202,7 +1222,7 @@ msgstr "Vendido al Propietario Actual"
 msgid "Some large corporations, however, are a bit more complicated and may share personnel and financial stake with other related companies, which all will show up on Who Owns What as one large portfolio."
 msgstr "Sin embargo, algunas grandes corporaciones son un poco más complicadas y pueden compartir personal y participación financiera con otras compañías relacionadas, que todos se mostrarán en Quién es el Dueño como un gran portafolio."
 
-#: src/components/PropertiesMap.tsx:168
+#: src/components/PropertiesMap.tsx:243
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Lo sentimos, parece que hay un error en el mapa. Inténtalo de nuevo con un navegador diferente o <0>habilita WebGL</0>."
 
@@ -1222,11 +1242,11 @@ msgstr "Código fuente"
 #~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:575
+#: src/components/PortfolioTable.tsx:579
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
-#: src/containers/AddressPage.tsx:157
+#: src/containers/AddressPage.tsx:164
 msgid "Summary"
 msgstr "Resúmen"
 
@@ -1241,6 +1261,10 @@ msgstr "Resúmen"
 #: src/util/helpers.ts:23
 msgid "TENANT HARASSMENT"
 msgstr "ACOSO DE INQUILINO"
+
+#: src/components/PortfolioFilters.tsx:132
+msgid "Table"
+msgstr ""
 
 #: src/components/DetailView.tsx:264
 #: src/containers/NychaPage.tsx:179
@@ -1388,7 +1412,7 @@ msgstr "El cambio en apartamentos de renta estabilizada que hay en el edificio (
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:141
+#: src/containers/AddressPage.tsx:148
 msgid "Timeline"
 msgstr "Cronología"
 
@@ -1406,7 +1430,7 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Violaciones Totales"
 
-#: src/components/PortfolioFilters.tsx:216
+#: src/components/PortfolioFilters.tsx:240
 msgid "Try adjusting or clearing the filters to show more than 0 results."
 msgstr "Intente ajustar o borrar los filtros para mostrar más de 0 resultados."
 
@@ -1454,7 +1478,7 @@ msgstr "SISTEMA DE VENTILACIÓN"
 msgid "View Detail"
 msgstr "Ver detalles"
 
-#: src/components/PortfolioFilters.tsx:194
+#: src/components/PortfolioFilters.tsx:218
 msgid "View Results"
 msgstr "Ver resultados"
 
@@ -1476,7 +1500,7 @@ msgstr "Ver datos a lo largo del tiempo ↗︎"
 msgid "View documents on <0>ACRIS</0>"
 msgstr "Ver documentos en <0>ACRIS</0>"
 
-#: src/components/PropertiesMap.tsx:207
+#: src/components/PropertiesMap.tsx:290
 msgid "View legend"
 msgstr "Ver leyenda"
 
@@ -1527,7 +1551,7 @@ msgstr "Comparamos la dirección que buscaste con una base de datos de más de 2
 msgid "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 msgstr "Revisamos la pestaña Portafolio para ayudarle navegar por esta gran tabla de datos, especialmente para dispositivos móviles."
 
-#: src/components/PortfolioFilters.tsx:154
+#: src/components/PortfolioFilters.tsx:178
 msgid "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 msgstr "Extraemos datos de registros públicos para calcular estos resultados. Nuestro algoritmo se basa en los <0>datos públicos de registro de la HPD</0> para edificios residenciales, que contiene información de contacto de los dueños de alrededor de 170.000 propiedades en toda la ciudad."
 
@@ -1564,7 +1588,7 @@ msgstr "Qué hay de nuevo"
 #~ msgid "What's this?"
 #~ msgstr "What's this?"
 
-#: src/components/PortfolioFilters.tsx:84
+#: src/components/PortfolioFilters.tsx:100
 msgid "What’s the difference between a landlord, an owner, and head officer?"
 msgstr "¿Cuál es la diferencia entre un dueño, un propietario y oficial principal?"
 
@@ -1580,7 +1604,7 @@ msgstr "Cuando dos partes comparten la misma dirección comercial, los agrupamos
 #~ msgid "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with the Department of Housing Preservation (“HPD”) offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 #~ msgstr "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with the Department of Housing Preservation (“HPD”) offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 
-#: src/components/PortfolioFilters.tsx:87
+#: src/components/PortfolioFilters.tsx:103
 msgid "While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with the Department of Housing Preservation and Development (“HPD”) offer a clearer picture of who really controls the building. People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading. Learn more about HPD registrations and how this information powers this tool on the <0>About page</0>."
 msgstr "Aunque el propietario legal de un edificio suele ser una empresa (normalmente denominada \"LLC\"), estos nombres y direcciones comerciales registrados en el Departamento de Conservación de la Vivienda (\"HPD\") ofrecen una imagen más clara de quién controla realmente el edificio. Las personas que figuran aquí como \" Oficial Principal\" o \"Propietario\" suelen estar vinculadas a la propiedad del edificio, mientras que los \" Gerentes de Sitio\" forman parte de la administración. Dicho esto, estos nombres son autodeclarados por el dueño, por lo que pueden inducir a error. Obtenga más información sobre los registros de la HPD y cómo esta información alimenta esta herramienta en la <0>página Acerca de</0>."
 
@@ -1588,7 +1612,7 @@ msgstr "Aunque el propietario legal de un edificio suele ser una empresa (normal
 msgid "Who Owns What is a free tool built by JustFix to research property owners in NYC. It has helped over 200,000 New Yorkers find out who really owns their building, what other buildings that their landlord or management company owns, and other critical information about code violations, evictions, rent stabilized units, and so much more in any given building. You can look up any residential building located in NYC, even public housing (NYCHA) buildings! Search your address here: {url}"
 msgstr "Quién Es El Dueño es una herramienta gratis construida por JustFix para investigar los dueños de edificios en NYC. Ha asistido más de 200.000 neoyorquinos a enterarse quien realmente son los responsables por su edificio, cuáles otros edificios su dueño o compañía de administración poseen, y otra información crítica sobre violaciones del código de vivienda, desalojos, apartamentos con renta estabilizada y mucho más en cualquier edificio. Puedes buscar información sobre cualquier edificio residencial, también incluyen viviendas públicas (NYCHA). Busca tu dirección aquí: {url}"
 
-#: src/components/PortfolioFilters.tsx:120
+#: src/components/PortfolioFilters.tsx:144
 msgid "Who are they?"
 msgstr "¿Quiénes son?"
 
@@ -1649,16 +1673,16 @@ msgstr "Está viendo la versión antigua de ¿Quién es el Dueño en NY? <0>Camb
 #~ msgid "ZIP CODE is not applicable"
 #~ msgstr "ZIP CODE is not applicable"
 
-#: src/components/PortfolioFilters.tsx:127
+#: src/components/PortfolioFilters.tsx:151
 msgid "ZIP code is not applicable"
 msgstr "Código postal no aplicable"
 
-#: src/components/PortfolioFilters.tsx:126
+#: src/components/PortfolioFilters.tsx:150
 #: src/components/PortfolioTable.tsx:88
 msgid "Zip Code"
 msgstr "Código postal"
 
-#: src/components/PortfolioFilters.tsx:127
+#: src/components/PortfolioFilters.tsx:151
 msgid "Zip code filter"
 msgstr "Filtro de código postal"
 
@@ -1680,8 +1704,8 @@ msgid "and"
 msgstr "y"
 
 #: src/components/PropertiesMap.tsx:214
-msgid "associated building"
-msgstr "edificio asociado"
+#~ msgid "associated building"
+#~ msgstr "edificio asociado"
 
 #: src/components/DetailView.tsx:242
 msgid "for ${0}"
@@ -1691,7 +1715,7 @@ msgstr "por ${0}"
 msgid "month"
 msgstr "mes"
 
-#: src/components/PortfolioTable.tsx:528
+#: src/components/PortfolioTable.tsx:532
 msgid "of"
 msgstr "de"
 
@@ -1699,7 +1723,7 @@ msgstr "de"
 msgid "quarter"
 msgstr "trimestre"
 
-#: src/components/PropertiesMap.tsx:213
+#: src/components/PropertiesMap.tsx:296
 msgid "search address"
 msgstr "dirección de búsqueda"
 
@@ -1710,6 +1734,14 @@ msgstr "dirección de búsqueda"
 #: src/components/Indicators.tsx:18
 msgid "year"
 msgstr "año"
+
+#: src/components/PropertiesMap.tsx:333
+msgid "{0, plural, one {unit} other {units}}"
+msgstr ""
+
+#: src/components/PropertiesMap.tsx:299
+msgid "{0}"
+msgstr ""
 
 #: src/components/FeatureCalloutWidget.tsx:26
 msgid "{0} of {numberOfEntries}"
@@ -1742,4 +1774,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:37
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2010} other {# Violaciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -51,7 +51,7 @@ msgstr "(caduca {formattedRegEndDate})"
 msgid "(hover over a box to learn more)"
 msgstr "(pase el cursor sobre una casilla para aprender más)"
 
-#: src/components/PropertiesList.tsx:125
+#: src/components/PortfolioTable.tsx:441
 msgid "(this may take a while)"
 msgstr "(esto puede tardar un rato)"
 
@@ -59,7 +59,7 @@ msgstr "(esto puede tardar un rato)"
 #~ msgid "({browserType, select, mobile {tap} other {click}} to view details)"
 #~ msgstr "({browserType, select, mobile {tap} other {click}} to view details)"
 
-#: src/containers/HomePage.tsx:120
+#: src/containers/HomePage.tsx:117
 msgid "... or view some sample portfolios:"
 msgstr "... o descubre ejemplos de portafolios de edificios:"
 
@@ -117,8 +117,8 @@ msgstr "En todos los dueños y administradores, {0, plural, one {el nombre más 
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
-#: src/components/PortfolioTable.tsx:72
-#: src/containers/HomePage.tsx:104
+#: src/components/PortfolioTable.tsx:66
+#: src/containers/HomePage.tsx:101
 msgid "Address"
 msgstr "Dirección"
 
@@ -134,7 +134,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "All the public info on your landlord"
 msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 
-#: src/components/PortfolioTable.tsx:339
+#: src/components/PortfolioTable.tsx:333
 msgid "Amount"
 msgstr "Importe"
 
@@ -164,7 +164,7 @@ msgstr "¿Tienes problemas en este edificio?"
 msgid "Are you having issues in this development?"
 msgstr "¿Tienes problemas en tu edificio?"
 
-#: src/components/PropertiesMap.tsx:322
+#: src/components/PropertiesMap.tsx:348
 msgid "Associated names/entities: {0}"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgstr "TIMBRE/INTERCOMUNICADOR"
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
-#: src/components/PortfolioTable.tsx:97
+#: src/components/PortfolioTable.tsx:91
 #: src/containers/NychaPage.tsx:79
 msgid "Borough"
 msgstr "Municipio"
@@ -194,7 +194,7 @@ msgstr "Solicitudes de Permisos de Construcción"
 msgid "Building Permits Applied For"
 msgstr "Permisos de Construcción Solicitados"
 
-#: src/components/PortfolioFilters.tsx:147
+#: src/components/PortfolioFilters.tsx:148
 msgid "Building Size"
 msgstr "Tamaño del Edificio"
 
@@ -202,7 +202,7 @@ msgstr "Tamaño del Edificio"
 msgid "Building info"
 msgstr "Información de edificios"
 
-#: src/components/PropertiesMap.tsx:330
+#: src/components/PropertiesMap.tsx:356
 msgid "Building size: {0}"
 msgstr ""
 
@@ -210,7 +210,7 @@ msgstr ""
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
-#: src/components/PortfolioTable.tsx:131
+#: src/components/PortfolioTable.tsx:125
 msgid "Built"
 msgstr "Construido"
 
@@ -269,7 +269,7 @@ msgstr "Clase I"
 #~ msgid "Clear"
 #~ msgstr "Clear"
 
-#: src/components/PortfolioFilters.tsx:167
+#: src/components/PortfolioFilters.tsx:168
 msgid "Clear Filters"
 msgstr "Borrar filtros"
 
@@ -307,8 +307,8 @@ msgid "Close"
 msgstr "Cerrar"
 
 #: src/components/PropertiesMap.tsx:290
-msgid "Close legend"
-msgstr "Cerrar leyenda"
+#~ msgid "Close legend"
+#~ msgstr "Cerrar leyenda"
 
 #: src/components/IndicatorsDatasets.tsx:14
 msgid "Complaints Issued"
@@ -330,7 +330,7 @@ msgstr "Dueño Corporativo"
 msgid "Corporation"
 msgstr "Corporación"
 
-#: src/components/PortfolioTable.tsx:117
+#: src/components/PortfolioTable.tsx:111
 msgid "Council"
 msgstr "Concejo"
 
@@ -358,7 +358,7 @@ msgstr "PUERTA/VENTANA"
 msgid "DOORS"
 msgstr "PUERTAS"
 
-#: src/components/PortfolioTable.tsx:328
+#: src/components/PortfolioTable.tsx:322
 msgid "Date"
 msgstr "Fecha"
 
@@ -408,7 +408,7 @@ msgstr "Emergencia"
 #~ msgid "Enter NYC ZIP CODE"
 #~ msgstr "Enter NYC ZIP CODE"
 
-#: src/containers/HomePage.tsx:89
+#: src/containers/HomePage.tsx:86
 msgid "Enter an NYC address and find other buildings your landlord might own:"
 msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
 
@@ -449,7 +449,7 @@ msgstr "Desalojos"
 msgid "Evictions Executed"
 msgstr "Desalojos ejecutados"
 
-#: src/components/PortfolioTable.tsx:236
+#: src/components/PortfolioTable.tsx:230
 msgid "Evictions Since 2017"
 msgstr "Desalojos desde 2017"
 
@@ -461,11 +461,11 @@ msgstr "Desalojos ejecutados en este edificio por el Mariscal de NYC desde el 20
 msgid "Evictions executed in this development by NYC Marshals since 2017. ANHD and the Housing Data Coalition cleaned, geocoded, and validated the data, originally sourced from DOI."
 msgstr "Desalojos ejecutados en este complejo por el Mariscal de NYC desde el 2017. ANHD y la Coalición de Datos de Vivienda limpiaron, codificaron y validaron los datos, originalmente provenientes del DOI."
 
-#: src/components/PortfolioTable.tsx:251
+#: src/components/PortfolioTable.tsx:245
 msgid "Executed"
 msgstr "Ejecutado"
 
-#: src/components/PortfolioFilters.tsx:228
+#: src/components/PortfolioFilters.tsx:235
 msgid "Expand the Person/ Entity column in the Table to see all contacts associated with that building."
 msgstr "Expanda la columna Persona/Entidad en la Tabla para ver todos los contactos asociados a ese edificio."
 
@@ -493,7 +493,7 @@ msgstr "PISO/ESCALERAS"
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
-#: src/components/PortfolioTable.tsx:242
+#: src/components/PortfolioTable.tsx:236
 msgid "Filed"
 msgstr "Presentado"
 
@@ -501,7 +501,7 @@ msgstr "Presentado"
 #~ msgid "Filied"
 #~ msgstr "Filied"
 
-#: src/components/PortfolioFilters.tsx:270
+#: src/components/PortfolioFilters.tsx:274
 msgid "Filter"
 msgstr "Filtro"
 
@@ -509,7 +509,7 @@ msgstr "Filtro"
 #~ msgid "Filter through this portfolio in <0>the Portfolio tab.</0>"
 #~ msgstr "Filter through this portfolio in <0>the Portfolio tab.</0>"
 
-#: src/components/PortfolioFilters.tsx:209
+#: src/components/PortfolioFilters.tsx:216
 msgid "Filters"
 msgstr "Filtros"
 
@@ -521,7 +521,7 @@ msgstr "Filtros:"
 #~ msgid "Filter <0/>for"
 #~ msgstr "Filter <0/>for"
 
-#: src/containers/HomePage.tsx:90
+#: src/containers/HomePage.tsx:87
 msgid "Find other buildings your landlord might own:"
 msgstr "Encuentra otros edificios que su dueño podría poseer:"
 
@@ -529,7 +529,7 @@ msgstr "Encuentra otros edificios que su dueño podría poseer:"
 msgid "GARBAGE/RECYCLING STORAGE"
 msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 
-#: src/components/PortfolioTable.tsx:366
+#: src/components/PortfolioTable.tsx:360
 msgid "Group Sale?"
 msgstr "¿Venta en grupo?"
 
@@ -546,7 +546,7 @@ msgid "HPD Building Profile"
 msgstr "Perfil de edificio del HPD"
 
 #: src/components/IndicatorsDatasets.tsx:7
-#: src/components/PortfolioTable.tsx:181
+#: src/components/PortfolioTable.tsx:175
 msgid "HPD Complaints"
 msgstr "Quejas del HPD"
 
@@ -555,7 +555,7 @@ msgid "HPD Complaints are housing issues reported to the City <0>by a tenant cal
 msgstr "Las quejas de HPD son problemas de vivienda presentados a la Ciudad <0>por un inquilino al llamar al 311</0>. Cuando alguien presenta una queja, el Departamento de Preservación y Desarrollo de la Vivienda, DHCR por sus siglas en inglés, inicia un proceso de investigación que puede conducir a la emisión de una infracción oficial por parte de la Ciudad. Las quejas se pueden identificar como:<1/><2/><3>Emergencia</3> — se ha informado de que son peligrosas<4/><5>No-Emergencia</5> — todas las demás<6/><7/> Encontrarás más información sobre las quejas de HPD y cómo presentarlas en la página <8>oficial del HPD</8>."
 
 #: src/components/IndicatorsDatasets.tsx:35
-#: src/components/PortfolioTable.tsx:214
+#: src/components/PortfolioTable.tsx:208
 msgid "HPD Violations"
 msgstr "Violaciones del HPD"
 
@@ -571,7 +571,11 @@ msgstr "Formulario de queja HUD 958"
 msgid "Head Officer"
 msgstr "Oficial Principal"
 
-#: src/components/PortfolioFilters.tsx:175
+#: src/components/PropertiesMap.tsx:319
+msgid "Hide legend"
+msgstr ""
+
+#: src/components/PortfolioFilters.tsx:182
 msgid "How are the results calculated?"
 msgstr "¿Cómo se calculan los resultados?"
 
@@ -636,7 +640,7 @@ msgstr "Dueño Individual"
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
-#: src/components/PortfolioTable.tsx:126
+#: src/components/PortfolioTable.tsx:120
 msgid "Information"
 msgstr "Información"
 
@@ -656,24 +660,28 @@ msgstr "Dueño Conjunto"
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc es una organización registrada 501(c)(3) sin fines de lucro."
 
+#: src/containers/HomePage.tsx:166
+msgid "Known for <0>deregulating rent stabilized apartments</0>, Stellar Management is also one of the city’s of <1>Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where they have a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
+msgstr ""
+
 #: src/containers/HomePage.tsx:215
-msgid "Known for <0>unscrupulously deregulating rent stabilized apartments</0>, Larry Gluck’s Stellar Management has also secured a prominent place as one of <1>New York City’s Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where Gluck operates the majority of his properties. Stellar has a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
-msgstr "Conocido por <0>desregulando apartamentos de renta estabilizada sin escrúpulos</0>, Larry Gluck de Stellar Management ha asegurado un lugar prominente como unos de los <1>peores desalojadores en la Cuidad de Nueva York</1>. Stellar es una fuerza de gentrificación, especialmente en el Norte de Manhattan, en donde Gluck opera la mayoría de sus propiedades. Stellar tiene fama de desplazar inquilinos a largo plazo, renovando sus apartamentos mientras están vacantes, y aumentando rápidamente las rentas a la tasa de mercado."
+#~ msgid "Known for <0>unscrupulously deregulating rent stabilized apartments</0>, Larry Gluck’s Stellar Management has also secured a prominent place as one of <1>New York City’s Worst Evictors</1>. Stellar is a gentrifying force, particularly in upper Manhattan where Gluck operates the majority of his properties. Stellar has a reputation for displacing long-term tenants, renovating their units while vacant, and skyrocketing rents to market rate."
+#~ msgstr "Conocido por <0>desregulando apartamentos de renta estabilizada sin escrúpulos</0>, Larry Gluck de Stellar Management ha asegurado un lugar prominente como unos de los <1>peores desalojadores en la Cuidad de Nueva York</1>. Stellar es una fuerza de gentrificación, especialmente en el Norte de Manhattan, en donde Gluck opera la mayoría de sus propiedades. Stellar tiene fama de desplazar inquilinos a largo plazo, renovando sus apartamentos mientras están vacantes, y aumentando rápidamente las rentas a la tasa de mercado."
 
 #: src/util/helpers.ts:40
 msgid "LOCKS"
 msgstr "CERRADURAS"
 
-#: src/components/PortfolioFilters.tsx:144
-#: src/components/PortfolioTable.tsx:260
+#: src/components/PortfolioFilters.tsx:145
+#: src/components/PortfolioTable.tsx:254
 msgid "Landlord"
 msgstr "Dueño del edificio"
 
-#: src/components/PortfolioFilters.tsx:145
+#: src/components/PortfolioFilters.tsx:146
 msgid "Landlord filter"
 msgstr "Filtro de dueño"
 
-#: src/containers/HomePage.tsx:108
+#: src/containers/HomePage.tsx:105
 msgid "Landlord name"
 msgstr "Nombre del dueño"
 
@@ -681,11 +689,11 @@ msgstr "Nombre del dueño"
 msgid "Landlord, Portfolio, Tenant, Displacement, Map, JustFix, NYC, New York, Housing, Who Owns What"
 msgstr "Arrendador, Portafolio, Inquilino, Desalojo, Mapa, JustFix, NYC, Nueva York, Vivienda, Quién es el Dueño"
 
-#: src/components/PortfolioTable.tsx:194
+#: src/components/PortfolioTable.tsx:188
 msgid "Last 3 Years"
 msgstr "Últimos 3 años"
 
-#: src/components/PortfolioTable.tsx:323
+#: src/components/PortfolioTable.tsx:317
 msgid "Last Sale"
 msgstr "Última venta"
 
@@ -706,15 +714,19 @@ msgstr "Vendido por última vez:"
 msgid "Learn more"
 msgstr "Aprende más"
 
-#: src/components/PortfolioFilters.tsx:163
+#: src/components/PortfolioFilters.tsx:164
 msgid "Learn more about how the results are calculated"
 msgstr "Más información sobre cómo se calculan los resultados"
+
+#: src/components/PortfolioFilters.tsx:145
+msgid "Learn more about what it means for someone to be listed as a landlord"
+msgstr ""
 
 #: src/components/PortfolioAlerts.tsx:39
 msgid "Learn more."
 msgstr "Aprende más."
 
-#: src/components/PropertiesMap.tsx:290
+#: src/components/PropertiesMap.tsx:319
 msgid "Legend"
 msgstr "Leyenda"
 
@@ -722,22 +734,22 @@ msgstr "Leyenda"
 msgid "Lessee"
 msgstr "Arrendatario"
 
-#: src/components/PortfolioTable.tsx:347
-#: src/components/PortfolioTable.tsx:352
+#: src/components/PortfolioTable.tsx:341
+#: src/components/PortfolioTable.tsx:346
 msgid "Link to Deed"
 msgstr "Enlace a la Escritura"
 
 #: src/components/Loader.tsx:19
-#: src/components/PropertiesList.tsx:126
-#: src/components/PropertiesMap.tsx:233
+#: src/components/PortfolioTable.tsx:442
+#: src/components/PropertiesMap.tsx:260
 msgid "Loading"
 msgstr "Cargando"
 
-#: src/components/PropertiesList.tsx:123
+#: src/components/PortfolioTable.tsx:439
 msgid "Loading {0} rows"
 msgstr "Cargando {0} filas"
 
-#: src/components/PortfolioTable.tsx:83
+#: src/components/PortfolioTable.tsx:77
 msgid "Location"
 msgstr "Ubicación"
 
@@ -746,8 +758,8 @@ msgstr "Ubicación"
 #~ msgstr "Look out for multiple spellings for the same person/entity. Names can be spelled multiple ways in official documents."
 
 #: src/components/PortfolioFilters.tsx:243
-msgid "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
-msgstr "Preste atención a las múltiples formas de escribir una misma persona o entidad. Los nombres pueden escribirse de varias maneras en los documentos oficiales."
+#~ msgid "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
+#~ msgstr "Preste atención a las múltiples formas de escribir una misma persona o entidad. Los nombres pueden escribirse de varias maneras en los documentos oficiales."
 
 #: src/components/PropertiesSummary.tsx:134
 msgid "Looking for more information?"
@@ -879,11 +891,11 @@ msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:552
+#: src/components/PortfolioTable.tsx:548
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/components/PortfolioTable.tsx:370
+#: src/components/PortfolioTable.tsx:364
 msgid "No"
 msgstr "No"
 
@@ -932,7 +944,7 @@ msgstr "No encontrado"
 #~ msgid "Notice an inaccuracy? Click here."
 #~ msgstr "Notice an inaccuracy? Click here."
 
-#: src/components/PortfolioFilters.tsx:147
+#: src/components/PortfolioFilters.tsx:148
 msgid "Number of Units"
 msgstr "Número de unidades"
 
@@ -963,7 +975,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/PortfolioTable.tsx:219
+#: src/components/PortfolioTable.tsx:213
 msgid "Open"
 msgstr "Actuales"
 
@@ -1003,7 +1015,7 @@ msgstr "PLOMERÍA"
 msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
-#: src/components/PortfolioTable.tsx:521
+#: src/components/PortfolioTable.tsx:517
 msgid "Page"
 msgstr "Página"
 
@@ -1012,8 +1024,8 @@ msgstr "Página"
 msgid "People"
 msgstr "Personas"
 
-#: src/components/PortfolioFilters.tsx:144
-#: src/components/PortfolioTable.tsx:273
+#: src/components/PortfolioFilters.tsx:145
+#: src/components/PortfolioTable.tsx:267
 msgid "Person/Entity"
 msgstr "Persona/Entidad"
 
@@ -1021,7 +1033,7 @@ msgstr "Persona/Entidad"
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/containers/AddressPage.tsx:156
+#: src/containers/AddressPage.tsx:148
 msgid "Portfolio"
 msgstr "Portafolio"
 
@@ -1030,7 +1042,7 @@ msgid "Portfolio Table Redesign"
 msgstr "Rediseño de la tabla del portafolio"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:515
+#: src/components/PortfolioTable.tsx:511
 msgid "Previous"
 msgstr "Anterior"
 
@@ -1044,7 +1056,7 @@ msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
 #: src/components/BuildingStatsTable.tsx:90
-#: src/components/PortfolioTable.tsx:149
+#: src/components/PortfolioTable.tsx:143
 msgid "RS Units"
 msgstr "Unidades RS"
 
@@ -1054,7 +1066,7 @@ msgstr "Unidades RS"
 #~ msgstr "Read more about our Methodology"
 
 #: src/components/PortfolioFilters.tsx:116
-#: src/components/PortfolioFilters.tsx:187
+#: src/components/PortfolioFilters.tsx:194
 msgid "Read more in our Methodology section"
 msgstr "Más información sobre nuestra metodología"
 
@@ -1062,11 +1074,11 @@ msgstr "Más información sobre nuestra metodología"
 msgid "Registration expired:"
 msgstr "El registro ha caducado:"
 
-#: src/components/PortfolioFilters.tsx:141
+#: src/components/PortfolioFilters.tsx:142
 msgid "Rent Stabilized Units"
 msgstr "Unidades con renta estabilizada"
 
-#: src/components/PortfolioFilters.tsx:138
+#: src/components/PortfolioFilters.tsx:139
 msgid "Rent Stabilized Units filter"
 msgstr "Filtro de Unidades con renta estabilizada"
 
@@ -1074,7 +1086,7 @@ msgstr "Filtro de Unidades con renta estabilizada"
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
-#: src/components/PropertiesMap.tsx:318
+#: src/components/PropertiesMap.tsx:344
 msgid "Rent stabilized units ({0}): {1}"
 msgstr ""
 
@@ -1082,7 +1094,7 @@ msgstr ""
 #~ msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may appear to be deregulated."
 #~ msgstr "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may appear to be deregulated."
 
-#: src/components/PortfolioFilters.tsx:234
+#: src/components/PortfolioFilters.tsx:241
 msgid "Rent stabilized units are self-reported in yearly tax statements by building owners. As a result, many buildings with rent stabilized units may not be documented."
 msgstr "Las unidades de renta estabilizada son declaradas por los dueños de los edificios en sus declaraciones fiscales anuales. Como resultado, muchos edificios con unidades de renta estabilizada pueden parecer desregulados."
 
@@ -1115,7 +1127,7 @@ msgstr "Buscar"
 msgid "Search by your landlord's name"
 msgstr "Busca por el nombre de tu dueño"
 
-#: src/containers/HomePage.tsx:100
+#: src/containers/HomePage.tsx:97
 msgid "Search by:"
 msgstr "Buscar por:"
 
@@ -1128,7 +1140,7 @@ msgstr "Buscar otra dirección"
 msgid "Search landlords"
 msgstr "Buscar dueños"
 
-#: src/components/PropertiesMap.tsx:342
+#: src/components/PropertiesMap.tsx:368
 msgid "See Building Profile"
 msgstr ""
 
@@ -1165,6 +1177,10 @@ msgstr "Accionista"
 msgid "Show all {numSelections} selections"
 msgstr "Mostrar todas las {numSelections} selecciones"
 
+#: src/components/PropertiesMap.tsx:319
+msgid "Show legend"
+msgstr ""
+
 #: src/components/Multiselect.tsx:140
 msgid "Show less"
 msgstr "Mostrar menos"
@@ -1173,7 +1189,7 @@ msgstr "Mostrar menos"
 msgid "Show only {previewSelectedNum} selections"
 msgstr "Mostrar sólo {previewSelectedNum} selecciones"
 
-#: src/components/PortfolioFilters.tsx:158
+#: src/components/PortfolioFilters.tsx:159
 msgid "Showing {0} {1, plural, one {result} other {results}}"
 msgstr "Mostrar {0} {1, plural, one {resultado} other {resultados}}"
 
@@ -1206,7 +1222,7 @@ msgstr "Regístrate para recibir noticias por email"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde 2017, los dueños presentaron {totalEvictionFilings, plural, one {un caso de desalojo} other {# casos de desalojo}} y los alguaciles de la ciudad de Nueva York ejecutaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en toda esta cartera."
 
-#: src/components/PortfolioTable.tsx:579
+#: src/components/PortfolioTable.tsx:576
 msgid "Since {year}"
 msgstr "Desde {year}"
 
@@ -1222,7 +1238,7 @@ msgstr "Vendido al Propietario Actual"
 msgid "Some large corporations, however, are a bit more complicated and may share personnel and financial stake with other related companies, which all will show up on Who Owns What as one large portfolio."
 msgstr "Sin embargo, algunas grandes corporaciones son un poco más complicadas y pueden compartir personal y participación financiera con otras compañías relacionadas, que todos se mostrarán en Quién es el Dueño como un gran portafolio."
 
-#: src/components/PropertiesMap.tsx:243
+#: src/components/PropertiesMap.tsx:270
 msgid "Sorry, it looks like there's an error on the map. Try again on a different browser or <0>enable WebGL</0>."
 msgstr "Lo sentimos, parece que hay un error en el mapa. Inténtalo de nuevo con un navegador diferente o <0>habilita WebGL</0>."
 
@@ -1242,7 +1258,7 @@ msgstr "Código fuente"
 #~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:579
+#: src/components/PortfolioTable.tsx:576
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
@@ -1271,7 +1287,7 @@ msgstr ""
 msgid "Take action on JustFix.org!"
 msgstr "¡Toma acción en JustFix.org!"
 
-#: src/components/PortfolioTable.tsx:301
+#: src/components/PortfolioTable.tsx:295
 msgid "Tax Exemptions"
 msgstr "Exenciones de impuestos"
 
@@ -1308,7 +1324,7 @@ msgstr "El edificio con más desalojos ejecutados es <0>{0} {1}, {2}</0> con {bu
 msgid "The city borough where your search address is located"
 msgstr "El municipio donde se encuentra la dirección que has buscado"
 
-#: src/containers/HomePage.tsx:173
+#: src/containers/HomePage.tsx:130
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
@@ -1335,6 +1351,10 @@ msgstr "El número de unidades residenciales en este edificio, según el Departa
 #: src/containers/NotRegisteredPage.tsx:123
 msgid "The registration for this property is missing details for owner name or businesses address, which are required to link the property to a portfolio."
 msgstr "El registro de esta propiedad faltan detalles sobre el nombre del dueño o la dirección comercial, que son necesarios a vincular la propiedad a un portafolio."
+
+#: src/components/PortfolioFilters.tsx:250
+msgid "The same owner may have spelled their name several ways in official documents."
+msgstr ""
 
 #: src/components/BuildingStatsTable.tsx:34
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
@@ -1389,8 +1409,8 @@ msgid "This portfolio has an average of <0>{0}</0> open HPD violations per resid
 msgstr "Esta cartera de edificios tiene un promedio de <0>{0}</0> infracciones del HPD Actuales por cada unidad residencial."
 
 #: src/containers/HomePage.tsx:139
-msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
-msgstr "Esta empresa de gestión inmobiliaria es propiedad de la familia Kushner y es notoria por <0>violar las normas de vivienda</0> y por <1>comportamientos abusivos</1>. La participación financiera actualmente sostenida por Jared Kushner e Ivanka Trump asciende a 761 millones de dólares."
+#~ msgid "This property management company owned by the Kushner family is notorious for <0>violating rent regulations</0> and <1>harassing tenants</1>. The stake currently held by Jared Kushner and Ivanka Trump is worth as much as $761 million."
+#~ msgstr "Esta empresa de gestión inmobiliaria es propiedad de la familia Kushner y es notoria por <0>violar las normas de vivienda</0> y por <1>comportamientos abusivos</1>. La participación financiera actualmente sostenida por Jared Kushner e Ivanka Trump asciende a 761 millones de dólares."
 
 #: src/components/RentstabSummary.tsx:23
 msgid "This represents <0>{0}%</0> of the total size of this portfolio."
@@ -1412,17 +1432,17 @@ msgstr "El cambio en apartamentos de renta estabilizada que hay en el edificio (
 msgid "This will export <0>{0}</0> addresses associated with the landlord at <1>{userAddrStr}</1>!"
 msgstr "¡Esto exportará <0>{0}</0> direcciones asociadas al propietario de <1>{userAddrStr}</1>!"
 
-#: src/containers/AddressPage.tsx:148
+#: src/containers/AddressPage.tsx:156
 msgid "Timeline"
 msgstr "Cronología"
 
-#: src/components/PortfolioTable.tsx:202
+#: src/components/PortfolioTable.tsx:196
 msgid "Top Complaint"
 msgstr "Queja principal"
 
 #: src/components/IndicatorsViz.tsx:349
-#: src/components/PortfolioTable.tsx:186
-#: src/components/PortfolioTable.tsx:227
+#: src/components/PortfolioTable.tsx:180
+#: src/components/PortfolioTable.tsx:221
 msgid "Total"
 msgstr "Total"
 
@@ -1430,7 +1450,7 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Violaciones Totales"
 
-#: src/components/PortfolioFilters.tsx:240
+#: src/components/PortfolioFilters.tsx:247
 msgid "Try adjusting or clearing the filters to show more than 0 results."
 msgstr "Intente ajustar o borrar los filtros para mostrar más de 0 resultados."
 
@@ -1447,7 +1467,7 @@ msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
 #: src/components/BuildingStatsTable.tsx:44
-#: src/components/PortfolioTable.tsx:139
+#: src/components/PortfolioTable.tsx:133
 #: src/containers/NychaPage.tsx:83
 msgid "Units"
 msgstr "Unidades"
@@ -1473,12 +1493,12 @@ msgstr "Enlaces útiles"
 msgid "VENTILATION SYSTEM"
 msgstr "SISTEMA DE VENTILACIÓN"
 
-#: src/components/PortfolioTable.tsx:379
-#: src/components/PortfolioTable.tsx:386
+#: src/components/PortfolioTable.tsx:373
+#: src/components/PortfolioTable.tsx:380
 msgid "View Detail"
 msgstr "Ver detalles"
 
-#: src/components/PortfolioFilters.tsx:218
+#: src/components/PortfolioFilters.tsx:225
 msgid "View Results"
 msgstr "Ver resultados"
 
@@ -1501,18 +1521,21 @@ msgid "View documents on <0>ACRIS</0>"
 msgstr "Ver documentos en <0>ACRIS</0>"
 
 #: src/components/PropertiesMap.tsx:290
-msgid "View legend"
-msgstr "Ver leyenda"
+#~ msgid "View legend"
+#~ msgstr "Ver leyenda"
 
-#: src/containers/HomePage.tsx:154
-#: src/containers/HomePage.tsx:196
-#: src/containers/HomePage.tsx:233
+#: src/components/DetailView.tsx:146
+msgid "View map"
+msgstr ""
+
+#: src/containers/HomePage.tsx:153
+#: src/containers/HomePage.tsx:182
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
 #: src/components/DetailView.tsx:146
-msgid "View portfolio map"
-msgstr "Ver mapa del portafolio de edificios"
+#~ msgid "View portfolio map"
+#~ msgstr "Ver mapa del portafolio de edificios"
 
 #: src/components/IndicatorsDatasets.tsx:42
 #: src/components/IndicatorsDatasets.tsx:97
@@ -1551,7 +1574,7 @@ msgstr "Comparamos la dirección que buscaste con una base de datos de más de 2
 msgid "We overhauled the Portfolio tab to help make navigating this large table of data easier, especially for mobile phones."
 msgstr "Revisamos la pestaña Portafolio para ayudarle navegar por esta gran tabla de datos, especialmente para dispositivos móviles."
 
-#: src/components/PortfolioFilters.tsx:178
+#: src/components/PortfolioFilters.tsx:185
 msgid "We pull data from public records to calculate these results. Our algorithm relies on public <0>HPD registration data</0> for residential buildings, which contains self-reported landlord contact information on about 170,000 properties across the city."
 msgstr "Extraemos datos de registros públicos para calcular estos resultados. Nuestro algoritmo se basa en los <0>datos públicos de registro de la HPD</0> para edificios residenciales, que contiene información de contacto de los dueños de alrededor de 170.000 propiedades en toda la ciudad."
 
@@ -1613,8 +1636,8 @@ msgid "Who Owns What is a free tool built by JustFix to research property owners
 msgstr "Quién Es El Dueño es una herramienta gratis construida por JustFix para investigar los dueños de edificios en NYC. Ha asistido más de 200.000 neoyorquinos a enterarse quien realmente son los responsables por su edificio, cuáles otros edificios su dueño o compañía de administración poseen, y otra información crítica sobre violaciones del código de vivienda, desalojos, apartamentos con renta estabilizada y mucho más en cualquier edificio. Puedes buscar información sobre cualquier edificio residencial, también incluyen viviendas públicas (NYCHA). Busca tu dirección aquí: {url}"
 
 #: src/components/PortfolioFilters.tsx:144
-msgid "Who are they?"
-msgstr "¿Quiénes son?"
+#~ msgid "Who are they?"
+#~ msgstr "¿Quiénes son?"
 
 #: src/containers/App.tsx:42
 msgid "Who owns what in n y c?"
@@ -1644,7 +1667,7 @@ msgstr "¿Por qué estoy viendo un portafolio tan grande?"
 msgid "Year Built"
 msgstr "Año de construcción"
 
-#: src/components/PortfolioTable.tsx:369
+#: src/components/PortfolioTable.tsx:363
 msgid "Yes"
 msgstr "Sí"
 
@@ -1673,16 +1696,16 @@ msgstr "Está viendo la versión antigua de ¿Quién es el Dueño en NY? <0>Camb
 #~ msgid "ZIP CODE is not applicable"
 #~ msgstr "ZIP CODE is not applicable"
 
-#: src/components/PortfolioFilters.tsx:151
+#: src/components/PortfolioFilters.tsx:152
 msgid "ZIP code is not applicable"
 msgstr "Código postal no aplicable"
 
-#: src/components/PortfolioFilters.tsx:150
-#: src/components/PortfolioTable.tsx:88
+#: src/components/PortfolioFilters.tsx:151
+#: src/components/PortfolioTable.tsx:82
 msgid "Zip Code"
 msgstr "Código postal"
 
-#: src/components/PortfolioFilters.tsx:151
+#: src/components/PortfolioFilters.tsx:152
 msgid "Zip code filter"
 msgstr "Filtro de código postal"
 
@@ -1703,9 +1726,9 @@ msgstr "Alejar"
 msgid "and"
 msgstr "y"
 
-#: src/components/PropertiesMap.tsx:214
-#~ msgid "associated building"
-#~ msgstr "edificio asociado"
+#: src/components/PropertiesMap.tsx:328
+msgid "associated building"
+msgstr "edificio asociado"
 
 #: src/components/DetailView.tsx:242
 msgid "for ${0}"
@@ -1715,15 +1738,23 @@ msgstr "por ${0}"
 msgid "month"
 msgstr "mes"
 
-#: src/components/PortfolioTable.tsx:532
+#: src/components/PortfolioTable.tsx:530
+msgid "number of records per page"
+msgstr ""
+
+#: src/components/PortfolioTable.tsx:528
 msgid "of"
 msgstr "de"
+
+#: src/components/PortfolioTable.tsx:520
+msgid "page number"
+msgstr ""
 
 #: src/components/Indicators.tsx:17
 msgid "quarter"
 msgstr "trimestre"
 
-#: src/components/PropertiesMap.tsx:296
+#: src/components/PropertiesMap.tsx:325
 msgid "search address"
 msgstr "dirección de búsqueda"
 
@@ -1735,13 +1766,13 @@ msgstr "dirección de búsqueda"
 msgid "year"
 msgstr "año"
 
-#: src/components/PropertiesMap.tsx:333
+#: src/components/PropertiesMap.tsx:359
 msgid "{0, plural, one {unit} other {units}}"
 msgstr ""
 
 #: src/components/PropertiesMap.tsx:299
-msgid "{0}"
-msgstr ""
+#~ msgid "{0}"
+#~ msgstr ""
 
 #: src/components/FeatureCalloutWidget.tsx:26
 msgid "{0} of {numberOfEntries}"

--- a/client/src/styles/HomePage.scss
+++ b/client/src/styles/HomePage.scss
@@ -157,16 +157,6 @@
           }
         }
       }
-
-      img {
-        width: 60%;
-        margin: 15px auto;
-
-        &.emassoc {
-          max-height: 75px;
-          width: auto;
-        }
-      }
     }
   }
 }

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -28,7 +28,7 @@
   flex-wrap: wrap;
   gap: var(--filter-bar-row-gap) 1.8rem;
   padding: 1.4rem;
-  background-color: $justfix-table-grey;
+  background-color: $justfix-white;
   text-transform: uppercase;
 
   font-family: $wow-font;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -483,7 +483,6 @@
     @include for-tablet-portrait-up() {
       margin-left: calc(var(--new-container-width) + var(--filter-bar-row-gap));
     }
-
     .filter-status-info {
       display: flex;
       text-transform: none;
@@ -497,6 +496,9 @@
         align-self: start;
         margin-left: 1.8rem;
       }
+    }
+    .filter-results-alert {
+      max-width: 50rem;
     }
   }
 }

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -78,13 +78,35 @@
     flex-grow: 1;
     gap: 1.8rem;
 
-    .filter {
+    .view-type-toggle-container {
+      display: flex;
+    }
+
+    .filter,
+    .view-type-toggle {
       border: 0.1rem solid $justfix-black;
       border-radius: 0.8rem;
       text-transform: uppercase;
       display: flex;
       align-items: center;
+    }
 
+    .view-type-toggle {
+      width: 6.1rem;
+      justify-content: center;
+      &[aria-pressed="true"] {
+        @include white-on-black();
+        border-color: $justfix-black;
+      }
+      &:nth-child(1) {
+        border-radius: 0.8rem 0 0 0.8rem;
+      }
+      &:nth-child(2) {
+        border-radius: 0 0.8rem 0.8rem 0;
+      }
+    }
+
+    .filter {
       @include for-phone-only {
         &:not(.filters-mobile-wrapper) {
           border-radius: 0;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -278,6 +278,7 @@
 
           .filter-subtitle-container {
             display: flex;
+            align-items: center;
             width: 100%;
             font-size: 1.2rem;
             padding: 1.2rem;
@@ -296,7 +297,11 @@
               color: $justfix-grey-700;
             }
             .filter-subtitle {
-              margin-right: auto;
+              margin-right: 0.5rem;
+            }
+            .filter-info:focus-visible {
+              outline: 2px solid $focus-outline-color;
+              outline-offset: 2px;
             }
           }
 
@@ -492,6 +497,10 @@
       .results-count {
         font-size: 1.6rem;
         padding-right: 0.5rem;
+      }
+      .results-info:focus-visible {
+        outline: 2px solid $focus-outline-color;
+        outline-offset: 2px;
       }
       .clear-filters {
         color: $justfix-grey-700;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -71,27 +71,14 @@
     }
   }
 
-  .filters {
-    --checkbox-height: 2.4rem;
-
+  .view-type-toggle-container {
     display: flex;
-    flex-grow: 1;
-    gap: 1.8rem;
-
-    .view-type-toggle-container {
-      display: flex;
-    }
-
-    .filter,
     .view-type-toggle {
-      border: 0.1rem solid $justfix-black;
-      border-radius: 0.8rem;
-      text-transform: uppercase;
       display: flex;
       align-items: center;
-    }
-
-    .view-type-toggle {
+      text-transform: uppercase;
+      border: 0.1rem solid $justfix-black;
+      border-radius: 0.8rem;
       width: 6.1rem;
       justify-content: center;
       &[aria-pressed="true"] {
@@ -105,8 +92,22 @@
         border-radius: 0 0.8rem 0.8rem 0;
       }
     }
+  }
+
+  .filters {
+    --checkbox-height: 2.4rem;
+
+    display: flex;
+    flex-grow: 1;
+    gap: 1.8rem;
 
     .filter {
+      border: 0.1rem solid $justfix-black;
+      border-radius: 0.8rem;
+      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+
       @include for-phone-only {
         &:not(.filters-mobile-wrapper) {
           border-radius: 0;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -29,6 +29,7 @@
   gap: var(--filter-bar-row-gap) 1.8rem;
   padding: 1.4rem;
   background-color: $justfix-white;
+  border-bottom: 1px solid $justfix-black;
   text-transform: uppercase;
 
   font-family: $wow-font;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -26,7 +26,6 @@
   --checkbox-height: 2.4rem;
   display: flex;
   flex-wrap: wrap;
-  gap: var(--filter-bar-row-gap) 1.8rem;
   padding: 1.4rem;
   background-color: $justfix-white;
   border-bottom: 1px solid $justfix-black;
@@ -42,23 +41,21 @@
   line-height: 100%;
   letter-spacing: 0.02em;
 
+  gap: 1.8rem;
   @include for-phone-only() {
     gap: 1.2rem;
   }
 
   .filter-new-container {
-    text-align: right;
-    width: var(--new-container-width);
     letter-spacing: 0.04em;
     display: flex;
     flex-direction: column;
 
     .pill-new {
-      align-self: flex-end;
       font-family: $body-font;
       letter-spacing: 0.02em;
       background: $justfix-yellow;
-      padding: 0.5rem 1rem;
+      padding: 0.4rem 0.8rem;
       border-radius: 1.6rem;
       width: fit-content;
       margin-bottom: 0.26rem;
@@ -73,446 +70,449 @@
     }
   }
 
-  .view-type-toggle-container {
+  .filters-container {
     display: flex;
-    // height based on filter toggle checkbox plus padding
-    height: calc(var(--checkbox-height) + 1rem * 2);
-    .view-type-toggle {
+    flex-wrap: wrap;
+    gap: var(--filter-bar-row-gap) 1.8rem;
+
+    .view-type-toggle-container {
       display: flex;
-      align-items: center;
-      text-transform: uppercase;
-      border: 0.1rem solid $justfix-black;
-      border-radius: 0.8rem;
-      width: 6.1rem;
-      justify-content: center;
-      &[aria-pressed="true"] {
-        @include white-on-black();
-        border-color: $justfix-black;
-      }
-      &:nth-child(1) {
-        border-radius: 0.8rem 0 0 0.8rem;
-      }
-      &:nth-child(2) {
-        border-radius: 0 0.8rem 0.8rem 0;
-      }
-    }
-  }
-
-  .filters {
-    display: flex;
-    flex-grow: 1;
-    gap: 1.8rem;
-
-    .filter {
-      border: 0.1rem solid $justfix-black;
-      border-radius: 0.8rem;
-      text-transform: uppercase;
-      display: flex;
-      align-items: center;
-
-      @include for-phone-only {
-        &:not(.filters-mobile-wrapper) {
-          border-radius: 0;
-          box-sizing: border-box;
-          border: none;
-          border-bottom: 0.1rem solid $justfix-grey-400;
-        }
-        &.active:not([open]):not(.filter-toggle):not(.filters-mobile-wrapper) {
-          background-color: $justfix-table-grey;
-          color: $justfix-black;
-          border-color: $justfix-grey-400;
-        }
-      }
-
-      @include for-tablet-portrait-up() {
-        &.active,
-        &[aria-pressed="true"] {
-          @include white-on-black();
-        }
-
-        &:not([open]):hover,
-        [open] summary:not(.minmaxselect__custom-range-summary) {
-          text-decoration: underline;
-          text-underline-position: under;
-        }
-      }
-      &:focus-visible {
-        box-shadow: none;
-        outline: 2px solid $focus-outline-color;
-        outline-offset: 2px;
-      }
-    }
-
-    .filter-toggle {
-      gap: 1rem;
-      padding: 1rem;
-      letter-spacing: 0.02em;
-      @include for-phone-only {
-        height: var(--filter-bar-height);
-        min-height: var(--filter-bar-height);
-        padding: 0 2.4rem;
-        font-size: 1.8rem;
-        &[aria-pressed="false"]:hover {
-          text-decoration: none;
-        }
-        &[aria-pressed="true"] {
-          text-decoration: none;
-          @include white-on-black();
-        }
-      }
-      .checkbox {
-        box-sizing: border-box;
+      // height based on filter toggle checkbox plus padding
+      height: calc(var(--checkbox-height) + 1rem * 2);
+      .view-type-toggle {
+        display: flex;
+        align-items: center;
+        text-transform: uppercase;
         border: 0.1rem solid $justfix-black;
-        border-radius: 0.4rem;
-        width: var(--checkbox-height);
-        height: var(--checkbox-height);
-        display: flex;
+        border-radius: 0.8rem;
+        width: 6.1rem;
         justify-content: center;
-        align-items: center;
-        color: $justfix-white;
-        @include for-phone-only {
-          order: 1;
-          margin-left: auto;
+        &[aria-pressed="true"] {
+          @include white-on-black();
+          border-color: $justfix-black;
         }
-      }
-      &[aria-pressed="true"] {
-        .checkbox {
-          border-color: $justfix-white;
+        &:nth-child(1) {
+          border-radius: 0.8rem 0 0 0.8rem;
+        }
+        &:nth-child(2) {
+          border-radius: 0 0.8rem 0.8rem 0;
         }
       }
     }
 
-    .filter-accordion {
-      position: relative;
+    .filters {
+      display: flex;
+      flex-grow: 1;
+      gap: 1.8rem;
 
-      summary:not(.minmaxselect__custom-range-summary) {
-        // height based on toggle toggle checkbox plus 1rem padding
-        height: calc(var(--checkbox-height) + 1rem * 2);
-        padding: 0 1rem 0 1rem;
+      .filter {
+        border: 0.1rem solid $justfix-black;
+        border-radius: 0.8rem;
+        text-transform: uppercase;
         display: flex;
         align-items: center;
-        position: relative;
-        letter-spacing: 0.02em;
-        cursor: pointer;
 
-        &::-webkit-details-marker {
-          display: none;
+        @include for-phone-only {
+          &:not(.filters-mobile-wrapper) {
+            border-radius: 0;
+            box-sizing: border-box;
+            border: none;
+            border-bottom: 0.1rem solid $justfix-grey-400;
+          }
+          &.active:not([open]):not(.filter-toggle):not(.filters-mobile-wrapper) {
+            background-color: $justfix-table-grey;
+            color: $justfix-black;
+            border-color: $justfix-grey-400;
+          }
         }
-        .chevronIcon,
-        .closeIcon {
-          stroke-width: 2px;
+
+        @include for-tablet-portrait-up() {
+          &.active,
+          &[aria-pressed="true"] {
+            @include white-on-black();
+          }
+
+          &:not([open]):hover,
+          [open] summary:not(.minmaxselect__custom-range-summary) {
+            text-decoration: underline;
+            text-underline-position: under;
+          }
         }
-        .chevronIcon {
-          margin-left: 0.8rem;
-        }
-        .closeIcon {
-          margin-left: auto;
+        &:focus-visible {
+          box-shadow: none;
+          outline: 2px solid $focus-outline-color;
+          outline-offset: 2px;
         }
       }
-      &:not(.filters-mobile-wrapper) summary:not(.minmaxselect__custom-range-summary) {
+
+      .filter-toggle {
+        gap: 1rem;
+        padding: 1rem;
+        letter-spacing: 0.02em;
         @include for-phone-only {
           height: var(--filter-bar-height);
+          min-height: var(--filter-bar-height);
           padding: 0 2.4rem;
           font-size: 1.8rem;
-          .chevronIcon {
+          &[aria-pressed="false"]:hover {
+            text-decoration: none;
+          }
+          &[aria-pressed="true"] {
+            text-decoration: none;
+            @include white-on-black();
+          }
+        }
+        .checkbox {
+          box-sizing: border-box;
+          border: 0.1rem solid $justfix-black;
+          border-radius: 0.4rem;
+          width: var(--checkbox-height);
+          height: var(--checkbox-height);
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          color: $justfix-white;
+          @include for-phone-only {
+            order: 1;
             margin-left: auto;
           }
         }
-      }
-      .filter-selection-count {
-        @include for-tablet-portrait-up() {
-          margin-left: 0.5rem;
-          @include wrap-with-parentheses();
-        }
-        @include for-phone-only() {
-          @include white-on-black();
-          padding: 0.4rem 0.8rem;
-          border-radius: 1.5rem;
-          margin-left: 0.5rem;
-          font-size: 1.4rem;
+        &[aria-pressed="true"] {
+          .checkbox {
+            border-color: $justfix-white;
+          }
         }
       }
-      &[open] {
-        > summary {
-          svg {
-            transform: scaleY(-1);
+
+      .filter-accordion {
+        position: relative;
+
+        summary:not(.minmaxselect__custom-range-summary) {
+          // height based on toggle toggle checkbox plus 1rem padding
+          height: calc(var(--checkbox-height) + 1rem * 2);
+          padding: 0 1rem 0 1rem;
+          display: flex;
+          align-items: center;
+          position: relative;
+          letter-spacing: 0.02em;
+          cursor: pointer;
+
+          &::-webkit-details-marker {
+            display: none;
+          }
+          .chevronIcon,
+          .closeIcon {
+            stroke-width: 2px;
+          }
+          .chevronIcon {
+            margin-left: 0.8rem;
+          }
+          .closeIcon {
+            margin-left: auto;
           }
         }
-
-        @include for-tablet-portrait-up {
-          &.ownernames-accordion .dropdown-container {
-            width: 25.2rem;
-          }
-          &.unitsres-accordion .dropdown-container {
-            width: 26rem;
-          }
-          &.zip-accordion .dropdown-container {
-            width: 24rem;
+        &:not(.filters-mobile-wrapper) summary:not(.minmaxselect__custom-range-summary) {
+          @include for-phone-only {
+            height: var(--filter-bar-height);
+            padding: 0 2.4rem;
+            font-size: 1.8rem;
+            .chevronIcon {
+              margin-left: auto;
+            }
           }
         }
+        .filter-selection-count {
+          @include for-tablet-portrait-up() {
+            margin-left: 0.5rem;
+            @include wrap-with-parentheses();
+          }
+          @include for-phone-only() {
+            @include white-on-black();
+            padding: 0.4rem 0.8rem;
+            border-radius: 1.5rem;
+            margin-left: 0.5rem;
+            font-size: 1.4rem;
+          }
+        }
+        &[open] {
+          > summary {
+            svg {
+              transform: scaleY(-1);
+            }
+          }
 
-        .dropdown-container {
-          position: absolute;
-          top: 5rem;
-          left: -0.1rem;
-          z-index: 10;
-          overflow-y: scroll;
-          background-color: $justfix-table-grey;
-          box-sizing: border-box;
-          border: 0.1rem solid $justfix-black;
-          border-radius: 0.8rem;
           @include for-tablet-portrait-up {
-            max-height: 65vh;
+            &.ownernames-accordion .dropdown-container {
+              width: 25.2rem;
+            }
+            &.unitsres-accordion .dropdown-container {
+              width: 26rem;
+            }
+            &.zip-accordion .dropdown-container {
+              width: 24rem;
+            }
           }
-          @include for-phone-only {
-            padding: 0 2.4rem 2.4rem 2.4rem;
-            display: flex;
-            flex-direction: column;
-            width: 100%;
+
+          .dropdown-container {
+            position: absolute;
+            top: 5rem;
+            left: -0.1rem;
+            z-index: 10;
+            overflow-y: scroll;
             background-color: $justfix-table-grey;
-            border-radius: 0;
-            border: none;
-            top: unset;
-            position: relative;
-            max-height: none;
-          }
-
-          .filter-subtitle-container {
-            display: flex;
-            align-items: center;
-            width: 100%;
-            font-size: 1.2rem;
-            padding: 1.2rem;
-            @include for-phone-only {
-              padding: 0 0 1.2rem 0;
-              font-size: 1.6rem;
-              .filter-info {
-                font-size: 1.4rem;
-              }
-            }
-            @include for-tablet-portrait-up() {
-              border-bottom: 0.1rem solid $justfix-grey;
-            }
-            &,
-            .filter-info {
-              color: $justfix-grey-700;
-            }
-            .filter-subtitle {
-              margin-right: 0.5rem;
-            }
-            .filter-info:focus-visible {
-              outline: 2px solid $focus-outline-color;
-              outline-offset: 2px;
-            }
-          }
-
-          @include for-phone-only {
-            .multiselect-container,
-            .minmaxselect-container {
-              padding: 0;
-
-              .multiselect__menu,
-              .multiselect__control,
-              .multiselect__selected-value-control-container,
-              .minmaxselect__presets-container,
-              .jf-alert {
-                width: 75%;
-              }
-
-              .button.is-primary {
-                padding: 1.6rem 3.2rem;
-              }
-            }
-          }
-
-          .multiselect-container {
-            width: 100%;
-            @include for-phone-only {
-              padding: 0;
-
-              .multiselect__input-container,
-              .multiselect__placeholder {
-                font-size: 1.8rem;
-                line-height: 100%;
-                height: 5rem;
-                padding-left: 1.2rem;
-              }
-              .multiselect__menu {
-                font-size: 1.6rem;
-              }
-            }
+            box-sizing: border-box;
+            border: 0.1rem solid $justfix-black;
+            border-radius: 0.8rem;
             @include for-tablet-portrait-up {
-              .multiselect__selected-value-control-container {
-                font-size: 1.2rem;
+              max-height: 65vh;
+            }
+            @include for-phone-only {
+              padding: 0 2.4rem 2.4rem 2.4rem;
+              display: flex;
+              flex-direction: column;
+              width: 100%;
+              background-color: $justfix-table-grey;
+              border-radius: 0;
+              border: none;
+              top: unset;
+              position: relative;
+              max-height: none;
+            }
+
+            .filter-subtitle-container {
+              display: flex;
+              align-items: center;
+              width: 100%;
+              font-size: 1.2rem;
+              padding: 1.2rem;
+              @include for-phone-only {
+                padding: 0 0 1.2rem 0;
+                font-size: 1.6rem;
+                .filter-info {
+                  font-size: 1.4rem;
+                }
+              }
+              @include for-tablet-portrait-up() {
+                border-bottom: 0.1rem solid $justfix-grey;
+              }
+              &,
+              .filter-info {
+                color: $justfix-grey-700;
+              }
+              .filter-subtitle {
+                margin-right: 0.5rem;
+              }
+              .filter-info:focus-visible {
+                outline: 2px solid $focus-outline-color;
+                outline-offset: 2px;
               }
             }
-          }
-          .minmaxselect-container {
+
             @include for-phone-only {
-              .minmaxselect__presets-container {
-                grid-template-rows: 4.5rem 4.5rem;
-                .minmaxselect__preset-value {
+              .multiselect-container,
+              .minmaxselect-container {
+                padding: 0;
+
+                .multiselect__menu,
+                .multiselect__control,
+                .multiselect__selected-value-control-container,
+                .minmaxselect__presets-container,
+                .jf-alert {
+                  width: 80%;
+                }
+
+                .button.is-primary {
+                  padding: 1.6rem 3.2rem;
+                }
+              }
+            }
+
+            .multiselect-container {
+              width: 100%;
+              @include for-phone-only {
+                padding: 0;
+
+                .multiselect__input-container,
+                .multiselect__placeholder {
+                  font-size: 1.8rem;
+                  line-height: 100%;
+                  height: 5rem;
+                  padding-left: 1.2rem;
+                }
+                .multiselect__menu {
                   font-size: 1.6rem;
                 }
               }
-              .minmaxselect__custom-range-summary span,
-              .minmaxselect__clear-value-button {
-                font-size: 1.4rem;
+              @include for-tablet-portrait-up {
+                .multiselect__selected-value-control-container {
+                  font-size: 1.2rem;
+                }
               }
-              .chevronIcon {
-                stroke-width: 0.2rem;
-              }
-              .minmaxselect__label-input-container {
-                width: fit-content;
-                font-size: 1.6rem;
-                input {
-                  font-size: 1.8rem;
-                  width: 4.8rem;
-                  height: 4.8rem;
+            }
+            .minmaxselect-container {
+              @include for-phone-only {
+                .minmaxselect__presets-container {
+                  grid-template-rows: 4.5rem 4.5rem;
+                  .minmaxselect__preset-value {
+                    font-size: 1.6rem;
+                  }
+                }
+                .minmaxselect__custom-range-summary span,
+                .minmaxselect__clear-value-button {
+                  font-size: 1.4rem;
+                }
+                .chevronIcon {
+                  stroke-width: 0.2rem;
+                }
+                .minmaxselect__label-input-container {
+                  width: fit-content;
+                  font-size: 1.6rem;
+                  input {
+                    font-size: 1.8rem;
+                    width: 4.8rem;
+                    height: 4.8rem;
+                  }
                 }
               }
             }
           }
         }
       }
-    }
-    .filters-mobile-wrapper {
-      &.active:not([open]) {
-        @include white-on-black();
-        .active-filter-count {
-          margin-left: 0.5rem;
-          @include wrap-with-parentheses();
-        }
-      }
-      &[open] {
-        --filter-bar-top-height: 4.6rem;
-        --filter-bar-height: 6.6rem;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        z-index: 11;
-        height: 100%;
-        background-color: $justfix-table-grey;
-        border-radius: 0.8rem 0.8rem 0 0;
-        box-sizing: border-box;
-        border: none;
-
-        @keyframes slide-up {
-          0% {
-            transform: translateY(100vh);
-          }
-          100% {
-            transform: translateY(0);
+      .filters-mobile-wrapper {
+        &.active:not([open]) {
+          @include white-on-black();
+          .active-filter-count {
+            margin-left: 0.5rem;
+            @include wrap-with-parentheses();
           }
         }
-
-        animation-name: slide-up;
-        animation-duration: 0.5s;
-        animation-timing-function: ease-in-out;
-        animation-fill-mode: forwards;
-
-        // Hide page from showing through around rounded corners
-        // Sadly outline+offset doesn't work since in safari is doesn't follow border-radius
-        &::before {
-          --border-size: 0.5rem;
-          content: "";
+        &[open] {
+          --filter-bar-top-height: 4.6rem;
+          --filter-bar-height: 6.6rem;
           position: absolute;
-          top: calc(0rem - var(--border-size));
-          right: calc(0rem - var(--border-size));
-          bottom: calc(0rem - var(--border-size));
-          left: calc(0rem - var(--border-size));
-          border: var(--border-size) solid $justfix-black;
-          border-bottom: none;
-          border-radius: 1.25rem 1.25rem 0 0;
+          top: 0;
+          left: 0;
+          right: 0;
+          z-index: 11;
+          height: 100%;
+          background-color: $justfix-table-grey;
+          border-radius: 0.8rem 0.8rem 0 0;
+          box-sizing: border-box;
+          border: none;
 
-          @keyframes fade-in {
+          @keyframes slide-up {
             0% {
-              opacity: 0;
-            }
-            90% {
-              opacity: 0;
+              transform: translateY(100vh);
             }
             100% {
-              opacity: 1;
+              transform: translateY(0);
             }
           }
 
-          animation-name: fade-in;
+          animation-name: slide-up;
           animation-duration: 0.5s;
           animation-timing-function: ease-in-out;
           animation-fill-mode: forwards;
-        }
 
-        & > summary {
-          padding: 0 2.4rem;
-          border-bottom: 0.2rem solid $justfix-grey-700;
-        }
-        & > .dropdown-container {
-          height: calc(100% - var(--filter-bar-top-height));
-          z-index: 12;
-          padding: 0;
-          overflow: auto;
+          // Hide page from showing through around rounded corners
+          // Sadly outline+offset doesn't work since in safari is doesn't follow border-radius
+          &::before {
+            --border-size: 0.5rem;
+            content: "";
+            position: absolute;
+            top: calc(0rem - var(--border-size));
+            right: calc(0rem - var(--border-size));
+            bottom: calc(0rem - var(--border-size));
+            left: calc(0rem - var(--border-size));
+            border: var(--border-size) solid $justfix-black;
+            border-bottom: none;
+            border-radius: 1.25rem 1.25rem 0 0;
 
-          &.scroll-gradient {
-            // https://css-scroll-shadows.vercel.app/
-            --clear: rgba(0, 0, 0, 0);
-            --dark: rgba(100, 100, 100, 0.65);
-            background: linear-gradient($justfix-table-grey 10%, var(--clear)),
-              linear-gradient(var(--clear), $justfix-table-grey 90%) 0 100%,
-              linear-gradient(var(--dark) 10%, var(--clear));
-            background-color: $justfix-table-grey;
-            background-repeat: no-repeat;
-            background-attachment: local, local, scroll;
-            background-size: 100% 6rem, 100% 6rem, 100% 1rem, 100% 1rem;
+            @keyframes fade-in {
+              0% {
+                opacity: 0;
+              }
+              90% {
+                opacity: 0;
+              }
+              100% {
+                opacity: 1;
+              }
+            }
+
+            animation-name: fade-in;
+            animation-duration: 0.5s;
+            animation-timing-function: ease-in-out;
+            animation-fill-mode: forwards;
           }
 
-          & > .button.is-primary {
-            align-self: center;
-            padding: 1.6rem 3.2rem;
-            margin: 2.4rem 0;
-            letter-spacing: 0.02em;
-            .view-results-count {
-              margin-left: 1em;
-              @include wrap-with-parentheses();
+          & > summary {
+            padding: 0 2.4rem;
+            border-bottom: 0.2rem solid $justfix-grey-700;
+          }
+          & > .dropdown-container {
+            height: calc(100% - var(--filter-bar-top-height));
+            z-index: 12;
+            padding: 0;
+            overflow: auto;
+
+            &.scroll-gradient {
+              // https://css-scroll-shadows.vercel.app/
+              --clear: rgba(0, 0, 0, 0);
+              --dark: rgba(100, 100, 100, 0.65);
+              background: linear-gradient($justfix-table-grey 10%, var(--clear)),
+                linear-gradient(var(--clear), $justfix-table-grey 90%) 0 100%,
+                linear-gradient(var(--dark) 10%, var(--clear));
+              background-color: $justfix-table-grey;
+              background-repeat: no-repeat;
+              background-attachment: local, local, scroll;
+              background-size: 100% 6rem, 100% 6rem, 100% 1rem, 100% 1rem;
+            }
+
+            & > .button.is-primary {
+              align-self: center;
+              padding: 1.6rem 3.2rem;
+              margin: 2.4rem 0;
+              letter-spacing: 0.02em;
+              .view-results-count {
+                margin-left: 1em;
+                @include wrap-with-parentheses();
+              }
+            }
+            .zero-results-alert {
+              align-self: center;
+              margin: 0 2.45rem;
             }
           }
-          .zero-results-alert {
-            align-self: center;
-            margin: 0 2.45rem;
-          }
         }
       }
     }
-  }
-  .filter-status {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    gap: 1rem;
-    @include for-tablet-portrait-up() {
-      margin-left: calc(var(--new-container-width) + var(--filter-bar-row-gap));
-    }
-    .filter-status-info {
+    .filter-status {
       display: flex;
-      text-transform: none;
-      color: $justfix-grey-700;
-      .results-count {
-        font-size: 1.6rem;
-        padding-right: 0.5rem;
-      }
-      .results-info:focus-visible {
-        outline: 2px solid $focus-outline-color;
-        outline-offset: 2px;
-      }
-      .clear-filters {
+      flex-direction: column;
+      flex: 0 0 100%;
+      gap: 1rem;
+      .filter-status-info {
+        display: flex;
+        text-transform: none;
         color: $justfix-grey-700;
-        align-self: start;
-        margin-left: 1.8rem;
+        .results-count {
+          font-size: 1.6rem;
+          padding-right: 0.5rem;
+        }
+        .results-info:focus-visible {
+          outline: 2px solid $focus-outline-color;
+          outline-offset: 2px;
+        }
+        .clear-filters {
+          color: $justfix-grey-700;
+          align-self: start;
+          margin-left: 1.8rem;
+        }
       }
-    }
-    .filter-results-alert {
-      max-width: 50rem;
+      .filter-results-alert {
+        max-width: 50rem;
+      }
     }
   }
 }

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -258,13 +258,14 @@
             top: 5rem;
             left: -0.1rem;
             z-index: 10;
-            overflow-y: scroll;
+            overflow-y: auto;
             background-color: $justfix-table-grey;
             box-sizing: border-box;
             border: 0.1rem solid $justfix-black;
             border-radius: 0.8rem;
             @include for-tablet-portrait-up {
               max-height: 65vh;
+              @include scrollbar_wowza();
             }
             @include for-phone-only {
               padding: 0 2.4rem 2.4rem 2.4rem;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -311,6 +311,14 @@
             .minmaxselect-container {
               padding: 0;
 
+              .multiselect__menu,
+              .multiselect__control,
+              .multiselect__selected-value-control-container,
+              .minmaxselect__presets-container,
+              .jf-alert {
+                width: 75%;
+              }
+
               .button.is-primary {
                 padding: 1.6rem 3.2rem;
               }
@@ -322,11 +330,6 @@
             @include for-phone-only {
               padding: 0;
 
-              .multiselect__menu,
-              .multiselect__control,
-              .multiselect__selected-value-control-container {
-                width: 75%;
-              }
               .multiselect__input-container,
               .multiselect__placeholder {
                 font-size: 1.8rem;
@@ -347,7 +350,6 @@
           .minmaxselect-container {
             @include for-phone-only {
               .minmaxselect__presets-container {
-                grid-template-columns: 8rem 8rem 8rem;
                 grid-template-rows: 4.5rem 4.5rem;
                 .minmaxselect__preset-value {
                   font-size: 1.6rem;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -23,6 +23,7 @@
 .PortfolioFilters {
   --new-container-width: 10.2rem;
   --filter-bar-row-gap: 1.2rem;
+  --checkbox-height: 2.4rem;
   display: flex;
   flex-wrap: wrap;
   gap: var(--filter-bar-row-gap) 1.8rem;
@@ -73,6 +74,8 @@
 
   .view-type-toggle-container {
     display: flex;
+    // height based on filter toggle checkbox plus padding
+    height: calc(var(--checkbox-height) + 1rem * 2);
     .view-type-toggle {
       display: flex;
       align-items: center;
@@ -95,8 +98,6 @@
   }
 
   .filters {
-    --checkbox-height: 2.4rem;
-
     display: flex;
     flex-grow: 1;
     gap: 1.8rem;

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -186,21 +186,6 @@ $table-border-dark: 1px solid $dark;
         }
 
         td {
-          &.filter-table-alert-container {
-            background-color: #fff;
-            .filter-result-alert {
-              text-align: left;
-              margin: 1.2rem 3.2rem;
-              max-width: 50rem;
-              @include for-phone-only {
-                margin: 1.2rem;
-                width: calc(100vw - 1.2rem * 2);
-              }
-              &:not(:first-child) {
-                margin-top: 0;
-              }
-            }
-          }
           &.col-address {
             text-align: left;
             padding: 0.75rem;

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -127,14 +127,13 @@ $table-border-dark: 1px solid $dark;
         }
 
         tr:first-child th {
-          border-bottom: 1px solid $table-border-light;
-          border-top: 1px solid $gray-dark;
           color: #000;
           background-color: $justfix-table-white;
         }
 
         tr:last-child th {
           background-color: #fff;
+          border-top: $table-border-light;
           border-bottom: $table-border-dark;
           box-shadow: none;
           vertical-align: top;
@@ -301,4 +300,9 @@ $table-border-dark: 1px solid $dark;
 
 #PortfolioTable.is-hidden {
   display: none !important;
+}
+
+#PortfolioTable:has(.Loader-table) {
+  width: 100%;
+  height: 100%;
 }

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -313,3 +313,7 @@ $table-border-dark: 1px solid $dark;
     }
   }
 }
+
+#PortfolioTable.is-hidden {
+  display: none !important;
+}

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -9,9 +9,4 @@
   font-size: 1.4rem;
   line-height: 100%;
   letter-spacing: 0.02em;
-
-  .PropertiesMap {
-    height: 100%;
-    width: 100%;
-  }
 }

--- a/client/src/styles/PropertiesList.scss
+++ b/client/src/styles/PropertiesList.scss
@@ -9,4 +9,9 @@
   font-size: 1.4rem;
   line-height: 100%;
   letter-spacing: 0.02em;
+
+  .PropertiesMap {
+    height: 100%;
+    width: 100%;
+  }
 }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -15,19 +15,23 @@
 
   // overrides spacing/sizing rules for MapBox attribution control
   @include for-tablet-portrait-up() {
-    .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
+    .mapboxgl-ctrl-bottom-right {
       bottom: 112px;
     }
   }
   // slide up/down in sync with legend on mobile
   @include for-phone-only() {
-    .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
+    .mapboxgl-ctrl-bottom-right,
+    .mapboxgl-ctrl-bottom-left {
       bottom: 98px;
       transform: translateY(5.2rem); // height of hidden part of legend
       transition: transform 250ms ease-in-out;
     }
-    &:has(.PropertiesMap__legend--slide) .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
-      transform: translateY(0px);
+    &:has(.PropertiesMap__legend--slide) {
+      .mapboxgl-ctrl-bottom-right,
+      .mapboxgl-ctrl-bottom-left {
+        transform: translateY(0px);
+      }
     }
   }
 
@@ -69,7 +73,10 @@
   }
 
   .PropertiesMap__legend {
-    background: #fff;
+    background: rgb(255, 255, 255);
+    @include for-tablet-portrait-up() {
+      background: rgb(255, 255, 255, 0.8);
+    }
     position: absolute;
     z-index: 10;
     right: 0;
@@ -202,7 +209,8 @@
     }
 
     @include for-tablet-portrait-up() {
-      .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
+      .mapboxgl-ctrl-bottom-right,
+      .mapboxgl-ctrl-bottom-left {
         bottom: 0;
       }
 

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -178,7 +178,7 @@
 
       .PropertiesMap__legend {
         padding: 1.6rem;
-        margin: 0 4.4rem 2.9rem 0;
+        margin: 0 1rem 2.9rem 0;
         width: 22.5rem;
 
         p {

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -73,10 +73,7 @@
   }
 
   .PropertiesMap__legend {
-    background: rgb(255, 255, 255);
-    @include for-tablet-portrait-up() {
-      background: rgb(255, 255, 255, 0.8);
-    }
+    background: #ffffff;
     position: absolute;
     z-index: 10;
     right: 0;

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -69,8 +69,6 @@
   }
 
   .PropertiesMap__legend {
-    // background: $primary-color;
-    // color: $background;
     width: 180px;
     background: #fff;
     position: absolute;
@@ -79,20 +77,18 @@
     bottom: 0;
     border-left: 1px solid #000;
     border-top: 1px solid #000;
-    padding: 5px;
-    padding-top: 0;
+    padding: 1.2rem 0.5rem 0 0.5rem;
     font-size: 13px;
 
     p {
-      font-size: 1.5rem;
-      line-height: 34px;
+      font-size: 1.4rem;
+      line-height: 100%;
 
       text-align: center;
-      margin-bottom: 0;
+      margin-bottom: 1rem;
 
       span {
-        text-decoration: underline;
-        font-weight: bold;
+        text-transform: uppercase;
       }
 
       i {
@@ -106,29 +102,32 @@
       }
     }
 
-    ul {
-      margin: 0.5rem;
-      margin-top: 0;
-      list-style-type: none;
+    .legend-entry-container {
+      display: flex;
+      gap: 0.5rem;
 
-      li {
-        margin-top: 0.5rem;
+      @include for-tablet-portrait-up() {
+        flex-direction: column;
+      }
+
+      div {
+        display: flex;
+        align-items: center;
 
         &:before {
           content: "";
           display: inline-block;
+          flex: none;
           height: 11px;
           width: 11px;
           border-radius: 11px;
           position: relative;
-          top: 2px;
-          margin-right: 7px;
+          margin-right: 0.9rem;
           background-color: black;
           border: 1px solid #111;
         }
 
         &.addr-search {
-          margin-top: 0;
           &:before {
             background-color: $search-marker;
           }
@@ -148,7 +147,8 @@
     @include for-phone-only() {
       width: 100%;
       border-right: 1px solid #000;
-      padding-bottom: 10px;
+      padding: 1.2rem 0.5rem 1rem 0.5rem;
+      gap: 1.5rem;
 
       transform: translateY(28px);
       transition: transform 250ms ease-in-out;
@@ -157,18 +157,41 @@
         transform: translateY(1px);
       }
 
-      ul li {
-        float: left;
-
-        &:nth-child(2) {
-          margin-top: 0;
-          margin-left: 15px;
-        }
+      p span {
+        font-weight: 700;
+        text-decoration: underline;
       }
     }
   }
 }
 
-.PropertiesMap.is-hidden {
-  display: none !important;
+.PropertiesList {
+  .PropertiesMap {
+    height: 100%;
+    width: 100%;
+
+    &.is-hidden {
+      display: none !important;
+    }
+
+    @include for-tablet-portrait-up() {
+      .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
+        bottom: 0;
+      }
+
+      .PropertiesMap__legend {
+        padding: 1.6rem;
+        margin: 0 4.4rem 2.9rem 0;
+        width: 22.5rem;
+
+        p {
+          margin-bottom: 2rem;
+        }
+        .legend-entry-container div::before {
+          height: 16.5px;
+          width: 16.5px;
+        }
+      }
+    }
+  }
 }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -169,54 +169,6 @@
   }
 }
 
-.PropertiesMap {
-  .filter-toast-container {
-    position: fixed;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    width: fit-content;
-    bottom: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 101;
-
-    .filter-result-alert {
-      position: relative;
-      transform: translateY(100%);
-      width: 45.4rem;
-
-      @keyframes toast-up-down {
-        0% {
-          transform: translateY(100%);
-        }
-        25% {
-          transform: translateY(0%);
-        }
-        75% {
-          transform: translateY(0%);
-        }
-        100% {
-          transform: translateY(100%);
-        }
-      }
-
-      animation-name: toast-up-down;
-      animation-delay: 0.3s;
-      animation-duration: 7s;
-      animation-timing-function: ease-in-out;
-      animation-fill-mode: forwards;
-
-      &:hover {
-        animation-play-state: paused;
-      }
-    }
-    :not(:first-child) {
-      display: none;
-    }
-  }
-}
-
 .PropertiesMap.is-hidden {
   display: none !important;
 }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -127,19 +127,20 @@
           border: 1px solid #111;
         }
 
-        &:nth-child(1) {
+        &.addr-search {
           margin-top: 0;
           &:before {
             background-color: $search-marker;
           }
         }
 
-        &:nth-child(2):before {
+        &.addr-assoc:before {
           background-color: $assoc-marker;
         }
 
-        &:nth-child(3):before {
-          background-color: $justfix-blue;
+        &.addr-filter:before {
+          background-color: $justfix-grey-50;
+          border: 2px solid $justfix-blue;
         }
       }
     }
@@ -166,4 +167,56 @@
       }
     }
   }
+}
+
+.PropertiesMap {
+  .filter-toast-container {
+    position: fixed;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: fit-content;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 101;
+
+    .filter-result-alert {
+      position: relative;
+      transform: translateY(100%);
+      width: 45.4rem;
+
+      @keyframes toast-up-down {
+        0% {
+          transform: translateY(100%);
+        }
+        25% {
+          transform: translateY(0%);
+        }
+        75% {
+          transform: translateY(0%);
+        }
+        100% {
+          transform: translateY(100%);
+        }
+      }
+
+      animation-name: toast-up-down;
+      animation-delay: 0.3s;
+      animation-duration: 7s;
+      animation-timing-function: ease-in-out;
+      animation-fill-mode: forwards;
+
+      &:hover {
+        animation-play-state: paused;
+      }
+    }
+    :not(:first-child) {
+      display: none;
+    }
+  }
+}
+
+.PropertiesMap.is-hidden {
+  display: none !important;
 }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -60,7 +60,6 @@
   }
 
   .PropertiesMap__legend {
-    width: 180px;
     background: #fff;
     position: absolute;
     z-index: 10;
@@ -69,12 +68,13 @@
     border-left: 1px solid #000;
     border-top: 1px solid #000;
     font-size: 13px;
+    padding: 1.6rem;
 
     p {
       font-size: 1.4rem;
       line-height: 100%;
       text-align: center;
-      padding: 1rem;
+      padding: 0 0 2rem 0;
       margin: 0;
 
       span {
@@ -95,8 +95,8 @@
     .legend-entry-container {
       display: flex;
       flex-direction: column;
-      gap: 0.5rem;
-      padding: 0.6rem;
+      gap: 1rem;
+      padding: 0;
 
       div {
         display: flex;
@@ -133,9 +133,14 @@
       width: 100%;
       border-right: 1px solid #000;
       gap: 1.5rem;
+      padding: 0;
 
       transform: translateY(calc(100% - 4.8rem));
       transition: transform 250ms ease-in-out;
+
+      &.PropertiesMap__legend--slide {
+        transform: translateY(1px);
+      }
 
       p {
         padding: 1.7rem;
@@ -146,17 +151,7 @@
       }
 
       .legend-entry-container {
-        align-items: center;
-      }
-
-      &.PropertiesMap__legend--slide {
-        transform: translateY(1px);
-        p {
-          padding: 0.6rem 1.2rem 0 1.2rem;
-        }
-        .legend-entry-container {
-          padding: 0.6rem 1.2rem;
-        }
+        padding: 0 1rem 1rem 1rem;
       }
     }
   }
@@ -194,7 +189,6 @@
 
       .PropertiesMap__legend {
         margin: 0 1rem 2.9rem 0;
-        width: unset;
       }
     }
   }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -127,10 +127,8 @@
           border: 1px solid #111;
         }
 
-        &.addr-search {
-          &:before {
-            background-color: $search-marker;
-          }
+        &.addr-search:before {
+          background-color: $search-marker;
         }
 
         &.addr-assoc:before {
@@ -138,8 +136,7 @@
         }
 
         &.addr-filter:before {
-          background-color: $justfix-grey-50;
-          border: 2px solid $justfix-blue;
+          background-color: $justfix-blue;
         }
       }
     }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -110,7 +110,7 @@
           width: 16px;
           border-radius: 16px;
           position: relative;
-          margin-right: 0.9rem;
+          margin-right: 0.5rem;
           background-color: black;
           border: 1px solid #111;
         }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -68,15 +68,14 @@
     bottom: 0;
     border-left: 1px solid #000;
     border-top: 1px solid #000;
-    padding: 1.2rem 0.5rem 0 0.5rem;
     font-size: 13px;
 
     p {
       font-size: 1.4rem;
       line-height: 100%;
-
       text-align: center;
-      margin-bottom: 1rem;
+      padding: 1rem;
+      margin: 0;
 
       span {
         text-transform: uppercase;
@@ -97,7 +96,7 @@
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
-      padding: 0 1rem;
+      padding: 0.6rem;
 
       div {
         display: flex;
@@ -107,9 +106,9 @@
           content: "";
           display: inline-block;
           flex: none;
-          height: 11px;
-          width: 11px;
-          border-radius: 11px;
+          height: 19px;
+          width: 19px;
+          border-radius: 29px;
           position: relative;
           margin-right: 0.9rem;
           background-color: black;
@@ -133,19 +132,31 @@
     @include for-phone-only() {
       width: 100%;
       border-right: 1px solid #000;
-      padding: 1.2rem 0.5rem 1rem 0.5rem;
       gap: 1.5rem;
 
-      transform: translateY(calc(100% - 3.5rem));
+      transform: translateY(calc(100% - 4.8rem));
       transition: transform 250ms ease-in-out;
+
+      p {
+        padding: 1.7rem;
+        span {
+          font-weight: 700;
+          text-decoration: underline;
+        }
+      }
+
+      .legend-entry-container {
+        align-items: center;
+      }
 
       &.PropertiesMap__legend--slide {
         transform: translateY(1px);
-      }
-
-      p span {
-        font-weight: 700;
-        text-decoration: underline;
+        p {
+          padding: 0.6rem 1.2rem 0 1.2rem;
+        }
+        .legend-entry-container {
+          padding: 0.6rem 1.2rem;
+        }
       }
     }
   }
@@ -160,6 +171,16 @@
       display: none !important;
     }
 
+    .selected-addr-alert {
+      text-transform: uppercase;
+      .selected-addr-alert__address {
+        font-size: 1.6rem;
+      }
+      a {
+        text-underline-position: under;
+      }
+    }
+
     @include for-phone-only() {
       .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
         bottom: 90px;
@@ -167,31 +188,13 @@
     }
 
     @include for-tablet-portrait-up() {
-      .selected-addr-alert {
-        text-transform: uppercase;
-        .selected-addr-alert__address {
-          font-size: 1.6rem;
-        }
-        a {
-          text-underline-position: under;
-        }
-      }
       .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
         bottom: 0;
       }
 
       .PropertiesMap__legend {
-        padding: 1.6rem;
         margin: 0 1rem 2.9rem 0;
-        width: 22.5rem;
-
-        p {
-          margin-bottom: 2rem;
-        }
-        .legend-entry-container div::before {
-          height: 16.5px;
-          width: 16.5px;
-        }
+        width: unset;
       }
     }
   }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -167,7 +167,14 @@
     }
 
     .selected-addr-alert {
+      width: 36.4rem;
       text-transform: uppercase;
+      .jf-alert__content {
+        p,
+        a {
+          color: $justfix-black;
+        }
+      }
       .selected-addr-alert__address {
         font-size: 1.6rem;
       }
@@ -177,6 +184,9 @@
     }
 
     @include for-phone-only() {
+      .selected-addr-alert {
+        width: 100%;
+      }
       .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
         bottom: 90px;
       }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -106,9 +106,9 @@
           content: "";
           display: inline-block;
           flex: none;
-          height: 19px;
-          width: 19px;
-          border-radius: 29px;
+          height: 16px;
+          width: 16px;
+          border-radius: 16px;
           position: relative;
           margin-right: 0.9rem;
           background-color: black;

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -13,6 +13,24 @@
   position: relative;
   z-index: 5;
 
+  // overrides spacing/sizing rules for MapBox attribution control
+  @include for-tablet-portrait-up() {
+    .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
+      bottom: 112px;
+    }
+  }
+  // slide up/down in sync with legend on mobile
+  @include for-phone-only() {
+    .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
+      bottom: 98px;
+      transform: translateY(5.2rem); // height of hidden part of legend
+      transition: transform 250ms ease-in-out;
+    }
+    &:has(.PropertiesMap__legend--slide) .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
+      transform: translateY(0px);
+    }
+  }
+
   .mapboxgl-map {
     height: 100%;
     width: 100%;
@@ -20,15 +38,6 @@
 
     canvas {
       display: block;
-    }
-
-    // overrides spacing/sizing rules for MapBox attribution control
-    .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
-      bottom: 115px;
-
-      @include for-phone-only() {
-        bottom: 60px;
-      }
     }
 
     .MapAlert__container {
@@ -67,7 +76,6 @@
     bottom: 0;
     border-left: 1px solid #000;
     border-top: 1px solid #000;
-    font-size: 13px;
     padding: 1.6rem;
 
     p {
@@ -101,6 +109,8 @@
       div {
         display: flex;
         align-items: center;
+        font-size: 1.2rem;
+        line-height: 100%;
 
         &:before {
           content: "";
@@ -172,6 +182,9 @@
       }
       .selected-addr-alert {
         width: 36.4rem;
+        @include for-phone-only() {
+          width: 100%;
+        }
         text-transform: uppercase;
         .jf-alert__content {
           p,
@@ -185,15 +198,6 @@
         a {
           text-underline-position: under;
         }
-      }
-    }
-
-    @include for-phone-only() {
-      .selected-addr-alert {
-        width: 100%;
-      }
-      .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
-        bottom: 90px;
       }
     }
 

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -166,20 +166,25 @@
       display: none !important;
     }
 
-    .selected-addr-alert {
-      width: 36.4rem;
-      text-transform: uppercase;
-      .jf-alert__content {
-        p,
-        a {
-          color: $justfix-black;
+    .MapAlert__container {
+      @include for-tablet-portrait-up() {
+        width: fit-content;
+      }
+      .selected-addr-alert {
+        width: 36.4rem;
+        text-transform: uppercase;
+        .jf-alert__content {
+          p,
+          a {
+            color: $justfix-black;
+          }
         }
-      }
-      .selected-addr-alert__address {
-        font-size: 1.6rem;
-      }
-      a {
-        text-underline-position: under;
+        .selected-addr-alert__address {
+          font-size: 1.6rem;
+        }
+        a {
+          text-underline-position: under;
+        }
       }
     }
 

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -28,15 +28,6 @@
 
       @include for-phone-only() {
         bottom: 60px;
-
-        .mapboxgl-ctrl-attrib.mapboxgl-compact {
-          margin: 0 5px 10px 10px;
-
-          &:after {
-            width: 20px;
-            height: 20px;
-          }
-        }
       }
     }
 
@@ -104,11 +95,9 @@
 
     .legend-entry-container {
       display: flex;
+      flex-direction: column;
       gap: 0.5rem;
-
-      @include for-tablet-portrait-up() {
-        flex-direction: column;
-      }
+      padding: 0 1rem;
 
       div {
         display: flex;
@@ -147,7 +136,7 @@
       padding: 1.2rem 0.5rem 1rem 0.5rem;
       gap: 1.5rem;
 
-      transform: translateY(28px);
+      transform: translateY(calc(100% - 3.5rem));
       transition: transform 250ms ease-in-out;
 
       &.PropertiesMap__legend--slide {
@@ -171,7 +160,22 @@
       display: none !important;
     }
 
+    @include for-phone-only() {
+      .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
+        bottom: 90px;
+      }
+    }
+
     @include for-tablet-portrait-up() {
+      .selected-addr-alert {
+        text-transform: uppercase;
+        .selected-addr-alert__address {
+          font-size: 1.6rem;
+        }
+        a {
+          text-underline-position: under;
+        }
+      }
       .mapboxgl-control-container > .mapboxgl-ctrl-bottom-right {
         bottom: 0;
       }

--- a/client/src/styles/_alert.scss
+++ b/client/src/styles/_alert.scss
@@ -75,12 +75,14 @@
     background-color: $justfix-green;
   }
   &.is-info {
-    border: 0.1rem solid $justfix-grey-400;
-    &,
-    p,
-    a,
-    .button.is-text {
-      color: $justfix-grey-600;
+    &.is-secondary {
+      border: 0.1rem solid $justfix-grey-400;
+      &,
+      p,
+      a,
+      .button.is-text {
+        color: $justfix-grey-600;
+      }
     }
     &::before {
       background-color: $justfix-blue;

--- a/client/src/styles/_minmaxselect.scss
+++ b/client/src/styles/_minmaxselect.scss
@@ -133,8 +133,9 @@
       }
     }
   }
-  .button.is-primary {
+  button.button.is-primary {
     align-self: center;
+    width: 100%;
     letter-spacing: 0.02em;
   }
 }

--- a/client/src/styles/_minmaxselect.scss
+++ b/client/src/styles/_minmaxselect.scss
@@ -13,7 +13,8 @@
   }
   .minmaxselect__presets-container {
     display: grid;
-    grid-template-columns: 7rem 7rem 7rem;
+    width: 100%;
+    grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: 4rem 4rem;
     gap: 0.1rem;
     .minmaxselect__preset-value {

--- a/client/src/styles/_multiselect.scss
+++ b/client/src/styles/_multiselect.scss
@@ -1,6 +1,7 @@
 @import "_vars";
 @import "_typography";
 @import "_button.scss";
+@import "_scrollbar.scss";
 
 .multiselect-container {
   display: flex;
@@ -129,6 +130,10 @@
 
     .multiselect__menu-list {
       max-height: 25rem;
+      @include for-tablet-portrait-up() {
+        @include scrollbar_wowza(inherit, 0.8rem, $justfix-grey-50);
+      }
+
       .multiselect__option {
         background-color: unset;
         display: flex;

--- a/client/src/styles/_multiselect.scss
+++ b/client/src/styles/_multiselect.scss
@@ -167,8 +167,9 @@
       }
     }
   }
-  .button.is-primary {
+  button.button.is-primary {
     align-self: center;
+    width: 100%;
     letter-spacing: 0.02em;
   }
 }

--- a/client/src/styles/_scrollbar.scss
+++ b/client/src/styles/_scrollbar.scss
@@ -51,3 +51,22 @@ $scroll-body: darken($background, 15%);
       inset 2px 2px 0px 0px lighten($scroll-body, 10%);
   }
 }
+
+@mixin scrollbar_wowza($track-radius: inherit, $thumb-radius: inherit, $bg-color: $justfix-white) {
+  -webkit-overflow-scrolling: touch;
+  &::-webkit-scrollbar {
+    border-radius: $track-radius;
+    background-color: $bg-color;
+    width: 1.8rem;
+  }
+  &::-webkit-scrollbar-track {
+    border-radius: $track-radius;
+    background-color: $bg-color;
+  }
+  &::-webkit-scrollbar-thumb {
+    border-radius: $thumb-radius;
+    background-color: $justfix-grey;
+    border: 3px solid rgba(0, 0, 0, 0);
+    background-clip: padding-box;
+  }
+}

--- a/client/src/styles/_tabs.scss
+++ b/client/src/styles/_tabs.scss
@@ -80,9 +80,8 @@
       height: 26px;
       max-width: 105px;
 
-      background: #ffffff
-        url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAHElEQVQYV2NMS0v7P2vWLEYGKIAzMARgKjFUAABWhQgF0A6r6AAAAABJRU5ErkJggg==)
-        repeat;
+      color: $justfix-grey-600;
+      background-color: $justfix-white;
 
       border: 1px solid $gray-dark;
       border-bottom: none;
@@ -128,7 +127,9 @@
         height: 27px;
         top: 1px;
         border-color: $dark;
-        background: #fff;
+        color: $justfix-black;
+        font-weight: 700;
+        background-color: $justfix-white;
         z-index: 3;
 
         &:before,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # This only contains dependencies for running the API
 # server. For all other dependencies, see requirements-dev.txt.
 psycopg2==2.8.6
-django==3.2.16
+django==3.2.19
 rollbar==0.14.5
 dj-database-url==0.5.0
 gunicorn==19.9.0


### PR DESCRIPTION
This PR continues our work on WOW for Collective Action adding filters to the portfolio tab - first the filter UI and updated table were added in #709, and this adds the map view.

We adapt the existing PropertiesMap component used on the Overview tab to be used on both tabs, adding a new prop to indicate the version to use. There are different point styles, a new selected building info alert, and logic for filtering the list of addresses based on the selected filters (passed through the same ContextProvider as we used for the portfolio Table view). 

Each MapBox map load is fairly expensive, so we try to only load it when necessary (the tab is in view), and also prevent multiple loads. In the WOW AddressPage component, where all of the contents of the tabs (overview, portfolio, etc) is included, we now keep track of when the overview is active to prevent the MapBox load before the tab is in view. We do the same thing within the portfolio tab's PropertiesList component and also use display:none to toggle map/table view to prevent extra map loads.

For the filters context we add a `viewType` (map/table), and move some of the hooks for updating the filter options/selections react context from the table component to the filters component. In the filters bar we also add a map/table view toggle. In the filters component file we add a function for filtering a list addresses based on filter selections, and this is used in the map component. 

We also decided to make a few changes not directly tied to the portfolio map (sorry these are all bundled in this big PR!):
* the order of the tabs on the address page - to put Portfolio second - so there is some rearranging on the AddressPage component
* one of the sample portfolios on the homepage was removed (kushner/westminster) because it has been absorbed into a large network portfolio, so the info card isn't accurate and it doesn't serve as a good example anymore. 
* a few minor style changes to the filters ui to keep things more in line with design system rules
* the alerts for when RS & owner name filters are applied no longer appear within the body of the portfolio table, and just go in the filters bar

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/b193a870-4e65-4c28-84e4-83144701ec7e)
