### PR TITLE
limit subscriptions to 15 (not 16)

### DIFF
--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -74,7 +74,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
               <button
                 className="button is-primary"
                 onClick={() =>
-                  subscriptions.length <= SUBSCRIPTION_LIMIT
+                  subscriptions.length < SUBSCRIPTION_LIMIT
                     ? subscribe(bbl, housenumber, streetname, zip, boro)
                     : setShowSubscriptionLimitModal(true)
                 }


### PR DESCRIPTION
Limit users to 15 subscriptions (fix typo from #842 that was allowing 16)