### PR TITLE
update portfolio table pagination bar styles

### DIFF
--- a/client/src/components/Icons.tsx
+++ b/client/src/components/Icons.tsx
@@ -32,14 +32,7 @@ export const CheckIcon = (props: SVGProps<SVGSVGElement>) => (
 );
 
 export const ChevronIcon = (props: SVGProps<SVGSVGElement>) => (
-  <svg
-    width="11"
-    height="7"
-    viewBox="0 0 11 7"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    {...props}
-  >
+  <svg fill="none" viewBox="0 -2 10 10" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path d="M9.5 1L5.25 5.25L1 1" stroke="currentcolor" />
   </svg>
 );

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -30,7 +30,7 @@ import { AddressRecord, HpdComplaintCount } from "./APIDataTypes";
 import { FilterContext, FilterNumberRange, PortfolioAnalyticsEvent } from "./PropertiesList";
 import "styles/PortfolioTable.scss";
 import { sortContactsByImportance } from "./DetailView";
-import { ArrowIcon } from "./Icons";
+import { ArrowIcon, ChevronIcon } from "./Icons";
 import classnames from "classnames";
 import { isLegacyPath } from "./WowzaToggle";
 import Loader from "./Loader";
@@ -661,41 +661,7 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
           </div>
 
           <div className="pagination">
-            <div className="prev">
-              <button
-                className="page-btn"
-                onClick={() => {
-                  table.previousPage();
-                  logPortfolioAnalytics("portfolioPagination", {
-                    extraParams: { paginationType: "previous" },
-                  });
-                }}
-                disabled={!table.getCanPreviousPage()}
-              >
-                {i18n._(t`Previous`)}
-              </button>
-            </div>
-            <div className="center">
-              <span className="page-info">
-                <span>
-                  <Trans>Page</Trans>
-                </span>
-                <div>
-                  <input
-                    type="number"
-                    aria-label={i18n._(t`page number`)}
-                    value={String(table.getState().pagination.pageIndex + 1)}
-                    onChange={(e) => {
-                      const page = e.target.value ? Number(e.target.value) - 1 : 0;
-                      table.setPageIndex(page);
-                      logPortfolioAnalytics("portfolioPagination", {
-                        extraParams: { paginationType: "custom" },
-                      });
-                    }}
-                  />
-                </div>
-                <Trans>of</Trans> <span className="total-pages">{table.getPageCount()}</span>
-              </span>
+            <div className="page-size">
               <select
                 value={table.getState().pagination.pageSize}
                 aria-label={i18n._(t`number of records per page`)}
@@ -708,10 +674,30 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
               >
                 {[10, 20, 50, 100, 500].map((pageSize) => (
                   <option key={pageSize} value={pageSize}>
-                    Show {pageSize}
+                    {i18n._(t`Show`)} {pageSize}
                   </option>
                 ))}
               </select>
+            </div>
+            <div className="page-info">
+              <Trans>
+                Page {String(table.getState().pagination.pageIndex + 1)} of {table.getPageCount()}
+              </Trans>
+            </div>
+            <div className="prev">
+              <button
+                className="page-btn"
+                onClick={() => {
+                  table.previousPage();
+                  logPortfolioAnalytics("portfolioPagination", {
+                    extraParams: { paginationType: "previous" },
+                  });
+                }}
+                disabled={!table.getCanPreviousPage()}
+                aria-label={i18n._(t`Previous page`)}
+              >
+                <ChevronIcon className="chevronIcon left" />
+              </button>
             </div>
             <div className="next">
               <button
@@ -723,8 +709,9 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
                   });
                 }}
                 disabled={!table.getCanNextPage()}
+                aria-label={i18n._(t`Next page`)}
               >
