### PR TITLE
refactor unsubscribe page

### DIFF
--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -92,9 +92,9 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
             ) : (
               <Trans render="div" className="settings-no-subscriptions">
                 <LocaleNavLink exact to={home}>
-                  Search an address
+                  Search for an address
                 </LocaleNavLink>{" "}
-                to sign up for email alerts for that building.
+                to add to your Building Updates
               </Trans>
             )}
           </div>

--- a/client/src/containers/UnsubscribePage.tsx
+++ b/client/src/containers/UnsubscribePage.tsx
@@ -4,7 +4,6 @@ import { withI18n, withI18nProps } from "@lingui/react";
 import { Plural, Trans, t } from "@lingui/macro";
 import { Button } from "@justfixnyc/component-library";
 
-
 import "styles/UnsubscribePage.css";
 import "styles/UserSetting.css";
 import Page from "../components/Page";

--- a/client/src/containers/UnsubscribePage.tsx
+++ b/client/src/containers/UnsubscribePage.tsx
@@ -89,14 +89,12 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
 
   const renderNoSubscriptionsPage = () => (
     <>
-      <Trans render="h4" className="settings-section">
-        You are not subscribed to any buildings.
-      </Trans>
+      <Trans render="h4">You are not subscribed to any buildings</Trans>
       <Trans render="div" className="settings-no-subscriptions">
         <LocaleNavLink exact to={home}>
-          Search for a building
+          Search for an address
         </LocaleNavLink>{" "}
-        to add to your updates
+        to add to your Building Updates
       </Trans>
     </>
   );

--- a/client/src/containers/UnsubscribePage.tsx
+++ b/client/src/containers/UnsubscribePage.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import LegalFooter from "../components/LegalFooter";
-
-import Page from "../components/Page";
 import { withI18n, withI18nProps } from "@lingui/react";
-import { Trans, t } from "@lingui/macro";
+import { Plural, Trans, t } from "@lingui/macro";
+import { Button } from "@justfixnyc/component-library";
 
+
+import "styles/UnsubscribePage.css";
 import "styles/UserSetting.css";
+import Page from "../components/Page";
+import LegalFooter from "../components/LegalFooter";
 import AuthClient from "../components/AuthClient";
 import { SubscriptionField } from "./AccountSettingsPage";
 import { createWhoOwnsWhatRoutePaths } from "routes";
@@ -22,23 +24,16 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
   const token = params.get("u") || "";
   const isEmailUnsubscribeAll = !!params.get("all");
 
-  const [subscriptions, setSubscriptions] = React.useState<BuildingSubscription[] | undefined>();
+  const [subscriptions, setSubscriptions] = React.useState<BuildingSubscription[]>();
+  const subscriptionsNumber = subscriptions?.length;
 
   useEffect(() => {
-    if (isEmailUnsubscribeAll) {
-      const asyncUnsubscribeAll = async () => {
-        const response = await AuthClient.emailUnsubscribeAll(token);
-        setSubscriptions(response["subscriptions"]);
-      };
-      asyncUnsubscribeAll();
-    } else {
-      const asyncFetchSubscriptions = async () => {
-        const response = await AuthClient.emailUserSubscriptions(token);
-        setSubscriptions(response["subscriptions"]);
-      };
-      asyncFetchSubscriptions();
-    }
-  }, [token, isEmailUnsubscribeAll]);
+    const asyncFetchSubscriptions = async () => {
+      const response = await AuthClient.emailUserSubscriptions(token);
+      setSubscriptions(response["subscriptions"]);
+    };
+    asyncFetchSubscriptions();
+  }, [token]);
 
   const handleUnsubscribeBuilding = async (bbl: string) => {
     const result = await AuthClient.emailUnsubscribeBuilding(bbl, token);
@@ -50,45 +45,80 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
     if (!!result?.["subscriptions"]) setSubscriptions(result["subscriptions"]);
   };
 
