### PR TITLE
fix subscribed/verify/login state after adding building via login/signup

### DIFF
--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -151,7 +151,7 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => {
   const userContext = useContext(UserContext);
   const { user } = userContext;
   const [addViaLogin, setAddViaLogin] = useState(false);
-
+  const [loginRegisterInProgress, setLoginRegisterInProgress] = useState(false);
   return (
     <>
       <div className="Card EmailAlertSignup card-body-table">
@@ -166,13 +166,14 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => {
                   <Trans>Building Updates</Trans>
                 </label>
                 <div className="table-content">
-                  {!!user?.email ? (
+                  {!!user?.email && !loginRegisterInProgress ? (
                     <BuildingSubscribe {...props} addViaLogin={addViaLogin} />
                   ) : (
                     <Login
                       addr={addr}
                       registerInModal
                       onBuildingPage
+                      setLoginRegisterInProgress={setLoginRegisterInProgress}
                       onSuccess={(user: JustfixUser) => {
                         setAddViaLogin(true);
                         userContext.subscribe(

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -37,10 +37,18 @@ type LoginProps = {
   onSuccess?: (user: JustfixUser) => void;
   registerInModal?: boolean;
   showForgotPassword?: boolean;
+  setLoginRegisterInProgress?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const LoginWithoutI18n = (props: LoginProps) => {
-  const { i18n, addr, onBuildingPage, onSuccess, registerInModal } = props;
+  const {
+    i18n,
+    addr,
+    onBuildingPage,
+    onSuccess,
+    registerInModal,
+    setLoginRegisterInProgress,
+  } = props;
 
   const userContext = useContext(UserContext);
   const { home, account } = createWhoOwnsWhatRoutePaths();
@@ -235,6 +243,7 @@ const LoginWithoutI18n = (props: LoginProps) => {
   );
 
   const onEmailSubmit = async () => {
+    !!setLoginRegisterInProgress && setLoginRegisterInProgress(true);
     if (!email) {
       if (!onBuildingPage || showRegisterModal) {
         setEmailError(true);
@@ -298,6 +307,11 @@ const LoginWithoutI18n = (props: LoginProps) => {
       }
       return;
     }
+    !!setLoginRegisterInProgress && setLoginRegisterInProgress(false);
+
+    if (onBuildingPage) {
+      window.location.reload();
+    }
   };
 
   const onAccountSubmit = async () => {
@@ -336,7 +350,9 @@ const LoginWithoutI18n = (props: LoginProps) => {
       setStep(Step.RegisterAccount);
       return;
     }
-
+    if (!onBuildingPage || !registerInModal) {
+      !!setLoginRegisterInProgress && setLoginRegisterInProgress(false);
+    }
     setStep(Step.VerifyEmail);
   };
 
@@ -510,6 +526,8 @@ const LoginWithoutI18n = (props: LoginProps) => {
             setShowEmailError(false);
             setShowRegisterModal(false);
             setStep(Step.CheckEmail);
+            !!setLoginRegisterInProgress && setLoginRegisterInProgress(false);
+            isVerifyEmailStep && window.location.reload();
           }}
         >
           {renderLoginFlow()}


### PR DESCRIPTION
There is a weird bug with delayed user context update causing a flash, or at time persistently, showing the wrong state on the building page after adding a building via login/signup process. It would sometimes get stuck back on the beginning "check email" step when it should be subscribed/verify. And other attempted fixes would flash subscribed before verify or similar. In a rush to get this out for playbox UX testing we are just forcing a page reload at the end of login on building page and after closing the signup modal on building page. This ensures users see the correct state after the reload. Later we'll revisit and find a real solution

[sc-14242]