### PR TITLE
Use component library buttons in email alerts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "@amplitude/analytics-browser": "^1.2.3",
     "@babel/core": "^7.7.2",
     "@contentful/rich-text-react-renderer": "^15.0.0",
-    "@justfixnyc/component-library": "0.31.1",
+    "@justfixnyc/component-library": "0.32.1",
     "@justfixnyc/contentful-common-strings": "^0.1.0",
     "@justfixnyc/geosearch-requester": "1.0.0",
     "@justfixnyc/util": "^0.4.1",

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -31,8 +31,10 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const userContext = useContext(UserContext);
   const { user, subscribe, unsubscribe } = userContext;
   const { email, subscriptions, verified } = user! as JustfixUser;
-  const [showSubscriptionLimitModal, setShowSubscriptionLimitModal] = useState(false);
   const { account } = createWhoOwnsWhatRoutePaths();
+
+  const [verifyResent, setVerifyResent] = React.useState(false);
+  const [showSubscriptionLimitModal, setShowSubscriptionLimitModal] = useState(false);
 
   const showSubscribed = () => (
     <>
@@ -60,8 +62,10 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
       <Trans render="div" className="status-description">
         Click the link we sent to {email}. It may take a few minutes to arrive.
       </Trans>
-      <Trans render="div">Didn’t get the link?</Trans>
+      {!verifyResent && <Trans render="div">Didn’t get the link?</Trans>}
       <SendNewLink
+        linkSent={verifyResent}
+        setLinkSent={setVerifyResent}
         variant="secondary"
         className="is-full-width"
         onClick={() => AuthClient.resendVerifyEmail()}

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -14,6 +14,7 @@ import { SubscribedIcon } from "./Icons";
 import { Alert } from "./Alert";
 import Modal from "./Modal";
 import helpers from "util/helpers";
+import SendNewLink from "./SendNewLink";
 
 const SUBSCRIPTION_LIMIT = 15;
 
@@ -60,11 +61,9 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
         Click the link we sent to {email}. It may take a few minutes to arrive.
       </Trans>
       <Trans render="div">Didn’t get the link?</Trans>
-      <Button
+      <SendNewLink
         variant="secondary"
-        size="small"
         className="is-full-width"
-        labelText={i18n._(t`Send new link`)}
         onClick={() => AuthClient.resendVerifyEmail()}
       />
     </>

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -33,7 +33,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const { email, subscriptions, verified } = user! as JustfixUser;
   const { account } = createWhoOwnsWhatRoutePaths();
 
-  const [verifyResent, setVerifyResent] = React.useState(false);
+  const [isEmailResent, setIsEmailResent] = React.useState(false);
   const [showSubscriptionLimitModal, setShowSubscriptionLimitModal] = useState(false);
 
   const showSubscribed = () => (
@@ -62,10 +62,9 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
       <Trans render="div" className="status-description">
         Click the link we sent to {email}. It may take a few minutes to arrive.
       </Trans>
-      {!verifyResent && <Trans render="div">Didn’t get the link?</Trans>}
+      {!isEmailResent && <Trans render="div">Didn’t get the link?</Trans>}
       <SendNewLink
-        linkSent={verifyResent}
-        setLinkSent={setVerifyResent}
+        setParentState={setIsEmailResent}
         variant="secondary"
         className="is-full-width"
         onClick={() => AuthClient.resendVerifyEmail()}

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -86,6 +86,8 @@ const LoginWithoutI18n = (props: LoginProps) => {
     onChange: onChangeUserType,
   } = useInput("");
 
+  const [verifyResent, setVerifyResent] = React.useState(false);
+
   const [placeholderEmail, setPlaceholderEmail] = useState("");
 
   const [invalidAuthError, setInvalidAuthError] = useState(false);
@@ -212,10 +214,14 @@ const LoginWithoutI18n = (props: LoginProps) => {
     return (
       <div className="verify-email-container">
         <p>{i18n._(t`Click the link we sent to ${email}. It may take a few minutes to arrive.`)}</p>
-        <Trans render="span" className="resend-verify-label">
-          Didn’t get the link?
-        </Trans>
+        {!verifyResent && (
+          <Trans render="span" className="resend-verify-label">
+            Didn’t get the link?
+          </Trans>
+        )}
         <SendNewLink
+          linkSent={verifyResent}
+          setLinkSent={setVerifyResent}
           variant="secondary"
           className="is-full-width"
           onClick={() => AuthClient.resendVerifyEmail()}
@@ -235,6 +241,8 @@ const LoginWithoutI18n = (props: LoginProps) => {
         <br />
         <br />
         <SendNewLink
+          linkSent={verifyResent}
+          setLinkSent={setVerifyResent}
           variant="secondary"
           className="is-full-width"
           onClick={() => AuthClient.resendVerifyEmail()}

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -220,8 +220,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
           </Trans>
         )}
         <SendNewLink
-          linkSent={verifyResent}
-          setLinkSent={setVerifyResent}
+          setParentState={setVerifyResent}
           variant="secondary"
           className="is-full-width"
           onClick={() => AuthClient.resendVerifyEmail()}
@@ -241,8 +240,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
         <br />
         <br />
         <SendNewLink
-          linkSent={verifyResent}
-          setLinkSent={setVerifyResent}
+          setParentState={setVerifyResent}
           variant="secondary"
           className="is-full-width"
           onClick={() => AuthClient.resendVerifyEmail()}

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -17,7 +17,8 @@ import Modal from "./Modal";
 import "styles/Login.css";
 import "styles/UserTypeInput.css";
 import "styles/_input.scss";
-import { Button } from "@justfixnyc/component-library";
+import { Button, Link } from "@justfixnyc/component-library";
+import SendNewLink from "./SendNewLink";
 
 enum Step {
   CheckEmail,
@@ -182,12 +183,9 @@ const LoginWithoutI18n = (props: LoginProps) => {
           {isRegisterAccountStep ? (
             <>
               <Trans>Already have an account?</Trans>
-              <Button
-                variant="text"
-                labelText={i18n._(t`Log in`)}
-                onClick={() => toggleLoginSignup(Step.Login)}
-                className="ml-5"
-              />
+              <Link onClick={() => toggleLoginSignup(Step.Login)} className="ml-5">
+                <Trans>Log in</Trans>
+              </Link>
             </>
           ) : (
             <>
@@ -217,11 +215,9 @@ const LoginWithoutI18n = (props: LoginProps) => {
         <Trans render="span" className="resend-verify-label">
           Didn’t get the link?
         </Trans>
-        <Button
+        <SendNewLink
           variant="secondary"
-          size="small"
           className="is-full-width"
-          labelText={i18n._(t`Send new link`)}
           onClick={() => AuthClient.resendVerifyEmail()}
         />
       </div>
@@ -238,11 +234,9 @@ const LoginWithoutI18n = (props: LoginProps) => {
         <Trans>Once your email has been verified, you’ll be signed up for Building Updates.</Trans>
         <br />
         <br />
-        <Button
+        <SendNewLink
           variant="secondary"
-          size="small"
           className="is-full-width"
-          labelText={i18n._(t`Send new link`)}
           onClick={() => AuthClient.resendVerifyEmail()}
         />
       </>

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -17,7 +17,7 @@ import Modal from "./Modal";
 import "styles/Login.css";
 import "styles/UserTypeInput.css";
 import "styles/_input.scss";
-import { Button, Link } from "@justfixnyc/component-library";
+import { Button } from "@justfixnyc/component-library";
 import SendNewLink from "./SendNewLink";
 
 enum Step {
@@ -183,9 +183,9 @@ const LoginWithoutI18n = (props: LoginProps) => {
           {isRegisterAccountStep ? (
             <>
               <Trans>Already have an account?</Trans>
-              <Link onClick={() => toggleLoginSignup(Step.Login)} className="ml-5">
+              <button className="button is-text ml-5" onClick={() => toggleLoginSignup(Step.Login)}>
                 <Trans>Log in</Trans>
-              </Link>
+              </button>
             </>
           ) : (
             <>

--- a/client/src/components/SendNewLink.tsx
+++ b/client/src/components/SendNewLink.tsx
@@ -23,15 +23,17 @@ const SendNewLinkWithoutI18n = (props: SendNewLinkProps) => {
   };
 
   return (
-    <div className="send-new-link">
+    <div className="send-new-link-container">
       {!linkSent ? (
-        <Button
-          variant={variant}
-          size="small"
-          className={className}
-          labelText={i18n._(t`Send new link`)}
-          onClick={handleClick}
-        />
+        <div className="send-new-link">
+          <Button
+            variant={variant}
+            size="small"
+            className={className}
+            labelText={i18n._(t`Send new link`)}
+            onClick={handleClick}
+          />
+        </div>
       ) : (
         <div className="link-sent">
           <CheckIcon />

--- a/client/src/components/SendNewLink.tsx
+++ b/client/src/components/SendNewLink.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import { withI18n, withI18nProps } from "@lingui/react";
+import { Button } from "@justfixnyc/component-library";
+import { Trans, t } from "@lingui/macro";
+
+import "styles/SendNewLink.css";
+import { CheckIcon } from "./Icons";
+
+type SendNewLinkProps = withI18nProps & {
+  onClick: () => void;
+  variant: "primary" | "secondary" | "text";
+  className?: string;
+};
+
+const SendNewLinkWithoutI18n = (props: SendNewLinkProps) => {
+  const { onClick, variant, className, i18n } = props;
+
+  const [linkSent, setLinkSent] = useState(false);
+
+  const handleClick = () => {
+    onClick();
+    setLinkSent(true);
+  };
+
+  return (
+    <div className="send-new-link">
+      {!linkSent ? (
+        <Button
+          variant={variant}
+          size="small"
+          className={className}
+          labelText={i18n._(t`Send new link`)}
+          onClick={handleClick}
+        />
+      ) : (
+        <div className="link-sent">
+          <CheckIcon />
+          <Trans render="span">New link sent</Trans>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const BuildingStatsTable = withI18n()(SendNewLinkWithoutI18n);
+
+export default BuildingStatsTable;

--- a/client/src/components/SendNewLink.tsx
+++ b/client/src/components/SendNewLink.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { Button } from "@justfixnyc/component-library";
 import { Trans, t } from "@lingui/macro";
@@ -7,19 +7,21 @@ import "styles/SendNewLink.css";
 import { CheckIcon } from "./Icons";
 
 type SendNewLinkProps = withI18nProps & {
-  linkSent: boolean;
-  setLinkSent: React.Dispatch<React.SetStateAction<boolean>>;
+  setParentState: React.Dispatch<React.SetStateAction<boolean>>;
   onClick: () => void;
   variant: "primary" | "secondary" | "text";
   className?: string;
 };
 
 const SendNewLinkWithoutI18n = (props: SendNewLinkProps) => {
-  const { linkSent, setLinkSent, onClick, variant, className, i18n } = props;
+  const { setParentState, onClick, variant, className, i18n } = props;
+
+  const [linkSent, setLinkSent] = useState(false);
 
   const handleClick = () => {
     onClick();
     setLinkSent(true);
+    setParentState(true);
   };
 
   return (

--- a/client/src/components/SendNewLink.tsx
+++ b/client/src/components/SendNewLink.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { Button } from "@justfixnyc/component-library";
 import { Trans, t } from "@lingui/macro";
@@ -7,15 +7,15 @@ import "styles/SendNewLink.css";
 import { CheckIcon } from "./Icons";
 
 type SendNewLinkProps = withI18nProps & {
+  linkSent: boolean;
+  setLinkSent: React.Dispatch<React.SetStateAction<boolean>>;
   onClick: () => void;
   variant: "primary" | "secondary" | "text";
   className?: string;
 };
 
 const SendNewLinkWithoutI18n = (props: SendNewLinkProps) => {
-  const { onClick, variant, className, i18n } = props;
-
-  const [linkSent, setLinkSent] = useState(false);
+  const { linkSent, setLinkSent, onClick, variant, className, i18n } = props;
 
   const handleClick = () => {
     onClick();

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -120,6 +120,7 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
   const { i18n, currentValue, onSubmit } = props;
   const userContext = useContext(UserContext);
   const { email: oldEmail, verified } = userContext.user as JustfixUser;
+  const [verifyResent, setVerifyResent] = React.useState(false);
   const [existingUserError, setExistingUserError] = useState(false);
   const {
     value: email,
@@ -161,8 +162,13 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
         Email address not verified. Click the link we sent to {email} start receiving Building
         Updates.
       </Trans>
-      <Trans render="p">Didn’t get the link?</Trans>
-      <SendNewLink variant="secondary" onClick={() => AuthClient.resendVerifyEmail()} />
+      {!verifyResent && <Trans render="p">Didn’t get the link?</Trans>}
+      <SendNewLink
+        linkSent={verifyResent}
+        setLinkSent={setVerifyResent}
+        variant="secondary"
+        onClick={() => AuthClient.resendVerifyEmail()}
+      />
     </div>
   ) : undefined;
 

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -164,8 +164,7 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
       </Trans>
       {!verifyResent && <Trans render="p">Didn’t get the link?</Trans>}
       <SendNewLink
-        linkSent={verifyResent}
-        setLinkSent={setVerifyResent}
+        setParentState={setVerifyResent}
         variant="secondary"
         onClick={() => AuthClient.resendVerifyEmail()}
       />

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -13,6 +13,7 @@ import AuthClient from "./AuthClient";
 import { Alert } from "./Alert";
 import { AlertIconOutline } from "./Icons";
 import SendNewLink from "./SendNewLink";
+import { Button } from "@justfixnyc/component-library";
 
 type PasswordSettingFieldProps = withI18nProps & {
   onSubmit: (currentPassword: string, newPassword: string) => void;
@@ -212,7 +213,7 @@ type UserSettingFieldProps = withI18nProps & {
 };
 
 const UserSettingFieldWithoutI18n = (props: UserSettingFieldProps) => {
-  const { title, preview, onSubmit, children, verifyCallout } = props;
+  const { title, preview, onSubmit, children, verifyCallout, i18n } = props;
   const [editing, setEditing] = useState(false);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -230,12 +231,20 @@ const UserSettingFieldWithoutI18n = (props: UserSettingFieldProps) => {
           <>
             {children}
             <div className="user-setting-actions">
-              <button type="submit" className="button is-primary">
-                <Trans>Save</Trans>
-              </button>
-              <button type="button" className="button is-text" onClick={() => setEditing(false)}>
-                <Trans>Cancel</Trans>
-              </button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="small"
+                labelText={i18n._(t`Save`)}
+                className="user-setting-actions"
+              />
+              <Button
+                type="submit"
+                variant="text"
+                size="small"
+                labelText={i18n._(t`Cancel`)}
+                onClick={() => setEditing(false)}
+              />
             </div>
           </>
         ) : (

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -12,6 +12,7 @@ import EmailInput from "./EmailInput";
 import AuthClient from "./AuthClient";
 import { Alert } from "./Alert";
 import { AlertIconOutline } from "./Icons";
+import SendNewLink from "./SendNewLink";
 
 type PasswordSettingFieldProps = withI18nProps & {
   onSubmit: (currentPassword: string, newPassword: string) => void;
@@ -160,9 +161,7 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
         Updates.
       </Trans>
       <Trans render="p">Didn’t get the link?</Trans>
-      <button className="button is-secondary" onClick={() => AuthClient.resendVerifyEmail()}>
-        <Trans>Send new link</Trans>
-      </button>
+      <SendNewLink variant="secondary" onClick={() => AuthClient.resendVerifyEmail()} />
     </div>
   ) : undefined;
 

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -231,13 +231,7 @@ const UserSettingFieldWithoutI18n = (props: UserSettingFieldProps) => {
           <>
             {children}
             <div className="user-setting-actions">
-              <Button
-                type="submit"
-                variant="primary"
-                size="small"
-                labelText={i18n._(t`Save`)}
-                className="user-setting-actions"
-              />
+              <Button type="submit" variant="primary" size="small" labelText={i18n._(t`Save`)} />
               <Button
                 type="submit"
                 variant="text"

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from "react";
-import LegalFooter from "../components/LegalFooter";
-
-import Page from "../components/Page";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { Plural, t, Trans } from "@lingui/macro";
+import { Button } from "@justfixnyc/component-library";
 
 import "styles/AccountSettingsPage.css";
 import "styles/UserSetting.css";
+import Page from "components/Page";
+import LegalFooter from "components/LegalFooter";
 import { UserContext } from "components/UserContext";
 import { EmailSettingField, PasswordSettingField } from "components/UserSettingField";
 import { JustfixUser } from "state-machine";
@@ -14,7 +14,7 @@ import { createRouteForAddressPage, createWhoOwnsWhatRoutePaths } from "routes";
 import { Borough } from "components/APIDataTypes";
 import { LocaleNavLink } from "i18n";
 
-type SubscriptionFieldProps = {
+type SubscriptionFieldProps = withI18nProps & {
   bbl: string;
   housenumber: string;
   streetname: string;
@@ -23,7 +23,7 @@ type SubscriptionFieldProps = {
 };
 
 const SubscriptionFieldWithoutI18n = (props: SubscriptionFieldProps) => {
-  const { bbl, housenumber, streetname, boro, onRemoveClick } = props;
+  const { bbl, housenumber, streetname, boro, onRemoveClick, i18n } = props;
   return (
     <div className="subscription-field">
       <a
@@ -39,9 +39,13 @@ const SubscriptionFieldWithoutI18n = (props: SubscriptionFieldProps) => {
         <span>{`${housenumber} ${streetname},`}</span>
         <span>{`${boro}, NY`}</span>
       </a>
-      <button className="button is-secondary" onClick={() => onRemoveClick(bbl)}>
-        <Trans>Remove</Trans>
-      </button>
+      <Button
+        type="submit"
+        variant="secondary"
+        size="small"
+        labelText={i18n._(t`Remove`)}
+        onClick={() => onRemoveClick(bbl)}
+      />
     </div>
   );
 };

--- a/client/src/containers/ForgotPasswordPage.tsx
+++ b/client/src/containers/ForgotPasswordPage.tsx
@@ -86,8 +86,7 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
                 <div className="text-center">
                   {!requestSentAgain && <Trans render="span">Didn’t receive an email?</Trans>}
                   <SendNewLink
-                    linkSent={requestSentAgain}
-                    setLinkSent={setRequestSentAgain}
+                    setParentState={setRequestSentAgain}
                     variant="primary"
                     className="is-full-width"
                     onClick={sendResetEmail}

--- a/client/src/containers/ForgotPasswordPage.tsx
+++ b/client/src/containers/ForgotPasswordPage.tsx
@@ -10,6 +10,7 @@ import { Trans, t } from "@lingui/macro";
 import { UserContext } from "components/UserContext";
 import EmailInput from "components/EmailInput";
 import { useInput } from "util/helpers";
+import SendNewLink from "components/SendNewLink";
 
 const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -79,12 +80,11 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
                 </Trans>
                 <div className="text-center">
                   <Trans render="span">Didn’t receive an email?</Trans>
-                  <button
-                    className="button is-primary resend-link"
+                  <SendNewLink
+                    variant="primary"
+                    className="is-full-width"
                     onClick={resendPasswordResetRequest}
-                  >
-                    <Trans>Send new link</Trans>
-                  </button>
+                  />
                 </div>
               </>
             )}

--- a/client/src/containers/ForgotPasswordPage.tsx
+++ b/client/src/containers/ForgotPasswordPage.tsx
@@ -11,6 +11,7 @@ import { UserContext } from "components/UserContext";
 import EmailInput from "components/EmailInput";
 import { useInput } from "util/helpers";
 import SendNewLink from "components/SendNewLink";
+import { Button } from "@justfixnyc/component-library";
 
 const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -68,9 +69,12 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
                     labelText={i18n._(t`Email address`)}
                     autoFocus
                   />
-                  <button type="submit" className="button is-primary">
-                    <Trans>Reset password</Trans>
-                  </button>
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    size="small"
+                    labelText={i18n._(t`Reset password`)}
+                  />
                 </form>
               </>
             ) : (

--- a/client/src/containers/ForgotPasswordPage.tsx
+++ b/client/src/containers/ForgotPasswordPage.tsx
@@ -19,6 +19,7 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
   const params = new URLSearchParams(search);
 
   const [requestSent, setRequestSent] = React.useState(false);
+  const [requestSentAgain, setRequestSentAgain] = React.useState(false);
   const userContext = useContext(UserContext);
   const {
     value: email,
@@ -36,12 +37,12 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
       setShowEmailError(true);
       return;
     }
-    resendPasswordResetRequest();
+    sendResetEmail();
+    setRequestSent(true);
   };
 
-  const resendPasswordResetRequest = async () => {
+  const sendResetEmail = async () => {
     await userContext.requestPasswordReset(email);
-    setRequestSent(true);
   };
 
   return (
@@ -83,11 +84,13 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
                   We sent a reset link to {`${email}`}. Please check your inbox and spam.
                 </Trans>
                 <div className="text-center">
-                  <Trans render="span">Didn’t receive an email?</Trans>
+                  {!requestSentAgain && <Trans render="span">Didn’t receive an email?</Trans>}
                   <SendNewLink
+                    linkSent={requestSentAgain}
+                    setLinkSent={setRequestSentAgain}
                     variant="primary"
                     className="is-full-width"
-                    onClick={resendPasswordResetRequest}
+                    onClick={sendResetEmail}
                   />
                 </div>
               </>

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -81,8 +81,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
         <Trans>The password reset link that we sent you is no longer valid.</Trans>
       )}
       <SendNewLink
-        linkSent={emailIsResent}
-        setLinkSent={setEmailIsResent}
+        setParentState={setEmailIsResent}
         variant="secondary"
         onClick={async () => {
           setEmailIsResent(await AuthClient.resendVerifyEmail());

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -13,6 +13,7 @@ import { FixedLoadingLabel } from "components/Loader";
 import { createWhoOwnsWhatRoutePaths } from "routes";
 import { LocaleLink } from "i18n";
 import SendNewLink from "components/SendNewLink";
+import { Button } from "@justfixnyc/component-library";
 
 const ResetPasswordPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -112,9 +113,12 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
           showError={showPasswordError}
           setError={setPasswordError}
         />
-        <button type="submit" className="button is-primary">
-          <Trans>Reset password</Trans>
-        </button>
+        <Button
+          type="submit"
+          variant="primary"
+          size="small"
+          labelText={i18n._(t`Reset password`)}
+        />
       </form>
     </>
   );

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -81,6 +81,8 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
         <Trans>The password reset link that we sent you is no longer valid.</Trans>
       )}
       <SendNewLink
+        linkSent={emailIsResent}
+        setLinkSent={setEmailIsResent}
         variant="secondary"
         onClick={async () => {
           setEmailIsResent(await AuthClient.resendVerifyEmail());

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -12,6 +12,7 @@ import { useInput } from "util/helpers";
 import { FixedLoadingLabel } from "components/Loader";
 import { createWhoOwnsWhatRoutePaths } from "routes";
 import { LocaleLink } from "i18n";
+import SendNewLink from "components/SendNewLink";
 
 const ResetPasswordPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -71,32 +72,21 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
     setResetStatus(resp.statusCode);
   };
 
-  const expiredPage = () => {
-    const resendEmailPage = (
-      <>
-        <Trans render="h4">The password reset link that we sent you is no longer valid.</Trans>
-        <button
-          className="button is-primary"
-          onClick={async () => {
-            setEmailIsResent(await AuthClient.resetPasswordRequest());
-          }}
-        >
-          <Trans>Send new link</Trans>
-        </button>
-      </>
-    );
-
-    const resendEmailConfirmation = (
-      <>
-        <Trans render="h4">Check your email</Trans>
-        <Trans render="span">
-          We sent a new password reset link to your email. Please check your inbox and spam.
-        </Trans>
-      </>
-    );
-
-    return emailIsResent ? resendEmailConfirmation : resendEmailPage;
-  };
+  const expiredPage = () => (
+    <>
+      {emailIsResent ? (
+        <Trans>Click the link we sent to your email to reset your password.</Trans>
+      ) : (
+        <Trans>The password reset link that we sent you is no longer valid.</Trans>
+      )}
+      <SendNewLink
+        variant="secondary"
+        onClick={async () => {
+          setEmailIsResent(await AuthClient.resendVerifyEmail());
+        }}
+      />
+    </>
+  );
 
   const invalidPage = () => {
     return (

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -69,6 +69,8 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
         <Trans>The verification link that we sent you is no longer valid.</Trans>
       )}
       <SendNewLink
+        linkSent={isEmailResent}
+        setLinkSent={setIsEmailResent}
         variant="secondary"
         onClick={async () => {
           setIsEmailResent(await AuthClient.resendVerifyEmail(token));

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -120,7 +120,7 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
 
   return (
     <Page title={i18n._(t`Verify your email address`)}>
-      <div className="VerifyemailPage Page">
+      <div className="VerifyEmailPage Page">
         <div className="page-container">
           {!loading &&
             (isVerified

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -1,9 +1,12 @@
 import { useState, useEffect } from "react";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { Trans, t } from "@lingui/macro";
-import AuthClient, { VerifyStatusCode } from "../components/AuthClient";
-import Page from "components/Page";
 import { useLocation } from "react-router-dom";
+
+import "styles/VerifyEmailPage.css";
+import Page from "components/Page";
+import AuthClient, { VerifyStatusCode } from "../components/AuthClient";
+import SendNewLink from "components/SendNewLink";
 
 const VerifyEmailPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -58,35 +61,21 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
     }, delayInterval);
   };
 
-  const expiredLinkPage = () => {
-    const resendEmailPage = (
-      <div className="text-center">
-        <Trans render="h4">The link sent to you has timed out.</Trans>
-        <br />
-        <button
-          className="button is-secondary"
-          onClick={async () => {
-            setIsEmailResent(await AuthClient.resendVerifyEmail(token));
-          }}
-        >
-          <Trans>Send new link</Trans>
-        </button>
-      </div>
-    );
-
-    const resendEmailConfirmation = (
-      <div className="text-center">
-        <Trans render="h4">Check your email inbox & spam</Trans>
-        <br />
-        <Trans>
-          Click the link we sent to verify your email address. It may take a few minutes to arrive.
-          Once your email has been verified, you’ll be signed up for Building Updates.
-        </Trans>
-      </div>
-    );
-
-    return isEmailResent ? resendEmailConfirmation : resendEmailPage;
-  };
+  const expiredLinkPage = () => (
+    <div className="text-center">
+      {isEmailResent ? (
+        <Trans>Click the link we sent to your email to start receiving emails.</Trans>
+      ) : (
+        <Trans>The verification link that we sent you is no longer valid.</Trans>
+      )}
+      <SendNewLink
+        variant="secondary"
+        onClick={async () => {
+          setIsEmailResent(await AuthClient.resendVerifyEmail(token));
+        }}
+      />
+    </div>
+  );
 
   // TODO add error logging
   const errorPage = () => (
@@ -129,7 +118,7 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
 
   return (
     <Page title={i18n._(t`Verify your email address`)}>
-      <div className="TextPage Page">
+      <div className="VerifyemailPage Page">
         <div className="page-container">
           {!loading &&
             (isVerified

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -69,8 +69,7 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
         <Trans>The verification link that we sent you is no longer valid.</Trans>
       )}
       <SendNewLink
-        linkSent={isEmailResent}
-        setLinkSent={setIsEmailResent}
+        setParentState={setIsEmailResent}
         variant="secondary"
         onClick={async () => {
           setIsEmailResent(await AuthClient.resendVerifyEmail(token));

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -64,7 +64,7 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
   const expiredLinkPage = () => (
     <div className="text-center">
       {isEmailResent ? (
-        <Trans>Click the link we sent to your email to start receiving emails.</Trans>
+        <Trans> Click the link we sent to your email to start receiving emails.</Trans>
       ) : (
         <Trans>The verification link that we sent you is no longer valid.</Trans>
       )}

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -73,8 +73,8 @@
       display: flex;
       flex-direction: column;
       gap: 0.625;
-      .button.is-text {
-        width: fit-content;
+      .send-new-link {
+        justify-content: start;
       }
     }
   }

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -96,20 +96,11 @@
     justify-content: left;
     align-items: center;
     margin-top: 1rem;
+    column-gap: 1rem;
 
     @include for-phone-only() {
       justify-content: center;
     }
 
-    input[type="submit"] {
-      margin: 0 3rem 0 0 !important;
-    }
-
-    .button.is-text {
-      @include body-standard;
-      font-size: 1.125rem;
-      font-weight: 500;
-      text-decoration: none;
-    }
   }
 }

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -101,6 +101,5 @@
     @include for-phone-only() {
       justify-content: center;
     }
-
   }
 }

--- a/client/src/styles/SendNewLink.scss
+++ b/client/src/styles/SendNewLink.scss
@@ -1,11 +1,14 @@
-.send-new-link {
-  display: flex;
-  justify-content: center;
+.send-new-link-container {
+  .send-new-link {
+    display: flex;
+    justify-content: center;
+  }
 
   .link-sent {
     display: flex;
     align-items: start;
     font-size: 0.875rem;
+    padding: 0.875rem 0;
 
     svg {
       height: 20px;

--- a/client/src/styles/SendNewLink.scss
+++ b/client/src/styles/SendNewLink.scss
@@ -1,4 +1,5 @@
 .send-new-link-container {
+  display: flex;
   .send-new-link {
     display: flex;
     justify-content: center;

--- a/client/src/styles/SendNewLink.scss
+++ b/client/src/styles/SendNewLink.scss
@@ -1,0 +1,16 @@
+.send-new-link {
+  display: flex;
+  justify-content: center;
+
+  .link-sent {
+    display: flex;
+    align-items: start;
+    font-size: 0.875rem;
+
+    svg {
+      height: 20px;
+      width: 20px;
+      margin-right: 0.5rem;
+    }
+  }
+}

--- a/client/src/styles/VerifyEmailPage.scss
+++ b/client/src/styles/VerifyEmailPage.scss
@@ -1,5 +1,6 @@
-.VerifyemailPage {
-  .send-new-link {
+.VerifyEmailPage {
+  .send-new-link-container {
+    justify-content: center;
     margin-top: 2rem;
   }
 }

--- a/client/src/styles/VerifyEmailPage.scss
+++ b/client/src/styles/VerifyEmailPage.scss
@@ -1,0 +1,5 @@
+.VerifyemailPage {
+  .send-new-link {
+    margin-top: 2rem;
+  }
+}

--- a/client/src/styles/spectre/src/_utilities.scss
+++ b/client/src/styles/spectre/src/_utilities.scss
@@ -71,53 +71,53 @@
 
 // Spacing
 .mt-10 {
-  margin-top: 0.63rem;
+  margin-top: 0.625rem;
 }
 .mr-10 {
-  margin-right: 0.63rem;
+  margin-right: 0.625rem;
 }
 .mb-10 {
-  margin-bottom: 0.63rem;
+  margin-bottom: 0.625rem;
 }
 .ml-10 {
-  margin-left: 0.63rem;
+  margin-left: 0.625rem;
 }
 .mt-5 {
-  margin-top: 0.31rem;
+  margin-top: 0.3125rem;
 }
 .mr-5 {
-  margin-right: 0.31rem;
+  margin-right: 0.3125rem;
 }
 .mb-5 {
-  margin-bottom: 0.31rem;
+  margin-bottom: 0.3125rem;
 }
 .ml-5 {
-  margin-left: 0.31rem;
+  margin-left: 0.3125rem;
 }
 
 .pt-10 {
-  padding-top: 0.63rem;
+  padding-top: 0.625rem;
 }
 .pr-10 {
-  padding-right: 0.63rem;
+  padding-right: 0.625rem;
 }
 .pb-10 {
-  padding-bottom: 0.63rem;
+  padding-bottom: 0.625rem;
 }
 .pl-10 {
-  padding-left: 0.63rem;
+  padding-left: 0.625rem;
 }
 .pt-5 {
-  padding-top: 0.31rem;
+  padding-top: 0.3125rem;
 }
 .pr-5 {
-  padding-right: 0.31rem;
+  padding-right: 0.3125rem;
 }
 .pb-5 {
-  padding-bottom: 0.31rem;
+  padding-bottom: 0.3125rem;
 }
 .pl-5 {
-  padding-left: 0.31rem;
+  padding-left: 0.3125rem;
 }
 
 // Display

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2769,10 +2769,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@justfixnyc/component-library@0.31.1":
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.31.1.tgz#a6d41925f19640d87f4c02a20c962bfb5d247170"
-  integrity sha512-t6NkG6PvGKTfVDtnNgcayJjDEddDcBpByeRNTbl9feWJh9ih5G5LvDcPPf5P0N2B++EKUWTq7nanei59TaZ0/w==
+"@justfixnyc/component-library@0.32.1":
+  version "0.32.1"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.32.1.tgz#eaed25a8699bbaef5a1ab277fa13dd564030f14e"
+  integrity sha512-83tr8xeBGguK6mx9nG1+a49WTSPTWmOtQ7DkhgOHIq4n249W6cBrMMaVD9jCGBO9xOQbAK7lpGcIMYcjBHTK8w==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION
This PR swaps in component-library buttons for all the email alerts work, and creates `<SendNewLink>` that toggles between a "send new link" button -> "✔️ link sent" confirmation. There are also some changes to the reset password and verify pages for expired links for consistency and to update for content doc. 

[sc-13933]
[sc-14169]