### PR TITLE
add reset password landing pages, validate new password inputs

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -18,6 +18,18 @@ type VerifyEmailResponse = {
   error?: string;
 };
 
+export enum ResetStatusCode {
+  Success = 200,
+  Accepted = 202,
+  Invalid = 400,
+  Expired = 404,
+  Unknown = 500,
+}
+
+type PasswordResetResponse = Omit<VerifyEmailResponse, "statusCode"> & {
+  statusCode: ResetStatusCode;
+};
+
 let _user: JustfixUser | undefined;
 const user = () => _user;
 const fetchUser = async () => {
@@ -75,6 +87,31 @@ const logout = async () => {
 
 const resetPasswordRequest = async (username: string) => {
   return await postAuthRequest(`${BASE_URL}auth/reset_password`, { username });
+};
+
+/**
+ * Sends an unauthenticated request to checks if the password reset token is valid
+ */
+const resetPasswordCheck = async () => {
+  const params = new URLSearchParams(window.location.search);
+
+  let result: PasswordResetResponse = {
+    statusCode: ResetStatusCode.Unknown,
+    statusText: "",
+  };
+
+  try {
+    const response = await postAuthRequest(
+      `${BASE_URL}auth/reset_password/check?token=${params.get("token")}`
+    );
+    result.statusCode = response.status_code;
+    result.statusText = response.status_text;
+  } catch (e) {
+    if (e instanceof Error) {
+      result.error = e.message;
+    }
+  }
+  return result;
 };
 
 const resetPassword = async (token: string, newPassword: string) => {
@@ -308,6 +345,7 @@ const Client = {
   updateEmail,
   updatePassword,
   resetPasswordRequest,
+  resetPasswordCheck,
   resetPassword,
   buildingSubscribe,
   buildingUnsubscribe,

--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -22,7 +22,7 @@ export enum ResetStatusCode {
   Success = 200,
   Accepted = 202,
   Invalid = 400,
-  Expired = 404,
+  Expired = 410,
   Unknown = 500,
 }
 
@@ -85,8 +85,23 @@ const logout = async () => {
   return await postAuthRequest(`${BASE_URL}auth/logout`);
 };
 
-const resetPasswordRequest = async (username: string) => {
-  return await postAuthRequest(`${BASE_URL}auth/reset_password`, { username });
+/**
+ * Sends request to send a password reset link to the user's email
+ */
+const resetPasswordRequest = async (username?: string) => {
+  try {
+    if (username) {
+      await postAuthRequest(`${BASE_URL}auth/reset_password_request`, { username });
+    } else {
+      const params = new URLSearchParams(window.location.search);
+      await postAuthRequest(
+        `${BASE_URL}auth/reset_password_request_with_token?u=${params.get("token")}`
+      );
+    }
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 /**
@@ -115,9 +130,23 @@ const resetPasswordCheck = async () => {
 };
 
 const resetPassword = async (token: string, newPassword: string) => {
-  return await postAuthRequest(`${BASE_URL}auth/set_password?token=${token}`, {
-    new_password: newPassword,
-  });
+  let result: PasswordResetResponse = {
+    statusCode: ResetStatusCode.Unknown,
+    statusText: "",
+  };
+
+  try {
+    const response = await postAuthRequest(`${BASE_URL}auth/set_password?token=${token}`, {
+      new_password: newPassword,
+    });
+    result.statusCode = response.status_code;
+    result.statusText = response.status_text;
+  } catch (e) {
+    if (e instanceof Error) {
+      result.error = e.message;
+    }
+  }
+  return result;
 };
 
 /**

--- a/client/src/containers/ForgotPasswordPage.tsx
+++ b/client/src/containers/ForgotPasswordPage.tsx
@@ -34,7 +34,6 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
       setShowEmailError(true);
       return;
     }
-    // TODO: should we confirm that the email already exists?
     resendPasswordResetRequest();
   };
 
@@ -47,45 +46,49 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
     <Page title={i18n._(t`Forgot your password?`)}>
       <div className="ForgotPasswordPage Page">
         <div className="page-container">
-          <Trans render="h4" className="page-title">
-            Reset Password
-          </Trans>
-          {!requestSent ? (
-            <>
-              <Trans render="h5">
-                Review your email address below. You’ll receive a "Reset password" email to this
-                address.
-              </Trans>
-              <form onSubmit={handleSubmit} className="input-group">
-                <EmailInput
-                  email={email}
-                  error={emailError}
-                  showError={showEmailError}
-                  setError={setEmailError}
-                  onChange={onChangeEmail}
-                  placeholder={i18n._(t`Enter email`)}
-                  labelText={i18n._(t`Email address`)}
-                  autoFocus
-                />
-                <button type="submit" className="button is-primary">
-                  <Trans>Reset password</Trans>
-                </button>
-              </form>
-            </>
-          ) : (
-            <div className="request-sent-success">
-              <Trans render="h5">
-                We sent a reset link to {`${email}`}. Please check your inbox and spam.
-              </Trans>
-              <Trans render="span">Didn’t receive an email?</Trans>
-              <button
-                className="button is-primary resend-link"
-                onClick={resendPasswordResetRequest}
-              >
-                <Trans>Send new link</Trans>
-              </button>
-            </div>
-          )}
+          <div className="text-center">
+            <Trans render="h4" className="page-title">
+              Reset Password
+            </Trans>
+            {!requestSent ? (
+              <>
+                <Trans render="h5">
+                  Review your email address below. You’ll receive a "Reset password" email to this
+                  address.
+                </Trans>
+                <form onSubmit={handleSubmit} className="input-group">
+                  <EmailInput
+                    email={email}
+                    error={emailError}
+                    showError={showEmailError}
+                    setError={setEmailError}
+                    onChange={onChangeEmail}
+                    placeholder={i18n._(t`Enter email`)}
+                    labelText={i18n._(t`Email address`)}
+                    autoFocus
+                  />
+                  <button type="submit" className="button is-primary">
+                    <Trans>Reset password</Trans>
+                  </button>
+                </form>
+              </>
+            ) : (
+              <>
+                <Trans render="h5">
+                  We sent a reset link to {`${email}`}. Please check your inbox and spam.
+                </Trans>
+                <div className="text-center">
+                  <Trans render="span">Didn’t receive an email?</Trans>
+                  <button
+                    className="button is-primary resend-link"
+                    onClick={resendPasswordResetRequest}
+                  >
+                    <Trans>Send new link</Trans>
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
         </div>
         <LegalFooter />
       </div>

--- a/client/src/containers/ForgotPasswordPage.tsx
+++ b/client/src/containers/ForgotPasswordPage.tsx
@@ -8,7 +8,8 @@ import { withI18n, withI18nProps } from "@lingui/react";
 import { Trans, t } from "@lingui/macro";
 
 import { UserContext } from "components/UserContext";
-import { MailIcon } from "components/Icons";
+import EmailInput from "components/EmailInput";
+import { useInput } from "util/helpers";
 
 const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -16,16 +17,28 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
   const params = new URLSearchParams(search);
 
   const [requestSent, setRequestSent] = React.useState(false);
-  const [email, setEmail] = React.useState(decodeURIComponent(params.get("email") || ""));
   const userContext = useContext(UserContext);
+  const {
+    value: email,
+    error: emailError,
+    showError: showEmailError,
+    setError: setEmailError,
+    setShowError: setShowEmailError,
+    onChange: onChangeEmail,
+  } = useInput(decodeURIComponent(params.get("email") || ""));
 
-  const handleValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setEmail(e.target.value);
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!email || emailError) {
+      setEmailError(true);
+      setShowEmailError(true);
+      return;
+    }
+    // TODO: should we confirm that the email already exists?
+    resendPasswordResetRequest();
   };
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
+  const resendPasswordResetRequest = async () => {
     await userContext.requestPasswordReset(email);
     setRequestSent(true);
   };
@@ -35,7 +48,7 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
       <div className="ForgotPasswordPage Page">
         <div className="page-container">
           <Trans render="h4" className="page-title">
-            Forgot your password?
+            Reset Password
           </Trans>
           {!requestSent ? (
             <>
@@ -43,35 +56,33 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
                 Review your email address below. You’ll receive a "Reset password" email to this
                 address.
               </Trans>
-              <form onSubmit={handleSubmit}>
-                <Trans render="label">Email address</Trans>
-                <input
-                  type="email"
-                  className="input"
+              <form onSubmit={handleSubmit} className="input-group">
+                <EmailInput
+                  email={email}
+                  error={emailError}
+                  showError={showEmailError}
+                  setError={setEmailError}
+                  onChange={onChangeEmail}
                   placeholder={i18n._(t`Enter email`)}
-                  onChange={handleValueChange}
-                  value={email}
+                  labelText={i18n._(t`Email address`)}
+                  autoFocus
                 />
-                <input
-                  type="submit"
-                  className="button is-primary"
-                  value={i18n._(t`Reset password`)}
-                />
+                <button type="submit" className="button is-primary">
+                  <Trans>Reset password</Trans>
+                </button>
               </form>
             </>
           ) : (
             <div className="request-sent-success">
-              <MailIcon />
               <Trans render="h5">
-                An email has been sent to your email address {`${email}`}. Please check your inbox
-                and spam.
+                We sent a reset link to {`${email}`}. Please check your inbox and spam.
               </Trans>
-              <button className="button is-text" onClick={() => setRequestSent(false)}>
-                <Trans>
-                  Didn’t receive an email?
-                  <br />
-                  Click here to try again.
-                </Trans>
+              <Trans render="span">Didn’t receive an email?</Trans>
+              <button
+                className="button is-primary resend-link"
+                onClick={resendPasswordResetRequest}
+              >
+                <Trans>Send new link</Trans>
               </button>
             </div>
           )}

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -131,9 +131,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
 
   const successPage = () => (
     <>
-      <Trans render="h4">
-        Your password has successfully been reset
-      </Trans>
+      <Trans render="h4">Your password has successfully been reset</Trans>
       <Trans render="div">
         You will be redirected back to Who Owns What in
         {updateCountdown()}
@@ -159,7 +157,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
               successPage()
             ) : tokenStatus === ResetStatusCode.Accepted ? (
               resetPasswordPage()
-            ) : resetStatus === ResetStatusCode.Expired ? (
+            ) : tokenStatus === ResetStatusCode.Expired ? (
               expiredPage()
             ) : (
               invalidPage()

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import LegalFooter from "../components/LegalFooter";
 
@@ -6,21 +6,23 @@ import Page from "../components/Page";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { Trans, t } from "@lingui/macro";
 
-import { UserContext } from "components/UserContext";
+import AuthClient, { ResetStatusCode } from "components/AuthClient";
 import PasswordInput from "components/PasswordInput";
 import { useInput } from "util/helpers";
+import { FixedLoadingLabel } from "components/Loader";
 
 const ResetPasswordPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const { search } = useLocation();
   const params = new URLSearchParams(search);
 
+  const [tokenStatus, setTokenStatus] = React.useState<ResetStatusCode>();
   const [requestSent, setRequestSent] = React.useState(false);
-  const userContext = useContext(UserContext);
   const {
     value: password,
     error: passwordError,
     showError: showPasswordError,
+    setShowError: setShowPasswordError,
     setError: setPasswordError,
     onChange: onChangePassword,
   } = useInput("");
@@ -42,61 +44,111 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
     }, delayInterval);
   };
 
+  useEffect(() => {
+    const asyncCheckToken = async () => {
+      return await AuthClient.resetPasswordCheck();
+    };
+
+    asyncCheckToken().then((result) => {
+      setTokenStatus(result.statusCode);
+    });
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    await userContext.resetPassword(params.get("token") || "", password);
-    setRequestSent(true);
+    if (!password || passwordError) {
+      setPasswordError(true);
+      setShowPasswordError(true);
+      return;
+    }
+
+    const resp = await AuthClient.resetPassword(params.get("token") || "", password);
+    if (resp.statusCode === ResetStatusCode.Success) {
+      
+    } else {
+      setTokenStatus(resp.statusCode);
+    }
   };
+
+  const expiredTokenPage = () => (
+    <>
+      <Trans render="h4">The link sent to you has timed out.</Trans>
+        <br />
+        <button
+          className="button is-secondary"
+          onClick={async () => {
+            setIsEmailResent(await AuthClient.resendVerifyEmail());
+          }}
+        >
+          <Trans>Resend verification email</Trans>
+        </button>
+    </>
+  )
+
+  const invalidTokenPage = () => (
+    <>
+      <Trans render="h4">The link sent to you has timed out.</Trans>
+        <br />
+        <button
+          className="button is-secondary"
+          onClick={async () => {
+            setIsEmailResent(await AuthClient.resendVerifyEmail());
+          }}
+        >
+          <Trans>Resend verification email</Trans>
+        </button>
+    </>
+  )
+
+  const resetPasswordPage = () => (
+    <>
+      <Trans render="h4">Reset your password</Trans>
+      <form className="input-group" onSubmit={handleSubmit}>
+        <PasswordInput
+          labelText={i18n._(t`Create a password`)}
+          showPasswordRules={true}
+          password={password}
+          onChange={onChangePassword}
+          error={passwordError}
+          showError={showPasswordError}
+          setError={setPasswordError}
+        />
+        <button type="submit" className="button is-primary">
+          <Trans>Reset password</Trans>
+        </button>
+      </form>
+    </>
+  );
+
+  const successPage = () => (
+    <>
+      <Trans className="text-center" render="h4">
+        Your password has successfully been reset
+      </Trans>
+      <br />
+      <div className="text-center">
+        <Trans className="text-center">You will be redirected back to Who Owns What in</Trans>
+        <br>{updateCountdown()}</br>
+        <Trans className="d-flex justify-content-center">
+          <span id="countdown"> {delaySeconds}</span> seconds
+        </Trans>
+        <br />
+        <br />
+        <Trans className="text-center">
+          <a href={redirectUrl} style={{ color: "#242323" }}>
+            Click to log in
+          </a>{" "}
+          if you are not redirected
+        </Trans>
+      </div>
+    </>
+  );
 
   return (
     <Page title={i18n._(t`Reset your password`)}>
       <div className="ResetPasswordPage Page">
-        <div className="page-container">
-          {!requestSent ? (
-            <>
-              <Trans render="h4">Reset your password</Trans>
-              <form className="input-group" onSubmit={handleSubmit}>
-                <PasswordInput
-                  labelText={i18n._(t`Create a password`)}
-                  showPasswordRules={true}
-                  password={password}
-                  onChange={onChangePassword}
-                  error={passwordError}
-                  showError={showPasswordError}
-                  setError={setPasswordError}
-                />
-                <button type="submit" className="button is-primary">
-                  <Trans>Reset password</Trans>
-                </button>
-              </form>
-            </>
-          ) : (
-            <>
-              <Trans className="text-center" render="h4">
-                Your password has successfully been reset
-              </Trans>
-              <br />
-              <div className="text-center">
-                <Trans className="text-center">
-                  You will be redirected back to Who Owns What in
-                </Trans>
-                <br>{updateCountdown()}</br>
-                <Trans className="d-flex justify-content-center">
-                  <span id="countdown"> {delaySeconds}</span> seconds
-                </Trans>
-                <br />
-                <br />
-                <Trans className="text-center">
-                  <a href={redirectUrl} style={{ color: "#242323" }}>
-                    Click to log in
-                  </a>{" "}
-                  if you are not redirected
-                </Trans>
-              </div>
-            </>
-          )}
-        </div>
+        <div className="page-container">{tokenIsValid === undefined ? <FixedLoadingLabel/> : !tokenIsValid ? invalidTokenPage() : passwordIsReset ? successPage() : resetPasswordPage()}</div>
         <LegalFooter />
       </div>
     </Page>

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -76,7 +76,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
       <>
         <Trans render="h4">The password reset link that we sent you is no longer valid.</Trans>
         <button
-          className="button is-secondary"
+          className="button is-primary"
           onClick={async () => {
             setEmailIsResent(await AuthClient.resetPasswordRequest());
           }}
@@ -102,7 +102,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
     return (
       <>
         <Trans render="h4">Sorry, something went wrong with the password reset.</Trans>
-        <LocaleLink className="button is-secondary" to={account.forgotPassword}>
+        <LocaleLink className="button is-primary" to={account.forgotPassword}>
           <Trans>Request new link</Trans>
         </LocaleLink>
       </>

--- a/client/src/styles/ForgotPasswordPage.scss
+++ b/client/src/styles/ForgotPasswordPage.scss
@@ -8,45 +8,31 @@
     flex-direction: column;
     gap: 1.5rem;
   }
-
-  h4 {
-    font-size: 1.5rem;
-    margin: 0;
-  }
-
-  h5 {
-    font-size: 1rem;
-    margin: 0;
-  }
-
-  .button.is-primary {
-    margin: 0 auto;
-    &.resend-link {
-      margin-top: 1rem;
-    }
-  }
-
-  label {
-    @include desktop-eyebrow();
-
-    text-align: left;
-    margin-top: 0.39rem;
-    margin-bottom: 0.19rem;
-  }
-
-  .request-sent-success {
+  .text-center,
+  .input-group {
     display: flex;
     flex-direction: column;
     align-items: center;
+    gap: 2rem;
+    width: 100%;
 
-    svg {
-      margin: 0.39rem 0 0.98rem 0;
+    h4 {
+      font-size: 1.5rem;
+      margin: 0;
     }
 
-    .button.is-text {
-      margin-top: 0.39rem;
-      display: block !important;
-      color: $justfix-black;
+    h5 {
+      font-size: 1rem;
+      margin: 0;
+    }
+
+    .email-input-field,
+    .password-input-field {
+      width: 100%;
+    }
+
+    .text-center {
+      gap: 1rem;
     }
   }
 }

--- a/client/src/styles/ForgotPasswordPage.scss
+++ b/client/src/styles/ForgotPasswordPage.scss
@@ -1,7 +1,8 @@
 @import "_vars.scss";
 @import "_typography.scss";
 
-.ForgotPasswordPage {
+.ForgotPasswordPage,
+.ResetPasswordPage {
   .page-container {
     display: flex;
     flex-direction: column;
@@ -18,18 +19,19 @@
     margin: 0;
   }
 
+  .button.is-primary {
+    margin: 0 auto;
+    &.resend-link {
+      margin-top: 1rem;
+    }
+  }
+
   label {
     @include desktop-eyebrow();
 
     text-align: left;
     margin-top: 0.39rem;
     margin-bottom: 0.19rem;
-  }
-
-  input[type="submit"] {
-    padding: 0.63rem 1.25rem !important;
-    align-self: center;
-    margin: 1.02rem auto 0.23rem auto !important;
   }
 
   .request-sent-success {

--- a/jfauthprovider/urls.py
+++ b/jfauthprovider/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
         name="resend_verification_with_token",
     ),
     path("reset_password", views.password_reset_request, name="password_reset_request"),
+    path("reset_password/check", views.password_reset_token_check, name="password_reset_token_check"),
     path("set_password", views.password_reset, name="password_reset"),
     path("change_password", views.password_change, name="password_change"),
     path(

--- a/jfauthprovider/urls.py
+++ b/jfauthprovider/urls.py
@@ -18,8 +18,21 @@ urlpatterns = [
         views.resend_verification_with_token,
         name="resend_verification_with_token",
     ),
-    path("reset_password", views.password_reset_request, name="password_reset_request"),
-    path("reset_password/check", views.password_reset_token_check, name="password_reset_token_check"),
+    path(
+        "reset_password_request",
+        views.reset_password_request,
+        name="reset_password_request",
+    ),
+    path(
+        "reset_password_request_with_token",
+        views.reset_password_request_with_token,
+        name="reset_password_request_with_token",
+    ),
+    path(
+        "reset_password/check",
+        views.password_reset_token_check,
+        name="password_reset_token_check",
+    ),
     path("set_password", views.password_reset, name="password_reset"),
     path("change_password", views.password_change, name="password_change"),
     path(

--- a/jfauthprovider/views.py
+++ b/jfauthprovider/views.py
@@ -160,6 +160,19 @@ def password_reset_request(request):
 
 
 @api
+def password_reset_token_check(request):
+    post_data = {
+        "token": request.GET.get("token"),
+    }
+    return auth_server_request(
+        "POST",
+        "user/password_reset/check/",
+        post_data,
+        {"Cookie": request.headers.get("Cookie")},
+    )
+
+
+@api
 def password_reset(request):
     post_data = {
         "token": request.GET.get("token"),

--- a/jfauthprovider/views.py
+++ b/jfauthprovider/views.py
@@ -146,44 +146,72 @@ def resend_verification_with_token(request):
 
 
 @api
-def password_reset_request(request):
-    post_data = {
-        "username": request.POST.get("username"),
-        "origin": request.headers["Origin"],
-    }
-    return auth_server_request(
-        "POST",
-        "user/password_reset/request/",
-        post_data,
-        {"Cookie": request.headers.get("Cookie")},
-    )
+def reset_password_request(request):
+    try:
+        post_data = {
+            "username": request.POST.get("username"),
+            "origin": request.headers["Origin"],
+        }
+        return auth_server_request(
+            "POST",
+            "user/password_reset/request/",
+            post_data,
+            {"Cookie": request.headers.get("Cookie")},
+        )
+    except Exception:
+        print("failed")
+        return HttpResponse(content_type="application/json", status=401)
+
+
+@api
+def reset_password_request_with_token(request):
+    try:
+        print(request.GET.get("token"))
+        post_data = {
+            "token": request.GET.get("token"),
+            "origin": request.headers["Origin"],
+        }
+
+        return auth_server_request(
+            "POST",
+            "user/email/password_reset/request/",
+            post_data,
+        )
+    except KeyError:
+        return HttpResponse(content_type="application/json", status=401)
 
 
 @api
 def password_reset_token_check(request):
-    post_data = {
-        "token": request.GET.get("token"),
-    }
-    return auth_server_request(
-        "POST",
-        "user/password_reset/check/",
-        post_data,
-        {"Cookie": request.headers.get("Cookie")},
-    )
+    try:
+        post_data = {
+            "token": request.GET.get("token"),
+        }
+        return auth_server_request(
+            "POST",
+            "user/email/password_reset/check/",
+            post_data,
+            {"Cookie": request.headers.get("Cookie")},
+        )
+    except KeyError:
+        return HttpResponse(content_type="application/json", status=401)
 
 
 @api
 def password_reset(request):
-    post_data = {
-        "token": request.GET.get("token"),
-        "new_password": request.POST.get("new_password"),
-    }
-    return auth_server_request(
-        "POST",
-        "user/password_reset/",
-        post_data,
-        {"Cookie": request.headers.get("Cookie")},
-    )
+    try:
+        post_data = {
+            "token": request.GET.get("token"),
+            "new_password": request.POST.get("new_password"),
+        }
+        return auth_server_request(
+            "POST",
+            "user/password_reset/",
+            post_data,
+            {"Cookie": request.headers.get("Cookie")},
+        )
+    except KeyError:
+        return HttpResponse(content_type="application/json", status=401)
 
 
 @api


### PR DESCRIPTION
This PR changes the forgot/reset password flows, and goes along with changes to the auth backend in https://github.com/JustFixNYC/auth-provider/pull/31

From login you can click "forgot password?", your email is autofilled. This now has input validation to ensure a valid email (though it doesn't check for an existing account).

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/bf07ad15-8936-473c-a042-85f4af8f0494)

Submitting your email here will send a reset link to your email, and show you a success page.

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/84bc3873-8ddd-488b-b751-755bbf8e51af)

Then from your email you click the link back to wow with the reset token in url params. 

We now check that token immediately when you land on the page (and while waiting it shows the standard `Loading...` placeholder. If the token is valid and active still, it changes to reset password.
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/27172619-1ee1-48c7-9711-5de2ef41a9d6)

This now has full input validation for the password, same as for account creation. 

If that the reset is successful it shows this countdown then redirects you to login page. 

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/fb1b7646-b137-40cb-82f9-ff5f89fb4c03)

That's the "happy path" for this. 

If your email link is expired, you will get this message and a one-click button to resend the email, which uses the token to send the request using a new auth endpoint (https://github.com/JustFixNYC/auth-provider/pull/31)

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/050b9421-7848-481a-9f4d-3f8f45cbc177)

After clicking to resend the link you get this success page:

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/baaaaddd-5618-45fe-a346-9a5570c99ec7)

If anything else goes wrong in this process - the link is broken in some other way, missing completely from url params, or if the password reset fails for some reason (maybe times out between the check and the submit) - then you get this page, and the button sends you back to the "forgot password" page where you can enter you email and start again. 

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/adff838f-98bb-437a-9ec5-87f27ede5cc4)


I tried to follow a similar process as used for the verify email flow in https://github.com/JustFixNYC/who-owns-what/pull/867. With the handling of status codes in the auth client, the useEffect checking the token, etc.

[sc-13900]
[sc-13986]
[sc-13901]