### PR TITLE
update loader-utils

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -48,6 +48,7 @@
     "downshift": "^3.2.2",
     "focus-trap-react": "^10.1.1",
     "leaflet": "^1.1.0",
+    "loader-utils": "^2.0.4",
     "lodash": "^4.17.21",
     "mapbox-gl": "^1.12.0",
     "prop-types": "^15.7.2",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9912,7 +9912,7 @@ loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0:
+loader-utils@^2.0.0, loader-utils@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==


### PR DESCRIPTION
Addressing dependabot security alert: https://github.com/JustFixNYC/who-owns-what/security/dependabot/111