### PR TITLE
update immer to ^9.0.6 via resolution for security alert

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -114,7 +114,8 @@
     "shell-quote": "^1.7.2",
     "loader-utils": "^2.0.4",
     "set-value": "^2.0.1",
-    "minimist": "^0.2.4"
+    "minimist": "^0.2.4",
+    "immer": "^9.0.6"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8387,10 +8387,10 @@ ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-immer@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
-  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+immer@8.0.1, immer@^9.0.6:
+  version "9.0.21"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
+  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
 immutable@^4.0.0:
   version "4.2.2"


### PR DESCRIPTION
update immer to ^9.0.6 via resolution for security alert: https://github.com/JustFixNYC/who-owns-what/security/dependabot/61