+  const renderUnsubscribePage = () => (
+    <>
+      <Trans render="h4">Unsubscribe</Trans>
+      <div className="unsubscribe-container">
+        <Trans render="p">
+          You are signed up for Building Updates for {subscriptionsNumber}{" "}
+          <Plural value={subscriptionsNumber!} one="building" other="buildings" />. Click below to
+          unsubscribe from all and stop receiving Building Updates.
+        </Trans>
+        <Button
+          variant="primary"
+          size="small"
+          labelText={i18n._(t`Unsubscribe from all`)}
+          onClick={handleUnsubscribeAll}
+        />
+      </div>
+    </>
+  );
+
+  const renderManageSubscriptionsPage = () => (
+    <>
+      <Trans render="h4">Manage Subscriptions</Trans>
+      <Trans render="p" className="settings-section">
+        There <Plural value={subscriptionsNumber!} one="is" other="are" /> {subscriptionsNumber}{" "}
+        <Plural value={subscriptionsNumber!} one="building" other="buildings" /> in your weekly
+        updates
+      </Trans>
+      <div className="subscriptions-container">
+        {subscriptions!.map((s) => (
+          <SubscriptionField key={s.bbl} {...s} onRemoveClick={handleUnsubscribeBuilding} />
+        ))}
+        <div className="unsubscribe-all-field">
+          <Button
+            variant="text"
+            size="small"
+            labelText={i18n._(t`Unsubscribe from all`)}
+            onClick={handleUnsubscribeAll}
+          />
+        </div>
+      </div>
+    </>
+  );
+
+  const renderNoSubscriptionsPage = () => (
+    <>
+      <Trans render="h4" className="settings-section">
+        You are not subscribed to any buildings.
+      </Trans>
+      <Trans render="div" className="settings-no-subscriptions">
+        <LocaleNavLink exact to={home}>
+          Search for a building
+        </LocaleNavLink>{" "}
+        to add to your updates
+      </Trans>
+    </>
+  );
+
   return (
-    <Page title={i18n._(t`Modify your email preferences`)}>
+    <Page title={isEmailUnsubscribeAll ? i18n._(t`Unsubscribe`) : i18n._(t`Manage subscriptions`)}>
       <div className="UnsubscribePage Page">
         <div className="page-container">
           {subscriptions === undefined ? (
             <FixedLoadingLabel />
-          ) : isEmailUnsubscribeAll || !subscriptions.length ? (
-            <>
-              {isEmailUnsubscribeAll ? (
-                <Trans render="h4">You have sucessfully unsubscribed from all buildings.</Trans>
-              ) : (
-                <Trans render="h4">You are not subscribed to any buildings.</Trans>
-              )}
-              <Trans render="div" className="settings-no-subscriptions">
-                <LocaleNavLink exact to={home}>
-                  Search an address
-                </LocaleNavLink>{" "}
-                to sign up for email alerts for that building.
-              </Trans>
-              <div className="settings-contact">
-                <Trans>If you’d like to delete your account,</Trans>
-                <br />
-                <Trans>contact support@justfix.org </Trans>
-              </div>
-            </>
+          ) : subscriptionsNumber === 0 ? (
+            renderNoSubscriptionsPage()
+          ) : isEmailUnsubscribeAll ? (
+            renderUnsubscribePage()
           ) : (
-            <>
-              <Trans render="h4">You are signed up for email alerts from these bulidings:</Trans>
-              <div className="subscriptions-container">
-                {subscriptions.map((s: any) => (
-                  <SubscriptionField key={s.bbl} {...s} onRemoveClick={handleUnsubscribeBuilding} />
-                ))}
-                <div className="unsubscribe-all-field">
-                  <button className="button is-text" onClick={handleUnsubscribeAll}>
-                    <Trans>Unsubscribe from all</Trans>
-                  </button>
-                </div>
-              </div>
-            </>
+            renderManageSubscriptionsPage()
+          )}
+          {isEmailUnsubscribeAll && (
+            <Trans render="div" className="settings-contact">
+              Contact support@justfix.org to delete your account or get help
+            </Trans>
           )}
         </div>
         <LegalFooter />

--- a/client/src/styles/UnsubscribePage.scss
+++ b/client/src/styles/UnsubscribePage.scss
@@ -4,4 +4,7 @@
     flex-direction: column;
     align-items: center;
   }
+  p.settings-section {
+    margin-bottom: 2rem;
+  }
 }

--- a/client/src/styles/UnsubscribePage.scss
+++ b/client/src/styles/UnsubscribePage.scss
@@ -1,0 +1,7 @@
+.UnsubscribePage {
+  .unsubscribe-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
Refactor the unsubscribe/manage subscriptions page that you land on via email links.

When you first land on the page there is this standard wow placeholder while it fetches your subscriptions to be able to determine what to show. 
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/3efb7550-4610-41ce-8118-f9b762694f0d)

>Note: the plural words (are/is, building/buildings) are missing from these screenshots since we need to run all the internationalization which we are doing after merging in. 


Click "manage subscriptions" link from email, while having subscriptions:
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/a4d49403-b999-422c-ae71-368b73bfdae3)

Click the unsubscribe all button from "manage subscriptions" page, or coming from email when you have 0 subscriptions:
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/4bc6b595-5944-4852-8e7d-f9d412725ee7)


Click on "unsubscribe" link from email when you have subscriptions:
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/b2946d1b-3470-475c-898c-ad853654d313)

Click the unsubscribe all button from "unsubscribe" page, or coming from email when you have 0 subscriptions:
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/7d8e5186-fb29-4b12-865e-9403c8d4ea59)

[sc-14085]