### PR TITLE
custom "other" user type not required

### DIFF
--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -82,7 +82,6 @@ const LoginWithoutI18n = (props: LoginProps) => {
     setValue: setUserType,
     setError: setUserTypeError,
     setShowError: setShowUserTypeError,
-    onChange: onChangeUserType,
   } = useInput("");
 
   const [placeholderEmail, setPlaceholderEmail] = useState("");
@@ -478,7 +477,6 @@ const LoginWithoutI18n = (props: LoginProps) => {
                 error={userTypeError}
                 showError={userShowUserTypeError}
                 setError={setUserTypeError}
-                onChange={onChangeUserType}
               />
             )}
             <div className="submit-button-group">

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -472,7 +472,6 @@ const LoginWithoutI18n = (props: LoginProps) => {
             )}
             {isRegisterUserTypeStep && (
               <UserTypeInput
-                userType={userType}
                 setUserType={setUserType}
                 error={userTypeError}
                 showError={userShowUserTypeError}

--- a/client/src/components/UserTypeInput.tsx
+++ b/client/src/components/UserTypeInput.tsx
@@ -123,17 +123,15 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
         <label htmlFor={"user-type-input-other"}>{USER_TYPES.other}</label>
       </div>
       {activeRadio === USER_TYPES.other.toLocaleUpperCase("en") && (
-        <div className="user-type-input-text-group">
-          <input
-            autoFocus
-            id="user-type-input-other-text"
-            className={classNames("input", { invalid: error })}
-            type="text"
-            name="user-type"
-            value={userTypeText}
-            onChange={handleTextChange}
-          />
-        </div>
+        <input
+          autoFocus
+          id="user-type-input-other-text"
+          className={classNames("input", { invalid: error })}
+          type="text"
+          name="user-type"
+          value={userTypeText}
+          onChange={handleTextChange}
+        />
       )}
     </div>
   );

--- a/client/src/components/UserTypeInput.tsx
+++ b/client/src/components/UserTypeInput.tsx
@@ -12,32 +12,14 @@ type UserTypeInputProps = {
   showError: boolean;
   setError: React.Dispatch<React.SetStateAction<boolean>>;
   setUserType: React.Dispatch<React.SetStateAction<string>>;
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   required?: boolean;
 };
 
 const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
-  const { i18n, userType, error, showError, setError, setUserType, onChange, required } = props;
+  const { i18n, error, showError, setError, userType, setUserType, required } = props;
 
   const [activeRadio, setActiveRadio] = useState("");
-
-  const handleRadioChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setActiveRadio(value);
-    if (value === USER_TYPES.other) {
-      setUserType("");
-      setError(true);
-    } else {
-      setUserType(value);
-      setError(false);
-    }
-  };
-
-  const handleTextChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onChange(e);
-    const value = e.target.value;
-    setError(!value);
-  };
+  const [userTypeText, setUserTypeText] = useState("");
 
   const USER_TYPES = {
     tenant: i18n._(t`Tenant`),
@@ -48,9 +30,26 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
     other: i18n._(t`Other`),
   };
 
