### PR TITLE
add verify step to nav signup flow, same as in modal

### DIFF
--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -28,7 +28,6 @@ enum Step {
   RegisterAccount,
   RegisterUserType,
   VerifyEmail,
-  VerifyEmailReminder,
 }
 
 type LoginProps = {
@@ -64,7 +63,6 @@ const LoginWithoutI18n = (props: LoginProps) => {
   const isRegisterAccountStep = step === Step.RegisterAccount;
   const isRegisterUserTypeStep = step === Step.RegisterUserType;
   const isVerifyEmailStep = step === Step.VerifyEmail;
-  const isVerifyEmailReminderStep = step === Step.VerifyEmailReminder;
 
   const {
     value: email,
@@ -338,13 +336,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
       return;
     }
 
-    if (!onBuildingPage) {
-      !!setLoginRegisterInProgress && setLoginRegisterInProgress(false);
-      handleRedirect && handleRedirect();
-      return;
-    }
-
-    if (!registerInModal) {
+    if (!onBuildingPage || !registerInModal) {
       !!setLoginRegisterInProgress && setLoginRegisterInProgress(false);
     }
 
@@ -446,7 +438,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
         )}
         {!!subHeaderText && <div className="card-description">{subHeaderText}</div>}
         {renderAlert()}
-        {!isVerifyEmailStep && !isVerifyEmailReminderStep && (
+        {!isVerifyEmailStep && (
           <form
             className="input-group"
             onSubmit={(e) => {


### PR DESCRIPTION
Previous the signup flow from Nav would end after user type selection and redirect users to the account settings page. This was confusing during initial user testing since it never said anything about email verification until later it was show on building pages, also there is no need to do anything on account settings after sign up. This PR removes that redirect and shows the same "verify email" prompt as we show at the end of the on-page/in-modal sign up flow. So the final step looks like this.
[sc-14126]

(I also remove a few old references to a "verify reminder" step that doesn't exist anymore)

> Note that we'll be changing the style of this page, including adding a link to WOW homepage, as part of the "standalone page" standardized design implementation [sc-14218]

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/38286539-17cd-4cb6-b360-2d2812f88b6e)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/98ce608d-8be5-44e0-ad8e-5e4d51ce1c0b)