### PR TITLE
update HPD Online link for bbl search results, useful links and alerts api

### DIFF
--- a/client/src/components/UsefulLinks.tsx
+++ b/client/src/components/UsefulLinks.tsx
@@ -41,7 +41,7 @@ export const UsefulLinks: React.FC<UsefulLinksProps> = ({ addrForLinks, location
             href={
               !!hpdbuildingid && hpdbuildings === 1
                 ? `https://hpdonline.nyc.gov/hpdonline/building/${hpdbuildingid}/overview`
-                : "https://hpdonline.nyc.gov/hpdonline"
+                : `https://hpdonline.nyc.gov/hpdonline/building/search-results?boroId=${boro}&block=${block}&lot=${lot}`
             }
             target="_blank"
             rel="noopener noreferrer"

--- a/wow/forms.py
+++ b/wow/forms.py
@@ -54,6 +54,8 @@ class CommaSeparatedField(forms.CharField):
 
 
 def validate_indicators(value):
+    # "hpd_link" included here for email alerts api, this is temporary until we refactor
+    # this to use a pre-built table with all values instead of this composable option
     valid_indicators = [
         "violations",
         "complaints",

--- a/wow/forms.py
+++ b/wow/forms.py
@@ -79,10 +79,11 @@ class EmailAlertLaggedEvictionFilingsForm(PaddedBBLForm):
 
 
 class EmailAlertSingleIndicatorForm(PaddedBBLForm):
+    regex = r"^(violations)|(complaints)|(eviction_filings)|(lagged_eviction_filings)|(hpd_link)$"
     indicator = forms.CharField(
         validators=[
             RegexValidator(
-                r"^(violations)|(complaints)|(eviction_filings)|(lagged_eviction_filings)|(hpd_link)$",
+                regex,
                 message="This must be one of 'violations', 'complaints', 'eviction_filings', \
                     'lagged_eviction_filings', 'hpd_link'.",
             )

--- a/wow/forms.py
+++ b/wow/forms.py
@@ -59,12 +59,13 @@ def validate_indicators(value):
         "complaints",
         "eviction_filings",
         "lagged_eviction_filings",
+        "hpd_link",
     ]
     for i in value:
         if i not in valid_indicators:
             raise ValidationError(
                 "Indicators must be comma-separated list of: 'violations',\
-                'complaints', 'eviction_filings', or 'lagged_eviction_filings'"
+                'complaints', 'eviction_filings', 'lagged_eviction_filings', or 'hpd_link"
             )
 
 
@@ -81,9 +82,9 @@ class EmailAlertSingleIndicatorForm(PaddedBBLForm):
     indicator = forms.CharField(
         validators=[
             RegexValidator(
-                r"^(violations)|(complaints)|(eviction_filings)|(lagged_eviction_filings)$",
+                r"^(violations)|(complaints)|(eviction_filings)|(lagged_eviction_filings)|(hpd_link)$",
                 message="This must be one of 'violations', 'complaints', 'eviction_filings', \
-                    'lagged_eviction_filings'.",
+                    'lagged_eviction_filings', 'hpd_link'.",
             )
         ]
     )
@@ -123,11 +124,15 @@ class EmailAlertMultiIndicatorForm(PaddedBBLForm):
         indicators = data.get("indicators", [])
         start_end_indicators = ["violations", "complaints", "eviction_filings"]
 
+        if indicators == ["hpd_link"]:
+            return data
+
         if "lagged_eviction_filings" in indicators:
             if not data.get("prev_date", None):
                 raise forms.ValidationError(
                     "prev_date is required for lagged_eviction_filings"
                 )
+
         if not set(start_end_indicators).isdisjoint(indicators):
             if not data.get("start_date", None):
                 raise forms.ValidationError(
@@ -137,5 +142,5 @@ class EmailAlertMultiIndicatorForm(PaddedBBLForm):
                 raise forms.ValidationError(
                     "end_date is required for violations, complaints, and eviction_filings"
                 )
-        else:
-            return data
+
+        return data

--- a/wow/sql/alerts_hpd_link.sql
+++ b/wow/sql/alerts_hpd_link.sql
@@ -1,11 +1,11 @@
 SELECT
   CASE 
     WHEN hpdbuildingid is not null AND hpdbuildings = 1
-    	THEN concat('https://hpdonline.nyc.gov/hpdonline/building/', hpdbuildingid, '/overview')
+    	THEN concat('https://hpdonline.nyc.gov/hpdonline/building/', hpdbuildingid)
     ELSE
         concat(
           'https://hpdonline.nyc.gov/hpdonline/building/search-results', 
-          '?boroId=', strsub(bbl, 1, 1),
+          '?boroId=', substr(bbl, 1, 1),
         	'&block=', substr(bbl, 2, 5), 
           '&lot=', substr(bbl, 7, 4)
         )

--- a/wow/sql/alerts_hpd_link.sql
+++ b/wow/sql/alerts_hpd_link.sql
@@ -11,4 +11,4 @@ SELECT
         )
     END AS HPD_LINK
 FROM WOW_BLDGS
-WHERE BBL = %(bbl)s;
+WHERE BBL = %(bbl)s

--- a/wow/sql/alerts_hpd_link.sql
+++ b/wow/sql/alerts_hpd_link.sql
@@ -1,0 +1,14 @@
+SELECT
+  CASE 
+    WHEN hpdbuildingid is not null AND hpdbuildings = 1
+    	THEN concat('https://hpdonline.nyc.gov/hpdonline/building/', hpdbuildingid, '/overview')
+    ELSE
+        concat(
+          'https://hpdonline.nyc.gov/hpdonline/building/search-results', 
+          '?boroId=', strsub(bbl, 1, 1),
+        	'&block=', substr(bbl, 2, 5), 
+          '&lot=', substr(bbl, 7, 4)
+        )
+    END AS HPD_LINK
+FROM WOW_BLDGS
+WHERE BBL = %(bbl)s;

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -225,10 +225,11 @@ class TestAlertsMultiIndicator(ApiTest):
             f"{url_bbl_base}&indicators=violations&{start_date}&{end_date}",
             f"{url_bbl_base}&indicators=complaints&{start_date}&{end_date}",
             f"{url_bbl_base}&indicators=eviction_filings&{start_date}&{end_date}",
+            f"{url_bbl_base}&indicators=hpd_link",
             f"{url_bbl_base}&indicators=violations,complaints,eviction_filings \
                 &{start_date}&{end_date}",
             f"{url_bbl_base} \
-                &indicators=violations,complaints,eviction_filings,lagged_eviction_filings \
+                &indicators=violations,complaints,eviction_filings,lagged_eviction_filings,hpd_link \
                 &{start_date}&{end_date}&prev_date=2024-01-01",
         ]
         for url in urls:

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -228,8 +228,8 @@ class TestAlertsMultiIndicator(ApiTest):
             f"{url_bbl_base}&indicators=hpd_link",
             f"{url_bbl_base}&indicators=violations,complaints,eviction_filings \
                 &{start_date}&{end_date}",
-            f"{url_bbl_base} \
-                &indicators=violations,complaints,eviction_filings,lagged_eviction_filings,hpd_link \
+            f"{url_bbl_base}&indicators= \
+                violations,complaints,eviction_filings,lagged_eviction_filings,hpd_link \
                 &{start_date}&{end_date}&prev_date=2024-01-01",
         ]
         for url in urls:

--- a/wow/views.py
+++ b/wow/views.py
@@ -241,6 +241,7 @@ ALERTS_QUERIES = {
     "complaints": SQL_DIR / "alerts_complaints.sql",
     "eviction_filings": SQL_DIR / "alerts_eviction_filings.sql",
     "lagged_eviction_filings": SQL_DIR / "alerts_lagged_eviction_filings.sql",
+    "hpd_link": SQL_DIR / "alerts_hpd_link.sql",
 }
 
 


### PR DESCRIPTION
When the new HPD Online first launched it wouldn't allow you to link to search results based on BBL like the old version. This is important because since WOW uses BBLs for our pages, HPD uses their own "HPD building ID" and a single BBL can have multiple buildings. When there is only one building we can know that and link directly to the page, but when there are multiple we need to link to these bbl search results and the user can select the building they are interested in. 

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/a264c1c4-4c8e-4daa-b368-b1bae2c9bad4)

Now that HPD allows these links, we update our own "useful links" section. 

Also in this PR I add this link (single building or search results) as an optional "indicator" on the email alerts endpoint so that we can include those in the building update emails just like useful links. 

The corresponding PR that makes use of the new api changes: https://github.com/JustFixNYC/auth-provider/pull/34

[sc-12997]
[sc-13976]

