### PR TITLE
don't clear errors on login/signup toggle, only hide them

### DIFF
--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -95,18 +95,15 @@ const LoginWithoutI18n = (props: LoginProps) => {
     setExistingUserError(false);
   };
 
-  const resetInputErrorStates = () => {
-    setEmailError(false);
+  const hideInputErrors = () => {
     setShowEmailError(false);
-    setPasswordError(false);
     setShowPasswordError(false);
-    setUserTypeError(false);
     setShowUserTypeError(false);
   };
 
   const toggleLoginSignup = (toStep: Step) => {
     resetAlertErrorStates();
-    resetInputErrorStates();
+    hideInputErrors();
     setStep(toStep);
   };
 


### PR DESCRIPTION
When toggling between login/signup we had issue of errors persisting, then in #865 we cleared them on toggle. But this created a new bug that allowed you to create an account with a password not meeting rules if you first toggled between login/signup. Now we just turn off the showing of errors on toggle, but don't clear the errors themselves so submit is still prevented. 

[sc-14143]