### PR TITLE
update component-library for tertiary button and link icon updates

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "@amplitude/analytics-browser": "^1.2.3",
     "@babel/core": "^7.7.2",
     "@contentful/rich-text-react-renderer": "^15.0.0",
-    "@justfixnyc/component-library": "0.32.2",
+    "@justfixnyc/component-library": "0.33.0",
     "@justfixnyc/contentful-common-strings": "^0.1.0",
     "@justfixnyc/geosearch-requester": "1.0.0",
     "@justfixnyc/util": "^0.4.1",

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -706,7 +706,7 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
                 }}
                 disabled={!table.getCanPreviousPage()}
                 labelIcon={IconChevron}
-                variant="text"
+                variant="tertiary"
                 size="small"
                 labelText={i18n._(t`Previous page`)}
                 iconOnly
@@ -723,7 +723,7 @@ const PortfolioTableWithoutI18n = React.memo((props: PortfolioTableProps) => {
                 disabled={!table.getCanNextPage()}
                 labelText={i18n._(t`Next page`)}
                 labelIcon={IconChevron}
-                variant="text"
+                variant="tertiary"
                 size="small"
                 iconOnly
               />

--- a/client/src/components/SendNewLink.tsx
+++ b/client/src/components/SendNewLink.tsx
@@ -9,7 +9,7 @@ import { CheckIcon } from "./Icons";
 type SendNewLinkProps = withI18nProps & {
   setParentState: React.Dispatch<React.SetStateAction<boolean>>;
   onClick: () => void;
-  variant: "primary" | "secondary" | "text";
+  variant: "primary" | "secondary" | "tertiary";
   className?: string;
 };
 

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -239,7 +239,7 @@ const UserSettingFieldWithoutI18n = (props: UserSettingFieldProps) => {
               <Button type="submit" variant="primary" size="small" labelText={i18n._(t`Save`)} />
               <Button
                 type="button"
-                variant="text"
+                variant="tertiary"
                 size="small"
                 labelText={i18n._(t`Cancel`)}
                 onClick={() => setEditing(false)}
@@ -255,7 +255,7 @@ const UserSettingFieldWithoutI18n = (props: UserSettingFieldProps) => {
               <span>{preview}</span>
               <Button
                 type="button"
-                variant="text"
+                variant="tertiary"
                 size="small"
                 className="edit-button"
                 labelText={i18n._(t`Edit`)}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2474,6 +2474,32 @@
   dependencies:
     "@floating-ui/core" "^1.2.4"
 
+"@fortawesome/fontawesome-common-types@6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz#fdb1ec4952b689f5f7aa0bffe46180bb35490032"
+  integrity sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==
+
+"@fortawesome/fontawesome-svg-core@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz#9d56d46bddad78a7ebb2043a97957039fcebcf0a"
+  integrity sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.5.1"
+
+"@fortawesome/free-solid-svg-icons@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz#737b8d787debe88b400ab7528f47be333031274a"
+  integrity sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.5.1"
+
+"@fortawesome/react-fontawesome@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz#d90dd8a9211830b4e3c08e94b63a0ba7291ddcf4"
+  integrity sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==
+  dependencies:
+    prop-types "^15.8.1"
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -2769,12 +2795,15 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@justfixnyc/component-library@0.32.2":
-  version "0.32.2"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.32.2.tgz#9cc41ffbeb0e03dbcd66265d00ec7b52aafd2939"
-  integrity sha512-dEGO8hGpFrZz+9YqXGtk3HmWiOt0Xd87S8WpnizoXsFcLa1n4L6/qX7kDqz/RNeGNGElwIGwoejLCa1o8o4iSA==
+"@justfixnyc/component-library@0.33.0":
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.33.0.tgz#227941f59055faf1e763f8d0d6ee3bb4423d49e9"
+  integrity sha512-iHIg3ihO/zPJ6kwcyUDtPacBi90+RgBdiaaaN71oLJla2kcmyv19X7X0LXbZbFOWFkof+/dG5dUjLGXBexCRUg==
   dependencies:
     "@babel/runtime" "^7.12.5"
+    "@fortawesome/fontawesome-svg-core" "^6.5.1"
+    "@fortawesome/free-solid-svg-icons" "^6.5.1"
+    "@fortawesome/react-fontawesome" "^0.2.0"
 
 "@justfixnyc/contentful-common-strings@^0.1.0":
   version "0.1.0"


### PR DESCRIPTION
Update to component-library v0.33.0 for [tertiary button styles](https://github.com/JustFixNYC/component-library/pull/25) and [link icons styles](https://github.com/JustFixNYC/component-library/pull/24).

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/980662e7-6c1f-4e7f-840c-2154af7e9aff)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/0fa90302-baf1-4d73-99e4-dc1b08070109)
