### PR TITLE
update dead links to agency websites on timeline

### DIFF
--- a/client/src/components/IndicatorsDatasets.tsx
+++ b/client/src/components/IndicatorsDatasets.tsx
@@ -72,7 +72,7 @@ export const INDICATORS_DATASETS: IndicatorsDatasetMap = {
         <br />
         Read more about HPD Complaints and how to file them at the{" "}
         <a
-          href="https://www1.nyc.gov/site/hpd/renters/complaints-and-inspections.page"
+          href="https://www.nyc.gov/site/hpd/services-and-information/report-a-maintenance-issue.page"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -115,7 +115,7 @@ export const INDICATORS_DATASETS: IndicatorsDatasetMap = {
         <br />
         Read more about HPD Violations at the{" "}
         <a
-          href="https://www1.nyc.gov/site/hpd/owners/compliance-maintenance-requirements.page"
+          href="https://www.nyc.gov/site/hpd/services-and-information/report-a-maintenance-issue.page"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -146,7 +146,7 @@ export const INDICATORS_DATASETS: IndicatorsDatasetMap = {
         <br />
         Read more about DOB Building Applications/Permits at the{" "}
         <a
-          href="https://www1.nyc.gov/site/buildings/about/building-applications-and-permits.page"
+          href="https://www.nyc.gov/site/buildings/dob/building-applications-permits.page"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
The DOB and HPD links in indicator descriptions for the timeline are dead. DOB permits one was just moved, the others were changed a bit more, but there is now one that covers hpd complaints and violations/inspection info, so using that for both. 

[sc-13247]