### PR TITLE
change privacy info modal to new-tab links

### DIFF
--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -139,16 +139,29 @@ const LoginWithoutI18n = (props: LoginProps) => {
   const renderFooter = () => {
     return (
       <div className="building-page-footer">
-        <div className="privacy-modal">
-          <Trans>Your information is secure</Trans>
-          <button
-            className="info-icon"
-            onClick={() => setShowInfoModal(true)}
-            aria-label={i18n._(t`Learn more about how we use your data`)}
-          >
-            <InfoIcon />
-          </button>
-        </div>
+        {isRegisterAccountStep && (
+          <span className="privacy-links">
+            <Trans>
+              Your privacy is important to us. Read our{" "}
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://www.justfix.org/en/privacy-policy/"
+              >
+                Privacy Policy
+              </a>{" "}
+              and{" "}
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://www.justfix.org/en/terms-of-use/"
+              >
+                Terms of Service
+              </a>
+              .
+            </Trans>
+          </span>
+        )}
         <div className="login-type-toggle">
           {isRegisterAccountStep ? (
             <>
@@ -162,32 +175,18 @@ const LoginWithoutI18n = (props: LoginProps) => {
               <Trans>Don't have an account?</Trans>
               <button
                 className="button is-text ml-5 pt-20"
-                onClick={() => setStep(Step.RegisterAccount)}
+                onClick={() => {
+                  setStep(Step.RegisterAccount);
+                  if (registerInModal && !showRegisterModal) {
+                    setShowRegisterModal(true);
+                  }
+                }}
               >
                 <Trans>Sign up</Trans>
               </button>
             </>
           )}
         </div>
-        <Modal key={1} showModal={showInfoModal} width={40} onClose={() => setShowInfoModal(false)}>
-          <Trans render="h4">
-            Your privacy is very important to us. Here are some important things to know:
-          </Trans>
-          <ul>
-            <Trans render="li">Your personal information is secure.</Trans>
-            <Trans render="li">
-              We don’t use your personal information for profit and will never give or sell it to
-              third parties.
-            </Trans>
-          </ul>
-          <Trans>
-            If you would like to read more about our mission, please visit{" "}
-            <a href="https://www.justfix.org/">JustFix.org</a>. If you would like to read more about
-            the data we collect, please review our full{" "}
-            <a href="https://www.justfix.org/en/privacy-policy/">Privacy Policy</a> and{" "}
-            <a href="https://www.justfix.org/en/terms-of-use/">Terms of Use</a>.
-          </Trans>
-        </Modal>
       </div>
     );
   };

--- a/client/src/styles/Login.scss
+++ b/client/src/styles/Login.scss
@@ -36,25 +36,23 @@
     justify-content: center;
     gap: 1.5rem;
 
-    .privacy-modal {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-
-      .info-icon {
-        margin-left: 0.16rem;
-        width: 18px;
-        &:focus-visible {
-          outline: 2px solid $focus-outline-color;
-          outline-offset: 2px;
-        }
-      }
+    .privacy-links {
+      text-align: center;
+      padding: 0 1.875rem;
     }
 
     .login-type-toggle {
       display: flex;
       justify-content: center;
       font-size: 0.94rem;
+    }
+
+    .privacy-links,
+    .login-type-toggle {
+      a,
+      button {
+        color: inherit;
+      }
     }
   }
 


### PR DESCRIPTION
Remove the info icon opening modal and instead just use links to privacy and terms of use page (opening in new tab)

And only show this when registering new account, not when logging in.

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/e96add74-9393-41ec-873c-98621f5c40e0)

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/ac81d312-01cd-49b3-81d9-50071d6c79ba)

[sc-13835]