### PR TITLE
feature: autofocus the address search field

### DIFF
--- a/client/src/components/AddressSearch.tsx
+++ b/client/src/components/AddressSearch.tsx
@@ -225,6 +225,7 @@ export default class AddressSearch extends React.Component<AddressSearchProps, S
                       {this.props.labelText}
                     </label>
                     <input
+                      autoFocus
                       placeholder="Search places"
                       className="geosuggest__input form-input"
                       {...downshift.getInputProps(inputOptions)}


### PR DESCRIPTION
I've been using Who Owns What a lot lately and really wish I could just navigate to the website and start typing without having to click into the address search field or hit tab 14 times. This should auto-focus the address input on page load.

Full disclosure, I had some issues installing the client dependencies, so I haven't tested this locally.