### PR TITLE
use 16px in text inputs to prevent zooming on mobile safari

### DIFF
--- a/client/src/styles/EmailInput.scss
+++ b/client/src/styles/EmailInput.scss
@@ -30,6 +30,7 @@
 
     input {
       flex: 1;
+      font-size: 1rem; // below 16px zooms on mobile
 
       &:focus {
         border: 2px $justfix-black solid;

--- a/client/src/styles/Password.scss
+++ b/client/src/styles/Password.scss
@@ -32,6 +32,7 @@
       flex: 1;
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
+      font-size: 1rem; // below 16px zooms on mobile
 
       &:focus {
         border: 2px $justfix-black solid;

--- a/client/src/styles/UserTypeInput.scss
+++ b/client/src/styles/UserTypeInput.scss
@@ -54,6 +54,7 @@
 
   input[type="text"] {
     margin: 1.5rem 1.75rem 0 1.75rem;
+    font-size: 1rem; // below 16px zooms on mobile
 
     &:focus {
       border: 2px $justfix-black solid;


### PR DESCRIPTION
On mobile safari it was zooming in on text inputs when focused. This is because the font size was < 16px, so this bumps them all up to 16px (until we can swap with component library). Testing on the preview link it does not zoom now!

desktop:
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/b38d0e53-9eca-44d3-a857-94af3698d7f1)

mobile:
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/fb079500-60fe-4e43-adca-389b4b07f75f)

[sc-13908]