### PR TITLE
add resize-observer-polyfill package

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -72,6 +72,7 @@
     "react-select": "^5.7.2",
     "react-social": "^1.10.0",
     "react-transition-group": "^2.2.1",
+    "resize-observer-polyfill": "^1.5.1",
     "rollbar": "^2.14.4",
     "sass": "^1.49.9",
     "spectre.scss": "0.0.2",

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,6 +4,7 @@ import "babel-polyfill";
 import React from "react";
 import ReactDOM from "react-dom";
 import Modal from "react-modal";
+import ResizeObserver from "resize-observer-polyfill";
 import App from "containers/App.tsx";
 import { getBrowserName } from "util/helpers";
 
@@ -12,6 +13,10 @@ import "styles/spectre.css";
 import "styles/index.css";
 
 document.documentElement.setAttribute("data-browser", getBrowserName(navigator.userAgent));
+
+if (!window.ResizeObserver) {
+  window.ResizeObserver = ResizeObserver;
+}
 
 const root = document.getElementById("root");
 Modal.setAppElement(root);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -13190,6 +13190,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
In #787, when we had problems with the portfolio tab map not adjusting when the container height changed, we introduced a new package to use ResizeObserver. It is apparently supported by ~95% of browsers, but in the few cases it's not supported we are getting errors that it's not defined.

A [github issues thread](https://github.com/recharts/recharts/issues/2491) on the package repo explains that there is an alternative (the library [`resize-observer-polyfill`](https://www.npmjs.com/package/resize-observer-polyfill)) that can be assigned to `window.ResizeObserver` to handle these cases.

I tested this out by just first setting `window.ResizeObserver = undefined`, confirming it breaks, then using the polyfill and confirming it works again, and haven't had any problems. 

Only thing I wasn't totally sure about was if this `index.js` is the best place to put this - does that seem ok?

[sc-12880]