### PR TITLE
Standardize email addresses as lowercase

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -61,7 +61,7 @@ const clearUser = () => (_user = undefined);
  */
 const register = async (username: string, password: string, userType: string) => {
   const json = await postAuthRequest(`${BASE_URL}auth/register`, {
-    username,
+    username: username.toLowerCase(),
     password,
     user_type: userType,
   });
@@ -74,7 +74,10 @@ const register = async (username: string, password: string, userType: string) =>
  * and expiry time.
  */
 const login = async (username: string, password: string) => {
-  const json = await postLoginCredentials(`${BASE_URL}auth/login`, { username, password });
+  const json = await postLoginCredentials(`${BASE_URL}auth/login`, {
+    username: username.toLowerCase(),
+    password,
+  });
   return json;
 };
 
@@ -91,7 +94,9 @@ const logout = async () => {
 const resetPasswordRequest = async (username?: string) => {
   try {
     if (username) {
-      await postAuthRequest(`${BASE_URL}auth/reset_password_request`, { username });
+      await postAuthRequest(`${BASE_URL}auth/reset_password_request`, {
+        username: username.toLowerCase(),
+      });
     } else {
       const params = new URLSearchParams(window.location.search);
       await postAuthRequest(
@@ -201,7 +206,7 @@ const resendVerifyEmail = async (token?: string) => {
  * Sends an authenticated request to update the user email
  */
 const updateEmail = async (newEmail: string) => {
-  return await postAuthRequest(`${BASE_URL}auth/update`, { new_email: newEmail });
+  return await postAuthRequest(`${BASE_URL}auth/update`, { new_email: newEmail.toLowerCase() });
 };
 
 /**
@@ -246,7 +251,9 @@ const buildingUnsubscribe = async (bbl: string) => {
 };
 
 const isEmailAlreadyUsed = async (email: string) => {
-  const result = await friendlyFetch(`${BASE_URL}auth/account_exists/${email}`, {
+  const sanitizedEmail = email.toLowerCase();
+
+  const result = await friendlyFetch(`${BASE_URL}auth/account_exists/${sanitizedEmail}`, {
     method: "GET",
     mode: "cors",
     headers: {


### PR DESCRIPTION
- all emails are sent to API as lowercase. the casing remains as what user typed on the front end during the login/register process, but once redirected to account settings, it will show up as lowercase. 
- attempts to edit the email w/  different capitalizations look like this: 
<img width="665" alt="Screenshot 2024-03-26 at 5 03 11 PM" src="https://github.com/JustFixNYC/who-owns-what/assets/17574626/bb47b16d-9408-4530-8107-2a75fa41ccc4">

[sc-13910]