### PR TITLE
update unsubscribe page for unsubscribe-all via email

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -186,15 +186,22 @@ const isEmailAlreadyUsed = async (email: string) => {
 /**
  * Sends an unauthenticated request to unsubscribe the user from the building
  */
-const emailBuildingUnsubscribe = async (bbl: string, token: string) => {
+const emailUnsubscribeBuilding = async (bbl: string, token: string) => {
   return await postAuthRequest(`${BASE_URL}auth/unsubscribe/${bbl}?u=${token}`);
+};
+
+/**
+ * Sends an unauthenticated request to unsubscribe the user from all buildings
+ */
+const emailUnsubscribeAll = async (token: string) => {
+  return await postAuthRequest(`${BASE_URL}auth/email/unsubscribe?u=${token}`);
 };
 
 /**
  * Fetches the list of all subscriptions associated with a user
  */
-const userSubscriptions = async (token: string) => {
-  return await postAuthRequest(`${BASE_URL}auth/subscriptions?u=${token}`);
+const emailUserSubscriptions = async (token: string) => {
+  return await postAuthRequest(`${BASE_URL}auth/email/subscriptions?u=${token}`);
 };
 
 /**
@@ -294,8 +301,9 @@ const Client = {
   resetPassword,
   buildingSubscribe,
   buildingUnsubscribe,
-  userSubscriptions,
-  emailBuildingUnsubscribe,
+  emailUserSubscriptions,
+  emailUnsubscribeBuilding,
+  emailUnsubscribeAll,
 };
 
 export default Client;

--- a/client/src/containers/UnsubscribePage.tsx
+++ b/client/src/containers/UnsubscribePage.tsx
@@ -9,24 +9,41 @@ import { Trans, t } from "@lingui/macro";
 import "styles/UserSetting.css";
 import AuthClient from "../components/AuthClient";
 import { SubscriptionField } from "./AccountSettingsPage";
+import { createWhoOwnsWhatRoutePaths } from "routes";
+import { LocaleNavLink } from "i18n";
 
 const UnsubscribePage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const { search } = useLocation();
+  const { home } = createWhoOwnsWhatRoutePaths();
   const params = new URLSearchParams(search);
   const token = params.get("u") || "";
+  const isEmailUnsubscribeAll = !!params.get("all");
 
   const [subscriptions, setSubscriptions] = React.useState([]);
   useEffect(() => {
-    const asyncFetchSubscriptions = async () => {
-      const response = await AuthClient.userSubscriptions(token);
-      setSubscriptions(response["subscriptions"]);
-    };
-    asyncFetchSubscriptions();
-  }, [token]);
+    if (isEmailUnsubscribeAll) {
+      const asyncUnsubscribeAll = async () => {
+        const response = await AuthClient.emailUnsubscribeAll(token);
+        setSubscriptions(response["subscriptions"]);
+      };
+      asyncUnsubscribeAll();
+    } else {
+      const asyncFetchSubscriptions = async () => {
+        const response = await AuthClient.emailUserSubscriptions(token);
+        setSubscriptions(response["subscriptions"]);
+      };
+      asyncFetchSubscriptions();
+    }
+  }, [token, isEmailUnsubscribeAll]);
 
-  const handleUnsubscribe = async (bbl: string) => {
-    const result = await AuthClient.emailBuildingUnsubscribe(bbl, token);
+  const handleUnsubscribeBuilding = async (bbl: string) => {
+    const result = await AuthClient.emailUnsubscribeBuilding(bbl, token);
+    if (!!result?.["subscriptions"]) setSubscriptions(result["subscriptions"]);
+  };
+
+  const handleUnsubscribeAll = async () => {
+    const result = await AuthClient.emailUnsubscribeAll(token);
     if (!!result?.["subscriptions"]) setSubscriptions(result["subscriptions"]);
   };
 
@@ -34,12 +51,38 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
     <Page title={i18n._(t`Modify your email preferences`)}>
       <div className="UnsubscribePage Page">
         <div className="page-container">
-          <Trans render="h4">You are signed up for email alerts from these bulidings:</Trans>
-          <div>
-            {subscriptions?.map((s: any) => (
-              <SubscriptionField key={s.bbl} {...s} onRemoveClick={handleUnsubscribe} />
-            ))}
-          </div>
+          {isEmailUnsubscribeAll || !subscriptions.length ? (
+            <>
+              {isEmailUnsubscribeAll ? (
+                <Trans render="h4">You have sucessfully unsubscribed from all buildings.</Trans>
+              ) : (
+                <Trans render="h4">You are not subscribed to any buildings.</Trans>
+              )}
+              <Trans render="div" className="settings-no-subscriptions">
+                <LocaleNavLink exact to={home}>
+                  Search an address
+                </LocaleNavLink>{" "}
+                to sign up for email alerts for that building.
+              </Trans>
+              <div className="settings-contact">
+                <Trans>If you’d like to delete your account,</Trans>
+                <br />
+                <Trans>contact support@justfix.org </Trans>
+              </div>
+            </>
+          ) : (
+            <>
+              <Trans render="h4">You are signed up for email alerts from these bulidings:</Trans>
+              <button className="button is-primary" onClick={handleUnsubscribeAll}>
+                <Trans>Unsubscribe from all</Trans>
+              </button>
+              <div>
+                {subscriptions.map((s: any) => (
+                  <SubscriptionField key={s.bbl} {...s} onRemoveClick={handleUnsubscribeBuilding} />
+                ))}
+              </div>
+            </>
+          )}
         </div>
         <LegalFooter />
       </div>

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -24,18 +24,6 @@
     font-size: 0.81rem;
     font-weight: 500;
   }
-
-  .settings-contact {
-    margin: 3.75rem 1.25rem 3.13rem;
-    text-align: center;
-  }
-
-  .settings-no-subscriptions {
-    padding: 1rem;
-    background-color: $justfix-grey-50;
-    border-radius: 4px;
-    margin: auto 1rem;
-  }
 }
 
 .UserSetting {

--- a/client/src/styles/UserSetting.scss
+++ b/client/src/styles/UserSetting.scss
@@ -21,3 +21,15 @@ a.subscription-address {
 a.subscription-address:hover {
   text-decoration: none;
 }
+
+.settings-contact {
+  margin: 6rem 2rem 5rem;
+  text-align: center;
+}
+
+.settings-no-subscriptions {
+  padding: 1.6rem;
+  background-color: $justfix-grey-50;
+  border-radius: 4px;
+  margin: auto 1.6rem;
+}

--- a/jfauthprovider/urls.py
+++ b/jfauthprovider/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
         views.SubscriptionView.as_view(),
         name="subscriptions",
     ),
-    path("subscriptions", views.user_subscriptions, name="user_subscriptions"),
+    path("email/subscriptions", views.email_user_subscriptions, name="email_user_subscriptions"),
+    path("email/unsubscribe", views.email_unsubscribe_all, name="email_unsubscribe_all"),
     path("unsubscribe/<int:bbl>", views.email_unsubscribe, name="email_unsubscribe"),
 ]

--- a/jfauthprovider/views.py
+++ b/jfauthprovider/views.py
@@ -194,13 +194,27 @@ class SubscriptionView(View):
 
 
 @api
-def user_subscriptions(request):
+def email_user_subscriptions(request):
     try:
         post_data = {"token": request.GET.get("u")}
 
         return auth_server_request(
             "POST",
-            "user/subscriptions/",
+            "user/email/subscriptions/",
+            post_data,
+        )
+    except KeyError:
+        return HttpResponse(content_type="application/json", status=401)
+
+
+@api
+def email_unsubscribe_all(request):
+    try:
+        post_data = {"token": request.GET.get("u")}
+
+        return auth_server_request(
+            "POST",
+            "user/email/unsubscribe/",
             post_data,
         )
     except KeyError:


### PR DESCRIPTION
We'll have two links in our emails - **Unsubscribe All** and **Manage Subscriptions**

Both will go to WOW `/unsubscribe` page with a param `u=<token>` and the "all" version will also have `all=true`.

If the token and `all=true` are present, it should automatically call `AuthClient.emailUnsubscribeAll(token)` and show a success messaging confirming you've unsubscribed from all building updates. 

If the token is present but not `all`, it should do what its' already doing: automatically fetch user subscriptions via `AuthClient.emailUserSubscriptions(token)` and display them all with remove buttons to call `AuthClient.emailUnsubscribeBuilding(token)`. And there will also be a button at the top to 'Unsubscribe From All'.

If there are no subscriptions but not because you had the `all=true` option, have message saying no subscriptions.

In either situation where there are no subscriptions, prompt user to subscribe to buildings or delete their account (same as on account settings page).

Edge case: What if you land on this page without the token param? Maybe redirect to login, as we do for all other pages like this when you aren't logged in. We'll wait to deal with that all at once in [sc-13754]

In a separate PR we'll add a button for the login-auth version "unsubscribe from all" to the Account Settings page. [sc-13811]


Waiting on design review. I just guessed about using the elements from account settings, and need to see how the unsubscribe-all button should be styled (just a placeholder for now)

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/d5d9402c-fe15-446e-b733-c69abfc45d3b)

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/3dd50169-a0f9-40b2-b1df-fa895c2de5bd)

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/24bdc12b-86c2-4c1c-acd1-023bb88f0e86)



[sc-13732]