### PR TITLE
fix alignment issues

### DIFF
--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -73,11 +73,6 @@
       display: flex;
       flex-direction: column;
       gap: 0.625;
-
-      .send-new-link {
-        justify-content: start;
-        align-items: center;
-      }
     }
   }
 

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -73,8 +73,10 @@
       display: flex;
       flex-direction: column;
       gap: 0.625;
+
       .send-new-link {
         justify-content: start;
+        align-items: center;
       }
     }
   }

--- a/client/src/styles/AddressToolbar.scss
+++ b/client/src/styles/AddressToolbar.scss
@@ -9,6 +9,7 @@
     flex-wrap: nowrap;
     min-width: 11.88rem;
     padding-left: 0.5rem;
+    align-items: center;
   }
 
   ul.menu {

--- a/client/src/styles/GetRepairs.scss
+++ b/client/src/styles/GetRepairs.scss
@@ -5,6 +5,6 @@
   margin-top: 1.25rem;
 
   .jfcl-link {
-    justify-content: center;
+    text-align: left;
   }
 }

--- a/client/src/styles/SendNewLink.scss
+++ b/client/src/styles/SendNewLink.scss
@@ -1,5 +1,8 @@
+@import "_typography.scss";
+
 .send-new-link-container {
   display: flex;
+
   .send-new-link {
     display: flex;
     justify-content: center;
@@ -7,9 +10,7 @@
 
   .link-sent {
     display: flex;
-    align-items: start;
-    font-size: 0.875rem;
-    padding: 0.875rem 0;
+    align-items: center;
 
     svg {
       height: 20px;

--- a/client/src/styles/SendNewLink.scss
+++ b/client/src/styles/SendNewLink.scss
@@ -5,7 +5,6 @@
 
   .send-new-link {
     display: flex;
-    justify-content: center;
   }
 
   .link-sent {

--- a/client/src/styles/_callout.scss
+++ b/client/src/styles/_callout.scss
@@ -2,7 +2,7 @@
 @import "_typography.scss";
 
 .jf-callout {
-  @include desktop-text-small;
+  @include wow-body-standard;
   background-color: $justfix-white-200;
   padding: 0.75rem;
 }

--- a/client/src/styles/_typography.scss
+++ b/client/src/styles/_typography.scss
@@ -9,6 +9,15 @@ $body-font: "Degular", Arial, Helvetica, sans-serif;
 $title-font: "Degular Display", Arial, Helvetica, sans-serif;
 $eyebrow-font: "Suisse Int'l Mono", "Courier New", Courier, monospace;
 
+@mixin wow-body-standard {
+  font-family: $wow-font;
+  font-size: 0.875rem; // 14px
+  font-style: normal;
+  font-weight: 500;
+  line-height: 130%;
+  letter-spacing: 0.042rem;
+}
+
 @mixin body-standard {
   font-family: $body-font;
   font-size: 0.7rem;


### PR DESCRIPTION
center these two buttons
<img width="398" alt="Screenshot 2024-03-28 at 2 01 18 PM" src="https://github.com/JustFixNYC/who-owns-what/assets/17574626/bae1816d-8553-4a83-a8e9-34c4930387fd">

left align get repairs 
<img width="337" alt="Screenshot 2024-03-28 at 2 00 19 PM" src="https://github.com/JustFixNYC/who-owns-what/assets/17574626/50bd0cc9-20c8-4880-a177-c438985efcac">

update fonts to match mock, fix alignment with "new link sent" and svg
<img width="640" alt="Screenshot 2024-03-28 at 2 01 01 PM" src="https://github.com/JustFixNYC/who-owns-what/assets/17574626/071843b0-81ac-412f-be3d-b8078859d7a4">
<img width="661" alt="Screenshot 2024-03-28 at 2 00 49 PM" src="https://github.com/JustFixNYC/who-owns-what/assets/17574626/8aa26ed9-2c7f-46dc-bc9a-5c651c87af19">

