### PR TITLE
change detail page streetview to static image

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -183,6 +183,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
 
   render() {
     const isMobile = Browser.isMobile();
+    const screenSize = Browser.getScreenSize();
     const { i18n } = this.props;
     const locale = (i18n.language as SupportedLocale) || defaultLocale;
     const { useNewPortfolioMethod, portfolioData } = this.props.state.context;
@@ -229,7 +230,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
             <a href={`https://www.google.com/maps/place/${streetViewAddr}`} target="blank">
               <img
                 src={`https://maps.googleapis.com/maps/api/streetview?size=${
-                  isMobile ? "800x200" : "800x500"
+                  screenSize.width < 900 ? "800x300" : "800x500"
                 }&location=${streetViewCoords.lat},${streetViewCoords.lng}&key=${
                   process.env.REACT_APP_STREETVIEW_API_KEY
                 }`}

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -22,6 +22,7 @@ import _groupBy from "lodash/groupBy";
 import { HpdContactAddress, HpdFullContact } from "./APIDataTypes";
 import { isLegacyPath } from "./WowzaToggle";
 import { logAmplitudeEvent } from "./Amplitude";
+import { StreetViewStatic } from "./StreetView";
 
 type Props = withI18nProps &
   withMachineInStateProps<"portfolioFound"> & {
@@ -183,7 +184,6 @@ class DetailViewWithoutI18n extends Component<Props, State> {
 
   render() {
     const isMobile = Browser.isMobile();
-    const screenSize = Browser.getScreenSize();
     const { i18n } = this.props;
     const locale = (i18n.language as SupportedLocale) || defaultLocale;
     const { useNewPortfolioMethod, portfolioData } = this.props.state.context;
@@ -227,17 +227,12 @@ class DetailViewWithoutI18n extends Component<Props, State> {
       streetViewAddr && streetViewCoords ? (
         <LazyLoadWhenVisible>
           <figure className="figure">
-            <a href={`https://www.google.com/maps/place/${streetViewAddr}`} target="blank">
-              <img
-                src={`https://maps.googleapis.com/maps/api/streetview?size=${
-                  screenSize.width < 900 ? "800x300" : "800x500"
-                }&location=${streetViewCoords.lat},${streetViewCoords.lng}&key=${
-                  process.env.REACT_APP_STREETVIEW_API_KEY
-                }`}
-                alt="Google Street View"
-                className="img-responsive"
-              />
-            </a>
+            <StreetViewStatic
+              lat={streetViewCoords.lat}
+              lng={streetViewCoords.lng}
+              imgHeight={(width, _height) => ((width || 0) < 900 ? 200 : 400)}
+              imgWidth={(width, _height) => ((width || 0) < 900 ? 500 : 600)}
+            />
             <figcaption className="figure-caption">
               <a href={`https://www.google.com/maps/place/${streetViewAddr}`} target="blank">
                 <Trans>View on Google Maps</Trans>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import { CSSTransition } from "react-transition-group";
-import { StreetView } from "./StreetView";
 import { LazyLoadWhenVisible } from "./LazyLoadWhenVisible";
 import Helpers, { longDateOptions } from "../util/helpers";
 import Browser from "../util/browser";
@@ -190,7 +189,12 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const { assocAddrs, detailAddr, searchAddr } = portfolioData;
 
     // Let's save some variables that will be helpful in rendering the front-end component
-    let takeActionURL, formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
+    let takeActionURL,
+      formattedRegEndDate,
+      streetViewCoords,
+      streetViewAddr,
+      ownernames,
+      userOwnernames;
 
     takeActionURL = Helpers.createTakeActionURL(detailAddr, "detail_view");
 
@@ -200,7 +204,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
       locale
     );
 
-    streetViewAddr =
+    streetViewCoords =
       detailAddr.lat && detailAddr.lng
         ? {
             lat: detailAddr.lat,
@@ -208,19 +212,41 @@ class DetailViewWithoutI18n extends Component<Props, State> {
           }
         : null;
 
+    streetViewAddr = encodeURIComponent(
+      `${detailAddr.housenumber} ${detailAddr.streetname}, ${detailAddr.boro}, NY ${detailAddr.zip}`
+    );
+
     if (detailAddr.ownernames && detailAddr.ownernames.length)
       ownernames = Helpers.uniq(detailAddr.ownernames);
 
     if (searchAddr.ownernames && searchAddr.ownernames.length)
       userOwnernames = Helpers.uniq(searchAddr.ownernames);
 
-    const streetView = streetViewAddr ? (
-      <LazyLoadWhenVisible>
-        <StreetView addr={streetViewAddr} />
-      </LazyLoadWhenVisible>
-    ) : (
-      <></>
-    );
+    const streetView =
+      streetViewAddr && streetViewCoords ? (
+        <LazyLoadWhenVisible>
+          <figure className="figure">
+            <a href={`https://www.google.com/maps/place/${streetViewAddr}`}>
+              <img
+                src={`https://maps.googleapis.com/maps/api/streetview?size=${
+                  isMobile ? "800x200" : "800x500"
+                }&location=${streetViewCoords.lat},${streetViewCoords.lng}&key=${
+                  process.env.REACT_APP_STREETVIEW_API_KEY
+                }`}
+                alt="Google Street View"
+                className="img-responsive"
+              />
+            </a>
+            <figcaption className="figure-caption">
+              <a href={`https://www.google.com/maps/place/${streetViewAddr}`} target="blank">
+                <Trans>View on Google Maps</Trans>
+              </a>
+            </figcaption>
+          </figure>
+        </LazyLoadWhenVisible>
+      ) : (
+        <></>
+      );
 
     return (
       <CSSTransition in={!isMobile || this.props.mobileShow} timeout={500} classNames="DetailView">

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -226,7 +226,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
       streetViewAddr && streetViewCoords ? (
         <LazyLoadWhenVisible>
           <figure className="figure">
-            <a href={`https://www.google.com/maps/place/${streetViewAddr}`}>
+            <a href={`https://www.google.com/maps/place/${streetViewAddr}`} target="blank">
               <img
                 src={`https://maps.googleapis.com/maps/api/streetview?size=${
                   isMobile ? "800x200" : "800x500"

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -19,6 +19,7 @@ import { PortfolioGraph } from "./PortfolioGraph";
 import { ComplaintsSummary } from "./ComplaintsSummary";
 import { BigPortfolioAlert } from "./PortfolioAlerts";
 import { LazyLoadWhenVisible } from "./LazyLoadWhenVisible";
+import { StreetViewStatic } from "./StreetView";
 
 type Props = withMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
@@ -138,9 +139,11 @@ export default class PropertiesSummary extends Component<Props, {}> {
               <aside>
                 {agg.violationsaddr.lat && agg.violationsaddr.lng && (
                   <figure className="figure">
-                    <img
-                      src={`https://maps.googleapis.com/maps/api/streetview?size=800x500&location=${agg.violationsaddr.lat},${agg.violationsaddr.lng}&key=${process.env.REACT_APP_STREETVIEW_API_KEY}`}
-                      alt="Google Street View"
+                    <StreetViewStatic
+                      lat={agg.violationsaddr.lat}
+                      lng={agg.violationsaddr.lng}
+                      imgHeight={() => 800}
+                      imgWidth={() => 500}
                       className="img-responsive"
                     />
                     <figcaption className="figure-caption text-center text-italic">

--- a/client/src/components/StreetView.tsx
+++ b/client/src/components/StreetView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { withGoogleMap, StreetViewPanorama } from "react-google-maps";
 import Browser from "../util/browser";
+import Helpers from "../util/helpers";
 
 export type StreetViewAddr = {
   lat: number;
@@ -121,3 +122,32 @@ export class StreetView extends React.Component<StreetViewProps, State> {
     );
   }
 }
+
+export const StreetViewStatic = ({
+  lat,
+  lng,
+  imgHeight,
+  imgWidth,
+}: {
+  lat: number;
+  lng: number;
+  imgHeight: (screenWidth?: number, screenHeight?: number) => number;
+  imgWidth: (screenWidth?: number, screenHeight?: number) => number;
+}) => {
+  const { width: screenWidth, height: screenHeight } = Helpers.useWindowSize();
+
+  const [imgSize, setImgSize] = React.useState(
+    `${imgWidth(screenWidth, screenHeight)}x${imgHeight(screenWidth, screenHeight)}`
+  );
+
+  React.useEffect(() => {
+    setImgSize(`${imgWidth(screenWidth, screenHeight)}x${imgHeight(screenWidth, screenHeight)}`);
+  }, [imgHeight, imgWidth, screenWidth, screenHeight]);
+
+  return (
+    <img
+      src={`https://maps.googleapis.com/maps/api/streetview?size=${imgSize}&location=${lat},${lng}&key=${process.env.REACT_APP_STREETVIEW_API_KEY}`}
+      alt="Google Street View"
+    />
+  );
+};

--- a/client/src/components/StreetView.tsx
+++ b/client/src/components/StreetView.tsx
@@ -123,31 +123,32 @@ export class StreetView extends React.Component<StreetViewProps, State> {
   }
 }
 
-export const StreetViewStatic = ({
-  lat,
-  lng,
-  imgHeight,
-  imgWidth,
-}: {
+export interface StreetViewStaticProps extends React.ComponentPropsWithoutRef<"img"> {
   lat: number;
   lng: number;
   imgHeight: (screenWidth?: number, screenHeight?: number) => number;
   imgWidth: (screenWidth?: number, screenHeight?: number) => number;
-}) => {
-  const { width: screenWidth, height: screenHeight } = Helpers.useWindowSize();
+}
 
-  const [imgSize, setImgSize] = React.useState(
-    `${imgWidth(screenWidth, screenHeight)}x${imgHeight(screenWidth, screenHeight)}`
-  );
+export const StreetViewStatic = React.forwardRef<HTMLImageElement, StreetViewStaticProps>(
+  ({ lat, lng, imgHeight, imgWidth, ...props }, ref) => {
+    const { width: screenWidth, height: screenHeight } = Helpers.useWindowSize();
 
-  React.useEffect(() => {
-    setImgSize(`${imgWidth(screenWidth, screenHeight)}x${imgHeight(screenWidth, screenHeight)}`);
-  }, [imgHeight, imgWidth, screenWidth, screenHeight]);
+    const [imgSize, setImgSize] = React.useState(
+      `${imgWidth(screenWidth, screenHeight)}x${imgHeight(screenWidth, screenHeight)}`
+    );
 
-  return (
-    <img
-      src={`https://maps.googleapis.com/maps/api/streetview?size=${imgSize}&location=${lat},${lng}&key=${process.env.REACT_APP_STREETVIEW_API_KEY}`}
-      alt="Google Street View"
-    />
-  );
-};
+    React.useEffect(() => {
+      setImgSize(`${imgWidth(screenWidth, screenHeight)}x${imgHeight(screenWidth, screenHeight)}`);
+    }, [imgHeight, imgWidth, screenWidth, screenHeight]);
+
+    return (
+      <img
+        ref={ref}
+        src={`https://maps.googleapis.com/maps/api/streetview?size=${imgSize}&location=${lat},${lng}&key=${process.env.REACT_APP_STREETVIEW_API_KEY}`}
+        alt="Google Street View"
+        {...props}
+      />
+    );
+  }
+);

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -21,7 +21,7 @@ msgstr ""
 #~ msgid "\"Select\""
 #~ msgstr "\"Select\""
 
-#: src/components/PropertiesSummary.tsx:144
+#: src/components/PropertiesSummary.tsx:145
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#WhoOwnsWhat via @JustFixNYC"
 
@@ -29,16 +29,16 @@ msgstr "#WhoOwnsWhat via @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
-#: src/components/DetailView.tsx:258
+#: src/components/DetailView.tsx:256
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:240
+#: src/components/DetailView.tsx:238
 #: src/containers/NotRegisteredPage.tsx:103
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:243
+#: src/components/DetailView.tsx:241
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -104,11 +104,11 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 
-#: src/components/PropertiesSummary.tsx:76
+#: src/components/PropertiesSummary.tsx:77
 msgid "Across owners and management staff, the most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "Across owners and management staff, the most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
-#: src/components/PropertiesSummary.tsx:130
+#: src/components/PropertiesSummary.tsx:131
 msgid "Additional links"
 msgstr "Additional links"
 
@@ -151,7 +151,7 @@ msgstr "Apply"
 msgid "Apply selections and get results"
 msgstr "Apply selections and get results"
 
-#: src/components/DetailView.tsx:271
+#: src/components/DetailView.tsx:269
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -167,7 +167,7 @@ msgstr "Associated names/entities: {0}"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:162
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -193,7 +193,7 @@ msgstr "Building Permits Applied For"
 msgid "Building Size"
 msgstr "Building Size"
 
-#: src/components/PropertiesSummary.tsx:101
+#: src/components/PropertiesSummary.tsx:102
 msgid "Building info"
 msgstr "Building info"
 
@@ -209,14 +209,14 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:330
-#: src/components/DetailView.tsx:339
+#: src/components/DetailView.tsx:328
+#: src/components/DetailView.tsx:337
 #: src/components/PortfolioGraph.tsx:129
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:310
-#: src/components/DetailView.tsx:319
+#: src/components/DetailView.tsx:308
+#: src/components/DetailView.tsx:317
 msgid "Business Entities"
 msgstr "Business Entities"
 
@@ -435,7 +435,7 @@ msgstr "Eviction Filings"
 msgid "Eviction cases filed in Housing Court since 2017. This data comes from the Office of Court Administration via the Housing Data Coalition."
 msgstr "Eviction cases filed in Housing Court since 2017. This data comes from the Office of Court Administration via the Housing Data Coalition."
 
-#: src/components/PropertiesSummary.tsx:123
+#: src/components/PropertiesSummary.tsx:124
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
 msgstr "Evictions"
@@ -591,7 +591,7 @@ msgstr "I just looked up this building on Who Owns What, a free tool built by Ju
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
-#: src/components/PropertiesSummary.tsx:146
+#: src/components/PropertiesSummary.tsx:147
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
@@ -696,12 +696,12 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:235
+#: src/components/DetailView.tsx:233
 #: src/containers/NotRegisteredPage.tsx:98
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:248
+#: src/components/DetailView.tsx:246
 msgid "Last sold:"
 msgstr "Last sold:"
 
@@ -756,7 +756,7 @@ msgstr "Location"
 #~ msgid "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
 #~ msgstr "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
 
-#: src/components/PropertiesSummary.tsx:134
+#: src/components/PropertiesSummary.tsx:135
 msgid "Looking for more information?"
 msgstr "Looking for more information?"
 
@@ -841,7 +841,7 @@ msgstr "Min must be less than {maxOption}"
 msgid "More Mobile Friendly"
 msgstr "More Mobile Friendly"
 
-#: src/components/DetailView.tsx:192
+#: src/components/DetailView.tsx:190
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -869,7 +869,7 @@ msgstr "NYCHA Directory"
 msgid "Narrow down this portfolio using filters in <0>the Portfolio tab.</0>"
 msgstr "Narrow down this portfolio using filters in <0>the Portfolio tab.</0>"
 
-#: src/components/PropertiesSummary.tsx:68
+#: src/components/PropertiesSummary.tsx:69
 msgid "Network of Landlords"
 msgstr "Network of Landlords"
 
@@ -927,7 +927,7 @@ msgstr "Non-ECB"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:198
 msgid "None"
 msgstr "None"
 
@@ -1014,8 +1014,8 @@ msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural,
 msgid "Page"
 msgstr "Page"
 
-#: src/components/DetailView.tsx:350
-#: src/components/DetailView.tsx:360
+#: src/components/DetailView.tsx:348
+#: src/components/DetailView.tsx:358
 msgid "People"
 msgstr "People"
 
@@ -1077,7 +1077,7 @@ msgstr "Rent Stabilized Units"
 msgid "Rent Stabilized Units filter"
 msgstr "Rent Stabilized Units filter"
 
-#: src/components/PropertiesSummary.tsx:125
+#: src/components/PropertiesSummary.tsx:126
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
@@ -1147,7 +1147,7 @@ msgstr "See the most common complaints reported by tenants to 311, now on the Ov
 msgid "Select one or more ranges of building units, or set a custom range, then apply selections to filter the list of portfolio properties."
 msgstr "Select one or more ranges of building units, or set a custom range, then apply selections to filter the list of portfolio properties."
 
-#: src/components/PropertiesSummary.tsx:39
+#: src/components/PropertiesSummary.tsx:40
 msgid "Send us a data request"
 msgstr "Send us a data request"
 
@@ -1156,9 +1156,9 @@ msgstr "Send us a data request"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:280
+#: src/components/DetailView.tsx:278
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:140
+#: src/components/PropertiesSummary.tsx:141
 #: src/containers/App.tsx:146
 #: src/containers/NotRegisteredPage.tsx:18
 msgid "Share this page with your neighbors"
@@ -1277,7 +1277,7 @@ msgstr "TENANT HARASSMENT"
 msgid "Table"
 msgstr "Table"
 
-#: src/components/DetailView.tsx:274
+#: src/components/DetailView.tsx:272
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.org!"
 msgstr "Take action on JustFix.org!"
@@ -1323,7 +1323,7 @@ msgstr "The city borough where your search address is located"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 
-#: src/components/PropertiesSummary.tsx:82
+#: src/components/PropertiesSummary.tsx:83
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
@@ -1355,11 +1355,11 @@ msgstr "The same owner may have spelled their name several ways in official docu
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "The year that this building was originally constructed, according to the Dept. of City Planning."
 
-#: src/components/PropertiesSummary.tsx:114
+#: src/components/PropertiesSummary.tsx:115
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 
-#: src/components/PropertiesSummary.tsx:103
+#: src/components/PropertiesSummary.tsx:104
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
@@ -1395,11 +1395,11 @@ msgstr "This is the official identifer for the building according to the Dept. o
 msgid "This is the old version of Who Owns What. <0>Check out the new version here.</0>"
 msgstr "This is the old version of Who Owns What. <0>Check out the new version here.</0>"
 
-#: src/components/PropertiesSummary.tsx:143
+#: src/components/PropertiesSummary.tsx:144
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 
-#: src/components/PropertiesSummary.tsx:145
+#: src/components/PropertiesSummary.tsx:146
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "This landlord’s buildings average {0} open HPD violations per apartment"
 
@@ -1510,7 +1510,7 @@ msgstr "View Results"
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:186
+#: src/components/DetailView.tsx:184
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
@@ -1527,11 +1527,11 @@ msgstr "View documents on <0>ACRIS</0>"
 #~ msgid "View legend"
 #~ msgstr "View legend"
 
-#: src/components/DetailView.tsx:156
+#: src/components/DetailView.tsx:154
 msgid "View map"
 msgstr "View map"
 
-#: src/components/DetailView.tsx:145
+#: src/components/DetailView.tsx:143
 msgid "View on Google Maps"
 msgstr "View on Google Maps"
 
@@ -1569,7 +1569,7 @@ msgstr "WINDOWS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:227
+#: src/components/DetailView.tsx:225
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 
@@ -1661,7 +1661,7 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:207
+#: src/components/DetailView.tsx:205
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -1737,7 +1737,7 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:252
+#: src/components/DetailView.tsx:250
 msgid "for ${0}"
 msgstr "for ${0}"
 
@@ -1785,7 +1785,7 @@ msgstr "{0, plural, one {unit} other {units}}"
 msgid "{0} of {numberOfEntries}"
 msgstr "{0} of {numberOfEntries}"
 
-#: src/components/PropertiesSummary.tsx:92
+#: src/components/PropertiesSummary.tsx:93
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -29,16 +29,16 @@ msgstr "#WhoOwnsWhat via @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
-#: src/components/DetailView.tsx:248
+#: src/components/DetailView.tsx:258
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:230
+#: src/components/DetailView.tsx:240
 #: src/containers/NotRegisteredPage.tsx:103
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:233
+#: src/components/DetailView.tsx:243
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -151,7 +151,7 @@ msgstr "Apply"
 msgid "Apply selections and get results"
 msgstr "Apply selections and get results"
 
-#: src/components/DetailView.tsx:261
+#: src/components/DetailView.tsx:271
 msgid "Are you having issues in this building?"
 msgstr "Are you having issues in this building?"
 
@@ -167,7 +167,7 @@ msgstr "Associated names/entities: {0}"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:154
+#: src/components/DetailView.tsx:164
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -209,14 +209,14 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:320
-#: src/components/DetailView.tsx:329
+#: src/components/DetailView.tsx:330
+#: src/components/DetailView.tsx:339
 #: src/components/PortfolioGraph.tsx:129
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:300
-#: src/components/DetailView.tsx:309
+#: src/components/DetailView.tsx:310
+#: src/components/DetailView.tsx:319
 msgid "Business Entities"
 msgstr "Business Entities"
 
@@ -696,12 +696,12 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:225
+#: src/components/DetailView.tsx:235
 #: src/containers/NotRegisteredPage.tsx:98
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:238
+#: src/components/DetailView.tsx:248
 msgid "Last sold:"
 msgstr "Last sold:"
 
@@ -841,7 +841,7 @@ msgstr "Min must be less than {maxOption}"
 msgid "More Mobile Friendly"
 msgstr "More Mobile Friendly"
 
-#: src/components/DetailView.tsx:182
+#: src/components/DetailView.tsx:192
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -927,7 +927,7 @@ msgstr "Non-ECB"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:190
+#: src/components/DetailView.tsx:200
 msgid "None"
 msgstr "None"
 
@@ -1014,8 +1014,8 @@ msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural,
 msgid "Page"
 msgstr "Page"
 
-#: src/components/DetailView.tsx:340
 #: src/components/DetailView.tsx:350
+#: src/components/DetailView.tsx:360
 msgid "People"
 msgstr "People"
 
@@ -1156,7 +1156,7 @@ msgstr "Send us a data request"
 msgid "Share"
 msgstr "Share"
 
-#: src/components/DetailView.tsx:270
+#: src/components/DetailView.tsx:280
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:140
 #: src/containers/App.tsx:146
@@ -1277,7 +1277,7 @@ msgstr "TENANT HARASSMENT"
 msgid "Table"
 msgstr "Table"
 
-#: src/components/DetailView.tsx:264
+#: src/components/DetailView.tsx:274
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.org!"
 msgstr "Take action on JustFix.org!"
@@ -1510,7 +1510,7 @@ msgstr "View Results"
 msgid "View by:"
 msgstr "View by:"
 
-#: src/components/DetailView.tsx:176
+#: src/components/DetailView.tsx:186
 msgid "View data over time ↗︎"
 msgstr "View data over time ↗︎"
 
@@ -1527,9 +1527,13 @@ msgstr "View documents on <0>ACRIS</0>"
 #~ msgid "View legend"
 #~ msgstr "View legend"
 
-#: src/components/DetailView.tsx:146
+#: src/components/DetailView.tsx:156
 msgid "View map"
 msgstr "View map"
+
+#: src/components/DetailView.tsx:145
+msgid "View on Google Maps"
+msgstr "View on Google Maps"
 
 #: src/containers/HomePage.tsx:153
 #: src/containers/HomePage.tsx:182
@@ -1565,7 +1569,7 @@ msgstr "WINDOWS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:217
+#: src/components/DetailView.tsx:227
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 
@@ -1657,7 +1661,7 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:197
+#: src/components/DetailView.tsx:207
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -1733,7 +1737,7 @@ msgstr "and"
 msgid "associated building"
 msgstr "associated building"
 
-#: src/components/DetailView.tsx:242
+#: src/components/DetailView.tsx:252
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -34,16 +34,16 @@ msgstr "#QuiénEsElDueño por @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
-#: src/components/DetailView.tsx:248
+#: src/components/DetailView.tsx:258
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:230
+#: src/components/DetailView.tsx:240
 #: src/containers/NotRegisteredPage.tsx:103
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:233
+#: src/components/DetailView.tsx:243
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -156,7 +156,7 @@ msgstr "Aplique"
 msgid "Apply selections and get results"
 msgstr "Aplicar selecciones y obtener resultados"
 
-#: src/components/DetailView.tsx:261
+#: src/components/DetailView.tsx:271
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -172,7 +172,7 @@ msgstr "Nombres/entidades asociados: {0}"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:154
+#: src/components/DetailView.tsx:164
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -214,14 +214,14 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:320
-#: src/components/DetailView.tsx:329
+#: src/components/DetailView.tsx:330
+#: src/components/DetailView.tsx:339
 #: src/components/PortfolioGraph.tsx:129
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:300
-#: src/components/DetailView.tsx:309
+#: src/components/DetailView.tsx:310
+#: src/components/DetailView.tsx:319
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
@@ -701,12 +701,12 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:225
+#: src/components/DetailView.tsx:235
 #: src/containers/NotRegisteredPage.tsx:98
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:238
+#: src/components/DetailView.tsx:248
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
@@ -846,7 +846,7 @@ msgstr "Mín debe ser menor que {maxOption}"
 msgid "More Mobile Friendly"
 msgstr "Más útil para dispositivos móviles"
 
-#: src/components/DetailView.tsx:182
+#: src/components/DetailView.tsx:192
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -932,7 +932,7 @@ msgstr "No ECB"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:190
+#: src/components/DetailView.tsx:200
 msgid "None"
 msgstr "Ninguna"
 
@@ -1019,8 +1019,8 @@ msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada co
 msgid "Page"
 msgstr "Página"
 
-#: src/components/DetailView.tsx:340
 #: src/components/DetailView.tsx:350
+#: src/components/DetailView.tsx:360
 msgid "People"
 msgstr "Personas"
 
@@ -1161,7 +1161,7 @@ msgstr "Envíanos una solicitud de datos"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:270
+#: src/components/DetailView.tsx:280
 #: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:140
 #: src/containers/App.tsx:146
@@ -1282,7 +1282,7 @@ msgstr "ACOSO DE INQUILINO"
 msgid "Table"
 msgstr "Tabla"
 
-#: src/components/DetailView.tsx:264
+#: src/components/DetailView.tsx:274
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.org!"
 msgstr "¡Toma acción en JustFix.org!"
@@ -1515,7 +1515,7 @@ msgstr "Ver resultados"
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:176
+#: src/components/DetailView.tsx:186
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
@@ -1532,9 +1532,13 @@ msgstr "Ver documentos en <0>ACRIS</0>"
 #~ msgid "View legend"
 #~ msgstr "View legend"
 
-#: src/components/DetailView.tsx:146
+#: src/components/DetailView.tsx:156
 msgid "View map"
 msgstr "Ver mapa"
+
+#: src/components/DetailView.tsx:145
+msgid "View on Google Maps"
+msgstr ""
 
 #: src/containers/HomePage.tsx:153
 #: src/containers/HomePage.tsx:182
@@ -1570,7 +1574,7 @@ msgstr "VENTANAS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:217
+#: src/components/DetailView.tsx:227
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Aviso: Este edificio tiene un registro vencido y se vendió después del vencimiento del registro. La información del dueño que se incluye aquí puede estar desactualizada."
 
@@ -1662,7 +1666,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:197
+#: src/components/DetailView.tsx:207
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
@@ -1738,7 +1742,7 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:242
+#: src/components/DetailView.tsx:252
 msgid "for ${0}"
 msgstr "por ${0}"
 
@@ -1813,4 +1817,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:37
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2010} other {# Violaciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -26,7 +26,7 @@ msgstr ""
 #~ msgid "\"Select\""
 #~ msgstr "\"Select\""
 
-#: src/components/PropertiesSummary.tsx:144
+#: src/components/PropertiesSummary.tsx:145
 msgid "#WhoOwnsWhat via @JustFixNYC"
 msgstr "#QuiénEsElDueño por @JustFixNYC"
 
@@ -34,16 +34,16 @@ msgstr "#QuiénEsElDueño por @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
-#: src/components/DetailView.tsx:258
+#: src/components/DetailView.tsx:256
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:240
+#: src/components/DetailView.tsx:238
 #: src/containers/NotRegisteredPage.tsx:103
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:243
+#: src/components/DetailView.tsx:241
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -109,11 +109,11 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha recibido un total de <0>{totalviolations}</0> violaciones."
 
-#: src/components/PropertiesSummary.tsx:76
+#: src/components/PropertiesSummary.tsx:77
 msgid "Across owners and management staff, the most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "En todos los dueños y administradores, {0, plural, one {el nombre más común que aparece en esta cartera de edificios es} other {los nombres más comunes que aparecen en esta cartera de edificios son}} <0/>."
 
-#: src/components/PropertiesSummary.tsx:130
+#: src/components/PropertiesSummary.tsx:131
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
@@ -156,7 +156,7 @@ msgstr "Aplique"
 msgid "Apply selections and get results"
 msgstr "Aplicar selecciones y obtener resultados"
 
-#: src/components/DetailView.tsx:271
+#: src/components/DetailView.tsx:269
 msgid "Are you having issues in this building?"
 msgstr "¿Tienes problemas en este edificio?"
 
@@ -172,7 +172,7 @@ msgstr "Nombres/entidades asociados: {0}"
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:162
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -198,7 +198,7 @@ msgstr "Permisos de Construcción Solicitados"
 msgid "Building Size"
 msgstr "Tamaño del Edificio"
 
-#: src/components/PropertiesSummary.tsx:101
+#: src/components/PropertiesSummary.tsx:102
 msgid "Building info"
 msgstr "Información de edificios"
 
@@ -214,14 +214,14 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:330
-#: src/components/DetailView.tsx:339
+#: src/components/DetailView.tsx:328
+#: src/components/DetailView.tsx:337
 #: src/components/PortfolioGraph.tsx:129
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:310
-#: src/components/DetailView.tsx:319
+#: src/components/DetailView.tsx:308
+#: src/components/DetailView.tsx:317
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
@@ -440,7 +440,7 @@ msgstr "Demandas de desalojo"
 msgid "Eviction cases filed in Housing Court since 2017. This data comes from the Office of Court Administration via the Housing Data Coalition."
 msgstr "Casos de desalojo presentados en la Corte de Vivienda desde 2017. Estos datos proceden de la Oficina de Administración Judicial a través del la Coalición de Datos de Vivienda."
 
-#: src/components/PropertiesSummary.tsx:123
+#: src/components/PropertiesSummary.tsx:124
 #: src/containers/NychaPage.tsx:87
 msgid "Evictions"
 msgstr "Desalojos"
@@ -596,7 +596,7 @@ msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta grat
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
-#: src/components/PropertiesSummary.tsx:146
+#: src/components/PropertiesSummary.tsx:147
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
@@ -701,12 +701,12 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:235
+#: src/components/DetailView.tsx:233
 #: src/containers/NotRegisteredPage.tsx:98
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:248
+#: src/components/DetailView.tsx:246
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
@@ -761,7 +761,7 @@ msgstr "Ubicación"
 #~ msgid "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
 #~ msgstr "Look out for multiple spellings of the same person/entity. Names can be spelled multiple ways in official documents."
 
-#: src/components/PropertiesSummary.tsx:134
+#: src/components/PropertiesSummary.tsx:135
 msgid "Looking for more information?"
 msgstr "¿Buscas más información?"
 
@@ -846,7 +846,7 @@ msgstr "Mín debe ser menor que {maxOption}"
 msgid "More Mobile Friendly"
 msgstr "Más útil para dispositivos móviles"
 
-#: src/components/DetailView.tsx:192
+#: src/components/DetailView.tsx:190
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -874,7 +874,7 @@ msgstr "Directorio de NYCHA"
 msgid "Narrow down this portfolio using filters in <0>the Portfolio tab.</0>"
 msgstr "Restrinja esta cartera utilizando los filtros de la <0>pestaña Cartera.</0>"
 
-#: src/components/PropertiesSummary.tsx:68
+#: src/components/PropertiesSummary.tsx:69
 msgid "Network of Landlords"
 msgstr "Red de Dueños"
 
@@ -932,7 +932,7 @@ msgstr "No ECB"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:198
 msgid "None"
 msgstr "Ninguna"
 
@@ -1019,8 +1019,8 @@ msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada co
 msgid "Page"
 msgstr "Página"
 
-#: src/components/DetailView.tsx:350
-#: src/components/DetailView.tsx:360
+#: src/components/DetailView.tsx:348
+#: src/components/DetailView.tsx:358
 msgid "People"
 msgstr "Personas"
 
@@ -1082,7 +1082,7 @@ msgstr "Unidades con renta estabilizada"
 msgid "Rent Stabilized Units filter"
 msgstr "Filtro de Unidades con renta estabilizada"
 
-#: src/components/PropertiesSummary.tsx:125
+#: src/components/PropertiesSummary.tsx:126
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
@@ -1152,7 +1152,7 @@ msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en l
 msgid "Select one or more ranges of building units, or set a custom range, then apply selections to filter the list of portfolio properties."
 msgstr "Seleccione uno o varios rangos de unidades de edificios o establezca un rango personalizado y, a continuación, aplique las selecciones para filtrar la lista de propiedades de la cartera."
 
-#: src/components/PropertiesSummary.tsx:39
+#: src/components/PropertiesSummary.tsx:40
 msgid "Send us a data request"
 msgstr "Envíanos una solicitud de datos"
 
@@ -1161,9 +1161,9 @@ msgstr "Envíanos una solicitud de datos"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/components/DetailView.tsx:280
+#: src/components/DetailView.tsx:278
 #: src/components/EngagementPanel.tsx:18
-#: src/components/PropertiesSummary.tsx:140
+#: src/components/PropertiesSummary.tsx:141
 #: src/containers/App.tsx:146
 #: src/containers/NotRegisteredPage.tsx:18
 msgid "Share this page with your neighbors"
@@ -1282,7 +1282,7 @@ msgstr "ACOSO DE INQUILINO"
 msgid "Table"
 msgstr "Tabla"
 
-#: src/components/DetailView.tsx:274
+#: src/components/DetailView.tsx:272
 #: src/containers/NychaPage.tsx:179
 msgid "Take action on JustFix.org!"
 msgstr "¡Toma acción en JustFix.org!"
@@ -1328,7 +1328,7 @@ msgstr "El municipio donde se encuentra la dirección que has buscado"
 msgid "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example of a landlord who engages in <1>aggressive eviction strategies</1> to displace low-income tenants. Besides lack of repairs and frivolous evictions in housing court, A&E has also been known to use <2>MCIs</2> to <3>double rents</3> in rent-stabilized buildings."
 msgstr "A&E fue el quinto <0>\"peor desalojador\"</0> de la ciudad en el 2018, y es un excelente ejemplo de un propietario que participa en <1>estrategias agresivas de desalojo</1> para desplazar a inquilinos de bajos ingresos. Además de usar la falta de arreglos y los desalojos frívolos en la corte de viviendas, se sabe que A&E también utiliza los <2>IMCs</2> para <3>alquileres dobles</3> en edificios de resta estabilizada."
 
-#: src/components/PropertiesSummary.tsx:82
+#: src/components/PropertiesSummary.tsx:83
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
@@ -1360,11 +1360,11 @@ msgstr "El mismo dueño puede haber escrito su nombre de varias maneras en los d
 msgid "The year that this building was originally constructed, according to the Dept. of City Planning."
 msgstr "El año en que este edificio fue construido, según el Departamento de Planificación de la Ciudad."
 
-#: src/components/PropertiesSummary.tsx:114
+#: src/components/PropertiesSummary.tsx:115
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
-#: src/components/PropertiesSummary.tsx:103
+#: src/components/PropertiesSummary.tsx:104
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
@@ -1400,11 +1400,11 @@ msgstr "El identificador oficial del edificio según los registros del Departame
 msgid "This is the old version of Who Owns What. <0>Check out the new version here.</0>"
 msgstr "Esta es la versión antigua de ¿Quién es el Dueño en Nueva York? <0>Visite la nueva versión aquí.</0>"
 
-#: src/components/PropertiesSummary.tsx:143
+#: src/components/PropertiesSummary.tsx:144
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "Este dueño de edificio posee {0} edificios, y según @NYCHousing, ha recibido un total de {1} violaciones del código de vivienda. ¿Puedes adivinar como se llama el dueño? Encuentra su nombre y ve más estadísticas aquí:"
 
-#: src/components/PropertiesSummary.tsx:145
+#: src/components/PropertiesSummary.tsx:146
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "Los edificios de este dueño tienen un promedio de {0} violaciones abiertas de HPD por cada apartamento"
 
@@ -1515,7 +1515,7 @@ msgstr "Ver resultados"
 msgid "View by:"
 msgstr "Visualizar por:"
 
-#: src/components/DetailView.tsx:186
+#: src/components/DetailView.tsx:184
 msgid "View data over time ↗︎"
 msgstr "Ver datos a lo largo del tiempo ↗︎"
 
@@ -1532,11 +1532,11 @@ msgstr "Ver documentos en <0>ACRIS</0>"
 #~ msgid "View legend"
 #~ msgstr "View legend"
 
-#: src/components/DetailView.tsx:156
+#: src/components/DetailView.tsx:154
 msgid "View map"
 msgstr "Ver mapa"
 
-#: src/components/DetailView.tsx:145
+#: src/components/DetailView.tsx:143
 msgid "View on Google Maps"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr "VENTANAS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:227
+#: src/components/DetailView.tsx:225
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Aviso: Este edificio tiene un registro vencido y se vendió después del vencimiento del registro. La información del dueño que se incluye aquí puede estar desactualizada."
 
@@ -1666,7 +1666,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:207
+#: src/components/DetailView.tsx:205
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
@@ -1742,7 +1742,7 @@ msgstr "y"
 msgid "associated building"
 msgstr "edificio asociado"
 
-#: src/components/DetailView.tsx:252
+#: src/components/DetailView.tsx:250
 msgid "for ${0}"
 msgstr "por ${0}"
 
@@ -1790,7 +1790,7 @@ msgstr "{0, plural, one {unidad} other {unidades}}"
 msgid "{0} of {numberOfEntries}"
 msgstr "{0} de {numberOfEntries}"
 
-#: src/components/PropertiesSummary.tsx:92
+#: src/components/PropertiesSummary.tsx:93
 msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 msgstr "{0} {1}, {2} tiene {3, plural, one {una violación del HPD actual} other {# violaciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -162,7 +162,24 @@
 
     .card-image {
       padding-top: 0;
-      border-bottom: 1px solid $dark;
+      figure {
+        display: inline-block;
+        width: 100%;
+        height: 300px;
+        @include for-phone-only {
+          height: 180px;
+        }
+        img {
+          width: 100%;
+          height: 100%;
+        }
+      }
+      figcaption {
+        margin: 0;
+        @include for-phone-only {
+          padding-left: 13px;
+        }
+      }
     }
 
     .card-body {

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -123,7 +123,7 @@
     }
 
     .DetailView__mobilePortfolioView {
-      padding: 13px;
+      padding: 1.3rem 2rem;
 
       display: none;
       @include for-phone-only() {
@@ -141,6 +141,9 @@
 
     .card-header {
       padding-bottom: 1.5rem;
+      @include for-phone-only {
+        padding: 1.5rem 1rem;
+      }
 
       .card-title {
         margin-bottom: 0;
@@ -177,7 +180,7 @@
       figcaption {
         margin: 0;
         @include for-phone-only {
-          padding-left: 13px;
+          padding-left: 2rem;
         }
       }
     }

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -168,19 +168,20 @@
       figure {
         display: inline-block;
         width: 100%;
-        height: 300px;
+        max-height: 300px;
         @include for-phone-only {
-          height: 180px;
+          max-height: 180px;
         }
         img {
           width: 100%;
-          height: 100%;
-          object-fit: cover;
-          object-position: bottom;
+          height: auto;
         }
       }
       figcaption {
         margin: 0;
+        @include for-tablet-landscape-down {
+          padding-left: 2.5rem;
+        }
         @include for-phone-only {
           padding-left: 2rem;
         }

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -168,13 +168,14 @@
       figure {
         display: inline-block;
         width: 100%;
-        max-height: 300px;
-        @include for-phone-only {
-          max-height: 180px;
-        }
         img {
+          object-fit: cover;
+          object-position: bottom;
           width: 100%;
-          height: auto;
+          max-height: 300px;
+          @include for-tablet-landscape-down {
+            max-height: 180px;
+          }
         }
       }
       figcaption {
@@ -183,7 +184,8 @@
           padding-left: 2.5rem;
         }
         @include for-phone-only {
-          padding-left: 2rem;
+          padding-right: 2rem;
+          text-align: right;
         }
       }
     }

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -175,6 +175,8 @@
         img {
           width: 100%;
           height: 100%;
+          object-fit: cover;
+          object-position: bottom;
         }
       }
       figcaption {

--- a/client/src/util/browser.ts
+++ b/client/src/util/browser.ts
@@ -34,6 +34,26 @@ export default {
     return width <= 599;
   },
 
+  getScreenSize(): { width: number; height: number } {
+    let width = 0,
+      height = 0;
+    if (typeof window != "undefined") {
+      width =
+        window.innerWidth && document.documentElement.clientWidth
+          ? Math.min(window.innerWidth, document.documentElement.clientWidth)
+          : window.innerWidth ||
+            document.documentElement.clientWidth ||
+            document.getElementsByTagName("body")[0].clientWidth;
+      height =
+        window.innerHeight && document.documentElement.clientHeight
+          ? Math.min(window.innerHeight, document.documentElement.clientHeight)
+          : window.innerHeight ||
+            document.documentElement.clientHeight ||
+            document.getElementsByTagName("body")[0].clientHeight;
+    }
+    return { width, height };
+  },
+
   getMobileOperatingSystem(): string {
     var userAgent = navigator.userAgent || navigator.vendor;
 


### PR DESCRIPTION
The API for the dynamic google sreetview embed we use on the address page detail view is super expensive, and also the quality of the images has been declining (it's now common to be weird interiors of storefronts etc.). So we've decided to swap it with the way cheaper static streetview image we are already using on summary tab and have a link to google maps. 

[sc-11959]