### PR TITLE
Login mirror bug

### DIFF
--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -135,14 +135,14 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => {
                   <span className="pill-new">
                     <Trans>NEW</Trans>
                   </span>
-                  {!user ? (
+                  {!user?.email ? (
                     <Trans>Get Data Updates for this building</Trans>
                   ) : (
                     <Trans>Data Updates</Trans>
                   )}
                 </label>
                 <div className="table-content">
-                  {user && !loginRegisterInProgress ? (
+                  {!!user?.email && !loginRegisterInProgress ? (
                     <BuildingSubscribe {...props} />
                   ) : (
                     <Login

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -84,6 +84,8 @@ const LoginWithoutI18n = (props: LoginProps) => {
     onChange: onChangeUserType,
   } = useInput("");
 
+  const [placeholderEmail, setPlaceholderEmail] = useState("");
+
   const [invalidAuthError, setInvalidAuthError] = useState(false);
   const [existingUserError, setExistingUserError] = useState(false);
 
@@ -271,6 +273,8 @@ const LoginWithoutI18n = (props: LoginProps) => {
         }
       }
     }
+
+    setPlaceholderEmail(email);
   };
 
   const onLoginSubmit = async () => {
@@ -392,6 +396,31 @@ const LoginWithoutI18n = (props: LoginProps) => {
       break;
   }
 
+  const renderOnPagePlaceholder = () => {
+    return (
+      <div className="Login">
+        <Trans render="div" className="email-description">
+          Get weekly Data Updates for complaints, violations, and evictions.
+        </Trans>
+        <div className="input-group">
+          <EmailInput
+            email={placeholderEmail}
+            onChange={() => {}}
+            error={false}
+            setError={() => {}}
+            showError={false}
+            labelText={i18n._(t`Email address`)}
+          />
+          <div className="submit-button-group">
+            <button type="button" className="button is-primary">
+              <Trans>Get updates</Trans>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   const renderLoginFlow = () => {
     return (
       <div className="Login">
@@ -462,8 +491,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
 
   return (
     <>
-      {(!showRegisterModal || isCheckEmailStep || isLoginStep || isVerifyEmailStep) &&
-        renderLoginFlow()}
+      {!showRegisterModal ? renderLoginFlow() : renderOnPagePlaceholder()}
       {registerInModal && (
         <Modal
           key={1}

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -231,7 +231,9 @@ const UserSettingFieldWithoutI18n = (props: UserSettingFieldProps) => {
           <>
             {children}
             <div className="user-setting-actions">
-              <input type="submit" className="button is-primary" value={`Save`} />
+              <button type="submit" className="button is-primary">
+                <Trans>Save</Trans>
+              </button>
               <button type="button" className="button is-text" onClick={() => setEditing(false)}>
                 <Trans>Cancel</Trans>
               </button>

--- a/client/src/styles/Login.scss
+++ b/client/src/styles/Login.scss
@@ -17,8 +17,7 @@
     .submit-button-group {
       display: flex;
 
-      button[type="submit"],
-      input[type="submit"] {
+      .button.is-primary {
         padding: 1rem 2rem !important;
         align-self: center;
         margin: 0 auto !important;


### PR DESCRIPTION
On the building page, while the login/register modal is open on the page the login was being mirrored. This PR removes that by using a placeholder for on-page while the modal is open. This placeholder mimics what is there when you first land on the page (the email input). In the input box it persists whatever was in there when the modal opened, so that it doesn't update if you were to change the email in the modal. When you close the modal it swaps the placeholder for the real <Login> so the email will reset to whatever it is in state. 

And edge case we decided not to deal with at this time: if you start the on-page login process, then manually toggle to sign up in the modal. We don't persist the login as placeholder, but switch back to the email only state. 

https://www.loom.com/share/6f4864e5a4474d72ab9045aa418262d0?sid=8a151af4-3eff-4420-8a69-bbd28bf54a16

This whole thing is hard to preview at the moment since the modal covers the placeholder. So I'm going to wait until we implement the layout change that moves the Building Updates to the right column since then this will be easy to see alongside the modal. 


I also made a couple other small changes:
* I noticed a weird bug that is new (not sure what cases it though) related to how we were conditioning on the `user` object on the building page updates box. For some reason `user` was now resolving to `true` because it was created but all fields undefined, so I changed to use `user.email` instead. 
* There was still one place using `<input type="submit"/>` instead of button, also it's value wasn't translated

[sc-14072]