### PR TITLE
small updates based on feedback from early Playbook UX testing

### DIFF
--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -84,7 +84,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const renderEmailVerification = () => (
     <>
       <Alert type="info">
-        <Trans>Verify your email to start receiving updates.</Trans>
+        <Trans>Verify your email to receive updates and to add new buildings.</Trans>
       </Alert>
       <Trans render="div" className="card-description">
         Click the link we sent to {user?.email}. It may take a few minutes to arrive.

--- a/client/src/components/EngagementPanel.tsx
+++ b/client/src/components/EngagementPanel.tsx
@@ -8,32 +8,33 @@ import { Trans } from "@lingui/macro";
 
 const EngagementPanel: React.FC<{
   location: SocialShareLocation;
-}> = (props) => {
-  return (
-    <div className="EngagementPanel">
-      <Trans render="h5">Join the fight for tenant rights!</Trans>
-      <div className="EngagementWrapper">
+  newsletter?: boolean;
+}> = ({ location, newsletter = true }) => (
+  <div className="EngagementPanel">
+    <Trans render="h5">Join the fight for tenant rights!</Trans>
+    <div className="EngagementWrapper">
+      {newsletter && (
         <div className="EngagementItem">
           <p>
             <Trans>Sign up for our newsletter</Trans>
           </p>
           <Subscribe />
         </div>
-        <div className="EngagementItem">
-          <p>
-            <Trans>Share with your neighbors</Trans>
-          </p>
-          <SocialShare location={props.location} />
-        </div>
-        <div className="EngagementItem">
-          <p>
-            <Trans>Visit our website</Trans>
-          </p>
-          <Link href="https://www.justfix.org/">www.JustFix.org</Link>
-        </div>
+      )}
+      <div className="EngagementItem">
+        <p>
+          <Trans>Share with your neighbors</Trans>
+        </p>
+        <SocialShare location={location} />
+      </div>
+      <div className="EngagementItem">
+        <p>
+          <Trans>Visit our website</Trans>
+        </p>
+        <Link href="https://www.justfix.org/">www.JustFix.org</Link>
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 export default EngagementPanel;

--- a/client/src/components/EngagementPanel.tsx
+++ b/client/src/components/EngagementPanel.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Subscribe from "./Subscribe";
 import SocialShare, { SocialShareLocation } from "./SocialShare";
 import { Link } from "@justfixnyc/component-library";
 
@@ -8,24 +7,15 @@ import { Trans } from "@lingui/macro";
 
 const EngagementPanel: React.FC<{
   location: SocialShareLocation;
-  newsletter?: boolean;
-}> = ({ location, newsletter = true }) => (
+}> = (props) => (
   <div className="EngagementPanel">
     <Trans render="h5">Join the fight for tenant rights!</Trans>
     <div className="EngagementWrapper">
-      {newsletter && (
-        <div className="EngagementItem">
-          <p>
-            <Trans>Sign up for our newsletter</Trans>
-          </p>
-          <Subscribe />
-        </div>
-      )}
       <div className="EngagementItem">
         <p>
           <Trans>Share with your neighbors</Trans>
         </p>
-        <SocialShare location={location} />
+        <SocialShare location={props.location} />
       </div>
       <div className="EngagementItem">
         <p>

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -253,7 +253,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
       <Trans render="h1">You are logged in</Trans>
       <Trans render="h2">
         <JFCLLocaleLink to={home}>Search for an address</JFCLLocaleLink> to add to your Building
-        Updates, or visit your <JFCLLocaleLink to={account.settings}>Account</JFCLLocaleLink>.
+        Updates, or visit your <JFCLLocaleLink to={account.settings}>account</JFCLLocaleLink> page to manage subscriptions.
       </Trans>
     </>
   );

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -422,7 +422,9 @@ const LoginWithoutI18n = (props: withI18nProps) => {
           )}
           {(isLoginStep || isRegisterAccountStep) && (
             <PasswordInput
-              labelText={i18n._(t`Password`)}
+              labelText={
+                isRegisterAccountStep ? i18n._(t`Create password`) : i18n._(t`Enter your password`)
+              }
               password={password}
               username={email}
               error={passwordError}

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -252,7 +252,8 @@ const LoginWithoutI18n = (props: withI18nProps) => {
     <>
       <Trans render="h1">You are logged in</Trans>
       <Trans render="h2">
-        <JFCLLocaleLink to={home}>Search for an address</JFCLLocaleLink> to add to Building Updates
+        <JFCLLocaleLink to={home}>Search for an address</JFCLLocaleLink> to add to your Building
+        Updates, or visit your <JFCLLocaleLink to={account.settings}>Account</JFCLLocaleLink>.
       </Trans>
     </>
   );

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -253,7 +253,8 @@ const LoginWithoutI18n = (props: withI18nProps) => {
       <Trans render="h1">You are logged in</Trans>
       <Trans render="h2">
         <JFCLLocaleLink to={home}>Search for an address</JFCLLocaleLink> to add to your Building
-        Updates, or visit your <JFCLLocaleLink to={account.settings}>account</JFCLLocaleLink> page to manage subscriptions.
+        Updates, or visit your <JFCLLocaleLink to={account.settings}>account</JFCLLocaleLink> page
+        to manage subscriptions.
       </Trans>
     </>
   );

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -302,7 +302,7 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
               </div>
             </div>
           </div>
-          <EngagementPanel location="homepage" />
+          <EngagementPanel location="homepage" newsletter={false} />
         </div>
         <LegalFooter />
       </div>

--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -302,7 +302,7 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
               </div>
             </div>
           </div>
-          <EngagementPanel location="homepage" newsletter={false} />
+          <EngagementPanel location="homepage" />
         </div>
         <LegalFooter />
       </div>

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -77,9 +77,12 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
   const successPage = () => (
     <>
       <Trans render="h1">Email address verified</Trans>
-      <Trans render="h2">You can now start receiving Building Updates</Trans>
       <Trans render="h2">
-        <JFCLLocaleLink to={home}>Search for an address</JFCLLocaleLink> to add to Building Updates
+        If you already added a building, you will get your first Building Update on Monday morning.
+      </Trans>
+      <Trans render="h2">
+        You can now close this window or{" "}
+        <JFCLLocaleLink to={home}>search for another building</JFCLLocaleLink> to add.
       </Trans>
     </>
   );

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -29,16 +29,16 @@ msgstr "#WhoOwnsWhat via @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
-#: src/components/DetailView.tsx:251
+#: src/components/DetailView.tsx:250
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:233
+#: src/components/DetailView.tsx:232
 #: src/containers/NotRegisteredPage.tsx:104
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:236
+#: src/components/DetailView.tsx:235
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -251,7 +251,7 @@ msgstr "At this time we can only support {SUBSCRIPTION_LIMIT} buildings in each 
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:163
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -303,14 +303,14 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:316
-#: src/components/DetailView.tsx:325
+#: src/components/DetailView.tsx:315
+#: src/components/DetailView.tsx:324
 #: src/components/PortfolioGraph.tsx:129
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:296
-#: src/components/DetailView.tsx:305
+#: src/components/DetailView.tsx:295
+#: src/components/DetailView.tsx:304
 msgid "Business Entities"
 msgstr "Business Entities"
 
@@ -416,7 +416,7 @@ msgstr "Click the link we sent to <0>{email}</0> to verify your email. It may ta
 msgid "Click the link we sent to your email to reset your password."
 msgstr "Click the link we sent to your email to reset your password."
 
-#: src/containers/VerifyEmailPage.tsx:51
+#: src/containers/VerifyEmailPage.tsx:54
 msgid "Click the link we sent to your email to start receiving emails."
 msgstr "Click the link we sent to your email to start receiving emails."
 
@@ -593,7 +593,7 @@ msgstr "Email address"
 msgid "Email address not verified. Click the link we sent to {email} start receiving Building Updates."
 msgstr "Email address not verified. Click the link we sent to {email} start receiving Building Updates."
 
-#: src/containers/VerifyEmailPage.tsx:64
+#: src/containers/VerifyEmailPage.tsx:67
 msgid "Email address verified"
 msgstr "Email address verified"
 
@@ -743,7 +743,7 @@ msgstr "GARBAGE/RECYCLING STORAGE"
 #~ msgid "Get Data Updates for this building"
 #~ msgstr "Get Data Updates for this building"
 
-#: src/components/GetRepairs.tsx:25
+#: src/components/GetRepairs.tsx:23
 msgid "Get Repairs"
 msgstr "Get Repairs"
 
@@ -844,6 +844,10 @@ msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open viol
 #: src/components/PropertiesSummary.tsx:146
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
+
+#: src/containers/VerifyEmailPage.tsx:68
+msgid "If you already added a building, you will get your first Building Update on Monday morning."
+msgstr "If you already added a building, you will get your first Building Update on Monday morning."
 
 #: src/containers/VerifyEmailPage.tsx:114
 #~ msgid "If you are not redirected, please click <0>[here]</0>"
@@ -966,12 +970,12 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:228
+#: src/components/DetailView.tsx:227
 #: src/containers/NotRegisteredPage.tsx:99
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:241
+#: src/components/DetailView.tsx:240
 msgid "Last sold:"
 msgstr "Last sold:"
 
@@ -1161,7 +1165,7 @@ msgstr "Min must be less than {maxOption}"
 msgid "More Mobile Friendly"
 msgstr "More Mobile Friendly"
 
-#: src/components/DetailView.tsx:185
+#: src/components/DetailView.tsx:184
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -1193,7 +1197,7 @@ msgstr "NYCHA Directory"
 #~ msgid "Narrow down this portfolio using filters in <0>the Portfolio tab.</0>"
 #~ msgstr "Narrow down this portfolio using filters in <0>the Portfolio tab.</0>"
 
-#: src/components/GetRepairs.tsx:17
+#: src/components/GetRepairs.tsx:15
 msgid "Need repairs in this building?"
 msgstr "Need repairs in this building?"
 
@@ -1267,7 +1271,7 @@ msgstr "Non-ECB"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:193
+#: src/components/DetailView.tsx:192
 msgid "None"
 msgstr "None"
 
@@ -1391,8 +1395,8 @@ msgstr "Password"
 msgid "Password reset successful"
 msgstr "Password reset successful"
 
-#: src/components/DetailView.tsx:336
-#: src/components/DetailView.tsx:346
+#: src/components/DetailView.tsx:335
+#: src/components/DetailView.tsx:345
 msgid "People"
 msgstr "People"
 
@@ -1421,7 +1425,7 @@ msgstr "Please enter password."
 msgid "Please select an option."
 msgstr "Please select an option."
 
-#: src/containers/VerifyEmailPage.tsx:59
+#: src/containers/VerifyEmailPage.tsx:62
 msgid "Please try again later. If you’re still having issues, contact support@justfix.org."
 msgstr "Please try again later. If you’re still having issues, contact support@justfix.org."
 
@@ -1607,7 +1611,7 @@ msgstr "See the most common complaints reported by tenants to 311, now on the Ov
 msgid "Select one or more ranges of building units, or set a custom range, then apply selections to filter the list of portfolio properties."
 msgstr "Select one or more ranges of building units, or set a custom range, then apply selections to filter the list of portfolio properties."
 
-#: src/components/GetRepairs.tsx:20
+#: src/components/GetRepairs.tsx:18
 msgid "Send a free, legally vetted letter to notify your landlord of repair issues"
 msgstr "Send a free, legally vetted letter to notify your landlord of repair issues"
 
@@ -1635,7 +1639,7 @@ msgstr "Send us a data request"
 #~ msgid "Share this page with your neighbors"
 #~ msgstr "Share this page with your neighbors"
 
-#: src/components/DetailView.tsx:265
+#: src/components/DetailView.tsx:264
 #: src/components/EngagementPanel.tsx:19
 #: src/components/PropertiesSummary.tsx:140
 #: src/containers/NotRegisteredPage.tsx:19
@@ -1911,7 +1915,7 @@ msgstr "The registration for this property is missing details for owner name or 
 msgid "The same owner may have spelled their name several ways in official documents."
 msgstr "The same owner may have spelled their name several ways in official documents."
 
-#: src/containers/VerifyEmailPage.tsx:51
+#: src/containers/VerifyEmailPage.tsx:54
 msgid "The verification link that we sent you is no longer valid."
 msgstr "The verification link that we sent you is no longer valid."
 
@@ -2102,7 +2106,7 @@ msgstr "VENTILATORS"
 #~ msgid "Verify this email:"
 #~ msgstr "Verify this email:"
 
-#: src/containers/VerifyEmailPage.tsx:68
+#: src/containers/VerifyEmailPage.tsx:77
 msgid "Verify your email address"
 msgstr "Verify your email address"
 
@@ -2153,11 +2157,11 @@ msgstr "View documents on ACRIS"
 #~ msgid "View legend"
 #~ msgstr "View legend"
 
-#: src/components/DetailView.tsx:156
+#: src/components/DetailView.tsx:155
 msgid "View map"
 msgstr "View map"
 
-#: src/components/DetailView.tsx:145
+#: src/components/DetailView.tsx:144
 msgid "View on Google Maps"
 msgstr "View on Google Maps"
 
@@ -2195,7 +2199,7 @@ msgstr "WINDOWS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:220
+#: src/components/DetailView.tsx:219
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 
@@ -2227,7 +2231,7 @@ msgstr "We send Building Updates to this email."
 msgid "We sent a reset link to {email}. Please check your inbox and spam."
 msgstr "We sent a reset link to {email}. Please check your inbox and spam."
 
-#: src/containers/VerifyEmailPage.tsx:58
+#: src/containers/VerifyEmailPage.tsx:61
 msgid "We’re having trouble verifying your email at this time."
 msgstr "We’re having trouble verifying your email at this time."
 
@@ -2311,7 +2315,7 @@ msgstr "Who owns what in nyc?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:199
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -2372,9 +2376,13 @@ msgstr "You are viewing a legacy version of Who Owns What"
 #~ msgid "You are viewing the old version of Who Owns What. <0>Switch to the new version.</0>"
 #~ msgstr "You are viewing the old version of Who Owns What. <0>Switch to the new version.</0>"
 
+#: src/containers/VerifyEmailPage.tsx:71
+msgid "You can now close this window or <0>search for another building</0> to add."
+msgstr "You can now close this window or <0>search for another building</0> to add."
+
 #: src/containers/VerifyEmailPage.tsx:65
-msgid "You can now start receiving Building Updates"
-msgstr "You can now start receiving Building Updates"
+#~ msgid "You can now start receiving Building Updates"
+#~ msgstr "You can now start receiving Building Updates"
 
 #: src/components/EmailAlertSignup.tsx:99
 msgid "You have reached the maximum number of Building Updates"
@@ -2396,7 +2404,7 @@ msgstr "You have reached the maximum number of Building Updates"
 #~ msgid "You will be redirected back to Who Owns What in:"
 #~ msgstr "You will be redirected back to Who Owns What in:"
 
-#: src/containers/VerifyEmailPage.tsx:67
+#: src/containers/VerifyEmailPage.tsx:76
 msgid "Your email is already verified"
 msgstr "Your email is already verified"
 
@@ -2479,7 +2487,7 @@ msgstr "associated building"
 #~ msgid "contact support@justfix.org"
 #~ msgstr "contact support@justfix.org"
 
-#: src/components/DetailView.tsx:245
+#: src/components/DetailView.tsx:244
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -920,7 +920,7 @@ msgstr "Information"
 msgid "JANITOR/SUPER"
 msgstr "JANITOR/SUPER"
 
-#: src/components/EngagementPanel.tsx:9
+#: src/components/EngagementPanel.tsx:8
 msgid "Join the fight for tenant rights!"
 msgstr "Join the fight for tenant rights!"
 
@@ -1650,7 +1650,7 @@ msgstr "Send us a data request"
 #~ msgstr "Share this page with your neighbors"
 
 #: src/components/DetailView.tsx:264
-#: src/components/EngagementPanel.tsx:19
+#: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:140
 #: src/containers/NotRegisteredPage.tsx:19
 msgid "Share with your neighbors"
@@ -1722,7 +1722,7 @@ msgstr "Sign up for Building Updates"
 #~ msgid "Sign up for email updates on the buildings you choose:"
 #~ msgstr "Sign up for email updates on the buildings you choose:"
 
-#: src/components/EngagementPanel.tsx:13
+#: src/components/EngagementPanel.tsx:12
 msgid "Sign up for our newsletter"
 msgstr "Sign up for our newsletter"
 
@@ -2193,7 +2193,7 @@ msgstr "View portfolio"
 msgid "Violations Issued"
 msgstr "Violations Issued"
 
-#: src/components/EngagementPanel.tsx:25
+#: src/components/EngagementPanel.tsx:24
 msgid "Visit our website"
 msgstr "Visit our website"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -482,6 +482,10 @@ msgstr "Create a password"
 #~ msgid "Create a password to start receiving Data Updates"
 #~ msgstr "Create a password to start receiving Data Updates"
 
+#: src/components/Login.tsx:292
+msgid "Create password"
+msgstr "Create password"
+
 #: src/components/UserSettingField.tsx:60
 msgid "Current password"
 msgstr "Current password"
@@ -634,6 +638,10 @@ msgstr "Enter new email address"
 #: src/components/UserSettingField.tsx:58
 #~ msgid "Enter your old password"
 #~ msgstr "Enter your old password"
+
+#: src/components/Login.tsx:292
+msgid "Enter your password"
+msgstr "Enter your password"
 
 #: src/components/BuildingStatsTable.tsx:83
 #: src/components/IndicatorsDatasets.tsx:128
@@ -1385,7 +1393,6 @@ msgstr "Page"
 #~ msgid "Page {0} of {1}"
 #~ msgstr "Page {0} of {1}"
 
-#: src/components/Login.tsx:292
 #: src/components/UserSettingField.tsx:52
 #: src/components/UserSettingField.tsx:57
 msgid "Password"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -82,7 +82,6 @@ msgstr "<0>Rent stabilization</0> protects tenants by limiting rent increases an
 #~ msgid "<0>Search an address</0> to sign up for email alerts for that building."
 #~ msgstr "<0>Search an address</0> to sign up for email alerts for that building."
 
-#: src/components/Login.tsx:164
 #: src/containers/UnsubscribePage.tsx:74
 msgid "<0>Search for an address</0> to add to Building Updates"
 msgstr "<0>Search for an address</0> to add to Building Updates"
@@ -90,6 +89,10 @@ msgstr "<0>Search for an address</0> to add to Building Updates"
 #: src/containers/AccountSettingsPage.tsx:56
 msgid "<0>Search for an address</0> to add to your Building Updates"
 msgstr "<0>Search for an address</0> to add to your Building Updates"
+
+#: src/components/Login.tsx:164
+msgid "<0>Search for an address</0> to add to your Building Updates, or visit your <1>Account</1>."
+msgstr "<0>Search for an address</0> to add to your Building Updates, or visit your <1>Account</1>."
 
 #: src/containers/NotRegisteredPage.tsx:73
 msgid "<0>This property is not required to register with HPD</0> because it doesn't have any residential units."
@@ -338,7 +341,7 @@ msgstr "Cancel"
 msgid "Check out the issues in this building"
 msgstr "Check out the issues in this building"
 
-#: src/components/Login.tsx:272
+#: src/components/Login.tsx:273
 msgid "Check your email"
 msgstr "Check your email"
 
@@ -404,7 +407,7 @@ msgstr "Clearer Landlord Contact Info"
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
-#: src/components/Login.tsx:273
+#: src/components/Login.tsx:274
 msgid "Click the link we sent to <0>{email}</0> to verify your email. It may take a few minutes to arrive. If you can't find it, check your spam and promotions folders for an email from <1>no-reply@justfix.org</1>."
 msgstr "Click the link we sent to <0>{email}</0> to verify your email. It may take a few minutes to arrive. If you can't find it, check your spam and promotions folders for an email from <1>no-reply@justfix.org</1>."
 
@@ -482,7 +485,7 @@ msgstr "Create a password"
 #~ msgid "Create a password to start receiving Data Updates"
 #~ msgstr "Create a password to start receiving Data Updates"
 
-#: src/components/Login.tsx:292
+#: src/components/Login.tsx:293
 msgid "Create password"
 msgstr "Create password"
 
@@ -586,7 +589,7 @@ msgstr "Edit"
 msgid "Email"
 msgstr "Email"
 
-#: src/components/Login.tsx:291
+#: src/components/Login.tsx:292
 #: src/components/UserSettingField.tsx:100
 #: src/components/UserSettingField.tsx:105
 #: src/containers/ForgotPasswordPage.tsx:52
@@ -639,7 +642,7 @@ msgstr "Enter new email address"
 #~ msgid "Enter your old password"
 #~ msgstr "Enter your old password"
 
-#: src/components/Login.tsx:292
+#: src/components/Login.tsx:293
 msgid "Enter your password"
 msgstr "Enter your password"
 
@@ -1040,19 +1043,19 @@ msgstr "Location"
 
 #: src/components/Login.tsx:99
 #: src/components/Login.tsx:137
-#: src/components/Login.tsx:255
-#: src/components/Login.tsx:258
+#: src/components/Login.tsx:256
+#: src/components/Login.tsx:259
 #: src/containers/AccountSettingsPage.tsx:41
 #: src/containers/App.tsx:117
 msgid "Log in"
 msgstr "Log in"
 
-#: src/components/Login.tsx:246
+#: src/components/Login.tsx:247
 #: src/containers/LoginPage.tsx:7
 msgid "Log in / sign up"
 msgstr "Log in / sign up"
 
-#: src/components/Login.tsx:256
+#: src/components/Login.tsx:257
 msgid "Log in to add {0} to your Building Updates"
 msgstr "Log in to add {0} to your Building Updates"
 
@@ -1234,7 +1237,7 @@ msgid "New password"
 msgstr "New password"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/Login.tsx:263
+#: src/components/Login.tsx:264
 msgid "Next"
 msgstr "Next"
 
@@ -1702,8 +1705,8 @@ msgstr "Showing {0} {1, plural, one {result} other {results}}"
 msgid "Sign up"
 msgstr "Sign up"
 
-#: src/components/Login.tsx:261
-#: src/components/Login.tsx:266
+#: src/components/Login.tsx:262
+#: src/components/Login.tsx:267
 msgid "Sign up for Building Updates"
 msgstr "Sign up for Building Updates"
 
@@ -1784,7 +1787,7 @@ msgstr "Source code"
 msgid "Starts {year}"
 msgstr "Starts {year}"
 
-#: src/components/Login.tsx:252
+#: src/components/Login.tsx:253
 msgid "Submit"
 msgstr "Submit"
 
@@ -2080,7 +2083,7 @@ msgstr "Use this free tool from JustFix to research your building and investigat
 #~ msgid "Use your account to get weekly email updates on the buildings you choose"
 #~ msgstr "Use your account to get weekly email updates on the buildings you choose"
 
-#: src/components/Login.tsx:247
+#: src/components/Login.tsx:248
 msgid "Use your account to get weekly email updates on {0}."
 msgstr "Use your account to get weekly email updates on {0}."
 
@@ -2283,7 +2286,7 @@ msgstr "What’s the difference between a landlord, an owner, and head officer?"
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "When two parties share the same business address, we group them as part of the same portfolio."
 
-#: src/components/Login.tsx:267
+#: src/components/Login.tsx:268
 msgid "Which best describes you?"
 msgstr "Which best describes you?"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -920,7 +920,7 @@ msgstr "Information"
 msgid "JANITOR/SUPER"
 msgstr "JANITOR/SUPER"
 
-#: src/components/EngagementPanel.tsx:8
+#: src/components/EngagementPanel.tsx:7
 msgid "Join the fight for tenant rights!"
 msgstr "Join the fight for tenant rights!"
 
@@ -1650,7 +1650,7 @@ msgstr "Send us a data request"
 #~ msgstr "Share this page with your neighbors"
 
 #: src/components/DetailView.tsx:264
-#: src/components/EngagementPanel.tsx:18
+#: src/components/EngagementPanel.tsx:11
 #: src/components/PropertiesSummary.tsx:140
 #: src/containers/NotRegisteredPage.tsx:19
 msgid "Share with your neighbors"
@@ -1723,8 +1723,8 @@ msgstr "Sign up for Building Updates"
 #~ msgstr "Sign up for email updates on the buildings you choose:"
 
 #: src/components/EngagementPanel.tsx:12
-msgid "Sign up for our newsletter"
-msgstr "Sign up for our newsletter"
+#~ msgid "Sign up for our newsletter"
+#~ msgstr "Sign up for our newsletter"
 
 #: src/components/PropertiesList.tsx:295
 #: src/components/PropertiesList.tsx:300
@@ -2193,7 +2193,7 @@ msgstr "View portfolio"
 msgid "Violations Issued"
 msgstr "Violations Issued"
 
-#: src/components/EngagementPanel.tsx:24
+#: src/components/EngagementPanel.tsx:17
 msgid "Visit our website"
 msgstr "Visit our website"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -2117,13 +2117,17 @@ msgstr "VENTILATORS"
 msgid "Verify your email address"
 msgstr "Verify your email address"
 
+#: src/components/EmailAlertSignup.tsx:58
+msgid "Verify your email to receive updates and to add new buildings."
+msgstr "Verify your email to receive updates and to add new buildings."
+
 #: src/components/Login.tsx:128
 #~ msgid "Verify your email to start receiving updates"
 #~ msgstr "Verify your email to start receiving updates"
 
 #: src/components/EmailAlertSignup.tsx:58
-msgid "Verify your email to start receiving updates."
-msgstr "Verify your email to start receiving updates."
+#~ msgid "Verify your email to start receiving updates."
+#~ msgstr "Verify your email to start receiving updates."
 
 #: src/components/PortfolioTable.tsx:378
 #: src/components/PortfolioTable.tsx:385

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -34,16 +34,16 @@ msgstr "#QuiénEsElDueño por @JustFixNYC"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
-#: src/components/DetailView.tsx:251
+#: src/components/DetailView.tsx:250
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:233
+#: src/components/DetailView.tsx:232
 #: src/containers/NotRegisteredPage.tsx:104
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:236
+#: src/components/DetailView.tsx:235
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:163
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -308,14 +308,14 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:316
-#: src/components/DetailView.tsx:325
+#: src/components/DetailView.tsx:315
+#: src/components/DetailView.tsx:324
 #: src/components/PortfolioGraph.tsx:129
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:296
-#: src/components/DetailView.tsx:305
+#: src/components/DetailView.tsx:295
+#: src/components/DetailView.tsx:304
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Click the link we sent to your email to reset your password."
 msgstr ""
 
-#: src/containers/VerifyEmailPage.tsx:51
+#: src/containers/VerifyEmailPage.tsx:54
 msgid "Click the link we sent to your email to start receiving emails."
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 #~ msgid "Email address not verified. Click the link we sent to {email} start receiving emails."
 #~ msgstr ""
 
-#: src/containers/VerifyEmailPage.tsx:64
+#: src/containers/VerifyEmailPage.tsx:67
 msgid "Email address verified"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr "ALMACENAMIENTO DE BASURA/RECICLAJE"
 #~ msgid "Get Data Updates for this building"
 #~ msgstr ""
 
-#: src/components/GetRepairs.tsx:25
+#: src/components/GetRepairs.tsx:23
 msgid "Get Repairs"
 msgstr ""
 
@@ -861,6 +861,10 @@ msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las
 #: src/components/PropertiesSummary.tsx:146
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
+
+#: src/containers/VerifyEmailPage.tsx:68
+msgid "If you already added a building, you will get your first Building Update on Monday morning."
+msgstr ""
 
 #: src/containers/VerifyEmailPage.tsx:114
 #~ msgid "If you are not redirected, please click <0>[here]</0>"
@@ -983,12 +987,12 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:228
+#: src/components/DetailView.tsx:227
 #: src/containers/NotRegisteredPage.tsx:99
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:241
+#: src/components/DetailView.tsx:240
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "More Mobile Friendly"
 msgstr "Más útil para dispositivos móviles"
 
-#: src/components/DetailView.tsx:185
+#: src/components/DetailView.tsx:184
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -1210,7 +1214,7 @@ msgstr "Directorio de NYCHA"
 #~ msgid "Narrow down this portfolio using filters in <0>the Portfolio tab.</0>"
 #~ msgstr "Restrinja esta cartera utilizando los filtros de la <0>pestaña Cartera.</0>"
 
-#: src/components/GetRepairs.tsx:17
+#: src/components/GetRepairs.tsx:15
 msgid "Need repairs in this building?"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr "No ECB"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:193
+#: src/components/DetailView.tsx:192
 msgid "None"
 msgstr "Ninguna"
 
@@ -1408,8 +1412,8 @@ msgstr ""
 msgid "Password reset successful"
 msgstr ""
 
-#: src/components/DetailView.tsx:336
-#: src/components/DetailView.tsx:346
+#: src/components/DetailView.tsx:335
+#: src/components/DetailView.tsx:345
 msgid "People"
 msgstr "Personas"
 
@@ -1438,7 +1442,7 @@ msgstr ""
 msgid "Please select an option."
 msgstr ""
 
-#: src/containers/VerifyEmailPage.tsx:59
+#: src/containers/VerifyEmailPage.tsx:62
 msgid "Please try again later. If you’re still having issues, contact support@justfix.org."
 msgstr ""
 
@@ -1624,7 +1628,7 @@ msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en l
 msgid "Select one or more ranges of building units, or set a custom range, then apply selections to filter the list of portfolio properties."
 msgstr "Seleccione uno o varios rangos de unidades de edificios o establezca un rango personalizado y, a continuación, aplique las selecciones para filtrar la lista de propiedades de la cartera."
 
-#: src/components/GetRepairs.tsx:20
+#: src/components/GetRepairs.tsx:18
 msgid "Send a free, legally vetted letter to notify your landlord of repair issues"
 msgstr ""
 
@@ -1652,7 +1656,7 @@ msgstr "Envíanos una solicitud de datos"
 #~ msgid "Share this page with your neighbors"
 #~ msgstr "Comparte esta página con tus vecinos"
 
-#: src/components/DetailView.tsx:265
+#: src/components/DetailView.tsx:264
 #: src/components/EngagementPanel.tsx:19
 #: src/components/PropertiesSummary.tsx:140
 #: src/containers/NotRegisteredPage.tsx:19
@@ -1928,7 +1932,7 @@ msgstr "El registro de esta propiedad faltan detalles sobre el nombre del dueño
 msgid "The same owner may have spelled their name several ways in official documents."
 msgstr "El mismo dueño puede haber escrito su nombre de varias maneras en los documentos oficiales."
 
-#: src/containers/VerifyEmailPage.tsx:51
+#: src/containers/VerifyEmailPage.tsx:54
 msgid "The verification link that we sent you is no longer valid."
 msgstr ""
 
@@ -2119,7 +2123,7 @@ msgstr "VENTILADORES"
 #~ msgid "Verify this email:"
 #~ msgstr ""
 
-#: src/containers/VerifyEmailPage.tsx:68
+#: src/containers/VerifyEmailPage.tsx:77
 msgid "Verify your email address"
 msgstr ""
 
@@ -2170,11 +2174,11 @@ msgstr ""
 #~ msgid "View legend"
 #~ msgstr "View legend"
 
-#: src/components/DetailView.tsx:156
+#: src/components/DetailView.tsx:155
 msgid "View map"
 msgstr "Ver mapa"
 
-#: src/components/DetailView.tsx:145
+#: src/components/DetailView.tsx:144
 msgid "View on Google Maps"
 msgstr "Ver en Google Maps"
 
@@ -2212,7 +2216,7 @@ msgstr "VENTANAS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:220
+#: src/components/DetailView.tsx:219
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Aviso: Este edificio tiene un registro vencido y se vendió después del vencimiento del registro. La información del dueño que se incluye aquí puede estar desactualizada."
 
@@ -2244,7 +2248,7 @@ msgstr ""
 msgid "We sent a reset link to {email}. Please check your inbox and spam."
 msgstr ""
 
-#: src/containers/VerifyEmailPage.tsx:58
+#: src/containers/VerifyEmailPage.tsx:61
 msgid "We’re having trouble verifying your email at this time."
 msgstr ""
 
@@ -2328,7 +2332,7 @@ msgstr "¿Quién Es El Dueño en Nueva York?"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:200
+#: src/components/DetailView.tsx:199
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
@@ -2389,9 +2393,13 @@ msgstr ""
 #~ msgid "You are viewing the old version of Who Owns What. <0>Switch to the new version.</0>"
 #~ msgstr "You are viewing the old version of Who Owns What. <0>Switch to the new version.</0>"
 
-#: src/containers/VerifyEmailPage.tsx:65
-msgid "You can now start receiving Building Updates"
+#: src/containers/VerifyEmailPage.tsx:71
+msgid "You can now close this window or <0>search for another building</0> to add."
 msgstr ""
+
+#: src/containers/VerifyEmailPage.tsx:65
+#~ msgid "You can now start receiving Building Updates"
+#~ msgstr ""
 
 #: src/components/EmailAlertSignup.tsx:99
 msgid "You have reached the maximum number of Building Updates"
@@ -2413,7 +2421,7 @@ msgstr ""
 #~ msgid "You will be redirected back to Who Owns What in:"
 #~ msgstr ""
 
-#: src/containers/VerifyEmailPage.tsx:67
+#: src/containers/VerifyEmailPage.tsx:76
 msgid "Your email is already verified"
 msgstr ""
 
@@ -2496,7 +2504,7 @@ msgstr "edificio asociado"
 #~ msgid "contact support@justfix.org"
 #~ msgstr ""
 
-#: src/components/DetailView.tsx:245
+#: src/components/DetailView.tsx:244
 msgid "for ${0}"
 msgstr "por ${0}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -2134,13 +2134,17 @@ msgstr "VENTILADORES"
 msgid "Verify your email address"
 msgstr ""
 
+#: src/components/EmailAlertSignup.tsx:58
+msgid "Verify your email to receive updates and to add new buildings."
+msgstr ""
+
 #: src/components/Login.tsx:128
 #~ msgid "Verify your email to start receiving updates"
 #~ msgstr ""
 
 #: src/components/EmailAlertSignup.tsx:58
-msgid "Verify your email to start receiving updates."
-msgstr ""
+#~ msgid "Verify your email to start receiving updates."
+#~ msgstr ""
 
 #: src/components/PortfolioTable.tsx:378
 #: src/components/PortfolioTable.tsx:385

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -937,7 +937,7 @@ msgstr "Información"
 msgid "JANITOR/SUPER"
 msgstr "CONSERJE/SÚPER"
 
-#: src/components/EngagementPanel.tsx:9
+#: src/components/EngagementPanel.tsx:8
 msgid "Join the fight for tenant rights!"
 msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 
@@ -1667,7 +1667,7 @@ msgstr "Envíanos una solicitud de datos"
 #~ msgstr "Comparte esta página con tus vecinos"
 
 #: src/components/DetailView.tsx:264
-#: src/components/EngagementPanel.tsx:19
+#: src/components/EngagementPanel.tsx:18
 #: src/components/PropertiesSummary.tsx:140
 #: src/containers/NotRegisteredPage.tsx:19
 msgid "Share with your neighbors"
@@ -1739,7 +1739,7 @@ msgstr ""
 #~ msgid "Sign up for email updates on the buildings you choose:"
 #~ msgstr ""
 
-#: src/components/EngagementPanel.tsx:13
+#: src/components/EngagementPanel.tsx:12
 msgid "Sign up for our newsletter"
 msgstr ""
 
@@ -2210,7 +2210,7 @@ msgstr "Ver portafolio de edificios"
 msgid "Violations Issued"
 msgstr "Violaciones emitidas"
 
-#: src/components/EngagementPanel.tsx:25
+#: src/components/EngagementPanel.tsx:24
 msgid "Visit our website"
 msgstr "Visite nuestro sitio web"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -937,7 +937,7 @@ msgstr "Información"
 msgid "JANITOR/SUPER"
 msgstr "CONSERJE/SÚPER"
 
-#: src/components/EngagementPanel.tsx:8
+#: src/components/EngagementPanel.tsx:7
 msgid "Join the fight for tenant rights!"
 msgstr "¡Únete a la lucha por los derechos de los inquilinos!"
 
@@ -1667,7 +1667,7 @@ msgstr "Envíanos una solicitud de datos"
 #~ msgstr "Comparte esta página con tus vecinos"
 
 #: src/components/DetailView.tsx:264
-#: src/components/EngagementPanel.tsx:18
+#: src/components/EngagementPanel.tsx:11
 #: src/components/PropertiesSummary.tsx:140
 #: src/containers/NotRegisteredPage.tsx:19
 msgid "Share with your neighbors"
@@ -1740,8 +1740,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/EngagementPanel.tsx:12
-msgid "Sign up for our newsletter"
-msgstr ""
+#~ msgid "Sign up for our newsletter"
+#~ msgstr ""
 
 #: src/components/PropertiesList.tsx:295
 #: src/components/PropertiesList.tsx:300
@@ -2210,7 +2210,7 @@ msgstr "Ver portafolio de edificios"
 msgid "Violations Issued"
 msgstr "Violaciones emitidas"
 
-#: src/components/EngagementPanel.tsx:24
+#: src/components/EngagementPanel.tsx:17
 msgid "Visit our website"
 msgstr "Visite nuestro sitio web"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -87,13 +87,16 @@ msgstr "<0>Renta estabilizada</0> protege a los inquilinos al limitar los aument
 #~ msgid "<0>Search an address</0> to sign up for email alerts for that building."
 #~ msgstr ""
 
-#: src/components/Login.tsx:164
 #: src/containers/UnsubscribePage.tsx:74
 msgid "<0>Search for an address</0> to add to Building Updates"
 msgstr ""
 
 #: src/containers/AccountSettingsPage.tsx:56
 msgid "<0>Search for an address</0> to add to your Building Updates"
+msgstr ""
+
+#: src/components/Login.tsx:164
+msgid "<0>Search for an address</0> to add to your Building Updates, or visit your <1>Account</1>."
 msgstr ""
 
 #: src/containers/NotRegisteredPage.tsx:73
@@ -343,7 +346,7 @@ msgstr ""
 msgid "Check out the issues in this building"
 msgstr "Mira los problemas en este edificio"
 
-#: src/components/Login.tsx:272
+#: src/components/Login.tsx:273
 msgid "Check your email"
 msgstr ""
 
@@ -409,7 +412,7 @@ msgstr "Información de contacto del dueño más clara"
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
-#: src/components/Login.tsx:273
+#: src/components/Login.tsx:274
 msgid "Click the link we sent to <0>{email}</0> to verify your email. It may take a few minutes to arrive. If you can't find it, check your spam and promotions folders for an email from <1>no-reply@justfix.org</1>."
 msgstr ""
 
@@ -487,7 +490,7 @@ msgstr ""
 #~ msgid "Create a password to start receiving Data Updates"
 #~ msgstr ""
 
-#: src/components/Login.tsx:292
+#: src/components/Login.tsx:293
 msgid "Create password"
 msgstr ""
 
@@ -591,7 +594,7 @@ msgstr ""
 msgid "Email"
 msgstr "Email"
 
-#: src/components/Login.tsx:291
+#: src/components/Login.tsx:292
 #: src/components/UserSettingField.tsx:100
 #: src/components/UserSettingField.tsx:105
 #: src/containers/ForgotPasswordPage.tsx:52
@@ -656,7 +659,7 @@ msgstr ""
 #~ msgid "Enter your old password"
 #~ msgstr ""
 
-#: src/components/Login.tsx:292
+#: src/components/Login.tsx:293
 msgid "Enter your password"
 msgstr ""
 
@@ -1057,19 +1060,19 @@ msgstr "Ubicación"
 
 #: src/components/Login.tsx:99
 #: src/components/Login.tsx:137
-#: src/components/Login.tsx:255
-#: src/components/Login.tsx:258
+#: src/components/Login.tsx:256
+#: src/components/Login.tsx:259
 #: src/containers/AccountSettingsPage.tsx:41
 #: src/containers/App.tsx:117
 msgid "Log in"
 msgstr ""
 
-#: src/components/Login.tsx:246
+#: src/components/Login.tsx:247
 #: src/containers/LoginPage.tsx:7
 msgid "Log in / sign up"
 msgstr ""
 
-#: src/components/Login.tsx:256
+#: src/components/Login.tsx:257
 msgid "Log in to add {0} to your Building Updates"
 msgstr ""
 
@@ -1251,7 +1254,7 @@ msgid "New password"
 msgstr ""
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/Login.tsx:263
+#: src/components/Login.tsx:264
 msgid "Next"
 msgstr "Siguiente"
 
@@ -1719,8 +1722,8 @@ msgstr "Mostrar {0} {1, plural, one {resultado} other {resultados}}"
 msgid "Sign up"
 msgstr "Regístrate"
 
-#: src/components/Login.tsx:261
-#: src/components/Login.tsx:266
+#: src/components/Login.tsx:262
+#: src/components/Login.tsx:267
 msgid "Sign up for Building Updates"
 msgstr ""
 
@@ -1801,7 +1804,7 @@ msgstr "Código fuente"
 msgid "Starts {year}"
 msgstr "Comienza {year}"
 
-#: src/components/Login.tsx:252
+#: src/components/Login.tsx:253
 msgid "Submit"
 msgstr ""
 
@@ -2097,7 +2100,7 @@ msgstr "Utilice esta herramienta gratuita de JustFix para investigar tu edificio
 #~ msgid "Use your account to get weekly email updates on the buildings you choose"
 #~ msgstr ""
 
-#: src/components/Login.tsx:247
+#: src/components/Login.tsx:248
 msgid "Use your account to get weekly email updates on {0}."
 msgstr ""
 
@@ -2300,7 +2303,7 @@ msgstr "¿Cuál es la diferencia entre un dueño, un propietario y oficial princ
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "Cuando dos partes comparten la misma dirección comercial, los agrupamos como parte del mismo portafolio."
 
-#: src/components/Login.tsx:267
+#: src/components/Login.tsx:268
 msgid "Which best describes you?"
 msgstr ""
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -487,6 +487,10 @@ msgstr ""
 #~ msgid "Create a password to start receiving Data Updates"
 #~ msgstr ""
 
+#: src/components/Login.tsx:292
+msgid "Create password"
+msgstr ""
+
 #: src/components/UserSettingField.tsx:60
 msgid "Current password"
 msgstr ""
@@ -651,6 +655,10 @@ msgstr ""
 #: src/components/UserSettingField.tsx:58
 #~ msgid "Enter your old password"
 #~ msgstr ""
+
+#: src/components/Login.tsx:292
+msgid "Enter your password"
+msgstr ""
 
 #: src/components/BuildingStatsTable.tsx:83
 #: src/components/IndicatorsDatasets.tsx:128
@@ -1402,7 +1410,6 @@ msgstr "Página"
 #~ msgid "Page {0} of {1}"
 #~ msgstr "Page {0} of {1}"
 
-#: src/components/Login.tsx:292
 #: src/components/UserSettingField.tsx:52
 #: src/components/UserSettingField.tsx:57
 msgid "Password"


### PR DESCRIPTION
A collection of small updates based on feedback from early platbook ux testing.

* [update copy on verify success page](https://github.com/JustFixNYC/who-owns-what/pull/906/commits/e1bfde5874c997902a71c650bb4a907fc1115c5e) - [[sc-14438]](https://app.shortcut.com/justfixnyc/story/14438)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/5af01170-cb28-494a-8d2f-2afc0a21a56a)

* [clarify password label for login vs register](https://github.com/JustFixNYC/who-owns-what/pull/906/commits/b1af1f8ebacf5b8a22521ee8d97404ab81910137) - [[sc-14439]](https://app.shortcut.com/justfixnyc/story/14439)

| login | register |
|--------|--------|
| ![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/51385f82-acf1-48c4-bb68-6a0175e75962) | ![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/cebe0fbe-a9ee-41d6-9c9e-015f47bf3880) | 

* [clarify "verify" message on building page](https://github.com/JustFixNYC/who-owns-what/pull/906/commits/f47d78cf6a4a6253bf56aa7a123b16666ce39858) - [[sc-14446]](https://app.shortcut.com/justfixnyc/story/14446)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/728a2d86-133b-427b-bd8b-2df6b484dc5e)

* [add account link to login success message](https://github.com/JustFixNYC/who-owns-what/pull/906/commits/5b9d77637352ca8ec311d1815446c984c96fa8e8) - [[sc-14447]](https://app.shortcut.com/justfixnyc/story/14447)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/1c460f78-c72d-42c8-b6a0-10463f631bab)

* [remove newsletter from homepage](https://github.com/JustFixNYC/who-owns-what/pull/906/commits/083eb216f305225d2f43db09dbc1af1392054d57) - [[sc-14440]](https://app.shortcut.com/justfixnyc/story/14440)
  * update: now removed from all pages, not just homepage. 
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/c0a136ab-5653-40f9-bb4a-08912fdeffa2)
