### PR TITLE
add focus state outline for all text inputs

### DIFF
--- a/client/src/components/EngagementPanel.tsx
+++ b/client/src/components/EngagementPanel.tsx
@@ -15,7 +15,7 @@ const EngagementPanel: React.FC<{
       <div className="EngagementWrapper">
         <div className="EngagementItem">
           <p>
-            <Trans>Sign up for email updates</Trans>
+            <Trans>Sign up for our newsletter</Trans>
           </p>
           <Subscribe />
         </div>

--- a/client/src/styles/EmailInput.scss
+++ b/client/src/styles/EmailInput.scss
@@ -31,6 +31,11 @@
     input {
       flex: 1;
 
+      &:focus {
+        border: 2px $justfix-black solid;
+        box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+      }
+
       &.invalid {
         border-color: $justfix-orange;
       }

--- a/client/src/styles/HomePage.scss
+++ b/client/src/styles/HomePage.scss
@@ -121,7 +121,8 @@
           border: 1px solid $wowza-dark;
 
           &:focus {
-            box-shadow: 0 0 0 0.13rem $dark;
+            border: 2px $justfix-black solid;
+            box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
           }
 
           &::placeholder {

--- a/client/src/styles/Password.scss
+++ b/client/src/styles/Password.scss
@@ -33,6 +33,11 @@
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
 
+      &:focus {
+        border: 2px $justfix-black solid;
+        box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+      }
+
       &:invalid,
       &.invalid {
         border-color: $justfix-orange;

--- a/client/src/styles/UserTypeInput.scss
+++ b/client/src/styles/UserTypeInput.scss
@@ -54,6 +54,12 @@
 
   input[type="text"] {
     margin: 1.5rem 1.75rem 0 1.75rem;
+
+    &:focus {
+      border: 2px $justfix-black solid;
+      box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+    }
+
     &.invalid {
       border-color: $justfix-orange;
     }

--- a/client/src/styles/_minmaxselect.scss
+++ b/client/src/styles/_minmaxselect.scss
@@ -127,6 +127,10 @@
             &:focus-visible {
               outline: none;
             }
+            &:focus {
+              border: 2px $justfix-black solid;
+              box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+            }
             &.hasError {
               outline: 3px solid $justfix-orange;
             }

--- a/client/src/styles/_multiselect.scss
+++ b/client/src/styles/_multiselect.scss
@@ -109,6 +109,11 @@
         font-size: 1rem;
         color: $justfix-black;
 
+        &:focus-within {
+          border: 2px $justfix-black solid;
+          box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+        }
+
         &::placeholder,
         &::-moz-placeholder,
         &::-webkit-input-placeholder {


### PR DESCRIPTION
Adds a focus state for all text inputs, matching design system (temporary until component library is ready)
[sc-13909]

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/dc85382f-9881-4f57-986c-4914ce467343)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/a6b97efa-4d2b-4aed-958b-1572bff3c3be)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/480c9c2f-9565-4b79-8843-5ee4a1cdb1bd)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/ba98637c-bae1-40de-a133-b8c6a3445a6d)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/0277c83d-11d1-4c1b-8e3d-22706ffc72c1)


