### PR TITLE
avoid extra streetview api call using "loading" placeholder

### DIFF
--- a/client/src/components/StreetView.tsx
+++ b/client/src/components/StreetView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { withGoogleMap, StreetViewPanorama } from "react-google-maps";
 import Browser from "../util/browser";
 import Helpers from "../util/helpers";
+import { FixedLoadingLabel } from "./Loader";
 
 export type StreetViewAddr = {
   lat: number;
@@ -142,7 +143,9 @@ export const StreetViewStatic = React.forwardRef<HTMLImageElement, StreetViewSta
       setImgSize(`${imgWidth(screenWidth, screenHeight)}x${imgHeight(screenWidth, screenHeight)}`);
     }, [imgHeight, imgWidth, screenWidth, screenHeight]);
 
-    return (
+    return !screenWidth || !screenHeight ? (
+      <FixedLoadingLabel />
+    ) : (
       <img
         ref={ref}
         src={`https://maps.googleapis.com/maps/api/streetview?size=${imgSize}&location=${lat},${lng}&key=${process.env.REACT_APP_STREETVIEW_API_KEY}`}


### PR DESCRIPTION
In #793 we switched from dynamic to static streetview images for the address page. Because the images get easily distorted switching between mobile and desktop, we fetch a new version of the image based on window size, but on initial load there is a delay in getting the screen size and so it was defaulting to mobile size then quickly switching to desktop size, causing an extra API call. 

This PR fixes the issue by just using a "loading" placeholder until the window size is known so we only make one request. 