### PR TITLE
add jfcl-locale-link, link focus, pw toggle focus

### DIFF
--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -18,7 +18,7 @@ import UserTypeInput from "./UserTypeInput";
 import { Alert } from "./Alert";
 import Modal from "./Modal";
 import SendNewLink from "./SendNewLink";
-import { LocaleLink } from "i18n";
+import { JFCLLocaleLink } from "i18n";
 import { createWhoOwnsWhatRoutePaths } from "routes";
 
 enum Step {
@@ -161,36 +161,32 @@ const LoginWithoutI18n = (props: LoginProps) => {
           <span className="privacy-links">
             <Trans>
               Your privacy is important to us. Read our{" "}
-              <a
+              <JFCLLink
+                href="https://www.justfix.org/en/privacy-policy/"
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://www.justfix.org/en/privacy-policy/"
               >
                 Privacy Policy
-              </a>{" "}
+              </JFCLLink>{" "}
               and{" "}
-              <a
+              <JFCLLink
+                href="https://www.justfix.org/en/terms-of-use/"
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://www.justfix.org/en/terms-of-use/"
               >
                 Terms of Service
-              </a>
+              </JFCLLink>
               .
             </Trans>
           </span>
         )}
         {isLoginStep && (
-          <LocaleLink
+          <JFCLLocaleLink
             to={`${account.forgotPassword}?email=${encodeURIComponent(email || "")}`}
-            onClick={() => {
-              window.gtag("event", "view-data-over-time-overview-tab");
-            }}
-            component={JFCLLink}
             className="forgot-password"
           >
-            <Trans render="span">Forgot your password?</Trans>
-          </LocaleLink>
+            <Trans>Forgot your password?</Trans>
+          </JFCLLocaleLink>
         )}
         <div className="login-type-toggle">
           {isRegisterAccountStep ? (

--- a/client/src/i18n.tsx
+++ b/client/src/i18n.tsx
@@ -11,12 +11,14 @@ import {
   NavLink,
 } from "react-router-dom";
 import { I18nProvider } from "@lingui/react";
+import { Link as JFCLLink } from "@justfixnyc/component-library";
 
 import catalogEn from "./locales/en/messages";
 import catalogEs from "./locales/es/messages";
 import { LocationDescriptorObject, History } from "history";
 import { SupportedLocale, defaultLocale, isSupportedLocale } from "./i18n-base";
 import { logAmplitudeEvent } from "./components/Amplitude";
+import JFCLLinkInternal from "components/JFCLLinkInternal";
 
 /** The structure for message catalogs that lingui expects. */
 type LocaleCatalog = {
@@ -226,6 +228,30 @@ export function LocaleNavLink(props: NavLinkProps & { to: string }): JSX.Element
  */
 export function LocaleLink(props: LinkProps & { to: string }): JSX.Element {
   return <Route render={(rProps) => <Link {...props} to={localePrefixPath(rProps, props.to)} />} />;
+}
+
+/**
+ * Like React Router's <Link>, but it prefixes the passed-in `to` prop with
+ * the current locale, and uses JustFix Component Library's Link for styles.
+ *
+ * Note that this doesn't localize the actual *text* of the link--it only localizes
+ * the path!
+ */
+export function JFCLLocaleLink(props: LinkProps & { to: string; icon?: "internal" }): JSX.Element {
+  const { icon, ...linkProps } = props;
+  const JFCLLinkComponent = icon === "internal" ? JFCLLinkInternal : JFCLLink;
+
+  return (
+    <Route
+      render={(rProps) => (
+        <Link
+          {...linkProps}
+          to={localePrefixPath(rProps, props.to)}
+          component={JFCLLinkComponent}
+        />
+      )}
+    />
+  );
 }
 
 /**

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -24,12 +24,14 @@
   }
 
   // Standard inline-link focus class:
+  // use component library default
+  // https://github.com/JustFixNYC/component-library/blob/701c58d033e12f2410d7203e5c6c75a7522d772c/src/buttons/styles.scss#L31
   a:not(.btn):not(.image):focus,
   summary:focus-visible,
   button.dropdown-toggle:focus {
-    box-shadow: none;
-    outline: 2px solid $gray-dark;
-    outline-offset: 2px;
+    outline-style: solid;
+    outline-width: 2px;
+    outline-color: $justfix-blue;
   }
 }
 

--- a/client/src/styles/Password.scss
+++ b/client/src/styles/Password.scss
@@ -49,7 +49,7 @@
       }
     }
 
-    button {
+    .show-hide-toggle {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -58,6 +58,13 @@
       border-top-right-radius: 4px;
       border-bottom-right-radius: 4px;
       width: 2.5rem;
+      &:focus,
+      &:focus-visible {
+        outline-style: solid;
+        outline-offset: 2px;
+        outline-width: 2px;
+        outline-color: $justfix-blue;
+      }
     }
   }
 

--- a/client/src/styles/_button.scss
+++ b/client/src/styles/_button.scss
@@ -238,8 +238,11 @@
   text-underline-position: under;
   &:focus,
   &:focus-visible {
-    outline: 0.13rem solid $justfix-grey;
-    outline-offset: 0.13rem;
+    // match component library until we can swap the remaining uses
+    // https://github.com/JustFixNYC/component-library/blob/701c58d033e12f2410d7203e5c6c75a7522d772c/src/buttons/styles.scss#L31
+    outline-style: solid;
+    outline-width: 2px;
+    outline-color: $justfix-blue;
   }
 }
 

--- a/client/src/styles/spectre/src/_base.scss
+++ b/client/src/styles/spectre/src/_base.scss
@@ -22,20 +22,20 @@ body {
   text-rendering: optimizeLegibility;
 }
 
-a {
-  color: $link-color;
-  outline: none;
-  text-decoration: none;
+// a {
+//   color: $link-color;
+//   outline: none;
+//   text-decoration: none;
 
-  &:focus {
-    @include control-shadow();
-  }
+//   &:focus {
+//     @include control-shadow();
+//   }
 
-  &:focus,
-  &:hover,
-  &:active,
-  &.active {
-    color: $link-color-dark;
-    text-decoration: underline;
-  }
-}
+//   &:focus,
+//   &:hover,
+//   &:active,
+//   &.active {
+//     color: $link-color-dark;
+//     text-decoration: underline;
+//   }
+// }


### PR DESCRIPTION
* update link focus states everywhere to match component library standard (blue outline)
  * remove spectre link focus styles, make old `.button.is-text` focus style same as link until we can transition these to component library option
* add focus state to password visibility toggle [sc-14200]
* add a `<JFCLLocleLink>` to simplify usage [sc-14267]
* remove a copy/paste typo that added a ga tag to forgot password

This also fixes the focus stats for privacy/terms links on sign up [sc-13896]
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/6ad71352-f8df-4573-9bd6-7e866c0688e8)

A couple other example of new link focus:
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/e3de73e6-3895-4bd5-94ce-cc79b527a81d)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/0084a721-12ee-423f-8f11-c298064f3560)


