### PR TITLE
update nycdb version in requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-https://github.com/nycdb/nycdb/archive/cacc0219517e557eeed61bc105278c0575e83ad0.zip#subdirectory=src
+https://github.com/nycdb/nycdb/archive/82238cae28e1816d513c10a8c864878ede85f5b9.zip#subdirectory=src
 mypy==0.782
 PyYAML>=5.1
 pytest==6.2.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-https://github.com/nycdb/nycdb/archive/82238cae28e1816d513c10a8c864878ede85f5b9.zip#subdirectory=src
+https://github.com/nycdb/nycdb/archive/e4a59b3acf6629fefb0d18be74e6a5a44343eb43.zip#subdirectory=src
 mypy==0.782
 PyYAML>=5.1
 pytest==6.2.5


### PR DESCRIPTION
I'm having problems with tests failing in the hpd complaints update that I can't explain. Trying to slowly update the nycdb versions (there are a number of changes we are behind on) to narrow it down. 
https://github.com/nycdb/nycdb/commits/main