### PR TITLE
Add url params for timeline indicators

### DIFF
--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -25,6 +25,8 @@ import {
 import { NetworkErrorMessage } from "./NetworkErrorMessage";
 import { Dropdown } from "./Dropdown";
 import { AmplitudeEvent, logAmplitudeEvent } from "./Amplitude";
+import { withRouter } from "react-router-dom";
+import { RouteComponentProps } from "react-router";
 
 type TimeSpanTranslationsMap = {
   [K in IndicatorsTimeSpan]: (i18n: I18n) => string;
@@ -49,10 +51,19 @@ const getDropdownWidthFromLongestSelection = (selections: string[]) => {
   return Math.min(lengthOfLongestSelection * LETTER_WIDTH + MENU_BUFFER, MAX_WIDTH);
 };
 
-class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> {
-  constructor(props: IndicatorsProps) {
+type TimelinePageParams = {
+  indicator?: IndicatorsDatasetId;
+};
+
+type IndicatorsWithRouterProps = RouteComponentProps<TimelinePageParams> & IndicatorsProps;
+
+class IndicatorsWithoutI18n extends Component<IndicatorsWithRouterProps, IndicatorsState> {
+  constructor(props: IndicatorsWithRouterProps) {
     super(props);
-    this.state = indicatorsInitialState;
+    this.state = {
+      ...indicatorsInitialState,
+      activeVis: props.match.params.indicator || indicatorsInitialState.defaultVis,
+    };
     this.handleVisChange = this.handleVisChange.bind(this);
   }
 
@@ -98,6 +109,9 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
   handleVisChange(selectedVis: IndicatorsDatasetId) {
     this.setState({
       activeVis: selectedVis,
+    });
+    this.props.history.push(`${this.props.addressPageRoutes.timeline}/${selectedVis}`, {
+      shallow: true,
     });
   }
 
@@ -370,5 +384,5 @@ class IndicatorsWithoutI18n extends Component<IndicatorsProps, IndicatorsState> 
   }
 }
 
-const Indicators = withI18n()(IndicatorsWithoutI18n);
+const Indicators = withRouter(withI18n()(IndicatorsWithoutI18n));
 export default Indicators;

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -61,6 +61,7 @@ export const createAddressPageRoutes = (
   return {
     overview: `${prefix}`,
     timeline: `${prefix}/timeline`,
+    timeline_indicator: `${prefix}/timeline/:indicator`,
     portfolio: `${prefix}/portfolio`,
     summary: `${prefix}/summary`,
   };


### PR DESCRIPTION
This PR adds a URL parameter on to the `/timeline` route so that we can link to specific indicators, eg. `.../timeline/hpdcomplaints`. 
All of the others use the names we already have set up in the codebase, which are: `hpdcomplaints`, `hpdviolations`,  `dobpermits`, `dobviolations`, `evictionfilings`.
Going to just `/timeline` will bring up the default one (currently HPD Complaints). 
When using the UI to switch between indicators, the URL will update without reloading the page, using the `history` from the router with the `shallow` option. 