### PR TITLE
Add react-error-overlay@6.0.9

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -104,7 +104,8 @@
     "dotenv": "^8.2.0",
     "jest-fetch-mock": "^3.0.3",
     "npm-run-all": "^4.0.2",
-    "prettier": "2.0.5"
+    "prettier": "2.0.5",
+    "react-error-overlay": "6.0.9"
   },
   "overrides": {
     "@svgr/webpack": "$@svgr/webpack"
@@ -115,7 +116,8 @@
     "loader-utils": "^2.0.4",
     "set-value": "^2.0.1",
     "minimist": "^0.2.4",
-    "immer": "^9.0.6"
+    "immer": "^9.0.6",
+    "react-error-overlay": "6.0.9"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -12563,10 +12563,10 @@ react-draggable@^3.0.5:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-error-overlay@^6.0.9:
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
-  integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-fast-compare@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
Discussion: https://justfixnyc.slack.com/archives/C06H8RTJY5D/p1709657586611259

Relevant github threads: 
https://github.com/facebook/create-react-app/issues/11880
https://github.com/facebook/create-react-app/issues/11773

This seems to have resolved the issue. I guess `react-error-overlay@6.0.11` introduced it? 🤷 


I haven't had the issue reappear since I made this change locally.