### PR TITLE
last min QA fixes for map filters

### DIFF
--- a/client/src/styles/Modal.scss
+++ b/client/src/styles/Modal.scss
@@ -14,6 +14,7 @@
   .ReactModal__Content {
     transform: translate(-50%, -50%);
     min-width: 300px;
+    max-height: 90vh;
 
     h5 {
       margin-bottom: 1.5rem;

--- a/client/src/styles/Modal.scss
+++ b/client/src/styles/Modal.scss
@@ -14,7 +14,7 @@
   .ReactModal__Content {
     transform: translate(-50%, -50%);
     min-width: 300px;
-    max-height: 90vh;
+    max-height: 90%;
 
     h5 {
       margin-bottom: 1.5rem;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -125,6 +125,7 @@
             box-sizing: border-box;
             border: none;
             border-bottom: 0.1rem solid $justfix-grey-400;
+            text-align: left;
           }
           &.active:not([open]):not(.filter-toggle):not(.filters-mobile-wrapper) {
             background-color: $justfix-table-grey;

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -23,6 +23,8 @@
 .PortfolioFilters {
   --filter-bar-row-gap: 1.2rem;
   --checkbox-height: 2.4rem;
+  // height based on filter toggle checkbox + border + padding
+  --filter-height: calc(var(--checkbox-height) + ((0.1rem + 1rem) * 2));
   display: flex;
   flex-wrap: wrap;
   padding: 1.4rem;
@@ -79,8 +81,8 @@
 
     .view-type-toggle-container {
       display: flex;
-      // height based on filter toggle checkbox plus padding
-      height: calc(var(--checkbox-height) + 1rem * 2);
+      // adjust for border difference with filters
+      height: calc(var(--filter-height) + (0.1rem * 2));
       .view-type-toggle {
         display: flex;
         align-items: center;
@@ -193,8 +195,7 @@
         position: relative;
 
         summary:not(.minmaxselect__custom-range-summary) {
-          // height based on toggle toggle checkbox plus 1rem padding
-          height: calc(var(--checkbox-height) + 1rem * 2);
+          height: var(--filter-height);
           padding: 0 1rem 0 1rem;
           display: flex;
           align-items: center;


### PR DESCRIPTION
After having the spanish translations added, I did a final QA pass and noticed a few minor issues. 

- The landlord info modal overflows the page. So I've just added a max height, so it will scroll if necessary. 
  - before // after
  - ![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/bcf5244a-39c3-4dda-a90d-9f8a37d9b488)
- The RS filter toggle text alignment is off when it wraps to a second line
  - before // after
  - ![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/571b60c4-aecf-466f-943f-1674818adfed)
- The map/table view toggle is a couple pixels smaller than the filter bars