### PR TITLE
remove new pill on portfolio tab

### DIFF
--- a/client/src/components/PortfolioFilters.tsx
+++ b/client/src/components/PortfolioFilters.tsx
@@ -195,16 +195,6 @@ const PortfolioFiltersWithoutI18n = React.memo(
     return (
       <div className="PortfolioFilters" ref={ref}>
         <div className="filters-container">
-          <div className="filter-new-container">
-            <span className="pill-new">
-              <Trans>New</Trans>
-            </span>
-            {!isMobile && (
-              <span>
-                <Trans>Filters:</Trans>
-              </span>
-            )}
-          </div>
           <div className="view-type-toggle-container">
             <button
               aria-pressed={viewType === "table"}

--- a/client/src/styles/PortfolioFilters.scss
+++ b/client/src/styles/PortfolioFilters.scss
@@ -55,30 +55,6 @@
       gap: var(--filter-bar-row-gap) 1.2rem;
     }
 
-    .filter-new-container {
-      letter-spacing: 0.04em;
-      display: flex;
-      flex-direction: column;
-
-      .pill-new {
-        font-family: $body-font;
-        letter-spacing: 0.02em;
-        background: $justfix-yellow;
-        padding: 0.4rem 0.8rem;
-        border-radius: 1.6rem;
-        width: fit-content;
-        margin-bottom: 0.26rem;
-      }
-
-      @include for-phone-only() {
-        width: unset;
-        justify-content: center;
-        .pill-new {
-          margin: 0;
-        }
-      }
-    }
-
     .view-type-toggle-container {
       display: flex;
       // adjust for border difference with filters


### PR DESCRIPTION
Remove the temporary "new" pill on portfolio tab from launch of filters

before:
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/3c1603cf-3bc8-4051-a936-8bd61ef6220f)

after:
desktop | mobile
:--:|:--:
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/0f3540d8-f5bb-48e0-b6d1-dc9e512673e4) | ![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/46410981-3047-4843-87bb-3b1758dc7e84)

[sc-13350]