### PR TITLE
update address page url for detailAddr

### DIFF
--- a/client/src/containers/AddressPage.tsx
+++ b/client/src/containers/AddressPage.tsx
@@ -13,6 +13,7 @@ import NychaPage from "./NychaPage";
 import NotRegisteredPage from "./NotRegisteredPage";
 import { Trans, Plural } from "@lingui/macro";
 import { Link, RouteComponentProps } from "react-router-dom";
+import _find from "lodash/find";
 import Page from "../components/Page";
 import { SearchResults, Borough } from "../components/APIDataTypes";
 import { SearchAddress } from "../components/AddressSearch";
@@ -20,9 +21,10 @@ import { withMachineProps } from "state-machine";
 import { AddrNotFoundPage } from "./NotFoundPage";
 import { searchAddrsAreEqual } from "util/helpers";
 import { NetworkErrorMessage } from "components/NetworkErrorMessage";
-import { removeIndicatorSuffix, createAddressPageRoutes } from "routes";
+import { removeIndicatorSuffix, createAddressPageRoutes, createRouteForAddressPage } from "routes";
 import { isLegacyPath } from "../components/WowzaToggle";
 import { logAmplitudeEvent } from "components/Amplitude";
+import { localeFromRouter } from "i18n";
 
 type RouteParams = {
   locale?: string;
@@ -115,13 +117,24 @@ export default class AddressPage extends Component<AddressPageProps, State> {
     });
   };
 
+  setAddrUrl = (bbl: string) => {
+    const addr = _find(this.props.state.context.portfolioData?.assocAddrs, { bbl });
+    if (!addr) return;
+    const locale = localeFromRouter(this.props);
+    const isLegacy = isLegacyPath(this.props.location.pathname);
+    const addrRoute = createRouteForAddressPage({ ...addr, locale }, isLegacy);
+    this.props.history.replace(addrRoute);
+  };
+
   handleAddrChange = (newFocusBbl: string) => {
     if (!this.props.state.matches("portfolioFound")) {
       throw new Error("A change of detail address was attempted without any portfolio data found.");
     }
     const detailBbl = this.props.state.context.portfolioData.detailAddr.bbl;
-    if (newFocusBbl !== detailBbl)
+    if (newFocusBbl !== detailBbl) {
       this.props.send({ type: "SELECT_DETAIL_ADDR", bbl: newFocusBbl });
+      this.setAddrUrl(newFocusBbl);
+    }
     this.handleOpenDetail();
   };
 


### PR DESCRIPTION
replace the address page URL with the selected `detailAdddr`

Previously on WOW the address page url would always reflect the search address, and when you click on other properties in the portfolio from the map the detail page updates to that address but the URL remains the same. This caused confusion, since you could think you're copying the link for building you're currently viewing but its still the search address. Also it makes linking and using browser history navigation difficult or confusing. This will make other future changes easier, like getting back to your building after going through login/signup flow, or linking back to details from portfolio tba without needing to open a new tab or reloading the page.

[sc-14358]