### PR TITLE
Include origin to email verification request

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -192,14 +192,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const { assocAddrs, detailAddr, searchAddr } = portfolioData;
 
     // Let's save some variables that will be helpful in rendering the front-end component
-    let takeActionURL,
-      formattedRegEndDate,
-      streetViewCoords,
-      streetViewAddr,
-      ownernames,
-      userOwnernames;
-
-    takeActionURL = Helpers.createTakeActionURL(detailAddr, "detail_view");
+    let formattedRegEndDate, streetViewCoords, streetViewAddr, ownernames, userOwnernames;
 
     formattedRegEndDate = Helpers.formatDate(
       detailAddr.registrationenddate,
@@ -398,7 +391,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                   </div>
                   <div className="column col-lg-12 col-5">
                     <EmailAlertSignup addr={detailAddr} />
-                    <GetRepairs url={takeActionURL} />
+                    <GetRepairs />
                     <div className="card-body-links column-right">
                       <UsefulLinks addrForLinks={detailAddr} location="overview-tab" />
                       <div className="card-body-social social-group">

--- a/client/src/components/GetRepairs.tsx
+++ b/client/src/components/GetRepairs.tsx
@@ -6,11 +6,8 @@ import { Link as JFCLLink } from "@justfixnyc/component-library";
 import "styles/GetRepairs.css";
 import "styles/Card.css";
 
-type GetRepairsProps = {
-  url: string | undefined;
-};
-const GetRepairsWithoutI18n = (props: GetRepairsProps) => {
-  const fallbackUrl = "https://app.justfix.org/en/loc/splash";
+const GetRepairsWithoutI18n = () => {
+  const locSplashUrl = "https://app.justfix.org/en/loc/splash";
 
   return (
     <>
@@ -28,7 +25,7 @@ const GetRepairsWithoutI18n = (props: GetRepairsProps) => {
                   </Trans>
 
                   <JFCLLink
-                    href={props.url ?? fallbackUrl}
+                    href={locSplashUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="jfcl-link"

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -6,6 +6,8 @@ import { useLocation } from "react-router-dom";
 import AuthClient, { VerifyStatusCode } from "../components/AuthClient";
 import SendNewLink from "components/SendNewLink";
 import StandalonePage from "components/StandalonePage";
+import { JFCLLocaleLink } from "i18n";
+import { createWhoOwnsWhatRoutePaths } from "routes";
 
 const VerifyEmailPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -18,6 +20,7 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
   const [unknownError, setUnknownError] = useState(false);
   const params = new URLSearchParams(search);
   const token = params.get("u") || "";
+  const { home } = createWhoOwnsWhatRoutePaths();
 
   useEffect(() => {
     const asyncVerifyEmail = async () => {
@@ -75,6 +78,9 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
     <>
       <Trans render="h1">Email address verified</Trans>
       <Trans render="h2">You can now start receiving Building Updates</Trans>
+      <Trans render="h2">
+        <JFCLLocaleLink to={home}>Search for an address</JFCLLocaleLink> to add to Building Updates
+      </Trans>
     </>
   );
 

--- a/jfauthprovider/views.py
+++ b/jfauthprovider/views.py
@@ -104,7 +104,10 @@ def auth_check(request):
 @api
 def verify_email(request):
     try:
-        post_data = {"code": request.GET.get("code")}
+        post_data = {
+            "code": request.GET.get("code"),
+            "origin": request.headers["Origin"],
+        }
         return auth_server_request(
             "POST",
             "user/verify_email/",


### PR DESCRIPTION
the email verification endpoint now handles sending confirmation emails for subscriptions users created before email verification. works in conjunction with https://github.com/JustFixNYC/auth-provider/pull/38