### PR TITLE
Content updates for login flow

### DIFF
--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -157,6 +157,7 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => {
                     <BuildingSubscribe {...props} />
                   ) : (
                     <Login
+                      addr={addr}
                       registerInModal
                       onBuildingPage
                       setLoginRegisterInProgress={setLoginRegisterInProgress}

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -85,8 +85,6 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
       <br />
       <Trans>
         Please try again later. If you’re still having issues, contact support@justfix.org.
-        <br />
-        <br />A report about this issue has been sent to our team.
       </Trans>
     </div>
   );

--- a/client/src/styles/Login.scss
+++ b/client/src/styles/Login.scss
@@ -1,13 +1,39 @@
 @import "_vars.scss";
 @import "_typography.scss";
 
-// TODO REFACTOR THIS PAGE
 .Login,
 .ForgotPasswordPage,
 .ResetPasswordPage {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+
+  .page-title {
+    margin-top: 0.9375rem;
+  }
+
+  .jf-alert {
+    width: auto;
+    font-size: 0.81rem;
+
+    .jfcl-button.jfcl-variant-text {
+      display: block !important;
+      color: $justfix-white;
+    }
+
+    .jf-alert__content {
+      display: flex;
+      text-align: left;
+    }
+  }
+
+  h4 {
+    font-size: 1.5rem;
+    margin-bottom: 0;
+  }
+  h5 {
+    font-size: 0.63rem;
+  }
 
   .input-group {
     display: flex;
@@ -25,8 +51,12 @@
     }
   }
 
-  .page-title {
-    margin-top: 0.9375rem;
+  .resend-verify-label {
+    text-align: center;
+  }
+
+  .send-new-link-container {
+    justify-content: center;
   }
 
   .building-page-footer {
@@ -55,76 +85,6 @@
       font-size: 0.875rem;
       font-weight: 400;
       color: inherit;
-    }
-  }
-
-  .login-response-text {
-    margin: 0.39rem 0 0.39rem;
-  }
-
-  .login-password-label {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    label {
-      flex: 1;
-    }
-  }
-
-  h4 {
-    font-size: 1.5rem;
-    margin-bottom: 0;
-  }
-  h5 {
-    font-size: 0.63rem;
-  }
-
-  .verify-email-container {
-    color: $justfix-black;
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-
-    p {
-      margin: 0;
-    }
-
-    h4,
-    .resend-verify-label {
-      display: flex;
-      justify-content: center;
-    }
-  }
-
-  .jf-alert {
-    width: auto;
-    font-size: 0.81rem;
-
-    .jfcl-button.jfcl-variant-text {
-      display: block !important;
-      color: $justfix-white;
-    }
-
-    .jf-alert__content {
-      display: flex;
-      text-align: left;
-    }
-  }
-
-  .request-sent-success {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    svg {
-      margin: 0.39rem 0 0.98rem 0;
-    }
-
-    .button.is-text {
-      margin-top: 0.39rem;
-      display: block !important;
-      color: $justfix-black;
     }
   }
 }


### PR DESCRIPTION
This makes updates to content for login/signup flow for more consistency with header/sub-header text. Also remove an old step for "verify reminder" that wasn't being used. Also cuts a line about sending error report from verify page. 
[sc-14236]

Also centers the resend verify email within the sign up modal
[sc-14270]

I also clean up the login styles - nothing other than the following was added, everything else just rearranged to make it a little more clear. 
```scss
.resend-verify-label {
  text-align: center;
}

.send-new-link-container {
  justify-content: center;
}
```

here are all the variations:

## nav page
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/30c49082-5f12-4eb0-a7ad-4fa77e2565d1)

### log in
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/0a728091-539d-4942-83df-a1ebbd3584b8)

### sign up
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/4318f01c-dcb9-45a1-b369-749fa826934f)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/d1e42e0a-60ae-477a-aa69-7c79bccaee4f)

## building page

### on page
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/887c20e8-494a-42e6-a729-509a960b12ad)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/5447cc1b-45ed-4525-8fe8-b7b3e0ebca23)

### in modal
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/227be014-106a-4f7b-91e2-e97fce795d66)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/0b00e086-8f33-4498-9bbb-6a8d61dc536a)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/051bd040-e54c-4b95-bc9d-c727eaf063d3)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/3d997fb9-bb15-400d-bd80-9d6df0a74bf9)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/5cd693b3-f140-4963-ab72-e82d7b7c6c4f)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/73005d83-5c2c-476e-add2-ecf3ca5af4cd)


