### PR TITLE
User object not clearing on logout, Redirects from restricted pages

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -21,22 +21,22 @@ type VerifyEmailResponse = {
 let _user: JustfixUser | undefined;
 const user = () => _user;
 const fetchUser = async () => {
-  if (!_user) { 
+  if (!_user) {
     const authCheck = await userAuthenticated();
 
     if (!!authCheck) {
       const subscriptions =
-      authCheck["subscriptions"]?.map((s: any) => {
-        return { ...s };
-      }) || [];
+        authCheck["subscriptions"]?.map((s: any) => {
+          return { ...s };
+        }) || [];
       _user = {
         email: authCheck["email"],
         verified: authCheck["verified"],
         subscriptions,
       };
-    } else  {
+    } else {
       clearUser();
-    } 
+    }
   }
   return _user;
 };
@@ -214,7 +214,7 @@ const postAuthRequest = async (
 
   try {
     if (result.ok) {
-        return await result.json();
+      return await result.json();
     }
   } catch {
     return result;

--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -21,23 +21,27 @@ type VerifyEmailResponse = {
 let _user: JustfixUser | undefined;
 const user = () => _user;
 const fetchUser = async () => {
-  if (!_user) {
-    try {
-      const authCheck = await userAuthenticated();
+  if (!_user) { 
+    const authCheck = await userAuthenticated();
+
+    if (!!authCheck) {
       const subscriptions =
-        authCheck?.["subscriptions"]?.map((s: any) => {
-          return { ...s };
-        }) || [];
+      authCheck["subscriptions"]?.map((s: any) => {
+        return { ...s };
+      }) || [];
       _user = {
-        email: authCheck?.["email"],
-        verified: authCheck?.["verified"],
+        email: authCheck["email"],
+        verified: authCheck["verified"],
         subscriptions,
       };
-    } catch {}
+    } else  {
+      clearUser();
+    } 
   }
   return _user;
 };
 const setUser = (user: JustfixUser) => (_user = user);
+const clearUser = () => (_user = undefined);
 
 /**
  * Authenticates a user with the given email and password.
@@ -63,7 +67,7 @@ const login = async (username: string, password: string) => {
  */
 const logout = async () => {
   await postAuthRequest(`${BASE_URL}auth/logout`);
-  _user = undefined;
+  clearUser();
 };
 
 const resetPasswordRequest = async (username: string) => {
@@ -207,9 +211,11 @@ const postAuthRequest = async (
     },
     credentials: "include",
   });
+
   try {
-    const json = await result.json();
-    return json;
+    if (result.ok) {
+        return await result.json();
+    }
   } catch {
     return result;
   }

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -114,15 +114,12 @@ export const UserContextProvider = ({ children }: { children: React.ReactNode })
     []
   );
 
-  const logout = useCallback(
-    async (fromPath: string) => {
-      await AuthClient.logout();
-      if (authRequiredPaths().includes(fromPath)) {
-        document.location.href = `${window.location.origin}`;
-      }
-    },
-    []
-  )
+  const logout = useCallback(async (fromPath: string) => {
+    await AuthClient.logout();
+    if (authRequiredPaths().includes(fromPath)) {
+      document.location.href = `${window.location.origin}`;
+    }
+  }, []);
 
   const subscribe = useCallback(
     (

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useEffect, useMemo, useCallback } from "react";
 import { JustfixUser } from "state-machine";
 import AuthClient from "./AuthClient";
+import { authRequiredPaths } from "routes";
 
 export type UserContextProps = {
   user?: JustfixUser;
@@ -14,7 +15,7 @@ export type UserContextProps = {
     password: string,
     onSuccess?: (user: JustfixUser) => void
   ) => Promise<string | void>;
-  logout: () => void;
+  logout: (fromPath: string) => void;
   subscribe: (
     bbl: string,
     housenumber: string,
@@ -37,7 +38,7 @@ const initialState: UserContextProps = {
     onSuccess?: (user: JustfixUser) => void
   ) => {},
   login: async (username: string, password: string, onSuccess?: (user: JustfixUser) => void) => {},
-  logout: () => {},
+  logout: (fromPath: string) => {},
   subscribe: (
     bbl: string,
     housenumber: string,
@@ -113,13 +114,15 @@ export const UserContextProvider = ({ children }: { children: React.ReactNode })
     []
   );
 
-  const logout = useCallback(() => {
-    const asyncLogout = async () => {
+  const logout = useCallback(
+    async (fromPath: string) => {
       await AuthClient.logout();
-      setUser(undefined);
-    };
-    asyncLogout();
-  }, []);
+      if (authRequiredPaths().includes(fromPath)) {
+        document.location.href = `${window.location.origin}`;
+      }
+    },
+    []
+  )
 
   const subscribe = useCallback(
     (

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -205,7 +205,7 @@ const SearchLink = () => {
   );
 };
 
-const getAccountNavLinks = (handleLogout: () => void, isSignedIn?: boolean) => {
+const getAccountNavLinks = (handleLogout: (fromPath: string) => void, fromPath: string, isSignedIn?: boolean ) => {
   const { account } = createWhoOwnsWhatRoutePaths();
   const { settings, login } = account;
 
@@ -214,7 +214,7 @@ const getAccountNavLinks = (handleLogout: () => void, isSignedIn?: boolean) => {
         <LocaleNavLink to={settings} key="account-1">
           <Trans>Account settings</Trans>
         </LocaleNavLink>,
-        <button onClick={() => handleLogout()} key="account-2">
+        <button onClick={() => handleLogout(fromPath)} key="account-2">
           <Trans>Sign out</Trans>
         </button>,
       ]
@@ -281,7 +281,7 @@ const Navbar = () => {
             <Trans>Share</Trans>
           </a>
           <LocaleSwitcher />
-          {getAccountNavLinks(userContext.logout, !!userContext?.user?.email)}
+          {getAccountNavLinks(userContext.logout, pathname, !!userContext?.user?.email)}
         </span>
         <Dropdown>
           {getMainNavLinks(isLegacyPath(pathname)).map((link, i) => (
@@ -298,7 +298,7 @@ const Navbar = () => {
           <li className="menu-item">
             <LocaleSwitcherWithFullLanguageName />
           </li>
-          {getAccountNavLinks(userContext.logout, !!userContext?.user?.email).map((link, i) => (
+          {getAccountNavLinks(userContext.logout, pathname, !!userContext?.user?.email).map((link, i) => (
             <li className="menu-item" key={`account-${i}`}>
               {link}
             </li>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -205,7 +205,11 @@ const SearchLink = () => {
   );
 };
 
-const getAccountNavLinks = (handleLogout: (fromPath: string) => void, fromPath: string, isSignedIn?: boolean ) => {
+const getAccountNavLinks = (
+  handleLogout: (fromPath: string) => void,
+  fromPath: string,
+  isSignedIn?: boolean
+) => {
   const { account } = createWhoOwnsWhatRoutePaths();
   const { settings, login } = account;
 
@@ -298,11 +302,13 @@ const Navbar = () => {
           <li className="menu-item">
             <LocaleSwitcherWithFullLanguageName />
           </li>
-          {getAccountNavLinks(userContext.logout, pathname, !!userContext?.user?.email).map((link, i) => (
-            <li className="menu-item" key={`account-${i}`}>
-              {link}
-            </li>
-          ))}
+          {getAccountNavLinks(userContext.logout, pathname, !!userContext?.user?.email).map(
+            (link, i) => (
+              <li className="menu-item" key={`account-${i}`}>
+                {link}
+              </li>
+            )
+          )}
         </Dropdown>
       </nav>
       <Modal showModal={isEngageModalVisible} onClose={() => setEngageModalVisibility(false)}>

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -82,11 +82,11 @@ export const createAccountRoutePaths = (prefix?: string) => {
 };
 
 export const authRequiredPaths = () => {
-  const locales = ['en', 'es'];
+  const locales = ["en", "es"];
   let pathnames: string[] = [];
-  locales.forEach(locale => {
-    pathnames = pathnames.concat(Object.values(createAccountRoutePaths(`/${locale}/account`)))
-  })
+  locales.forEach((locale) => {
+    pathnames = pathnames.concat(Object.values(createAccountRoutePaths(`/${locale}/account`)));
+  });
   return pathnames;
 };
 

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -81,6 +81,15 @@ export const createAccountRoutePaths = (prefix?: string) => {
   };
 };
 
+export const authRequiredPaths = () => {
+  const locales = ['en', 'es'];
+  let pathnames: string[] = [];
+  locales.forEach(locale => {
+    pathnames = pathnames.concat(Object.values(createAccountRoutePaths(`/${locale}/account`)))
+  })
+  return pathnames;
+};
+
 export const createCoreRoutePaths = (prefix?: string) => {
   const pathPrefix = prefix || "";
   return {


### PR DESCRIPTION
* on logout, the user object was still being populated with undefined values in `email`, `verified` and empty `subscriptions`. turns out it's because of how the `postAuthRequest` was still returning a `response.json` even if the response was not 2xx. 
* redirects to home any time the user logs out from the nav bar while on pages that should require a login 

[sc-12766] [sc-12808]