-                {i18n._(t`Next`)}
+                <ChevronIcon className="chevronIcon right" />
               </button>
             </div>
           </div>

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -122,7 +122,7 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
 
   const pagination = React.useMemo(
     () => ({
-      pageIndex,  
+      pageIndex,
       pageSize,
     }),
     [pageIndex, pageSize]

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -680,8 +680,8 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
               </select>
             </div>
             <div className="page-info">
-              <Trans>Page</Trans> {String(table.getState().pagination.pageIndex + 1)}{" "}
-              <Trans>of</Trans> {table.getPageCount()}
+              <Trans>Page</Trans> <span>{String(table.getState().pagination.pageIndex + 1)}</span>{" "}
+              <Trans>of</Trans> <span>{table.getPageCount()}</span>
             </div>
             <div className="prev">
               <button

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -578,7 +578,6 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
         </Loader>
       ) : (
         <>
-        <div>{String(table.getState().pagination.pageIndex)}</div>
           <div className="portfolio-table-container">
             <table>
               <thead>

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -680,9 +680,8 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
               </select>
             </div>
             <div className="page-info">
-              <Trans>
-                Page {String(table.getState().pagination.pageIndex + 1)} of {table.getPageCount()}
-              </Trans>
+              <Trans>Page</Trans> {String(table.getState().pagination.pageIndex + 1)}{" "}
+              <Trans>of</Trans> {table.getPageCount()}
             </div>
             <div className="prev">
               <button

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -122,7 +122,7 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
 
   const pagination = React.useMemo(
     () => ({
-      pageIndex,
+      pageIndex,  
       pageSize,
     }),
     [pageIndex, pageSize]
@@ -578,6 +578,7 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
         </Loader>
       ) : (
         <>
+        <div>{String(table.getState().pagination.pageIndex)}</div>
           <div className="portfolio-table-container">
             <table>
               <thead>

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -680,8 +680,10 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
               </select>
             </div>
             <div className="page-info">
-              <Trans>Page</Trans> <span>{String(table.getState().pagination.pageIndex + 1)}</span>{" "}
-              <Trans>of</Trans> <span>{table.getPageCount()}</span>
+              <span>
+                <Trans>Page</Trans> <span>{String(table.getState().pagination.pageIndex + 1)}</span>{" "}
+                <Trans>of</Trans> <span>{table.getPageCount()}</span>
+              </span>
             </div>
             <div className="prev">
               <button

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -889,7 +889,7 @@ msgstr "New York Regional Office:"
 msgid "Next"
 msgstr "Next"
 
-#: src/components/PortfolioTable.tsx:530
+#: src/components/PortfolioTable.tsx:529
 msgid "Next page"
 msgstr "Next page"
 
@@ -1014,12 +1014,12 @@ msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, 
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
 #: src/components/PortfolioTable.tsx:510
-#~ msgid "Page"
-#~ msgstr "Page"
+msgid "Page"
+msgstr "Page"
 
 #: src/components/PortfolioTable.tsx:510
-msgid "Page {0} of {1}"
-msgstr "Page {0} of {1}"
+#~ msgid "Page {0} of {1}"
+#~ msgstr "Page {0} of {1}"
 
 #: src/components/DetailView.tsx:348
 #: src/components/DetailView.tsx:358
@@ -1047,7 +1047,7 @@ msgstr "Portfolio Table Redesign"
 msgid "Previous"
 msgstr "Previous"
 
-#: src/components/PortfolioTable.tsx:520
+#: src/components/PortfolioTable.tsx:519
 msgid "Previous page"
 msgstr "Previous page"
 
@@ -1231,7 +1231,7 @@ msgstr "Sign up for email updates"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/components/PortfolioTable.tsx:559
+#: src/components/PortfolioTable.tsx:558
 msgid "Since {year}"
 msgstr "Since {year}"
 
@@ -1267,7 +1267,7 @@ msgstr "Source code"
 #~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:559
+#: src/components/PortfolioTable.tsx:558
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
@@ -1763,9 +1763,9 @@ msgstr "month"
 msgid "number of records per page"
 msgstr "number of records per page"
 
-#: src/components/PortfolioTable.tsx:521
-#~ msgid "of"
-#~ msgstr "of"
+#: src/components/PortfolioTable.tsx:511
+msgid "of"
+msgstr "of"
 
 #: src/components/PortfolioTable.tsx:513
 #~ msgid "page number"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -886,9 +886,12 @@ msgid "New York Regional Office:"
 msgstr "New York Regional Office:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:541
 msgid "Next"
 msgstr "Next"
+
+#: src/components/PortfolioTable.tsx:530
+msgid "Next page"
+msgstr "Next page"
 
 #: src/components/PortfolioTable.tsx:364
 msgid "No"
@@ -1011,8 +1014,12 @@ msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, 
 msgstr "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, one {building} other {buildings}}"
 
 #: src/components/PortfolioTable.tsx:510
-msgid "Page"
-msgstr "Page"
+#~ msgid "Page"
+#~ msgstr "Page"
+
+#: src/components/PortfolioTable.tsx:510
+msgid "Page {0} of {1}"
+msgstr "Page {0} of {1}"
 
 #: src/components/DetailView.tsx:348
 #: src/components/DetailView.tsx:358
@@ -1037,9 +1044,12 @@ msgid "Portfolio Table Redesign"
 msgstr "Portfolio Table Redesign"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:504
 msgid "Previous"
 msgstr "Previous"
+
+#: src/components/PortfolioTable.tsx:520
+msgid "Previous page"
+msgstr "Previous page"
 
 #: src/components/LegalFooter.tsx:41
 #: src/containers/PrivacyPolicyPage.tsx:8
@@ -1168,6 +1178,10 @@ msgstr "Share this page with your neighbors"
 msgid "Shareholder"
 msgstr "Shareholder"
 
+#: src/components/PortfolioTable.tsx:505
+msgid "Show"
+msgstr "Show"
+
 #: src/components/Multiselect.tsx:122
 msgid "Show all {numSelections} selections"
 msgstr "Show all {numSelections} selections"
@@ -1217,7 +1231,7 @@ msgstr "Sign up for email updates"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 
-#: src/components/PortfolioTable.tsx:569
+#: src/components/PortfolioTable.tsx:559
 msgid "Since {year}"
 msgstr "Since {year}"
 
@@ -1253,7 +1267,7 @@ msgstr "Source code"
 #~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:569
+#: src/components/PortfolioTable.tsx:559
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
@@ -1745,17 +1759,17 @@ msgstr "for ${0}"
 msgid "month"
 msgstr "month"
 
-#: src/components/PortfolioTable.tsx:523
+#: src/components/PortfolioTable.tsx:498
 msgid "number of records per page"
 msgstr "number of records per page"
 
 #: src/components/PortfolioTable.tsx:521
-msgid "of"
-msgstr "of"
+#~ msgid "of"
+#~ msgstr "of"
 
 #: src/components/PortfolioTable.tsx:513
-msgid "page number"
-msgstr "page number"
+#~ msgid "page number"
+#~ msgstr "page number"
 
 #: src/components/Indicators.tsx:17
 msgid "quarter"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -894,7 +894,7 @@ msgstr "Oficina Regional de Nueva York:"
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/components/PortfolioTable.tsx:530
+#: src/components/PortfolioTable.tsx:529
 msgid "Next page"
 msgstr ""
 
@@ -1019,12 +1019,12 @@ msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, 
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
 #: src/components/PortfolioTable.tsx:510
-#~ msgid "Page"
-#~ msgstr "Página"
+msgid "Page"
+msgstr "Página"
 
 #: src/components/PortfolioTable.tsx:510
-msgid "Page {0} of {1}"
-msgstr ""
+#~ msgid "Page {0} of {1}"
+#~ msgstr ""
 
 #: src/components/DetailView.tsx:348
 #: src/components/DetailView.tsx:358
@@ -1052,7 +1052,7 @@ msgstr "Rediseño de la tabla del portafolio"
 msgid "Previous"
 msgstr "Anterior"
 
-#: src/components/PortfolioTable.tsx:520
+#: src/components/PortfolioTable.tsx:519
 msgid "Previous page"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr "Regístrate para recibir noticias por email"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde 2017, los dueños presentaron {totalEvictionFilings, plural, one {un caso de desalojo} other {# casos de desalojo}} y los alguaciles de la ciudad de Nueva York ejecutaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en toda esta cartera."
 
-#: src/components/PortfolioTable.tsx:559
+#: src/components/PortfolioTable.tsx:558
 msgid "Since {year}"
 msgstr "Desde {year}"
 
@@ -1272,7 +1272,7 @@ msgstr "Código fuente"
 #~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:559
+#: src/components/PortfolioTable.tsx:558
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
@@ -1768,9 +1768,9 @@ msgstr "mes"
 msgid "number of records per page"
 msgstr "número de registros por página"
 
-#: src/components/PortfolioTable.tsx:521
-#~ msgid "of"
-#~ msgstr "de"
+#: src/components/PortfolioTable.tsx:511
+msgid "of"
+msgstr "de"
 
 #: src/components/PortfolioTable.tsx:513
 #~ msgid "page number"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -891,9 +891,12 @@ msgid "New York Regional Office:"
 msgstr "Oficina Regional de Nueva York:"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/PortfolioTable.tsx:541
 msgid "Next"
 msgstr "Siguiente"
+
+#: src/components/PortfolioTable.tsx:530
+msgid "Next page"
+msgstr ""
 
 #: src/components/PortfolioTable.tsx:364
 msgid "No"
@@ -1016,8 +1019,12 @@ msgid "PORTFOLIO: Your search address is associated with <0>{0}</0> {1, plural, 
 msgstr "PORTAFOLIO DE EDIFICIOS: La dirección que has buscado está asociada con <0>{0}</0> {1, plural, one {construyendo} other {edificios}}"
 
 #: src/components/PortfolioTable.tsx:510
-msgid "Page"
-msgstr "Página"
+#~ msgid "Page"
+#~ msgstr "Página"
+
+#: src/components/PortfolioTable.tsx:510
+msgid "Page {0} of {1}"
+msgstr ""
 
 #: src/components/DetailView.tsx:348
 #: src/components/DetailView.tsx:358
@@ -1042,9 +1049,12 @@ msgid "Portfolio Table Redesign"
 msgstr "Rediseño de la tabla del portafolio"
 
 #: src/components/FeatureCalloutWidget.tsx:74
-#: src/components/PortfolioTable.tsx:504
 msgid "Previous"
 msgstr "Anterior"
+
+#: src/components/PortfolioTable.tsx:520
+msgid "Previous page"
+msgstr ""
 
 #: src/components/LegalFooter.tsx:41
 #: src/containers/PrivacyPolicyPage.tsx:8
@@ -1173,6 +1183,10 @@ msgstr "Comparte esta página con tus vecinos"
 msgid "Shareholder"
 msgstr "Accionista"
 
+#: src/components/PortfolioTable.tsx:505
+msgid "Show"
+msgstr ""
+
 #: src/components/Multiselect.tsx:122
 msgid "Show all {numSelections} selections"
 msgstr "Mostrar todas las {numSelections} selecciones"
@@ -1222,7 +1236,7 @@ msgstr "Regístrate para recibir noticias por email"
 msgid "Since 2017, landlords filed {totalEvictionFilings, plural, one {one eviction case} other {# eviction cases}} and NYC Marshals executed {totalEvictions, plural, one {one eviction} other {# evictions}} across this portfolio."
 msgstr "Desde 2017, los dueños presentaron {totalEvictionFilings, plural, one {un caso de desalojo} other {# casos de desalojo}} y los alguaciles de la ciudad de Nueva York ejecutaron {totalEvictions, plural, one {un desalojo} other {# desalojos}} en toda esta cartera."
 
-#: src/components/PortfolioTable.tsx:569
+#: src/components/PortfolioTable.tsx:559
 msgid "Since {year}"
 msgstr "Desde {year}"
 
@@ -1258,7 +1272,7 @@ msgstr "Código fuente"
 #~ msgid "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 #~ msgstr "Starting March 2023 <0>the old version</0> of Who Owns What will no longer be available."
 
-#: src/components/PortfolioTable.tsx:569
+#: src/components/PortfolioTable.tsx:559
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
@@ -1750,17 +1764,17 @@ msgstr "por ${0}"
 msgid "month"
 msgstr "mes"
 
-#: src/components/PortfolioTable.tsx:523
+#: src/components/PortfolioTable.tsx:498
 msgid "number of records per page"
 msgstr "número de registros por página"
 
 #: src/components/PortfolioTable.tsx:521
-msgid "of"
-msgstr "de"
+#~ msgid "of"
+#~ msgstr "de"
 
 #: src/components/PortfolioTable.tsx:513
-msgid "page number"
-msgstr "número de página"
+#~ msgid "page number"
+#~ msgstr "número de página"
 
 #: src/components/Indicators.tsx:17
 msgid "quarter"
@@ -1817,4 +1831,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2014} other {# Q
 #: src/components/IndicatorsDatasets.tsx:37
 msgid "{value, plural, one {One HPD Violation Issued since 2010} other {# HPD Violations Issued since 2010}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2010} other {# Violaciones del HPD emitidas desde el 2010}}"
-

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -128,7 +128,7 @@
             text-align: left;
           }
           &.active:not([open]):not(.filter-toggle):not(.filters-mobile-wrapper) {
-            background-color: $justfix-table-grey;
+            background-color: $justfix-white;
             color: $justfix-black;
             border-color: $justfix-grey-400;
           }
@@ -212,6 +212,7 @@
             stroke-width: 2px;
           }
           .chevronIcon {
+            height: 1.1rem;
             margin-left: 0.8rem;
           }
           .closeIcon {
@@ -279,7 +280,7 @@
               display: flex;
               flex-direction: column;
               width: 100%;
-              background-color: $justfix-table-grey;
+              background-color: $justfix-white;
               border-radius: 0;
               border: none;
               top: unset;
@@ -373,6 +374,7 @@
                   font-size: 1.4rem;
                 }
                 .chevronIcon {
+                  height: 1.1rem;
                   stroke-width: 0.2rem;
                 }
                 .minmaxselect__label-input-container {
@@ -406,7 +408,7 @@
           right: 0;
           z-index: 11;
           height: 100%;
-          background-color: $justfix-table-grey;
+          background-color: $justfix-white;
           border-radius: 0.8rem 0.8rem 0 0;
           box-sizing: border-box;
           border: none;
@@ -471,10 +473,10 @@
               // https://css-scroll-shadows.vercel.app/
               --clear: rgba(0, 0, 0, 0);
               --dark: rgba(100, 100, 100, 0.65);
-              background: linear-gradient($justfix-table-grey 10%, var(--clear)),
-                linear-gradient(var(--clear), $justfix-table-grey 90%) 0 100%,
+              background: linear-gradient($justfix-white 10%, var(--clear)),
+                linear-gradient(var(--clear), $justfix-white 90%) 0 100%,
                 linear-gradient(var(--dark) 10%, var(--clear));
-              background-color: $justfix-table-grey;
+              background-color: $justfix-white;
               background-repeat: no-repeat;
               background-attachment: local, local, scroll;
               background-size: 100% 6rem, 100% 6rem, 100% 1rem, 100% 1rem;

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -117,6 +117,7 @@ $table-border-dark: 1px solid $dark;
         white-space: nowrap;
 
         tr {
+          background-color: #fff;
           height: 30px;
           div {
             font-weight: 600 !important;
@@ -128,11 +129,9 @@ $table-border-dark: 1px solid $dark;
 
         tr:first-child th {
           color: #000;
-          background-color: $justfix-table-white;
         }
 
         tr:last-child th {
-          background-color: #fff;
           border-top: $table-border-light;
           border-bottom: $table-border-dark;
           box-shadow: none;
@@ -151,12 +150,12 @@ $table-border-dark: 1px solid $dark;
       tbody {
         overflow: auto;
         tr {
-          border-bottom: $table-border-light;
+          border-bottom: $gray-light;
 
           &.row-odd {
-            background-color: $justfix-table-white;
+            background-color: $justfix-white;
             &:hover {
-              background-color: $justfix-table-grey;
+              background-color: $gray-light;
             }
           }
           &.row-even {
@@ -212,78 +211,77 @@ $table-border-dark: 1px solid $dark;
     position: sticky;
     left: 0px;
     z-index: 2;
-    justify-content: space-between;
-    align-items: stretch;
+    align-items: center;
     flex-wrap: wrap;
-    padding: 3px;
-    background-color: $wowza-background;
+    padding: 1.4rem 1.7rem;
+    background-color: $justfix-white;
+    border-top: 0.1rem solid $gray-light;
+    text-align: center;
     margin: 0;
 
-    div {
-      display: block;
-      flex: 1 1;
-      text-align: center;
+    .page-size {
+      margin-right: auto;
+      select {
+        padding: 0.45rem 2.7rem 0.45rem 0.9rem;
+        cursor: pointer;
+        appearance: none;
+        // custom arrow, same as chevronIcon
+        background-image: url("data:image/svg+xml,%3Csvg width='11' height='7' viewBox='0 0 11 7' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.5 1L5.25 5.25L1 1' stroke='%23242323' stroke-width='2'/%3E%3C/svg%3E%0A");
+        background-repeat: no-repeat;
+        background-position: right 0.9rem top 50%;
+        background-size: 0.8rem auto;
+        &:focus,
+        &:focus-visible {
+          outline: 0.2rem solid $focus-outline-color;
+        }
+      }
     }
 
-    .center {
-      flex: 1.5 1;
-      text-align: center;
-      margin-bottom: 0;
-      display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: space-around;
-
-      .page-info {
-        display: flex;
-        align-items: center;
-        margin: 3px 10px;
-        white-space: nowrap;
-
-        input {
-          width: 70px;
-          text-align: center;
-          display: inline-block;
-          border: 1px solid rgba(0, 0, 0, 0.1);
-          background: #fff;
-          padding: 5px 7px;
-          margin: 5px 7px;
-          font-size: inherit;
-          border-radius: 3px;
-          font-weight: 400;
-          outline: none;
-        }
-        .total-pages {
-          margin-left: 5px;
-        }
+    .page-info {
+      font-size: 1.2rem;
+      margin-right: 3.2rem;
+      @include for-phone-only {
+        margin-right: 1.6rem;
       }
     }
 
     .next,
     .prev {
-      .page-btn[disabled] {
-        opacity: 0.65;
-        cursor: default;
-      }
-
       .page-btn {
-        -webkit-appearance: none;
-        -moz-appearance: none;
-        appearance: none;
-        display: block;
-        width: 100%;
-        height: 100%;
-        border: 0;
-        border-radius: 3px;
-        padding: 6px;
-        font-size: 1em;
         color: $justfix-black;
-        background: rgba(0, 0, 0, 0.1);
-        transition: all 0.1s ease;
-        cursor: pointer;
-        outline: none;
+        width: 4.8rem;
+        height: 4.8rem;
+        border-radius: 4rem;
+
+        .chevronIcon {
+          height: 1.2rem;
+          &.left {
+            transform: rotate(90deg);
+          }
+          &.right {
+            transform: rotate(-90deg);
+          }
+        }
+
+        &[disabled] {
+          color: $justfix-grey-400;
+          cursor: default;
+        }
+        &:not([disabled]) {
+          &:hover,
+          &:active,
+          &:focus,
+          &:focus-visible {
+            background-color: $justfix-white-200;
+          }
+        }
       }
+    }
+    .prev .page-btn .chevronIcon {
+      transform: rotate(90deg);
+    }
+    .next .page-btn .chevronIcon {
+      transform: rotate(-90deg);
     }
 
     select {

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -220,7 +220,6 @@ $table-border-dark: 1px solid $dark;
     margin: 0;
 
     .page-size {
-      margin-right: auto;
       select {
         padding: 0.45rem 2.7rem 0.45rem 0.9rem;
         color: $justfix-black;
@@ -240,6 +239,8 @@ $table-border-dark: 1px solid $dark;
 
     .page-info {
       font-size: 1.2rem;
+      text-align: right;
+      flex: 1;
       margin-right: 3.2rem;
       @include for-phone-only {
         margin-right: 1.6rem;

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -238,8 +238,9 @@ $table-border-dark: 1px solid $dark;
     }
 
     .page-info {
+      display: flex;
+      justify-content: end;
       font-size: 1.2rem;
-      text-align: right;
       flex: 1;
       margin-right: 3.2rem;
       @include for-phone-only {

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -211,6 +211,7 @@ $table-border-dark: 1px solid $dark;
     position: sticky;
     left: 0px;
     z-index: 2;
+    display: flex;
     align-items: center;
     flex-wrap: wrap;
     padding: 1.4rem 1.7rem;

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -208,9 +208,6 @@ $table-border-dark: 1px solid $dark;
     }
   }
   .pagination {
-    // position: sticky;
-    // left: 0px;
-    // z-index: 2;
     display: flex;
     align-items: center;
     flex-wrap: wrap;

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -208,9 +208,9 @@ $table-border-dark: 1px solid $dark;
     }
   }
   .pagination {
-    position: sticky;
-    left: 0px;
-    z-index: 2;
+    // position: sticky;
+    // left: 0px;
+    // z-index: 2;
     display: flex;
     align-items: center;
     flex-wrap: wrap;

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -223,6 +223,7 @@ $table-border-dark: 1px solid $dark;
       margin-right: auto;
       select {
         padding: 0.45rem 2.7rem 0.45rem 0.9rem;
+        color: $justfix-black;
         cursor: pointer;
         appearance: none;
         // custom arrow, same as chevronIcon

--- a/client/src/styles/PortfolioTable.scss
+++ b/client/src/styles/PortfolioTable.scss
@@ -256,6 +256,7 @@ $table-border-dark: 1px solid $dark;
 
         .chevronIcon {
           height: 1.2rem;
+          stroke-width: 2px;
           &.left {
             transform: rotate(90deg);
           }

--- a/client/src/styles/_button.scss
+++ b/client/src/styles/_button.scss
@@ -185,7 +185,7 @@
 
   &:hover {
     transition: all 0.1s linear;
-    box-shadow: 0rem 0.7rem 0rem 0rem $justfix-grey-light;
+    box-shadow: 0rem 0.7rem 0rem 0rem $justfix-white-200;
     transform: translateX(0.7rem);
   }
 
@@ -205,7 +205,7 @@
 
     border-style: solid;
     background-color: $color;
-    box-shadow: inset 0rem 0.4rem 0rem $justfix-grey-light;
+    box-shadow: inset 0rem 0.4rem 0rem $justfix-white-200;
   }
 }
 

--- a/client/src/styles/_minmaxselect.scss
+++ b/client/src/styles/_minmaxselect.scss
@@ -74,6 +74,7 @@
         display: none;
       }
       svg {
+        height: 1.1rem;
         margin-left: 0.2rem;
       }
     }

--- a/client/src/styles/_vars.scss
+++ b/client/src/styles/_vars.scss
@@ -113,13 +113,14 @@ $size-lg: 899px;
 // COLORS:
 $justfix-black: #242323;
 $justfix-white: #faf8f4;
+$justfix-white-100: #faf8f4;
+$justfix-white-200: #efe9dc;
 $justfix-grey: #9a9898;
 $justfix-grey-50: #f2f2f2;
 $justfix-grey-dark: #676565;
 $justfix-grey-600: #676565;
 $justfix-grey-700: #4e4b4b;
 $justfix-grey-400: #9a9898;
-$justfix-grey-light: #efe9dc;
 
 $justfix-green: #1aa551;
 $justfix-pink: #ffa0c7;


### PR DESCRIPTION
The contrast on the prev/next buttons in the portfolio table pagination bar were not meeting a11y standards, so while fixing that we made some other improvements to the design. The prev/next buttons now use icons, have clear hover and disabled states, and have 48px touch target for a11y.  We also removed the ability to select a specific page (the `page 1 of 2` is just text now).
[sc-12749]

While making these changes I needed to fix how the chevron icon was working. I had previously set a default size in the svg component but that made it difficult to override from the css, now those are there are no defaults and you set it in the css like everything else. The viewbox was also tweaked so it's a square and the icon is centered within that - this makes placement easier and ensures it stays centered when rotated. We should make similar fixes to the other icons eventually too. 
[sc-12916]


![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/eb3ff88b-8ca0-4060-a8e1-ba1b29caff61)


sidenote: for some reason we were using `position: sticky` for the pagination bar (not necessary anymore) but there is some weird kind of bug in some ios versions when something is position:sticky where the dom updates (the page number in this case) but the browser doesn't do the redraw/paint step and so the numbers wouldn't change or would get all glitchy looking. just removing sticky solved it.