### PR TITLE
fix forgot password link type styles on login

### DIFF
--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -187,10 +187,9 @@ const LoginWithoutI18n = (props: LoginProps) => {
               window.gtag("event", "view-data-over-time-overview-tab");
             }}
             component={JFCLLink}
+            className="forgot-password"
           >
-            <Trans render="span" className="forgot-password">
-              Forgot your password?
-            </Trans>
+            <Trans render="span">Forgot your password?</Trans>
           </LocaleLink>
         )}
         <div className="login-type-toggle">

--- a/client/src/styles/Login.scss
+++ b/client/src/styles/Login.scss
@@ -46,16 +46,15 @@
     .forgot-password {
       display: flex;
       justify-content: center;
-      font-size: 0.94rem;
     }
 
     .privacy-links,
     .login-type-toggle,
-    .forgot-password {
-      a,
-      button {
-        color: inherit;
-      }
+    .forgot-password,
+    a {
+      font-size: 0.875rem;
+      font-weight: 400;
+      color: inherit;
     }
   }
 


### PR DESCRIPTION
Small fix to the type styles for the forgot password link on login. (missed this initially in #881)