### PR TITLE
Multi-step log in/sign up modal, with user type

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -47,8 +47,8 @@ const clearUser = () => (_user = undefined);
  * Authenticates a user with the given email and password.
  * Creates an account for this user if one does not already exist.
  */
-const register = async (username: string, password: string) => {
-  const json = await postAuthRequest(`${BASE_URL}auth/register`, { username, password });
+const register = async (username: string, password: string, user_type: string) => {
+  const json = await postAuthRequest(`${BASE_URL}auth/register`, { username, password, user_type });
   fetchUser();
   return json;
 };

--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -47,8 +47,12 @@ const clearUser = () => (_user = undefined);
  * Authenticates a user with the given email and password.
  * Creates an account for this user if one does not already exist.
  */
-const register = async (username: string, password: string, user_type: string) => {
-  const json = await postAuthRequest(`${BASE_URL}auth/register`, { username, password, user_type });
+const register = async (username: string, password: string, userType: string) => {
+  const json = await postAuthRequest(`${BASE_URL}auth/register`, {
+    username,
+    password,
+    user_type: userType,
+  });
   fetchUser();
   return json;
 };

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -10,6 +10,7 @@ import "styles/EmailAlertSignup.css";
 import { JustfixUser } from "state-machine";
 import AuthClient from "./AuthClient";
 import { AlertIconOutline, SubscribedIcon } from "./Icons";
+import { Alert } from "./Alert";
 
 type BuildingSubscribeProps = withI18nProps & {
   bbl: string;
@@ -42,10 +43,9 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const showEmailVerification = (i18n: any) => {
     return (
       <div className="building-subscribe-status">
-        <div className="status-title">
-          <AlertIconOutline />
-          <Trans>Email verification required</Trans>
-        </div>
+        <Alert type="info">
+          <Trans>Verify your email to start receiving updates.</Trans>
+        </Alert>
         <div className="status-description">
           {i18n._(t`Click the link we sent to ${email}. It may take a few minutes to arrive.`)}
         </div>

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -9,7 +9,7 @@ import { UserContext } from "./UserContext";
 import "styles/EmailAlertSignup.css";
 import { JustfixUser } from "state-machine";
 import AuthClient from "./AuthClient";
-import { AlertIconOutline, SubscribedIcon } from "./Icons";
+import { SubscribedIcon } from "./Icons";
 import { Alert } from "./Alert";
 
 type BuildingSubscribeProps = withI18nProps & {

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -111,22 +111,14 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => {
                   {user && !loginRegisterInProgress ? (
                     <BuildingSubscribe {...props} />
                   ) : (
-                    <>
-                      <div className="email-description">
-                        <Trans>
-                          Each weekly email includes HPD Complaints, HPD Violations, and Eviction
-                          Filings.
-                        </Trans>
-                      </div>
-                      <Login
-                        registerInModal
-                        onBuildingPage
-                        setLoginRegisterInProgress={setLoginRegisterInProgress}
-                        onSuccess={(user: JustfixUser) => {
-                          userContext.subscribe(bbl, housenumber, streetname, zip, boro, user);
-                        }}
-                      />
-                    </>
+                    <Login
+                      registerInModal
+                      onBuildingPage
+                      setLoginRegisterInProgress={setLoginRegisterInProgress}
+                      onSuccess={(user: JustfixUser) => {
+                        userContext.subscribe(bbl, housenumber, streetname, zip, boro, user);
+                      }}
+                    />
                   )}
                 </div>
               </div>

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -10,7 +10,6 @@ import "styles/EmailAlertSignup.css";
 import { JustfixUser } from "state-machine";
 import AuthClient from "./AuthClient";
 import { AlertIconOutline, SubscribedIcon } from "./Icons";
-import Modal from "./Modal";
 
 type BuildingSubscribeProps = withI18nProps & {
   bbl: string;
@@ -91,7 +90,7 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => {
   const { bbl, housenumber, streetname, zip, boro } = props;
   const userContext = useContext(UserContext);
   const { user } = userContext;
-  const [showVerifyModal, setShowVerifyModal] = useState(false);
+  const [loginRegisterInProgress, setLoginRegisterInProgress] = useState(false);
 
   return (
     <>
@@ -114,8 +113,10 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => {
                   )}
                 </label>
                 <div className="table-content">
-                  {!user ? (
-                    <Fragment>
+                  {user && !loginRegisterInProgress ? (
+                    <BuildingSubscribe {...props} />
+                  ) : (
+                    <>
                       <div className="email-description">
                         <Trans>
                           Each weekly email includes HPD Complaints, HPD Violations, and Eviction
@@ -123,41 +124,16 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => {
                         </Trans>
                       </div>
                       <Login
-                        onBuildingPage={true}
+                        registerInModal
+                        onBuildingPage
+                        setLoginRegisterInProgress={setLoginRegisterInProgress}
                         onSuccess={(user: JustfixUser) => {
                           userContext.subscribe(bbl, housenumber, streetname, zip, boro, user);
-                          !user.verified && setShowVerifyModal(true);
                         }}
                       />
-                    </Fragment>
-                  ) : (
-                    <BuildingSubscribe {...props} />
+                    </>
                   )}
                 </div>
-                <Modal
-                  key={1}
-                  showModal={showVerifyModal}
-                  width={40}
-                  onClose={() => setShowVerifyModal(false)}
-                >
-                  <Trans render="h4">Verify your email to start receiving updates</Trans>
-                  {i18n._(
-                    t`Click the link we sent to ${user?.email}. It may take a few minutes to arrive.`
-                  )}
-                  <br />
-                  <br />
-                  <Trans>
-                    Once your email has been verified, you’ll be signed up for Data Updates.
-                  </Trans>
-                  <br />
-                  <br />
-                  <button
-                    className="button is-secondary is-full-width"
-                    onClick={() => AuthClient.resendVerifyEmail()}
-                  >
-                    <Trans>Resend email</Trans>
-                  </button>
-                </Modal>
               </div>
             )}
           </I18n>

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -1,7 +1,6 @@
 import React, { Fragment, useContext, useState } from "react";
 
 import { withI18n, withI18nProps, I18n } from "@lingui/react";
-import { t } from "@lingui/macro";
 import { Trans } from "@lingui/macro";
 import Login from "./Login";
 import { UserContext } from "./UserContext";
@@ -46,9 +45,10 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
         <Alert type="info">
           <Trans>Verify your email to start receiving updates.</Trans>
         </Alert>
-        <div className="status-description">
-          {i18n._(t`Click the link we sent to ${email}. It may take a few minutes to arrive.`)}
-        </div>
+        <Trans render="div" className="status-description">
+          Click the link we sent to {email}. It may take a few minutes to arrive.
+        </Trans>
+        <Trans render="div">Didn’t get the link?</Trans>
         <button
           className="button is-secondary is-full-width"
           onClick={() => AuthClient.resendVerifyEmail()}

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -63,7 +63,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   return (
     <I18n>
       {({ i18n }) => (
-        <div className="table-content building-subscribe">
+        <div className="building-subscribe">
           {!(subscriptions && !!subscriptions?.find((s) => s.bbl === bbl)) ? (
             <button
               className="button is-primary"

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -42,21 +42,19 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const showEmailVerification = (i18n: any) => {
     return (
       <div className="building-subscribe-status">
-        <div>
-          <div className="status-title">
-            <AlertIconOutline />
-            <Trans>Email verification required</Trans>
-          </div>
-          <div className="status-description">
-            {i18n._(t`Click the link we sent to ${email}. It may take a few minutes to arrive.`)}
-          </div>
-          <button
-            className="button is-secondary is-full-width"
-            onClick={() => AuthClient.resendVerifyEmail()}
-          >
-            <Trans>Resend email</Trans>
-          </button>
+        <div className="status-title">
+          <AlertIconOutline />
+          <Trans>Email verification required</Trans>
         </div>
+        <div className="status-description">
+          {i18n._(t`Click the link we sent to ${email}. It may take a few minutes to arrive.`)}
+        </div>
+        <button
+          className="button is-secondary is-full-width"
+          onClick={() => AuthClient.resendVerifyEmail()}
+        >
+          <Trans>Resend email</Trans>
+        </button>
       </div>
     );
   };

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -98,10 +98,7 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => {
         <div className="table-row">
           <I18n>
             {({ i18n }) => (
-              <div
-                title={i18n._(t`Get data updates for this building`)}
-                className="table-small-font"
-              >
+              <div className="table-small-font">
                 <label className="data-updates-label-container">
                   <span className="pill-new">
                     <Trans>NEW</Trans>

--- a/client/src/components/EmailInput.tsx
+++ b/client/src/components/EmailInput.tsx
@@ -15,10 +15,11 @@ interface EmailInputProps extends React.ComponentPropsWithoutRef<"input"> {
   setError: React.Dispatch<React.SetStateAction<boolean>>;
   showError: boolean;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  i18nHash?: string;
 }
 
 const EmailInputWithoutI18n = forwardRef<HTMLInputElement, EmailInputProps>(
-  ({ i18n, email, error, setError, showError, onChange, ...props }, ref) => {
+  ({ i18n, i18nHash, email, error, setError, showError, onChange, ...props }, ref) => {
     const isBadEmailFormat = (value: string) => {
       /* valid email regex rules 
       alpha numeric characters are ok, upper/lower case agnostic 
@@ -68,6 +69,6 @@ const EmailInputWithoutI18n = forwardRef<HTMLInputElement, EmailInputProps>(
   }
 );
 
-const EmailInput = withI18n()(EmailInputWithoutI18n);
+const EmailInput = withI18n({ withHash: false })(EmailInputWithoutI18n);
 
 export default EmailInput;

--- a/client/src/components/EmailInput.tsx
+++ b/client/src/components/EmailInput.tsx
@@ -43,7 +43,7 @@ const EmailInputWithoutI18n = (props: EmailInputProps) => {
   };
 
   return (
-    <>
+    <div className="email-input-field">
       <div className="email-input-label">
         <label htmlFor="email-input">
           <Trans>Email address</Trans>
@@ -62,7 +62,6 @@ const EmailInputWithoutI18n = (props: EmailInputProps) => {
           type="email"
           id="email-input"
           className="input"
-          placeholder={i18n._(t`Enter email`)}
           onChange={onChange}
           onBlur={isBadEmailFormat}
           value={email}
@@ -70,7 +69,7 @@ const EmailInputWithoutI18n = (props: EmailInputProps) => {
           // note: required={true} removed bc any empty state registers as invalid state
         />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/client/src/components/EmailInput.tsx
+++ b/client/src/components/EmailInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from "react";
+import { ChangeEvent, forwardRef } from "react";
 import { t } from "@lingui/macro";
 import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
@@ -8,66 +8,65 @@ import "styles/EmailInput.css";
 import "styles/_input.scss";
 import classNames from "classnames";
 
-type EmailInputProps = {
+interface EmailInputProps extends React.ComponentPropsWithoutRef<"input"> {
   i18n: I18n;
   email: string;
   error: boolean;
   setError: React.Dispatch<React.SetStateAction<boolean>>;
   showError: boolean;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-  required?: boolean;
-};
+}
 
-const EmailInputWithoutI18n = (props: EmailInputProps) => {
-  const { i18n, email, error, setError, showError, onChange, required } = props;
-
-  const isBadEmailFormat = (value: string) => {
-    /* valid email regex rules 
+const EmailInputWithoutI18n = forwardRef<HTMLInputElement, EmailInputProps>(
+  ({ i18n, email, error, setError, showError, onChange, ...props }, ref) => {
+    const isBadEmailFormat = (value: string) => {
+      /* valid email regex rules 
       alpha numeric characters are ok, upper/lower case agnostic 
       username: leading \_ ok, chars \_\.\-\+ ok in all other positions
       domain name: chars \.\- ok as long as not leading. must end in a \. and at least two alphabet chars */
-    const pattern =
-      "^([a-zA-Z0-9_]+[a-zA-Z0-9+_.-]+@[a-zA-Z0-9]+[a-zA-Z0-9.-]+[a-zA-Z0-9]+.[a-zA-Z]{2,})$";
+      const pattern =
+        "^([a-zA-Z0-9_]+[a-zA-Z0-9+_.-]+@[a-zA-Z0-9]+[a-zA-Z0-9.-]+[a-zA-Z0-9]+.[a-zA-Z]{2,})$";
 
-    // HTML input element has loose email validation requirements, so we check the input against a custom regex
-    const passStrictRegex = value.match(pattern);
-    const passAutoValidation = document.querySelectorAll("input:invalid").length === 0;
+      // HTML input element has loose email validation requirements, so we check the input against a custom regex
+      const passStrictRegex = value.match(pattern);
+      const passAutoValidation = document.querySelectorAll("input:invalid").length === 0;
 
-    return !passAutoValidation || !passStrictRegex;
-  };
+      return !passAutoValidation || !passStrictRegex;
+    };
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onChange(e);
-    const emailIsInvalid = isBadEmailFormat(e.target.value);
-    setError(emailIsInvalid);
-  };
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      onChange(e);
+      const emailIsInvalid = isBadEmailFormat(e.target.value);
+      setError(emailIsInvalid);
+    };
 
-  return (
-    <div className="email-input-field">
-      <div className="email-input-label">
-        <label htmlFor="email-input">{i18n._(t`Email address`)}</label>
-      </div>
-      {showError && error && (
-        <div className="email-input-errors">
-          <span id="input-field-error">
-            <AlertIcon />
-            {i18n._(t`Please enter a valid email address.`)}
-          </span>
+    return (
+      <div className="email-input-field">
+        <div className="email-input-label">
+          <label htmlFor="email-input">{i18n._(t`Email address`)}</label>
         </div>
-      )}
-      <div className="email-input">
-        <input
-          type="email"
-          id="email-input"
-          className={classNames("input", { invalid: showError && error })}
-          onChange={handleChange}
-          value={email}
-          required={required}
-        />
+        {showError && error && (
+          <div className="email-input-errors">
+            <span id="input-field-error">
+              <AlertIcon />
+              {i18n._(t`Please enter a valid email address.`)}
+            </span>
+          </div>
+        )}
+        <div className="email-input">
+          <input
+            type="email"
+            id="email-input"
+            className={classNames("input", { invalid: showError && error })}
+            onChange={handleChange}
+            value={email}
+            {...props}
+          />
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
 
 const EmailInput = withI18n()(EmailInputWithoutI18n);
 

--- a/client/src/components/EmailInput.tsx
+++ b/client/src/components/EmailInput.tsx
@@ -1,0 +1,79 @@
+import { ChangeEvent } from "react";
+import { Trans, t } from "@lingui/macro";
+import { I18n } from "@lingui/core";
+import { withI18n } from "@lingui/react";
+import { AlertIcon } from "./Icons";
+
+import "styles/EmailInput.css";
+import "styles/_input.scss";
+
+type EmailInputProps = {
+  i18n: I18n;
+  email: string;
+  error: boolean;
+  setError: React.Dispatch<React.SetStateAction<boolean>>;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  required?: boolean;
+};
+
+const EmailInputWithoutI18n = (props: EmailInputProps) => {
+  const { i18n, email, error, setError, onChange, required } = props;
+
+  const isBadEmailFormat = () => {
+    /* valid email regex rules 
+      alpha numeric characters are ok, upper/lower case agnostic 
+      username: leading \_ ok, chars \_\.\-\+ ok in all other positions
+      domain name: chars \.\- ok as long as not leading. must end in a \. and at least two alphabet chars */
+    const pattern =
+      "^([a-zA-Z0-9_]+[a-zA-Z0-9+_.-]+@[a-zA-Z0-9]+[a-zA-Z0-9.-]+[a-zA-Z0-9]+.[a-zA-Z]{2,})$";
+    const input = document.getElementById("email-input") as HTMLElement;
+    const inputValue = (input as HTMLInputElement).value;
+
+    // HTML input element has loose email validation requirements, so we check the input against a custom regex
+    const passStrictRegex = inputValue.match(pattern);
+    const passAutoValidation = document.querySelectorAll("input:invalid").length === 0;
+
+    if (!passAutoValidation || !passStrictRegex) {
+      setError(true);
+      input.className = input.className + " invalid";
+    } else {
+      setError(false);
+      input.className = input.className.split(" ")[0];
+    }
+  };
+
+  return (
+    <>
+      <div className="email-input-label">
+        <label htmlFor="email-input">
+          <Trans>Email address</Trans>
+        </label>
+      </div>
+      {error && (
+        <div className="email-input-errors">
+          <span id="input-field-error">
+            <AlertIcon />
+            <Trans>Please enter a valid email address. </Trans>
+          </span>
+        </div>
+      )}
+      <div className="email-input">
+        <input
+          type="email"
+          id="email-input"
+          className="input"
+          placeholder={i18n._(t`Enter email`)}
+          onChange={onChange}
+          onBlur={isBadEmailFormat}
+          value={email}
+          required={required}
+          // note: required={true} removed bc any empty state registers as invalid state
+        />
+      </div>
+    </>
+  );
+};
+
+const EmailInput = withI18n()(EmailInputWithoutI18n);
+
+export default EmailInput;

--- a/client/src/components/EmailInput.tsx
+++ b/client/src/components/EmailInput.tsx
@@ -1,59 +1,57 @@
 import { ChangeEvent } from "react";
-import { Trans, t } from "@lingui/macro";
+import { t } from "@lingui/macro";
 import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
 import { AlertIcon } from "./Icons";
 
 import "styles/EmailInput.css";
 import "styles/_input.scss";
+import classNames from "classnames";
 
 type EmailInputProps = {
   i18n: I18n;
   email: string;
   error: boolean;
   setError: React.Dispatch<React.SetStateAction<boolean>>;
+  showError: boolean;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   required?: boolean;
 };
 
 const EmailInputWithoutI18n = (props: EmailInputProps) => {
-  const { i18n, email, error, setError, onChange, required } = props;
+  const { i18n, email, error, setError, showError, onChange, required } = props;
 
-  const isBadEmailFormat = () => {
+  const isBadEmailFormat = (value: string) => {
     /* valid email regex rules 
       alpha numeric characters are ok, upper/lower case agnostic 
       username: leading \_ ok, chars \_\.\-\+ ok in all other positions
       domain name: chars \.\- ok as long as not leading. must end in a \. and at least two alphabet chars */
     const pattern =
       "^([a-zA-Z0-9_]+[a-zA-Z0-9+_.-]+@[a-zA-Z0-9]+[a-zA-Z0-9.-]+[a-zA-Z0-9]+.[a-zA-Z]{2,})$";
-    const input = document.getElementById("email-input") as HTMLElement;
-    const inputValue = (input as HTMLInputElement).value;
 
     // HTML input element has loose email validation requirements, so we check the input against a custom regex
-    const passStrictRegex = inputValue.match(pattern);
+    const passStrictRegex = value.match(pattern);
     const passAutoValidation = document.querySelectorAll("input:invalid").length === 0;
 
-    if (!passAutoValidation || !passStrictRegex) {
-      setError(true);
-      input.className = input.className + " invalid";
-    } else {
-      setError(false);
-      input.className = input.className.split(" ")[0];
-    }
+    return !passAutoValidation || !passStrictRegex;
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange(e);
+    const emailIsInvalid = isBadEmailFormat(e.target.value);
+    setError(emailIsInvalid);
   };
 
   return (
     <div className="email-input-field">
       <div className="email-input-label">
-        <label htmlFor="email-input">
-          <Trans>Email address</Trans>
-        </label>
+        <label htmlFor="email-input">{i18n._(t`Email address`)}</label>
       </div>
-      {error && (
+      {showError && error && (
         <div className="email-input-errors">
           <span id="input-field-error">
             <AlertIcon />
-            <Trans>Please enter a valid email address. </Trans>
+            {i18n._(t`Please enter a valid email address.`)}
           </span>
         </div>
       )}
@@ -61,12 +59,10 @@ const EmailInputWithoutI18n = (props: EmailInputProps) => {
         <input
           type="email"
           id="email-input"
-          className="input"
-          onChange={onChange}
-          onBlur={isBadEmailFormat}
+          className={classNames("input", { invalid: showError && error })}
+          onChange={handleChange}
           value={email}
           required={required}
-          // note: required={true} removed bc any empty state registers as invalid state
         />
       </div>
     </div>

--- a/client/src/components/Icons.tsx
+++ b/client/src/components/Icons.tsx
@@ -33,15 +33,15 @@ export const CheckIcon = (props: SVGProps<SVGSVGElement>) => (
 
 export const SubscribedIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
-    width="36"
+    width="31"
     height="30"
-    viewBox="0 0 36 30"
+    viewBox="0 0 31 30"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
-    <rect x="0.5" width="34.6667" height="30" rx="15" fill="#242323" />
-    <path d="M10.5 15.3333L15.1667 20L25.1667 10" stroke="#F2F2F2" stroke-width="2" />
+    <rect x="0.5" width="30" height="30" rx="15" fill="#242323" />
+    <path d="M8 15.3333L12.6667 20L22.6667 10" stroke="#F2F2F2" strokeWidth="2" />
   </svg>
 );
 

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -273,7 +273,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
     }
 
     !!setLoginRegisterInProgress && setLoginRegisterInProgress(false);
-    
+
     if (!onBuildingPage) {
       handleRedirect && handleRedirect();
       return;

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -79,8 +79,10 @@ const LoginWithoutI18n = (props: LoginProps) => {
   const {
     value: userType,
     error: userTypeError,
-    setError: setUserTypeError,
+    showError: userShowUserTypeError,
     setValue: setUserType,
+    setError: setUserTypeError,
+    setShowError: setShowUserTypeError,
     onChange: onChangeUserType,
   } = useInput("");
 
@@ -316,8 +318,8 @@ const LoginWithoutI18n = (props: LoginProps) => {
 
   const onUserTypeSubmit = async () => {
     if (!userType || userTypeError) {
-      // TODO: raise alert here that this is required?
       setUserTypeError(true);
+      setShowUserTypeError(true);
       return;
     }
 
@@ -325,6 +327,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
 
     if (!!resp?.error) {
       setInvalidAuthError(true);
+      setStep(Step.RegisterAccount);
       return;
     }
 
@@ -405,7 +408,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
                 error={emailError}
                 setError={setEmailError}
                 showError={showEmailError}
-                // note: required={true} removed bc any empty state registers as invalid state
+                autoFocus={showRegisterModal && !email}
               />
             )}
             {(isLoginStep || isRegisterAccountStep) && (
@@ -419,6 +422,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
                 onChange={onChangePassword}
                 showPasswordRules={isRegisterAccountStep}
                 showForgotPassword={!isRegisterAccountStep}
+                autoFocus={showRegisterModal && !!email && !password}
               />
             )}
             {isRegisterUserTypeStep && (
@@ -426,7 +430,8 @@ const LoginWithoutI18n = (props: LoginProps) => {
                 userType={userType}
                 setUserType={setUserType}
                 error={userTypeError}
-                setError={setUserTypeError}
+                showError={userShowUserTypeError}
+                setError={setShowUserTypeError}
                 onChange={onChangeUserType}
               />
             )}

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -323,7 +323,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
       return;
     }
 
-    const resp = await userContext.register(email, password, onSuccess);
+    const resp = await userContext.register(email, password, userType, onSuccess);
 
     if (!!resp?.error) {
       setInvalidAuthError(true);

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -436,15 +436,6 @@ const LoginWithoutI18n = (props: LoginProps) => {
               />
             )}
             <div className="submit-button-group">
-              {/* {isRegisterUserTypeStep && (
-                <button
-                  type="button"
-                  className="button is-primary button-back"
-                  onClick={() => setLoginStep(LoginStep.RegisterAccount)}
-                >
-                  <Trans>Back</Trans>
-                </button>
-              )} */}
               <button type="submit" className="button is-primary">
                 {submitButtonText}
               </button>

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -269,7 +269,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
       return;
     }
 
-    if (!password || passwordError) {
+    if (!password) {
       setPasswordError(true);
       setShowPasswordError(true);
       return;

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -338,7 +338,9 @@ const LoginWithoutI18n = (props: LoginProps) => {
         !onBuildingPage || showRegisterModal ? i18n._(t`Submit`) : i18n._(t`Get updates`);
       break;
     case Step.Login:
-      headerText = onBuildingPage ? "" : i18n._(t`Log in`);
+      headerText = onBuildingPage
+        ? i18n._(t`Get weekly Data Updates for complaints, violations, and evictions.`)
+        : i18n._(t`Log in`);
       onSubmit = onLoginSubmit;
       submitButtonText = i18n._(t`Log in`);
       break;
@@ -410,7 +412,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
                   className="button is-primary button-back"
                   onClick={() => setLoginStep(LoginStep.RegisterAccount)}
                 >
-                  Back
+                  <Trans>Back</Trans>
                 </button>
               )} */}
                 <button type="submit" className="button is-primary">

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -120,10 +120,15 @@ const LoginWithoutI18n = (props: LoginProps) => {
       case invalidAuthError:
         alertMessage = i18n._(t`The email and/or password you entered is incorrect.`);
         return renderPageLevelAlert("error", alertMessage);
-      case existingUserError && isRegisterAccountStep:
-        alertMessage = i18n._(t`That email is already used.`);
-        // show login button in alert
-        return renderPageLevelAlert("error", alertMessage, !onBuildingPage || showRegisterModal);
+      case existingUserError:
+        if (isRegisterAccountStep) {
+          alertMessage = i18n._(t`That email is already used.`);
+          // show login button in alert
+          return renderPageLevelAlert("error", alertMessage, !onBuildingPage || showRegisterModal);
+        } else if (isLoginStep && !(onBuildingPage && !showRegisterModal)) {
+          alertMessage = i18n._(t`Your email is associated with an account. Log in below.`);
+          return renderPageLevelAlert("info", alertMessage);
+        }
     }
   };
 
@@ -248,6 +253,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
 
       if (existingUser) {
         setStep(Step.Login);
+        setExistingUserError(true);
       } else {
         setStep(Step.RegisterAccount);
         if (registerInModal && !showRegisterModal) {
@@ -287,6 +293,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
 
     const existingUser = await AuthClient.isEmailAlreadyUsed(email);
     if (existingUser) {
+      setStep(Step.Login);
       setExistingUserError(true);
       return;
     }
@@ -338,9 +345,11 @@ const LoginWithoutI18n = (props: LoginProps) => {
         !onBuildingPage || showRegisterModal ? i18n._(t`Submit`) : i18n._(t`Get updates`);
       break;
     case Step.Login:
-      headerText = onBuildingPage
+      headerText = !onBuildingPage
+        ? i18n._(t`Log in`)
+        : showRegisterModal
         ? i18n._(t`Get weekly Data Updates for complaints, violations, and evictions.`)
-        : i18n._(t`Log in`);
+        : i18n._(t`Log in to start getting updates for this building.`);
       onSubmit = onLoginSubmit;
       submitButtonText = i18n._(t`Log in`);
       break;
@@ -365,6 +374,9 @@ const LoginWithoutI18n = (props: LoginProps) => {
           <>
             {(!onBuildingPage || showRegisterModal) && (
               <h4 className={classNames(!onBuildingPage && "page-title")}>{headerText}</h4>
+            )}
+            {onBuildingPage && !showRegisterModal && (
+              <div className="email-description">{headerText}</div>
             )}
             {renderAlert()}
             <form

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -135,6 +135,8 @@ const LoginWithoutI18n = (props: LoginProps) => {
     }
   };
 
+  // TODO: do we need this anymore?
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const renderFooter = () => {
     return (
       <div className="building-page-footer">

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -453,7 +453,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
         )}
         {isVerifyEmailStep && renderVerifyEmail()}
         {isVerifyEmailReminderStep && renderVerifyEmailReminder()}
-        {isRegisterAccountStep && renderFooter()}
+        {(isLoginStep || isRegisterAccountStep) && renderFooter()}
       </div>
     );
   };

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -272,15 +272,10 @@ const LoginWithoutI18n = (props: LoginProps) => {
       return;
     }
 
+    !!setLoginRegisterInProgress && setLoginRegisterInProgress(false);
+    
     if (!onBuildingPage) {
-      !!setLoginRegisterInProgress && setLoginRegisterInProgress(false);
       handleRedirect && handleRedirect();
-      return;
-    }
-
-    if (!!resp?.user && !resp.user.verified) {
-      setStep(Step.VerifyEmailReminder);
-      registerInModal && setShowRegisterModal(true);
       return;
     }
   };
@@ -390,7 +385,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
               )}
               {(isLoginStep || isRegisterAccountStep) && (
                 <PasswordInput
-                  labelText={isLoginStep ? i18n._(t`Password`) : i18n._(t`Create a password`)}
+                  labelText={i18n._(t`Password`)}
                   password={password}
                   username={email}
                   setError={setPasswordError}

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -431,7 +431,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
                 setUserType={setUserType}
                 error={userTypeError}
                 showError={userShowUserTypeError}
-                setError={setShowUserTypeError}
+                setError={setUserTypeError}
                 onChange={onChangeUserType}
               />
             )}

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -10,6 +10,7 @@ import { createWhoOwnsWhatRoutePaths } from "routes";
 import { I18n } from "@lingui/core";
 import { t } from "@lingui/macro";
 import { HideIcon, ShowIcon } from "./Icons";
+import classNames from "classnames";
 
 type PasswordRule = {
   regex: RegExp;
@@ -34,8 +35,10 @@ type PasswordInputProps = {
   i18n: I18n;
   labelText: string;
   password: string;
-  username?: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  error: boolean;
+  showError: boolean;
+  username?: string;
   setError?: React.Dispatch<React.SetStateAction<boolean>>;
   showPasswordRules?: boolean;
   showForgotPassword?: boolean;
@@ -48,7 +51,9 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
     labelText,
     username,
     password,
+    error,
     setError,
+    showError,
     onChange,
     showPasswordRules,
     showForgotPassword,
@@ -88,7 +93,7 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
         <input
           type={showPassword ? "text" : "password"}
           id="password-input"
-          className="input"
+          className={classNames("input", { invalid: showError && error })}
           onChange={onChange}
           onBlur={badPasswordFormat}
           value={password}

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-escape */
-import React, { ChangeEvent, Fragment, useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 
 import "styles/Password.css";
 import "styles/_input.scss";
@@ -63,7 +63,7 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
   };
 
   return (
-    <Fragment>
+    <div className="password-input-field">
       <div className="password-input-label">
         <label>{i18n._(t`${labelText}`)}</label>
         {showForgotPassword && (
@@ -101,7 +101,7 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
           {showPassword ? <HideIcon /> : <ShowIcon />}
         </button>
       </div>
-    </Fragment>
+    </div>
   );
 };
 

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -42,7 +42,6 @@ interface PasswordInputProps extends React.ComponentPropsWithoutRef<"input"> {
   username?: string;
   showPasswordRules?: boolean;
   showForgotPassword?: boolean;
-  inputId?: string;
 }
 
 const PasswordInputWithoutI18n = forwardRef<HTMLInputElement, PasswordInputProps>(

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-escape */
-import React, { Fragment, useState } from "react";
+import React, { ChangeEvent, Fragment, useState } from "react";
 
 import "styles/Password.css";
 import "styles/_input.scss";
@@ -33,22 +33,33 @@ export const validatePassword = (password: string) => {
 type PasswordInputProps = {
   i18n: I18n;
   labelText: string;
+  password: string;
   username?: string;
-  onChange?: (password: string) => void;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  setError?: React.Dispatch<React.SetStateAction<boolean>>;
   showPasswordRules?: boolean;
   showForgotPassword?: boolean;
 };
 
 const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
   const { account } = createWhoOwnsWhatRoutePaths();
-
-  const { i18n, labelText, username, onChange, showPasswordRules, showForgotPassword } = props;
-  const [password, setPassword] = useState("");
+  const {
+    i18n,
+    labelText,
+    username,
+    password,
+    setError,
+    onChange,
+    showPasswordRules,
+    showForgotPassword,
+  } = props;
   const [showPassword, setShowPassword] = useState(false);
 
-  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value);
-    if (onChange) onChange(e.target.value);
+  const badPasswordFormat = () => {
+    const input = document.getElementById("password-input") as HTMLElement;
+    const inputValue = (input as HTMLInputElement).value;
+    const isValid = validatePassword(inputValue);
+    setError && setError(!isValid);
   };
 
   return (
@@ -76,8 +87,10 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
       <div className="password-input">
         <input
           type={showPassword ? "text" : "password"}
+          id="password-input"
           className="input"
-          onChange={handlePasswordChange}
+          onChange={onChange}
+          onBlur={badPasswordFormat}
           value={password}
         />
         <button

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -42,6 +42,7 @@ type PasswordInputProps = {
   setError?: React.Dispatch<React.SetStateAction<boolean>>;
   showPasswordRules?: boolean;
   showForgotPassword?: boolean;
+  inputId?: string;
 };
 
 const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
@@ -57,6 +58,7 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
     onChange,
     showPasswordRules,
     showForgotPassword,
+    inputId,
   } = props;
   const [showPassword, setShowPassword] = useState(false);
 
@@ -70,7 +72,7 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
   return (
     <div className="password-input-field">
       <div className="password-input-label">
-        <label>{i18n._(t`${labelText}`)}</label>
+        <label htmlFor={inputId ?? "password-input"}>{i18n._(t`${labelText}`)}</label>
         {showForgotPassword && (
           <LocaleLink to={`${account.forgotPassword}?email=${encodeURIComponent(username || "")}`}>
             Forgot your password?
@@ -92,7 +94,7 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
       <div className="password-input">
         <input
           type={showPassword ? "text" : "password"}
-          id="password-input"
+          id={inputId ?? "password-input"}
           className={classNames("input", { invalid: showError && error })}
           onChange={onChange}
           onBlur={badPasswordFormat}

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -42,12 +42,14 @@ interface PasswordInputProps extends React.ComponentPropsWithoutRef<"input"> {
   username?: string;
   showPasswordRules?: boolean;
   showForgotPassword?: boolean;
+  i18nHash?: string;
 }
 
 const PasswordInputWithoutI18n = forwardRef<HTMLInputElement, PasswordInputProps>(
   (
     {
       i18n,
+      i18nHash,
       labelText,
       username,
       password,

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -25,10 +25,10 @@ const passwordRules: PasswordRule[] = [
   },
 ];
 
-export const validatePassword = (password: string) => {
+const isBadPasswordFormat = (password: string) => {
   let valid = true;
   passwordRules.forEach((rule) => (valid = valid && !!password.match(rule.regex)));
-  return valid;
+  return !valid;
 };
 
 type PasswordInputProps = {
@@ -38,8 +38,8 @@ type PasswordInputProps = {
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   error: boolean;
   showError: boolean;
+  setError: React.Dispatch<React.SetStateAction<boolean>>;
   username?: string;
-  setError?: React.Dispatch<React.SetStateAction<boolean>>;
   showPasswordRules?: boolean;
   showForgotPassword?: boolean;
   inputId?: string;
@@ -62,11 +62,10 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
   } = props;
   const [showPassword, setShowPassword] = useState(false);
 
-  const badPasswordFormat = () => {
-    const input = document.getElementById("password-input") as HTMLElement;
-    const inputValue = (input as HTMLInputElement).value;
-    const isValid = validatePassword(inputValue);
-    setError && setError(!isValid);
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange(e);
+    const passwordIsInvalid = isBadPasswordFormat(e.target.value);
+    setError(passwordIsInvalid);
   };
 
   return (
@@ -96,8 +95,7 @@ const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
           type={showPassword ? "text" : "password"}
           id={inputId ?? "password-input"}
           className={classNames("input", { invalid: showError && error })}
-          onChange={onChange}
-          onBlur={badPasswordFormat}
+          onChange={handleChange}
           value={password}
         />
         <button

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-escape */
-import React, { ChangeEvent, useState } from "react";
+import React, { ChangeEvent, forwardRef, useState } from "react";
 
 import "styles/Password.css";
 import "styles/_input.scss";
@@ -31,7 +31,7 @@ const isBadPasswordFormat = (password: string) => {
   return !valid;
 };
 
-type PasswordInputProps = {
+interface PasswordInputProps extends React.ComponentPropsWithoutRef<"input"> {
   i18n: I18n;
   labelText: string;
   password: string;
@@ -43,72 +43,85 @@ type PasswordInputProps = {
   showPasswordRules?: boolean;
   showForgotPassword?: boolean;
   inputId?: string;
-};
+}
 
-const PasswordInputWithoutI18n = (props: PasswordInputProps) => {
-  const { account } = createWhoOwnsWhatRoutePaths();
-  const {
-    i18n,
-    labelText,
-    username,
-    password,
-    error,
-    setError,
-    showError,
-    onChange,
-    showPasswordRules,
-    showForgotPassword,
-    inputId,
-  } = props;
-  const [showPassword, setShowPassword] = useState(false);
+const PasswordInputWithoutI18n = forwardRef<HTMLInputElement, PasswordInputProps>(
+  (
+    {
+      i18n,
+      labelText,
+      username,
+      password,
+      error,
+      setError,
+      showError,
+      onChange,
+      showPasswordRules,
+      showForgotPassword,
+      id,
+      ...props
+    },
+    ref
+  ) => {
+    const { account } = createWhoOwnsWhatRoutePaths();
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onChange(e);
-    const passwordIsInvalid = isBadPasswordFormat(e.target.value);
-    setError(passwordIsInvalid);
-  };
+    const [showPassword, setShowPassword] = useState(false);
 
-  return (
-    <div className="password-input-field">
-      <div className="password-input-label">
-        <label htmlFor={inputId ?? "password-input"}>{i18n._(t`${labelText}`)}</label>
-        {showForgotPassword && (
-          <LocaleLink to={`${account.forgotPassword}?email=${encodeURIComponent(username || "")}`}>
-            Forgot your password?
-          </LocaleLink>
-        )}
-      </div>
-      {showPasswordRules && (
-        <div className="password-input-rules">
-          {passwordRules.map((rule, i) => {
-            const ruleClass = !!password ? (password.match(rule.regex) ? "valid" : "invalid") : "";
-            return (
-              <span className={`password-input-rule ${ruleClass}`} key={`rule-${i}`}>
-                {rule.label}
-              </span>
-            );
-          })}
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      onChange(e);
+      const passwordIsInvalid = isBadPasswordFormat(e.target.value);
+      setError(passwordIsInvalid);
+    };
+
+    return (
+      <div className="password-input-field">
+        <div className="password-input-label">
+          <label htmlFor={id ?? "password-input"}>{i18n._(t`${labelText}`)}</label>
+          {showForgotPassword && (
+            <LocaleLink
+              to={`${account.forgotPassword}?email=${encodeURIComponent(username || "")}`}
+            >
+              Forgot your password?
+            </LocaleLink>
+          )}
         </div>
-      )}
-      <div className="password-input">
-        <input
-          type={showPassword ? "text" : "password"}
-          id={inputId ?? "password-input"}
-          className={classNames("input", { invalid: showError && error })}
-          onChange={handleChange}
-          value={password}
-        />
-        <button
-          type="button"
-          className="show-hide-toggle"
-          onClick={() => setShowPassword(!showPassword)}
-        >
-          {showPassword ? <HideIcon /> : <ShowIcon />}
-        </button>
+        {showPasswordRules && (
+          <div className="password-input-rules">
+            {passwordRules.map((rule, i) => {
+              const ruleClass = !!password
+                ? password.match(rule.regex)
+                  ? "valid"
+                  : "invalid"
+                : "";
+              return (
+                <span className={`password-input-rule ${ruleClass}`} key={`rule-${i}`}>
+                  {rule.label}
+                </span>
+              );
+            })}
+          </div>
+        )}
+        <div className="password-input">
+          <input
+            type={showPassword ? "text" : "password"}
+            id={id ?? "password-input"}
+            className={classNames("input", { invalid: showError && error })}
+            onChange={handleChange}
+            value={password}
+            {...props}
+          />
+          <button
+            type="button"
+            className="show-hide-toggle"
+            onClick={() => setShowPassword(!showPassword)}
+          >
+            {showPassword ? <HideIcon /> : <ShowIcon />}
+          </button>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
 
 PasswordInputWithoutI18n.defaultProps = {
   showPasswordRules: false,

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -13,6 +13,7 @@ export type UserContextProps = {
   register: (
     username: string,
     password: string,
+    userType: string,
     onSuccess?: (user: JustfixUser) => void
   ) => Promise<UserOrError | void>;
   login: (
@@ -40,6 +41,7 @@ const initialState: UserContextProps = {
   register: async (
     username: string,
     password: string,
+    userType: string,
     onSuccess?: (user: JustfixUser) => void
   ) => {},
   login: async (username: string, password: string, onSuccess?: (user: JustfixUser) => void) => {},
@@ -80,8 +82,13 @@ export const UserContextProvider = ({ children }: { children: React.ReactNode })
   }, []);
 
   const register = useCallback(
-    async (username: string, password: string, onSuccess?: (user: JustfixUser) => void) => {
-      const response = await AuthClient.register(username, password);
+    async (
+      username: string,
+      password: string,
+      userType: string,
+      onSuccess?: (user: JustfixUser) => void
+    ) => {
+      const response = await AuthClient.register(username, password, userType);
       if (!response.error && response.user) {
         const _user = {
           ...response.user,

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -3,18 +3,23 @@ import { JustfixUser } from "state-machine";
 import AuthClient from "./AuthClient";
 import { authRequiredPaths } from "routes";
 
+type UserOrError = {
+  user?: JustfixUser;
+  error?: string;
+};
+
 export type UserContextProps = {
   user?: JustfixUser;
   register: (
     username: string,
     password: string,
     onSuccess?: (user: JustfixUser) => void
-  ) => Promise<string | void>;
+  ) => Promise<UserOrError | void>;
   login: (
     username: string,
     password: string,
     onSuccess?: (user: JustfixUser) => void
-  ) => Promise<string | void>;
+  ) => Promise<UserOrError | void>;
   logout: (fromPath: string) => void;
   subscribe: (
     bbl: string,
@@ -87,8 +92,9 @@ export const UserContextProvider = ({ children }: { children: React.ReactNode })
         };
         setUser(_user);
         if (onSuccess) onSuccess(_user);
+        return { user: _user };
       } else {
-        return response.error_description;
+        return { error: response.error_description };
       }
     },
     []
@@ -108,8 +114,9 @@ export const UserContextProvider = ({ children }: { children: React.ReactNode })
         };
         setUser(_user);
         if (onSuccess) onSuccess(_user);
+        return { user: _user };
       } else {
-        return response.error;
+        return { error: response.error };
       }
     },
     []

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -39,6 +39,7 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
         onChange={onChangeCurrentPassword}
         error={currentPasswordError}
         showError={showCurrentPasswordError}
+        inputId="old-password-input"
       />
       <PasswordInput
         labelText={i18n._(t`Create a new password`)}
@@ -47,6 +48,7 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
         onChange={onChangeNewPassword}
         error={newPasswordError}
         showError={showNewPasswordError}
+        inputId="new-password-input"
       />
     </UserSettingField>
   );

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -13,8 +13,18 @@ type PasswordSettingFieldProps = withI18nProps & {
 
 const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
   const { i18n, onSubmit } = props;
-  const { value: currentPassword, onChange: onChangeCurrentPassword } = useInput("");
-  const { value: newPassword, onChange: onChangeNewPassword } = useInput("");
+  const {
+    value: currentPassword,
+    error: currentPasswordError,
+    showError: showCurrentPasswordError,
+    onChange: onChangeCurrentPassword,
+  } = useInput("");
+  const {
+    value: newPassword,
+    error: newPasswordError,
+    showError: showNewPasswordError,
+    onChange: onChangeNewPassword,
+  } = useInput("");
   // const [showCurrentPassword, setShowCurrentPassword] = useState(false);
 
   const handleSubmit = () => {
@@ -23,29 +33,20 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
 
   return (
     <UserSettingField title={i18n._(t`Password`)} preview="**********" onSubmit={handleSubmit}>
-      <Trans render="label">Password</Trans>
       <PasswordInput
         labelText={i18n._(t`Enter your old password`)}
         password={currentPassword}
         onChange={onChangeCurrentPassword}
+        error={currentPasswordError}
+        showError={showCurrentPasswordError}
       />
-
-      {/* <div className="password-input">
-        <input
-          type={showCurrentPassword ? "text" : "password"}
-          className="input"
-          onChange={handleCurrentPasswordChange}
-          value={currentPassword}
-        />
-        <button type="button" onClick={() => setShowCurrentPassword(!showCurrentPassword)}>
-          Show
-        </button>
-      </div> */}
       <PasswordInput
         labelText={i18n._(t`Create a new password`)}
         showPasswordRules={true}
         password={newPassword}
         onChange={onChangeNewPassword}
+        error={newPasswordError}
+        showError={showNewPasswordError}
       />
     </UserSettingField>
   );

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -42,7 +42,7 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
         showError={showCurrentPasswordError}
         setError={setCurrentPasswordError}
         onChange={onChangeCurrentPassword}
-        inputId="old-password-input"
+        id="old-password-input"
       />
       <PasswordInput
         labelText={i18n._(t`Create a new password`)}
@@ -52,7 +52,7 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
         showError={showNewPasswordError}
         setError={setNewPasswordError}
         onChange={onChangeNewPassword}
-        inputId="new-password-input"
+        id="new-password-input"
       />
     </UserSettingField>
   );

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -5,6 +5,7 @@ import { t, Trans } from "@lingui/macro";
 
 import "styles/EmailAlertSignup.css";
 import PasswordInput from "./PasswordInput";
+import { useInput } from "util/helpers";
 
 type PasswordSettingFieldProps = withI18nProps & {
   onSubmit: (currentPassword: string, newPassword: string) => void;
@@ -12,14 +13,9 @@ type PasswordSettingFieldProps = withI18nProps & {
 
 const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
   const { i18n, onSubmit } = props;
-  const [newPassword, setNewPassword] = useState("");
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [currentPassword, setCurrentPassword] = useState("");
+  const { value: currentPassword, onChange: onChangeCurrentPassword } = useInput("");
+  const { value: newPassword, onChange: onChangeNewPassword } = useInput("");
   // const [showCurrentPassword, setShowCurrentPassword] = useState(false);
-
-  // const handleCurrentPasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   setCurrentPassword(e.target.value);
-  // };
 
   const handleSubmit = () => {
     onSubmit(currentPassword, newPassword);
@@ -28,7 +24,11 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
   return (
     <UserSettingField title={i18n._(t`Password`)} preview="**********" onSubmit={handleSubmit}>
       <Trans render="label">Password</Trans>
-      <PasswordInput labelText="Enter your old password" />
+      <PasswordInput
+        labelText={i18n._(t`Enter your old password`)}
+        password={currentPassword}
+        onChange={onChangeCurrentPassword}
+      />
 
       {/* <div className="password-input">
         <input
@@ -42,9 +42,10 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
         </button>
       </div> */}
       <PasswordInput
-        labelText="Create a new password"
+        labelText={i18n._(t`Create a new password`)}
         showPasswordRules={true}
-        onChange={setNewPassword}
+        password={newPassword}
+        onChange={onChangeNewPassword}
       />
     </UserSettingField>
   );

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -17,12 +17,14 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
     value: currentPassword,
     error: currentPasswordError,
     showError: showCurrentPasswordError,
+    setError: setCurrentPasswordError,
     onChange: onChangeCurrentPassword,
   } = useInput("");
   const {
     value: newPassword,
     error: newPasswordError,
     showError: showNewPasswordError,
+    setError: setNewPasswordError,
     onChange: onChangeNewPassword,
   } = useInput("");
   // const [showCurrentPassword, setShowCurrentPassword] = useState(false);
@@ -36,18 +38,20 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
       <PasswordInput
         labelText={i18n._(t`Enter your old password`)}
         password={currentPassword}
-        onChange={onChangeCurrentPassword}
         error={currentPasswordError}
         showError={showCurrentPasswordError}
+        setError={setCurrentPasswordError}
+        onChange={onChangeCurrentPassword}
         inputId="old-password-input"
       />
       <PasswordInput
         labelText={i18n._(t`Create a new password`)}
         showPasswordRules={true}
         password={newPassword}
-        onChange={onChangeNewPassword}
         error={newPasswordError}
         showError={showNewPasswordError}
+        setError={setNewPasswordError}
+        onChange={onChangeNewPassword}
         inputId="new-password-input"
       />
     </UserSettingField>

--- a/client/src/components/UserTypeInput.tsx
+++ b/client/src/components/UserTypeInput.tsx
@@ -3,6 +3,7 @@ import { Trans, t } from "@lingui/macro";
 import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
 import { AlertIcon } from "./Icons";
+import classNames from "classnames";
 
 type UserTypeInputProps = {
   i18n: I18n;
@@ -31,15 +32,10 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
   };
 
   const missingOtherText = () => {
-    const input = document.getElementById("user-type-input-other-text") as HTMLElement;
-    const inputValue = (input as HTMLInputElement).value;
-
-    if (!inputValue) {
+    if (!userType) {
       setError(true);
-      input.className = input.className + " invalid";
     } else {
       setError(false);
-      input.className = input.className.split(" ")[0];
     }
   };
 
@@ -54,6 +50,12 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
 
   return (
     <div className="user-type-container">
+      {error && activeRadio !== USER_TYPES.other && (
+        <span id="input-field-error">
+          <AlertIcon />
+          <Trans>Please select an option.</Trans>
+        </span>
+      )}
       <div className="user-type-radio-group">
         <input
           id="user-type-input-tenant"
@@ -134,7 +136,7 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
             required={required}
             autoFocus
             id="user-type-input-other-text"
-            className="input"
+            className={classNames("input", { invalid: error })}
             type="text"
             name="user-type"
             value={userType}

--- a/client/src/components/UserTypeInput.tsx
+++ b/client/src/components/UserTypeInput.tsx
@@ -22,14 +22,13 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
   const [activeRadio, setActiveRadio] = useState("");
 
   const handleRadioChange = (e: ChangeEvent<HTMLInputElement>) => {
-    e.preventDefault();
     const value = e.target.value;
     setActiveRadio(value);
     if (value === USER_TYPES.other) {
       setUserType("");
       setError(true);
     } else {
-      onChange(e);
+      setUserType(value);
       setError(false);
     }
   };

--- a/client/src/components/UserTypeInput.tsx
+++ b/client/src/components/UserTypeInput.tsx
@@ -9,6 +9,7 @@ type UserTypeInputProps = {
   i18n: I18n;
   userType: string;
   error: boolean;
+  showError: boolean;
   setError: React.Dispatch<React.SetStateAction<boolean>>;
   setUserType: React.Dispatch<React.SetStateAction<string>>;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
@@ -16,27 +17,27 @@ type UserTypeInputProps = {
 };
 
 const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
-  const { i18n, userType, error, setError, setUserType, onChange, required } = props;
+  const { i18n, userType, error, showError, setError, setUserType, onChange, required } = props;
 
   const [activeRadio, setActiveRadio] = useState("");
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleRadioChange = (e: ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
     const value = e.target.value;
     setActiveRadio(value);
     if (value === USER_TYPES.other) {
       setUserType("");
+      setError(true);
     } else {
       onChange(e);
       setError(false);
     }
   };
 
-  const missingOtherText = () => {
-    if (!userType) {
-      setError(true);
-    } else {
-      setError(false);
-    }
+  const handleTextChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange(e);
+    const value = e.target.value;
+    setError(!value);
   };
 
   const USER_TYPES = {
@@ -50,7 +51,7 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
 
   return (
     <div className="user-type-container">
-      {error && activeRadio !== USER_TYPES.other && (
+      {showError && error && activeRadio !== USER_TYPES.other && (
         <span id="input-field-error">
           <AlertIcon />
           <Trans>Please select an option.</Trans>
@@ -65,7 +66,7 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           name="user-type"
           value={USER_TYPES.tenant}
           checked={activeRadio === USER_TYPES.tenant}
-          onChange={handleChange}
+          onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-tenant"}>{USER_TYPES.tenant}</label>
         <input
@@ -76,7 +77,7 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           name="user-type"
           value={USER_TYPES.organizer}
           checked={activeRadio === USER_TYPES.organizer}
-          onChange={handleChange}
+          onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-organizer"}>{USER_TYPES.organizer}</label>
         <input
@@ -87,7 +88,7 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           name="user-type"
           value={USER_TYPES.advocate}
           checked={activeRadio === USER_TYPES.advocate}
-          onChange={handleChange}
+          onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-advocate"}>{USER_TYPES.advocate}</label>
         <input
@@ -98,7 +99,7 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           name="user-type"
           value={USER_TYPES.legal}
           checked={activeRadio === USER_TYPES.legal}
-          onChange={handleChange}
+          onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-legal"}>{USER_TYPES.legal}</label>
         <input
@@ -109,7 +110,7 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           name="user-type"
           value={USER_TYPES.government}
           checked={activeRadio === USER_TYPES.government}
-          onChange={handleChange}
+          onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-government"}>{USER_TYPES.government}</label>
         <input
@@ -120,13 +121,13 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           name="user-type"
           value={USER_TYPES.other}
           checked={activeRadio === USER_TYPES.other}
-          onChange={handleChange}
+          onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-other"}>{USER_TYPES.other}</label>
       </div>
       {activeRadio === USER_TYPES.other && (
         <div className="user-type-input-text-group">
-          {error && (
+          {showError && error && (
             <span id="input-field-error">
               <AlertIcon />
               <Trans>Please enter a response. </Trans>
@@ -140,8 +141,7 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
             type="text"
             name="user-type"
             value={userType}
-            onChange={onChange}
-            onBlur={missingOtherText}
+            onChange={handleTextChange}
           />
         </div>
       )}

--- a/client/src/components/UserTypeInput.tsx
+++ b/client/src/components/UserTypeInput.tsx
@@ -1,0 +1,152 @@
+import { ChangeEvent, useState } from "react";
+import { Trans, t } from "@lingui/macro";
+import { I18n } from "@lingui/core";
+import { withI18n } from "@lingui/react";
+import { AlertIcon } from "./Icons";
+
+type UserTypeInputProps = {
+  i18n: I18n;
+  userType: string;
+  error: boolean;
+  setError: React.Dispatch<React.SetStateAction<boolean>>;
+  setUserType: React.Dispatch<React.SetStateAction<string>>;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  required?: boolean;
+};
+
+const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
+  const { i18n, userType, error, setError, setUserType, onChange, required } = props;
+
+  const [activeRadio, setActiveRadio] = useState("");
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setActiveRadio(value);
+    if (value === USER_TYPES.other) {
+      setUserType("");
+    } else {
+      onChange(e);
+      setError(false);
+    }
+  };
+
+  const missingOtherText = () => {
+    const input = document.getElementById("user-type-input-other-text") as HTMLElement;
+    const inputValue = (input as HTMLInputElement).value;
+
+    if (!inputValue) {
+      setError(true);
+      input.className = input.className + " invalid";
+    } else {
+      setError(false);
+      input.className = input.className.split(" ")[0];
+    }
+  };
+
+  const USER_TYPES = {
+    tenant: i18n._(t`Tenant`),
+    organizer: i18n._(t`Organizer`),
+    advocate: i18n._(t`Advocate`),
+    legal: i18n._(t`Legal Worker`),
+    government: i18n._(t`Government Worker (Non-Lawyer)`),
+    other: i18n._(t`Other`),
+  };
+
+  return (
+    <div className="user-type-container">
+      <div className="user-type-radio-group">
+        <input
+          id="user-type-input-tenant"
+          className="input-radio"
+          required={required}
+          type="radio"
+          name="user-type"
+          value={USER_TYPES.tenant}
+          checked={activeRadio === USER_TYPES.tenant}
+          onChange={handleChange}
+        />
+        <label htmlFor={"user-type-input-tenant"}>{USER_TYPES.tenant}</label>
+        <input
+          id="user-type-input-organizer"
+          className="input-radio"
+          required={required}
+          type="radio"
+          name="user-type"
+          value={USER_TYPES.organizer}
+          checked={activeRadio === USER_TYPES.organizer}
+          onChange={handleChange}
+        />
+        <label htmlFor={"user-type-input-organizer"}>{USER_TYPES.organizer}</label>
+        <input
+          id="user-type-input-advocate"
+          className="input-radio"
+          required={required}
+          type="radio"
+          name="user-type"
+          value={USER_TYPES.advocate}
+          checked={activeRadio === USER_TYPES.advocate}
+          onChange={handleChange}
+        />
+        <label htmlFor={"user-type-input-advocate"}>{USER_TYPES.advocate}</label>
+        <input
+          id="user-type-input-legal"
+          className="input-radio"
+          required={required}
+          type="radio"
+          name="user-type"
+          value={USER_TYPES.legal}
+          checked={activeRadio === USER_TYPES.legal}
+          onChange={handleChange}
+        />
+        <label htmlFor={"user-type-input-legal"}>{USER_TYPES.legal}</label>
+        <input
+          id="user-type-input-government"
+          className="input-radio"
+          required={required}
+          type="radio"
+          name="user-type"
+          value={USER_TYPES.government}
+          checked={activeRadio === USER_TYPES.government}
+          onChange={handleChange}
+        />
+        <label htmlFor={"user-type-input-government"}>{USER_TYPES.government}</label>
+        <input
+          id="user-type-input-other"
+          className="input-radio"
+          required={required}
+          type="radio"
+          name="user-type"
+          value={USER_TYPES.other}
+          checked={activeRadio === USER_TYPES.other}
+          onChange={handleChange}
+        />
+        <label htmlFor={"user-type-input-other"}>{USER_TYPES.other}</label>
+      </div>
+      {activeRadio === USER_TYPES.other && (
+        <div className="user-type-input-text-group">
+          {error && (
+            <span id="input-field-error">
+              <AlertIcon />
+              <Trans>Please enter a response. </Trans>
+            </span>
+          )}
+          <input
+            required={required}
+            autoFocus
+            id="user-type-input-other-text"
+            className="input"
+            type="text"
+            name="user-type"
+            value={userType}
+            onChange={onChange}
+            onBlur={missingOtherText}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const UserTypeInput = withI18n()(UserTypeInputWithoutI18n);
+
+export default UserTypeInput;

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -17,7 +17,12 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
 
   const [requestSent, setRequestSent] = React.useState(false);
   const userContext = useContext(UserContext);
-  const { value: password, onChange: onChangePassword } = useInput("");
+  const {
+    value: password,
+    error: passwordError,
+    showError: showPasswordError,
+    onChange: onChangePassword,
+  } = useInput("");
 
   const delaySeconds = 5;
   const baseUrl = window.location.origin;
@@ -56,6 +61,8 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
                   showPasswordRules={true}
                   password={password}
                   onChange={onChangePassword}
+                  error={passwordError}
+                  showError={showPasswordError}
                 />
                 <button type="submit" className="button is-primary">
                   <Trans>Reset password</Trans>

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -21,6 +21,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
     value: password,
     error: passwordError,
     showError: showPasswordError,
+    setError: setPasswordError,
     onChange: onChangePassword,
   } = useInput("");
 
@@ -63,6 +64,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
                   onChange={onChangePassword}
                   error={passwordError}
                   showError={showPasswordError}
+                  setError={setPasswordError}
                 />
                 <button type="submit" className="button is-primary">
                   <Trans>Reset password</Trans>

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -8,6 +8,7 @@ import { Trans, t } from "@lingui/macro";
 
 import { UserContext } from "components/UserContext";
 import PasswordInput from "components/PasswordInput";
+import { useInput } from "util/helpers";
 
 const ResetPasswordPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -15,8 +16,8 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
   const params = new URLSearchParams(search);
 
   const [requestSent, setRequestSent] = React.useState(false);
-  const [value, setValue] = React.useState("");
   const userContext = useContext(UserContext);
+  const { value: password, onChange: onChangePassword } = useInput("");
 
   const delaySeconds = 5;
   const baseUrl = window.location.origin;
@@ -38,7 +39,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    await userContext.resetPassword(params.get("token") || "", value);
+    await userContext.resetPassword(params.get("token") || "", password);
     setRequestSent(true);
   };
 
@@ -49,13 +50,16 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
           {!requestSent ? (
             <>
               <Trans render="h4">Reset your password</Trans>
-              <form onSubmit={handleSubmit}>
+              <form className="input-group" onSubmit={handleSubmit}>
                 <PasswordInput
-                  labelText="Create a password"
+                  labelText={i18n._(t`Create a password`)}
                   showPasswordRules={true}
-                  onChange={setValue}
+                  password={password}
+                  onChange={onChangePassword}
                 />
-                <input type="submit" className="button is-primary" value={`Reset password`} />
+                <button type="submit" className="button is-primary">
+                  <Trans>Reset password</Trans>
+                </button>
               </form>
             </>
           ) : (

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -6,8 +6,8 @@
     text-decoration: none;
     text-align: left !important;
     font-weight: 700;
-    padding-top: 0.37rem;
-    margin: 3.5rem 1rem 1.63rem;
+    padding-top: 0.23rem;
+    margin: 2.19rem 0.63rem 1.02rem;
   }
 
   h4.settings-section {
@@ -16,25 +16,25 @@
   }
 
   label {
-    font-size: 0.81rem;
+    font-size: 0.51rem;
     font-weight: 600;
   }
 
   p {
-    font-size: 0.81rem;
+    font-size: 0.51rem;
     font-weight: 500;
   }
 
   .settings-contact {
-    margin: 3.75rem 1.25rem 3.13rem;
+    margin: 2.34rem 0.78rem 1.96rem;
     text-align: center;
   }
 
   .settings-no-subscriptions {
-    padding: 1rem;
+    padding: 0.63rem;
     background-color: $justfix-grey-50;
     border-radius: 4px;
-    margin: auto 1rem;
+    margin: auto 0.63rem;
   }
 }
 
@@ -42,8 +42,8 @@
   form {
     display: flex;
     flex-direction: column;
-    margin: 3.2rem 1.6rem;
-    gap: 2.4rem;
+    margin: 2rem 1rem;
+    gap: 1.5rem;
 
     .password-input-field {
       display: flex;
@@ -51,7 +51,7 @@
     }
 
     p {
-      margin: -0.63rem 0 0.37rem 0;
+      margin: -0.39rem 0 0.23rem 0;
     }
   }
 
@@ -72,7 +72,7 @@
     }
 
     input[type="submit"] {
-      margin: 0 1rem 0 0 !important;
+      margin: 0 0.63rem 0 0 !important;
     }
   }
 
@@ -81,10 +81,10 @@
     // vars marked !important bc typography mixin is not available for inconsolata
     font-weight: 600 !important;
     font-family: $wow-font !important;
-    font-size: 0.81rem !important;
+    font-size: 0.51rem !important;
 
     text-align: left;
-    margin-bottom: 1rem;
+    margin-bottom: 0.63rem;
   }
 
   .password-input-rules {
@@ -92,7 +92,7 @@
     flex-direction: column;
 
     span:last-child {
-      margin-bottom: 0.37rem !important;
+      margin-bottom: 0.23rem !important;
     }
   }
 }

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -6,8 +6,8 @@
     text-decoration: none;
     text-align: left !important;
     font-weight: 700;
-    padding-top: 0.23rem;
-    margin: 2.19rem 0.63rem 1.02rem;
+    padding-top: 0.37rem;
+    margin: 3.5rem 1rem 1.63rem;
   }
 
   h4.settings-section {
@@ -16,25 +16,25 @@
   }
 
   label {
-    font-size: 0.51rem;
+    font-size: 0.81rem;
     font-weight: 600;
   }
 
   p {
-    font-size: 0.51rem;
+    font-size: 0.81rem;
     font-weight: 500;
   }
 
   .settings-contact {
-    margin: 2.34rem 0.78rem 1.96rem;
+    margin: 3.75rem 1.25rem 3.13rem;
     text-align: center;
   }
 
   .settings-no-subscriptions {
-    padding: 0.63rem;
+    padding: 1rem;
     background-color: $justfix-grey-50;
     border-radius: 4px;
-    margin: auto 0.63rem;
+    margin: auto 1rem;
   }
 }
 
@@ -42,8 +42,8 @@
   form {
     display: flex;
     flex-direction: column;
-    margin: 2rem 1rem;
-    gap: 1.5rem;
+    margin: 3.2rem 1.6rem;
+    gap: 2.4rem;
 
     .password-input-field {
       display: flex;
@@ -51,7 +51,7 @@
     }
 
     p {
-      margin: -0.39rem 0 0.23rem 0;
+      margin: -0.63rem 0 0.37rem 0;
     }
   }
 
@@ -72,7 +72,7 @@
     }
 
     input[type="submit"] {
-      margin: 0 0.63rem 0 0 !important;
+      margin: 0 1rem 0 0 !important;
     }
   }
 
@@ -81,10 +81,10 @@
     // vars marked !important bc typography mixin is not available for inconsolata
     font-weight: 600 !important;
     font-family: $wow-font !important;
-    font-size: 0.51rem !important;
+    font-size: 0.81rem !important;
 
     text-align: left;
-    margin-bottom: 0.63rem;
+    margin-bottom: 1rem;
   }
 
   .password-input-rules {
@@ -92,7 +92,7 @@
     flex-direction: column;
 
     span:last-child {
-      margin-bottom: 0.23rem !important;
+      margin-bottom: 0.37rem !important;
     }
   }
 }

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -43,6 +43,12 @@
     display: flex;
     flex-direction: column;
     margin: 3.2rem 1.6rem;
+    gap: 2.4rem;
+
+    .password-input-field {
+      display: flex;
+      flex-direction: column;
+    }
 
     p {
       margin: -1rem 0 0.6rem 0;
@@ -60,7 +66,6 @@
   .user-setting-actions {
     display: flex;
     justify-content: right;
-    margin-top: 1.6rem;
 
     @include for-phone-only() {
       justify-content: center;
@@ -80,10 +85,6 @@
 
     text-align: left;
     margin-bottom: 1.6rem;
-  }
-
-  .password-input-label {
-    margin-bottom: -1rem !important;
   }
 
   .password-input-rules {

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -123,7 +123,7 @@
     }
 
     .DetailView__mobilePortfolioView {
-      padding: 0.81rem 1.25rem;
+      padding: 0.8125rem 1.25rem;
 
       display: none;
       @include for-phone-only() {

--- a/client/src/styles/EmailAlertSignup.scss
+++ b/client/src/styles/EmailAlertSignup.scss
@@ -35,13 +35,20 @@
     }
   }
 
+  .table-small-font {
+    padding: 0 !important;
+  }
+
   .table-content {
-    margin: 1rem 1rem 1.7rem 1rem !important;
+    display: flex;
+    flex-direction: column;
+    gap: 2.4rem;
+    padding: 2.4rem;
+    margin: 0 !important;
   }
 
   .email-description {
     text-align: left;
-    margin: 1rem 0 !important;
     line-height: 117%;
   }
 

--- a/client/src/styles/EmailAlertSignup.scss
+++ b/client/src/styles/EmailAlertSignup.scss
@@ -42,8 +42,8 @@
   .table-content {
     display: flex;
     flex-direction: column;
-    gap: 2.4rem;
-    padding: 2.4rem;
+    gap: 1.5rem;
+    padding: 1.5rem;
     margin: 0 !important;
   }
 
@@ -62,7 +62,7 @@
     display: flex;
     flex-direction: column;
     text-align: left;
-    gap: 2.4rem;
+    gap: 1.5rem;
 
     button {
       align-self: center;

--- a/client/src/styles/EmailAlertSignup.scss
+++ b/client/src/styles/EmailAlertSignup.scss
@@ -62,6 +62,7 @@
     display: flex;
     flex-direction: column;
     text-align: left;
+    gap: 2.4rem;
 
     button {
       align-self: center;
@@ -70,15 +71,10 @@
     .status-title {
       display: flex;
       align-items: center;
-      margin-bottom: 2rem;
 
       svg {
         margin-right: 1rem;
       }
-    }
-
-    .status-description {
-      margin-bottom: 2rem;
     }
   }
 }

--- a/client/src/styles/EmailInput.scss
+++ b/client/src/styles/EmailInput.scss
@@ -1,0 +1,61 @@
+@import "_vars.scss";
+@import "_typography.scss";
+
+.email-input-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  label {
+    @include desktop-eyebrow();
+    // vars marked !important bc typography mixin is not available for inconsolata
+    font-weight: 600 !important;
+    font-family: $wow-font !important;
+    font-size: 1.3rem !important;
+    color: $justfix-black;
+
+    text-align: left;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  a {
+    color: $justfix-black;
+    font-size: 1.3rem;
+  }
+}
+
+.email-input {
+  display: flex;
+
+  input {
+    flex: 1;
+
+    &:invalid,
+    &.invalid {
+      border-color: $justfix-orange;
+    }
+
+    &:focus:invalid,
+    &.invalid:focus {
+      border-color: $justfix-black;
+    }
+  }
+}
+
+.email-input-errors {
+  display: flex;
+  flex-direction: column;
+
+  span {
+    display: flex;
+    align-items: center;
+    font-size: 1.3rem;
+    color: #ba4300;
+    margin-bottom: 0.5rem;
+
+    svg {
+      margin-right: 0.75rem;
+    }
+  }
+}

--- a/client/src/styles/EmailInput.scss
+++ b/client/src/styles/EmailInput.scss
@@ -32,12 +32,10 @@
     input {
       flex: 1;
 
-      &:invalid,
       &.invalid {
         border-color: $justfix-orange;
       }
 
-      &:focus:invalid,
       &.invalid:focus {
         border-color: $justfix-black;
       }

--- a/client/src/styles/EmailInput.scss
+++ b/client/src/styles/EmailInput.scss
@@ -12,17 +12,17 @@
       // vars marked !important bc typography mixin is not available for inconsolata
       // font-weight: 600 !important;
       font-family: $wow-font !important;
-      font-size: 1.3rem !important;
+      font-size: 0.8125rem !important;
       line-height: 120%;
       color: $justfix-black;
 
       text-align: left;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.3125rem;
     }
 
     a {
       color: $justfix-black;
-      font-size: 1.3rem;
+      font-size: 0.8125rem;
     }
   }
 
@@ -49,12 +49,12 @@
     span {
       display: flex;
       align-items: center;
-      font-size: 1.3rem;
+      font-size: 0.8125rem;
       color: #ba4300;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.3125rem;
 
       svg {
-        margin-right: 0.75rem;
+        margin-right: 0.47rem;
       }
     }
   }

--- a/client/src/styles/EmailInput.scss
+++ b/client/src/styles/EmailInput.scss
@@ -1,61 +1,63 @@
 @import "_vars.scss";
 @import "_typography.scss";
 
-.email-input-label {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  label {
-    @include desktop-eyebrow();
-    // vars marked !important bc typography mixin is not available for inconsolata
-    font-weight: 600 !important;
-    font-family: $wow-font !important;
-    font-size: 1.3rem !important;
-    color: $justfix-black;
-
-    text-align: left;
-    margin-top: 1rem;
-    margin-bottom: 0.5rem;
-  }
-
-  a {
-    color: $justfix-black;
-    font-size: 1.3rem;
-  }
-}
-
-.email-input {
-  display: flex;
-
-  input {
-    flex: 1;
-
-    &:invalid,
-    &.invalid {
-      border-color: $justfix-orange;
-    }
-
-    &:focus:invalid,
-    &.invalid:focus {
-      border-color: $justfix-black;
-    }
-  }
-}
-
-.email-input-errors {
-  display: flex;
-  flex-direction: column;
-
-  span {
+.email-input-field {
+  .email-input-label {
     display: flex;
     align-items: center;
-    font-size: 1.3rem;
-    color: #ba4300;
-    margin-bottom: 0.5rem;
+    justify-content: space-between;
 
-    svg {
-      margin-right: 0.75rem;
+    label {
+      @include body-standard;
+      // vars marked !important bc typography mixin is not available for inconsolata
+      // font-weight: 600 !important;
+      font-family: $wow-font !important;
+      font-size: 1.3rem !important;
+      line-height: 120%;
+      color: $justfix-black;
+
+      text-align: left;
+      margin-bottom: 0.5rem;
+    }
+
+    a {
+      color: $justfix-black;
+      font-size: 1.3rem;
+    }
+  }
+
+  .email-input {
+    display: flex;
+
+    input {
+      flex: 1;
+
+      &:invalid,
+      &.invalid {
+        border-color: $justfix-orange;
+      }
+
+      &:focus:invalid,
+      &.invalid:focus {
+        border-color: $justfix-black;
+      }
+    }
+  }
+
+  .email-input-errors {
+    display: flex;
+    flex-direction: column;
+
+    span {
+      display: flex;
+      align-items: center;
+      font-size: 1.3rem;
+      color: #ba4300;
+      margin-bottom: 0.5rem;
+
+      svg {
+        margin-right: 0.75rem;
+      }
     }
   }
 }

--- a/client/src/styles/ForgotPasswordPage.scss
+++ b/client/src/styles/ForgotPasswordPage.scss
@@ -5,16 +5,16 @@
   .page-container {
     display: flex;
     flex-direction: column;
-    gap: 2.4rem;
+    gap: 1.5rem;
   }
 
   h4 {
-    font-size: 2.4rem;
+    font-size: 1.5rem;
     margin: 0;
   }
 
   h5 {
-    font-size: 1.6rem;
+    font-size: 1rem;
     margin: 0;
   }
 
@@ -22,14 +22,14 @@
     @include desktop-eyebrow();
 
     text-align: left;
-    margin-top: 0.63rem;
-    margin-bottom: 0.31rem;
+    margin-top: 0.39rem;
+    margin-bottom: 0.19rem;
   }
 
   input[type="submit"] {
-    padding: 1rem 2rem !important;
+    padding: 0.63rem 1.25rem !important;
     align-self: center;
-    margin: 1.63rem auto 0.37rem auto !important;
+    margin: 1.02rem auto 0.23rem auto !important;
   }
 
   .request-sent-success {
@@ -38,11 +38,11 @@
     align-items: center;
 
     svg {
-      margin: 0.63rem 0 1.56rem 0;
+      margin: 0.39rem 0 0.98rem 0;
     }
 
     .button.is-text {
-      margin-top: 0.63rem;
+      margin-top: 0.39rem;
       display: block !important;
       color: $justfix-black;
     }

--- a/client/src/styles/ForgotPasswordPage.scss
+++ b/client/src/styles/ForgotPasswordPage.scss
@@ -2,16 +2,20 @@
 @import "_typography.scss";
 
 .ForgotPasswordPage {
-  .page-title {
-    margin-top: 1.5rem;
+  .page-container {
+    display: flex;
+    flex-direction: column;
+    gap: 2.4rem;
   }
 
   h4 {
     font-size: 2.4rem;
+    margin: 0;
   }
 
   h5 {
     font-size: 1.6rem;
+    margin: 0;
   }
 
   label {

--- a/client/src/styles/Login.scss
+++ b/client/src/styles/Login.scss
@@ -5,6 +5,10 @@
 .Login,
 .ForgotPasswordPage,
 .ResetPasswordPage {
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+
   .input-group {
     display: flex;
     flex-direction: column;
@@ -70,6 +74,7 @@
 
   h4 {
     font-size: 2.4rem;
+    margin-bottom: 0;
   }
   h5 {
     font-size: 1.6rem;

--- a/client/src/styles/Login.scss
+++ b/client/src/styles/Login.scss
@@ -34,12 +34,12 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    gap: 2.4rem;
 
     .privacy-modal {
       display: flex;
       justify-content: center;
       align-items: center;
-      margin: 2rem 0 2rem 0;
 
       .info-icon {
         margin-left: 0.4rem;
@@ -85,12 +85,19 @@
   }
 
   .verify-email-container {
+    color: $justfix-black;
+    display: flex;
+    flex-direction: column;
+    gap: 2.4rem;
+
+    p {
+      margin: 0;
+    }
+
     h4,
     .resend-verify-label {
       display: flex;
       justify-content: center;
-      margin-bottom: 1.2rem;
-      margin-top: 1.4rem;
     }
   }
 

--- a/client/src/styles/Login.scss
+++ b/client/src/styles/Login.scss
@@ -10,54 +10,26 @@
     flex-direction: column;
     margin-top: 1rem;
 
-    #input-field-error {
-      display: flex;
-      align-items: center;
-      font-size: 1.3rem;
-      color: #ba4300;
-      margin-bottom: 0.5rem;
-
-      svg {
-        margin-right: 0.75rem;
-      }
-    }
-
-    input[type="email"],
-    .password-input {
+    .email-input,
+    .password-input,
+    .user-type-container {
       margin-bottom: 2rem;
     }
 
-    input[type="submit"] {
-      padding: 1.6rem 3.2rem !important;
-      align-self: center;
-      margin: 0 auto !important;
-    }
+    .submit-button-group {
+      display: flex;
 
-    input:invalid,
-    .invalid {
-      border-color: $justfix-orange;
-    }
-
-    input:focus:invalid,
-    .invalid:focus {
-      border-color: $justfix-black;
+      button[type="submit"],
+      input[type="submit"] {
+        padding: 1.6rem 3.2rem !important;
+        align-self: center;
+        margin: 0 auto !important;
+      }
     }
   }
 
   .page-title {
     margin-top: 1.5rem;
-  }
-
-  label {
-    @include desktop-eyebrow();
-    // vars marked !important bc typography mixin is not available for inconsolata
-    font-weight: 600 !important;
-    font-family: $wow-font !important;
-    font-size: 1.3rem !important;
-
-    text-align: left;
-    margin-top: 1rem;
-    margin-bottom: 0.5rem;
   }
 
   .building-page-footer {
@@ -111,6 +83,16 @@
 
   .password-input {
     margin-top: 0.5rem;
+  }
+
+  .verify-email-container {
+    h4,
+    .resend-verify-label {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 1.2rem;
+      margin-top: 1.4rem;
+    }
   }
 
   .jf-alert {

--- a/client/src/styles/Login.scss
+++ b/client/src/styles/Login.scss
@@ -7,19 +7,19 @@
 .ResetPasswordPage {
   display: flex;
   flex-direction: column;
-  gap: 2.4rem;
+  gap: 1.5rem;
 
   .input-group {
     display: flex;
     flex-direction: column;
-    gap: 2.4rem;
+    gap: 1.5rem;
 
     .submit-button-group {
       display: flex;
 
       button[type="submit"],
       input[type="submit"] {
-        padding: 1.6rem 3.2rem !important;
+        padding: 1rem 2rem !important;
         align-self: center;
         margin: 0 auto !important;
       }
@@ -27,14 +27,14 @@
   }
 
   .page-title {
-    margin-top: 0.94rem;
+    margin-top: 0.59rem;
   }
 
   .building-page-footer {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: 2.4rem;
+    gap: 1.5rem;
 
     .privacy-modal {
       display: flex;
@@ -42,7 +42,7 @@
       align-items: center;
 
       .info-icon {
-        margin-left: 0.25rem;
+        margin-left: 0.16rem;
         width: 18px;
         &:focus-visible {
           outline: 2px solid $focus-outline-color;
@@ -59,7 +59,7 @@
   }
 
   .login-response-text {
-    margin: 0.63rem 0 0.63rem;
+    margin: 0.39rem 0 0.39rem;
   }
 
   .login-password-label {
@@ -73,22 +73,22 @@
   }
 
   h4 {
-    font-size: 2.4rem;
+    font-size: 1.5rem;
     margin-bottom: 0;
   }
   h5 {
-    font-size: 1rem;
+    font-size: 0.63rem;
   }
 
   .password-input {
-    margin-top: 0.31rem;
+    margin-top: 0.3125rem;
   }
 
   .verify-email-container {
     color: $justfix-black;
     display: flex;
     flex-direction: column;
-    gap: 2.4rem;
+    gap: 1.5rem;
 
     p {
       margin: 0;
@@ -122,11 +122,11 @@
     align-items: center;
 
     svg {
-      margin: 0.63rem 0 1.56rem 0;
+      margin: 0.39rem 0 0.98rem 0;
     }
 
     .button.is-text {
-      margin-top: 0.63rem;
+      margin-top: 0.39rem;
       display: block !important;
       color: $justfix-black;
     }

--- a/client/src/styles/Login.scss
+++ b/client/src/styles/Login.scss
@@ -8,13 +8,7 @@
   .input-group {
     display: flex;
     flex-direction: column;
-    margin-top: 1rem;
-
-    .email-input,
-    .password-input,
-    .user-type-container {
-      margin-bottom: 2rem;
-    }
+    gap: 2.4rem;
 
     .submit-button-group {
       display: flex;

--- a/client/src/styles/Password.scss
+++ b/client/src/styles/Password.scss
@@ -2,10 +2,22 @@
 @import "_typography.scss";
 
 .password-input-label {
-  font-weight: 600 !important;
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  label {
+    @include desktop-eyebrow();
+    // vars marked !important bc typography mixin is not available for inconsolata
+    font-weight: 600 !important;
+    font-family: $wow-font !important;
+    font-size: 1.3rem !important;
+    color: $justfix-black;
+
+    text-align: left;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+  }
 
   a {
     color: $justfix-black;
@@ -14,13 +26,22 @@
 }
 
 .password-input {
-  margin-bottom: 1rem;
   display: flex;
 
   input {
     flex: 1;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+
+    &:invalid,
+    &.invalid {
+      border-color: $justfix-orange;
+    }
+
+    &:focus:invalid,
+    &.invalid:focus {
+      border-color: $justfix-black;
+    }
   }
 
   button {

--- a/client/src/styles/Password.scss
+++ b/client/src/styles/Password.scss
@@ -1,97 +1,100 @@
 @import "_vars.scss";
 @import "_typography.scss";
 
-.password-input-label {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  label {
-    @include desktop-eyebrow();
-    // vars marked !important bc typography mixin is not available for inconsolata
-    font-weight: 600 !important;
-    font-family: $wow-font !important;
-    font-size: 1.3rem !important;
-    color: $justfix-black;
-
-    text-align: left;
-    margin-top: 1rem;
-    margin-bottom: 0.5rem;
-  }
-
-  a {
-    color: $justfix-black;
-    font-size: 1.3rem;
-  }
-}
-
-.password-input {
-  display: flex;
-
-  input {
-    flex: 1;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-
-    &:invalid,
-    &.invalid {
-      border-color: $justfix-orange;
-    }
-
-    &:focus:invalid,
-    &.invalid:focus {
-      border-color: $justfix-black;
-    }
-  }
-
-  button {
+.password-input-field {
+  .password-input-label {
     display: flex;
     align-items: center;
-    justify-content: center;
-    color: $justfix-white;
-    background-color: $justfix-black;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-    width: 4rem;
-  }
-}
+    justify-content: space-between;
 
-.password-input-rules {
-  display: flex;
-  flex-direction: column;
-}
+    label {
+      @include body-standard;
+      // vars marked !important bc typography mixin is not available for inconsolata
+      // font-weight: 600 !important;
+      font-family: $wow-font !important;
+      font-size: 1.3rem !important;
+      line-height: 120%;
+      color: $justfix-black;
 
-.password-input-rule {
-  @include desktop-eyebrow();
+      text-align: left;
+      margin-bottom: 0.5rem;
+    }
 
-  font-family: $wow-font !important;
-  font-size: 1.3rem !important;
-  font-weight: 500 !important;
-  text-transform: none !important;
-  color: $justfix-black;
-  text-align: left;
-
-  &::before {
-    content: "•";
-    display: inline-block;
-    margin-right: 0.5rem;
-    vertical-align: top;
+    a {
+      color: $justfix-black;
+      font-size: 1.3rem;
+    }
   }
 
-  // encoded SVG from https://yoksel.github.io/url-encoder/
-  &.invalid:before {
-    content: url("data:image/svg+xml, %3Csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 14C3.14 14 0 10.8599 0 7C0 3.14007 3.14007 0 7 0C10.8599 0 14 3.14007 14 7C14 10.84 10.8599 14 7 14Z' fill='%23FF813A' /%3E%3Cpath d='M7 8.75C6.50422 8.75 6.125 8.37612 6.125 7.88729V3.48771C6.125 2.9989 6.50421 2.625 7 2.625C7.49579 2.625 7.875 2.99888 7.875 3.48771V7.88729C7.875 8.3763 7.49579 8.75 7 8.75Z' fill='%23FAF8F4' /%3E%3Cpath d='M6.97194 11.375C6.74608 11.375 6.52022 11.2879 6.37902 11.1136C6.20967 10.9394 6.125 10.736 6.125 10.5036C6.125 10.4455 6.125 10.3875 6.15316 10.3294C6.15316 10.2712 6.18132 10.2133 6.20967 10.1551C6.23783 10.097 6.26619 10.068 6.29435 10.0099C6.3225 9.95174 6.35086 9.92277 6.40718 9.86462C6.71771 9.54513 7.28225 9.54513 7.59282 9.86462C7.62098 9.89359 7.6775 9.95174 7.70565 10.0099C7.73381 10.068 7.76217 10.097 7.79033 10.1551C7.81849 10.2133 7.81849 10.2712 7.84684 10.3294C7.84684 10.3875 7.875 10.4455 7.875 10.5036C7.875 10.736 7.79033 10.9684 7.62098 11.1136C7.42367 11.2879 7.19781 11.375 6.97195 11.375H6.97194Z' fill='%23FAF8F4' /%3E%3C/svg%3E%0A");
+  .password-input {
+    display: flex;
+
+    input {
+      flex: 1;
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+
+      &:invalid,
+      &.invalid {
+        border-color: $justfix-orange;
+      }
+
+      &:focus:invalid,
+      &.invalid:focus {
+        border-color: $justfix-black;
+      }
+    }
+
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: $justfix-white;
+      background-color: $justfix-black;
+      border-top-right-radius: 4px;
+      border-bottom-right-radius: 4px;
+      width: 4rem;
+    }
   }
 
-  &.invalid {
-    color: #ba4300;
+  .password-input-rules {
+    display: flex;
+    flex-direction: column;
   }
 
-  &.valid {
-    color: $justfix-green;
-  }
+  .password-input-rule {
+    @include body-standard;
 
-  &.valid::before {
-    content: url("data:image/svg+xml,%3Csvg width='14' height='14' viewBox='0 0 17 17' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.16666 7.97664L5.83332 12.6433L15.8333 2.64331' stroke='%231AA551' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E ");
+    font-family: $wow-font !important;
+    font-size: 1.3rem !important;
+    // font-weight: 500 !important;
+    line-height: 120%;
+    text-transform: none !important;
+    color: $justfix-black;
+    text-align: left;
+
+    &::before {
+      content: "•";
+      display: inline-block;
+      margin-right: 0.5rem;
+      vertical-align: top;
+    }
+
+    // encoded SVG from https://yoksel.github.io/url-encoder/
+    &.invalid:before {
+      content: url("data:image/svg+xml, %3Csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 14C3.14 14 0 10.8599 0 7C0 3.14007 3.14007 0 7 0C10.8599 0 14 3.14007 14 7C14 10.84 10.8599 14 7 14Z' fill='%23FF813A' /%3E%3Cpath d='M7 8.75C6.50422 8.75 6.125 8.37612 6.125 7.88729V3.48771C6.125 2.9989 6.50421 2.625 7 2.625C7.49579 2.625 7.875 2.99888 7.875 3.48771V7.88729C7.875 8.3763 7.49579 8.75 7 8.75Z' fill='%23FAF8F4' /%3E%3Cpath d='M6.97194 11.375C6.74608 11.375 6.52022 11.2879 6.37902 11.1136C6.20967 10.9394 6.125 10.736 6.125 10.5036C6.125 10.4455 6.125 10.3875 6.15316 10.3294C6.15316 10.2712 6.18132 10.2133 6.20967 10.1551C6.23783 10.097 6.26619 10.068 6.29435 10.0099C6.3225 9.95174 6.35086 9.92277 6.40718 9.86462C6.71771 9.54513 7.28225 9.54513 7.59282 9.86462C7.62098 9.89359 7.6775 9.95174 7.70565 10.0099C7.73381 10.068 7.76217 10.097 7.79033 10.1551C7.81849 10.2133 7.81849 10.2712 7.84684 10.3294C7.84684 10.3875 7.875 10.4455 7.875 10.5036C7.875 10.736 7.79033 10.9684 7.62098 11.1136C7.42367 11.2879 7.19781 11.375 6.97195 11.375H6.97194Z' fill='%23FAF8F4' /%3E%3C/svg%3E%0A");
+    }
+
+    &.invalid {
+      color: #ba4300;
+    }
+
+    &.valid {
+      color: $justfix-green;
+    }
+
+    &.valid::before {
+      content: url("data:image/svg+xml,%3Csvg width='14' height='14' viewBox='0 0 17 17' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.16666 7.97664L5.83332 12.6433L15.8333 2.64331' stroke='%231AA551' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E ");
+    }
   }
 }

--- a/client/src/styles/Password.scss
+++ b/client/src/styles/Password.scss
@@ -12,17 +12,17 @@
       // vars marked !important bc typography mixin is not available for inconsolata
       // font-weight: 600 !important;
       font-family: $wow-font !important;
-      font-size: 1.3rem !important;
+      font-size: 0.8125rem !important;
       line-height: 120%;
       color: $justfix-black;
 
       text-align: left;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.31rem;
     }
 
     a {
       color: $justfix-black;
-      font-size: 1.3rem;
+      font-size: 0.8125rem;
     }
   }
 
@@ -53,7 +53,7 @@
       background-color: $justfix-black;
       border-top-right-radius: 4px;
       border-bottom-right-radius: 4px;
-      width: 4rem;
+      width: 2.5rem;
     }
   }
 
@@ -66,7 +66,7 @@
     @include body-standard;
 
     font-family: $wow-font !important;
-    font-size: 1.3rem !important;
+    font-size: 0.8125rem !important;
     // font-weight: 500 !important;
     line-height: 120%;
     text-transform: none !important;
@@ -76,7 +76,7 @@
     &::before {
       content: "•";
       display: inline-block;
-      margin-right: 0.5rem;
+      margin-right: 0.31rem;
       vertical-align: top;
     }
 

--- a/client/src/styles/UserTypeInput.scss
+++ b/client/src/styles/UserTypeInput.scss
@@ -54,16 +54,26 @@
     flex-direction: column;
     margin: 2.4rem 2.8rem 0 2.8rem;
 
-    #input-field-error {
-      display: flex;
-      align-items: center;
-      font-size: 1.3rem;
-      color: #ba4300;
-      margin-bottom: 0.5rem;
-
-      svg {
-        margin-right: 0.75rem;
+    input {
+      &.invalid {
+        border-color: $justfix-orange;
       }
+
+      &.invalid:focus {
+        border-color: $justfix-black;
+      }
+    }
+  }
+
+  #input-field-error {
+    display: flex;
+    align-items: center;
+    font-size: 1.3rem;
+    color: #ba4300;
+    margin-bottom: 0.5rem;
+
+    svg {
+      margin-right: 0.75rem;
     }
   }
 }

--- a/client/src/styles/UserTypeInput.scss
+++ b/client/src/styles/UserTypeInput.scss
@@ -1,0 +1,69 @@
+@import "_vars.scss";
+@import "_typography.scss";
+
+.user-type-container {
+  .user-type-radio-group {
+    display: grid;
+    grid-template-columns: 2rem auto;
+    gap: 1rem 0.8rem;
+    align-items: center;
+
+    label {
+      margin: 0;
+    }
+
+    input[type="radio"] {
+      /* Remove most all native input styles */
+      appearance: none;
+      /* For iOS < 15 */
+      background-color: $justfix-white;
+      /* Not removed via appearance */
+      margin: 0;
+
+      font: inherit;
+      color: $justfix-black;
+      width: 2rem;
+      height: 2rem;
+      border: 0.15em solid $justfix-black;
+      border-radius: 50%;
+      transform: translateY(-0.075em);
+
+      display: grid;
+      place-content: center;
+
+      &::before {
+        content: "";
+        width: 1.2rem;
+        height: 1.2rem;
+        border-radius: 50%;
+        transform: scale(0);
+        transition: 120ms transform ease-in-out;
+        box-shadow: inset 1em 1em $justfix-black;
+        /* Windows High Contrast Mode */
+        background-color: CanvasText;
+      }
+
+      &:checked::before {
+        transform: scale(1);
+      }
+    }
+  }
+
+  .user-type-input-text-group {
+    display: flex;
+    flex-direction: column;
+    margin: 2.4rem 2.8rem 0 2.8rem;
+
+    #input-field-error {
+      display: flex;
+      align-items: center;
+      font-size: 1.3rem;
+      color: #ba4300;
+      margin-bottom: 0.5rem;
+
+      svg {
+        margin-right: 0.75rem;
+      }
+    }
+  }
+}

--- a/client/src/styles/UserTypeInput.scss
+++ b/client/src/styles/UserTypeInput.scss
@@ -4,8 +4,8 @@
 .user-type-container {
   .user-type-radio-group {
     display: grid;
-    grid-template-columns: 2rem auto;
-    gap: 1rem 0.8rem;
+    grid-template-columns: 1.25rem auto;
+    gap: 0.63rem 0.5rem;
     align-items: center;
 
     label {
@@ -22,8 +22,8 @@
 
       font: inherit;
       color: $justfix-black;
-      width: 2rem;
-      height: 2rem;
+      width: 1.25rem;
+      height: 1.25rem;
       border: 0.15em solid $justfix-black;
       border-radius: 50%;
       transform: translateY(-0.075em);
@@ -33,8 +33,8 @@
 
       &::before {
         content: "";
-        width: 1.2rem;
-        height: 1.2rem;
+        width: 0.75rem;
+        height: 0.75rem;
         border-radius: 50%;
         transform: scale(0);
         transition: 120ms transform ease-in-out;
@@ -52,7 +52,7 @@
   .user-type-input-text-group {
     display: flex;
     flex-direction: column;
-    margin: 2.4rem 2.8rem 0 2.8rem;
+    margin: 1.5rem 1.75rem 0 1.75rem;
 
     input {
       &.invalid {
@@ -68,12 +68,12 @@
   #input-field-error {
     display: flex;
     align-items: center;
-    font-size: 1.3rem;
+    font-size: 0.8125rem;
     color: #ba4300;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.31rem;
 
     svg {
-      margin-right: 0.75rem;
+      margin-right: 0.47rem;
     }
   }
 }

--- a/client/src/styles/_button.scss
+++ b/client/src/styles/_button.scss
@@ -170,6 +170,7 @@
   white-space: normal;
   word-wrap: break-word;
   text-decoration: none;
+  text-transform: unset;
 
   transition: all 0.1s linear;
   transform: translateX(0rem);

--- a/client/src/styles/_datatable.scss
+++ b/client/src/styles/_datatable.scss
@@ -45,13 +45,13 @@
         }
 
         @include for-phone-only() {
-          font-size: 0.81rem;
+          font-size: 0.8125rem;
         }
 
         > label {
           display: block;
           line-height: 1.1;
-          font-size: 0.81rem;
+          font-size: 0.8125rem;
           padding: 1px 0;
           // background-color: $background;
           border-bottom: 1px solid $gray-dark;
@@ -75,11 +75,11 @@
 
       .table-content {
         margin: 0.63rem 0.47rem;
-        line-height: 0.81rem;
+        line-height: 0.8125rem;
       }
 
       .table-small-font {
-        font-size: 0.81rem;
+        font-size: 0.8125rem;
       }
     }
   }

--- a/client/src/styles/_input.scss
+++ b/client/src/styles/_input.scss
@@ -3,7 +3,6 @@
 @mixin input() {
   display: inline-block;
   border: 1px solid $justfix-black;
-  background: $justfix-white;
   padding: 1rem;
   font-size: inherit;
   border-radius: 4px;

--- a/client/src/styles/_tabs.scss
+++ b/client/src/styles/_tabs.scss
@@ -157,7 +157,7 @@
       }
 
       a {
-        font-size: 0.81rem;
+        font-size: 0.8125rem;
         line-height: 1.5;
 
         border-bottom: none;

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -3,7 +3,7 @@ import { AddressRecord, HpdContactAddress, SearchAddressWithoutBbl } from "compo
 import { reportError } from "error-reporting";
 import { t } from "@lingui/macro";
 import { I18n, MessageDescriptor } from "@lingui/core";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, ChangeEvent } from "react";
 import _ from "lodash";
 
 const hpdComplaintTypeTranslations = new Map([
@@ -131,6 +131,24 @@ export function searchAddrsAreEqual(
     addr1.housenumber === addr2.housenumber
   );
 }
+
+// https://www.codevertiser.com/reusable-input-component-react/
+export const useInput = (initialValue: string) => {
+  const [value, setValue] = useState(initialValue);
+  const [error, setError] = useState(false);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  return {
+    value,
+    error,
+    onChange: handleChange,
+    setError,
+    setValue,
+  };
+};
 
 const helpers = {
   // filter repeated values in rbas and owners

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -136,6 +136,7 @@ export function searchAddrsAreEqual(
 export const useInput = (initialValue: string) => {
   const [value, setValue] = useState(initialValue);
   const [error, setError] = useState(false);
+  const [showError, setShowError] = useState(false);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
@@ -144,9 +145,11 @@ export const useInput = (initialValue: string) => {
   return {
     value,
     error,
-    onChange: handleChange,
-    setError,
+    showError,
     setValue,
+    setError,
+    setShowError,
+    onChange: handleChange,
   };
 };
 

--- a/jfauthprovider/views.py
+++ b/jfauthprovider/views.py
@@ -77,6 +77,7 @@ def register(request):
         "grant_type": "password",
         "username": request.POST.get("username"),
         "password": request.POST.get("password"),
+        "user_type": request.POST.get("user_type"),
         "origin": request.headers["Origin"],
     }
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -99,10 +99,6 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"https://deploy-preview-(?:\d{1,4})--wow-django-dev\.netlify\.app",
 ]
 
-CORS_ALLOWED_ORIGIN_REGEXES = [
-    r"https://\w+\.deploy-preview-(?:\d{1,4})--wow-django-dev\.netlify\.app"
-]
-
 # This is based off the default Django logging configuration:
 # https://github.com/django/django/blob/master/django/utils/log.py
 LOGGING = {

--- a/project/settings.py
+++ b/project/settings.py
@@ -91,6 +91,11 @@ CORS_ORIGIN_WHITELIST = (
     "http://127.0.0.1:3000",
     "http://localhost:3000",
     "http://demo-wowserver.justfix.org",
+    "https://deploy-preview-703--wow-django-dev.netlify.app",
+    "https://deploy-preview-785--wow-django-dev.netlify.app",
+    "https://deploy-preview-811--wow-django-dev.netlify.app",
+    "https://deploy-preview-843--wow-django-dev.netlify.app",
+    "https://deploy-preview-849--wow-django-dev.netlify.app",
 )
 
 CORS_ALLOWED_ORIGIN_REGEXES = [

--- a/project/settings.py
+++ b/project/settings.py
@@ -91,11 +91,11 @@ CORS_ORIGIN_WHITELIST = (
     "http://127.0.0.1:3000",
     "http://localhost:3000",
     "http://demo-wowserver.justfix.org",
-    "https://deploy-preview-703--wow-django-dev.netlify.app",
-    "https://deploy-preview-785--wow-django-dev.netlify.app",
-    "https://deploy-preview-811--wow-django-dev.netlify.app",
-    "https://deploy-preview-843--wow-django-dev.netlify.app",
 )
+
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"https://\w+\.deploy-preview-(?:\d{1,4})--wow-django-dev\.netlify\.app"
+]
 
 # This is based off the default Django logging configuration:
 # https://github.com/django/django/blob/master/django/utils/log.py


### PR DESCRIPTION
- adds ability for account sign up to happen all within a modal from the building page
- adds a required step for account sign up, asking user type (multiple-choice or write in)
- adds verify email/ re-send email step to the end of log in/sign up flow
- refactors email input into separate component (like `PasswordInput`)
  - email, password, and user type input components now work with custom `useInput` hook so that the parent can keep track of values in state. 
  - This makes it easier for the parent component to hold onto input values from each step to use for error alerts and registration at the end. The same setup also helps with the input-level errors for email and whether they shown. 
  - This still feels a bit overcomplicated, but we'll figure this all our for the component library and hopefully swap those in soon. 

https://github.com/JustFixNYC/auth-provider/pull/14 adds this new field to the user model, and https://github.com/JustFixNYC/auth-provider/pull/18 adds it to the `user/register` auth endpoint

[sc-13535]
[sc-13510]
[sc-13594]
[sc-13532]