+  const handleRadioChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === USER_TYPES.other.toLocaleUpperCase("en")) {
+      setUserType(!!userTypeText ? userTypeText : value);
+    } else {
+      setUserType(value);
+    }
+    setActiveRadio(value);
+    setError(false);
+  };
+
+  const handleTextChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setUserType(!!value ? value : activeRadio);
+    setUserTypeText(value);
+  };
+
   return (
     <div className="user-type-container">
-      {showError && error && activeRadio !== USER_TYPES.other && (
+      {showError && error && (
         <span id="input-field-error">
           <AlertIcon />
           <Trans>Please select an option.</Trans>
@@ -63,8 +62,8 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           required={required}
           type="radio"
           name="user-type"
-          value={USER_TYPES.tenant}
-          checked={activeRadio === USER_TYPES.tenant}
+          value={USER_TYPES.tenant.toLocaleUpperCase("en")}
+          checked={activeRadio === USER_TYPES.tenant.toLocaleUpperCase("en")}
           onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-tenant"}>{USER_TYPES.tenant}</label>
@@ -74,8 +73,8 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           required={required}
           type="radio"
           name="user-type"
-          value={USER_TYPES.organizer}
-          checked={activeRadio === USER_TYPES.organizer}
+          value={USER_TYPES.organizer.toLocaleUpperCase("en")}
+          checked={activeRadio === USER_TYPES.organizer.toLocaleUpperCase("en")}
           onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-organizer"}>{USER_TYPES.organizer}</label>
@@ -85,8 +84,8 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           required={required}
           type="radio"
           name="user-type"
-          value={USER_TYPES.advocate}
-          checked={activeRadio === USER_TYPES.advocate}
+          value={USER_TYPES.advocate.toLocaleUpperCase("en")}
+          checked={activeRadio === USER_TYPES.advocate.toLocaleUpperCase("en")}
           onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-advocate"}>{USER_TYPES.advocate}</label>
@@ -96,8 +95,8 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           required={required}
           type="radio"
           name="user-type"
-          value={USER_TYPES.legal}
-          checked={activeRadio === USER_TYPES.legal}
+          value={USER_TYPES.legal.toLocaleUpperCase("en")}
+          checked={activeRadio === USER_TYPES.legal.toLocaleUpperCase("en")}
           onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-legal"}>{USER_TYPES.legal}</label>
@@ -107,8 +106,8 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           required={required}
           type="radio"
           name="user-type"
-          value={USER_TYPES.government}
-          checked={activeRadio === USER_TYPES.government}
+          value={USER_TYPES.government.toLocaleUpperCase("en")}
+          checked={activeRadio === USER_TYPES.government.toLocaleUpperCase("en")}
           onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-government"}>{USER_TYPES.government}</label>
@@ -118,28 +117,21 @@ const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
           required={required}
           type="radio"
           name="user-type"
-          value={USER_TYPES.other}
-          checked={activeRadio === USER_TYPES.other}
+          value={USER_TYPES.other.toLocaleUpperCase("en")}
+          checked={activeRadio === USER_TYPES.other.toLocaleUpperCase("en")}
           onChange={handleRadioChange}
         />
         <label htmlFor={"user-type-input-other"}>{USER_TYPES.other}</label>
       </div>
-      {activeRadio === USER_TYPES.other && (
+      {activeRadio === USER_TYPES.other.toLocaleUpperCase("en") && (
         <div className="user-type-input-text-group">
-          {showError && error && (
-            <span id="input-field-error">
-              <AlertIcon />
-              <Trans>Please enter a response. </Trans>
-            </span>
-          )}
           <input
-            required={required}
             autoFocus
             id="user-type-input-other-text"
             className={classNames("input", { invalid: error })}
             type="text"
             name="user-type"
-            value={userType}
+            value={userTypeText}
             onChange={handleTextChange}
           />
         </div>

--- a/client/src/components/UserTypeInput.tsx
+++ b/client/src/components/UserTypeInput.tsx
@@ -16,7 +16,7 @@ type UserTypeInputProps = {
 };
 
 const UserTypeInputWithoutI18n = (props: UserTypeInputProps) => {
-  const { i18n, error, showError, setError, userType, setUserType, required } = props;
+  const { i18n, error, showError, setError, setUserType, required } = props;
 
   const [activeRadio, setActiveRadio] = useState("");
   const [userTypeText, setUserTypeText] = useState("");

--- a/client/src/components/UserTypeInput.tsx
+++ b/client/src/components/UserTypeInput.tsx
@@ -7,7 +7,6 @@ import classNames from "classnames";
 
 type UserTypeInputProps = {
   i18n: I18n;
-  userType: string;
   error: boolean;
   showError: boolean;
   setError: React.Dispatch<React.SetStateAction<boolean>>;

--- a/client/src/styles/UserTypeInput.scss
+++ b/client/src/styles/UserTypeInput.scss
@@ -2,6 +2,9 @@
 @import "_typography.scss";
 
 .user-type-container {
+  display: flex;
+  flex-direction: column;
+
   .user-type-radio-group {
     display: grid;
     grid-template-columns: 1.25rem auto;
@@ -49,19 +52,14 @@
     }
   }
 
-  .user-type-input-text-group {
-    display: flex;
-    flex-direction: column;
+  input[type="text"] {
     margin: 1.5rem 1.75rem 0 1.75rem;
+    &.invalid {
+      border-color: $justfix-orange;
+    }
 
-    input {
-      &.invalid {
-        border-color: $justfix-orange;
-      }
-
-      &.invalid:focus {
-        border-color: $justfix-black;
-      }
+    &.invalid:focus {
+      border-color: $justfix-black;
     }
   }
 


### PR DESCRIPTION
For user type we were previously requiring a custom input when "other" was selected, this PR removes that requirement so you can check "other" and leave the input blank and it saves the type as "OTHER".

This also fixes an issue that would have had the spanish translation of user types saved on the DB, now they are always uppercase english labels for presets or the user text.

https://www.loom.com/share/7118bff1d0e14c73884d22f3e859fbde?sid=d08eb555-33dc-45c2-adf7-f69f2205dfb6

[sc-13868]