### PR TITLE
fix user object condition

### DIFF
--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -51,7 +51,7 @@ export const SubscriptionField = withI18n()(SubscriptionFieldWithoutI18n);
 const AccountSettingsPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const userContext = useContext(UserContext);
-  if (!userContext.user) return <div />;
+  if (!userContext?.user?.email) return <div />;
 
   const { email, subscriptions } = userContext.user as JustfixUser;
   const { home } = createWhoOwnsWhatRoutePaths();


### PR DESCRIPTION
Found another case of conditioning on the `user` object that is now evaluating true when it's actually just the empty placeholder. This is another case of the issue fixed in #870 . It was causing the account settings page to appear but with all the user content missing. Now it correctly shows nothing, like before