### PR TITLE
remove alert on overview map to filter portfolio

### DIFF
--- a/client/src/components/PortfolioAlerts.tsx
+++ b/client/src/components/PortfolioAlerts.tsx
@@ -88,36 +88,3 @@ export const BigPortfolioAlert = ({ portfolioSize, className, ...props }: Portfo
     <></>
   );
 };
-
-export const FilterPortfolioAlert = ({
-  portfolioSize,
-  className,
-  addressPageRoutes,
-  ...props
-}: FilterPortfolioAlertProps) => {
-  const { pathname } = useLocation();
-
-  return !isLegacyPath(pathname) && portfolioSize >= FILTER_PORTFOLIO_THRESHOLD ? (
-    <Alert
-      className={classNames("big-portfolio-alert", className)}
-      variant="secondary"
-      type="info"
-      {...props}
-    >
-      <Trans>
-        Narrow down this portfolio using filters in{" "}
-        <Link
-          to={addressPageRoutes.portfolio}
-          onClick={() => {
-            logAmplitudeEvent("alertToFilterPortfolio", { portfolioSize });
-            window.gtag("event", "alert-to-filter-portfolio", { portfolioSize });
-          }}
-        >
-          the Portfolio tab.
-        </Link>
-      </Trans>
-    </Alert>
-  ) : (
-    <></>
-  );
-};

--- a/client/src/components/PortfolioAlerts.tsx
+++ b/client/src/components/PortfolioAlerts.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Trans } from "@lingui/macro";
 import classNames from "classnames";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import networkDiagram from "../assets/img/network-diagram.png";
 import { AddressPageRoutes } from "../routes";
 import { Alert, AlertProps } from "./Alert";
@@ -10,14 +10,9 @@ import Modal from "./Modal";
 import { isLegacyPath } from "./WowzaToggle";
 
 export const BIG_PORTFOLIO_THRESHOLD = 300;
-export const FILTER_PORTFOLIO_THRESHOLD = 15;
 
 type PortfolioAlertProps = Omit<AlertProps, "children"> & {
   portfolioSize: number;
-};
-
-type FilterPortfolioAlertProps = PortfolioAlertProps & {
-  addressPageRoutes: AddressPageRoutes;
 };
 
 export const BigPortfolioAlert = ({ portfolioSize, className, ...props }: PortfolioAlertProps) => {

--- a/client/src/components/PortfolioAlerts.tsx
+++ b/client/src/components/PortfolioAlerts.tsx
@@ -3,7 +3,6 @@ import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import { useLocation } from "react-router-dom";
 import networkDiagram from "../assets/img/network-diagram.png";
-import { AddressPageRoutes } from "../routes";
 import { Alert, AlertProps } from "./Alert";
 import { logAmplitudeEvent } from "./Amplitude";
 import Modal from "./Modal";

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -368,7 +368,6 @@ class PropertiesMapWithoutResizeDetector extends Component<Props, State> {
 
   render() {
     const { useNewPortfolioMethod } = this.props.state.context;
-    const portfolioFiltersEnabled = process.env.REACT_APP_PORTFOLIO_FILTERS_ENABLED === "1" || true;
     const { detailAddr } = this.getPortfolioData();
     const { locale, logPortfolioAnalytics } = this.props;
     const isMobile = Browser.isMobile();

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -12,7 +12,7 @@ import { AddressRecord } from "./APIDataTypes";
 import { FitBounds, Props as MapboxMapProps } from "react-mapbox-gl/lib/map";
 import { Events as MapboxMapEvents } from "react-mapbox-gl/lib/map-events";
 import { withMachineInStateProps } from "state-machine";
-import { BigPortfolioAlert, FilterPortfolioAlert } from "./PortfolioAlerts";
+import { BigPortfolioAlert } from "./PortfolioAlerts";
 import { AddressPageRoutes, createRouteForFullBbl } from "routes";
 import {
   FilterContext,
@@ -421,14 +421,6 @@ class PropertiesMapWithoutResizeDetector extends Component<Props, State> {
                     storageId="map-big-portfolio-alert"
                     portfolioSize={this.state.addrsPoints.length}
                   />
-                  {portfolioFiltersEnabled && (
-                    <FilterPortfolioAlert
-                      closeType="session"
-                      storageId="map-filter-portfolio-alert"
-                      portfolioSize={this.state.addrsPoints.length}
-                      addressPageRoutes={this.props.addressPageRoutes}
-                    />
-                  )}
                 </>
               )}
               {!this.isOnOverview() && !!selectedAddr && (


### PR DESCRIPTION
When we launched portfolio filters we added an alert on overview map that prompts users to check out the portfolio tab to filter down the properties. We are now seeing extremely low rates of clicks on this alert, so are going to remove it along with the launch of email alerts. 

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/611d7149-1937-4e2d-b0b2-6bb0574fe8e1)

[sc-13500]