### PR TITLE
use window size hook instead of one-time isMobile helper

### DIFF
--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -18,7 +18,6 @@ import { LocaleLink } from "i18n";
 import { createWhoOwnsWhatRoutePaths } from "routes";
 import { isLegacyPath } from "./WowzaToggle";
 import { useLocation } from "react-router-dom";
-import Browser from "../util/browser";
 import helpers from "util/helpers";
 import MultiSelect, { Option } from "./Multiselect";
 import MinMaxSelect from "./MinMaxSelect";
@@ -36,7 +35,8 @@ type PortfolioFilterProps = withMachineInStateProps<"portfolioFound"> &
 
 const PortfolioFiltersWithoutI18n = React.memo(
   React.forwardRef<HTMLDivElement, PortfolioFilterProps>((props, ref) => {
-    const isMobile = Browser.isMobile();
+    const { width } = helpers.useWindowSize();
+    const isMobile = !!width && width <= 599;
 
     const [showInfoModal, setShowInfoModal] = React.useState(false);
 


### PR DESCRIPTION
The filter bar layout would break when changing from desktop to mobile on the same device because they filters get wrapped in a menu for mobile but the component wasn't re-rendering when it crossed that screen width threshold. This was because I was using the one-time `Browser.isMobile`, so in this PR I just switch that to our `Helpers.useWindowSize` hook so that it gets updated and the filters wrapper component is re-rendered as needed. 

[sc-12882]