### PR TITLE
Add analytics tags for email alerts

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -44,6 +44,8 @@ const fetchUser = async () => {
       _user = {
         email: authCheck["email"],
         verified: authCheck["verified"],
+        id: authCheck["id"],
+        type: authCheck["type"],
         subscriptions,
       };
     } else {

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -57,7 +57,6 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const [showSubscriptionLimitModal, setShowSubscriptionLimitModal] = useState(false);
 
   const navigateToLogin = () => {
-    // logAmplitudeEvent("registerLoginViaBuilding");
     window.gtag("event", "register-login-via-building");
     const loginRoute = `/${i18n.language}${account.login}`;
     history.push({ pathname: loginRoute, state: { addr } });
@@ -99,24 +98,21 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
         className="is-full-width"
         onClick={() => {
           AuthClient.resendVerifyEmail();
-          const eventParams = { ...eventUserParams, from: "building page" };
-          // logAmplitudeEvent("emailVerifyResend", eventParams);
-          window.gtag("event", "email-verify-resend", { ...eventParams });
+          const params = { ...eventUserParams, from: "building page" };
+          window.gtag("event", "email-verify-resend", { ...params });
         }}
       />
     </>
   );
 
   const subscribeToBuilding = (addr: AddressRecord) => {
-    // logAmplitudeEvent("subscribeBuildingPage", gtagUserParams);
-    window.gtag("event", "subscribe-building-page", eventUserParams);
+    window.gtag("event", "subscribe-building-page", { ...eventUserParams });
     subscribe(addr.bbl, addr.housenumber, addr.streetname, addr.zip ?? "", addr.boro);
   };
 
   const handleSubscriptionLimitReached = () => {
-    const eventParams = { ...eventUserParams, limit: SUBSCRIPTION_LIMIT };
-    // logAmplitudeEvent("subscriptionLimitExceedAttempt", eventParams);
-    window.gtag("event", "subscription-limit-exceed-attempt", eventParams);
+    const params = { ...eventUserParams, limit: SUBSCRIPTION_LIMIT };
+    window.gtag("event", "subscription-limit-exceed-attempt", { ...params });
     setShowSubscriptionLimitModal(true);
   };
 
@@ -189,8 +185,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
             rel="noopener noreferrer"
             onClick={() => {
               const eventParams = { ...eventUserParams, limit: SUBSCRIPTION_LIMIT };
-              // logAmplitudeEvent("subscriptionLimitRequest", eventParams);
-              window.gtag("event", "subscription-limit-request", eventParams);
+              window.gtag("event", "subscription-limit-request", { ...eventParams });
             }}
           >
             request form

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -51,10 +51,14 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const showSubscribed =
     (justSubscribed && !!user?.verified) || !!user?.subscriptions?.find((s) => s.bbl === addr.bbl);
 
+  const eventUserParams = { user_id: user?.id, user_type: user?.type };
+
   const [isEmailResent, setIsEmailResent] = React.useState(false);
   const [showSubscriptionLimitModal, setShowSubscriptionLimitModal] = useState(false);
 
   const navigateToLogin = () => {
+    // logAmplitudeEvent("registerLoginViaBuilding");
+    window.gtag("event", "register-login-via-building");
     const loginRoute = `/${i18n.language}${account.login}`;
     history.push({ pathname: loginRoute, state: { addr } });
   };
@@ -93,13 +97,27 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
       <SendNewLink
         setParentState={setIsEmailResent}
         className="is-full-width"
-        onClick={() => AuthClient.resendVerifyEmail()}
+        onClick={() => {
+          AuthClient.resendVerifyEmail();
+          const eventParams = { ...eventUserParams, from: "building page" };
+          // logAmplitudeEvent("emailVerifyResend", eventParams);
+          window.gtag("event", "email-verify-resend", eventParams);
+        }}
       />
     </>
   );
 
   const subscribeToBuilding = (addr: AddressRecord) => {
+    // logAmplitudeEvent("subscribeBuildingPage", gtagUserParams);
+    window.gtag("event", "subscribe-building-page", eventUserParams);
     subscribe(addr.bbl, addr.housenumber, addr.streetname, addr.zip ?? "", addr.boro);
+  };
+
+  const handleSubscriptionLimitReached = () => {
+    const eventParams = { ...eventUserParams, limit: SUBSCRIPTION_LIMIT };
+    // logAmplitudeEvent("subscriptionLimitExceedAttempt", eventParams);
+    window.gtag("event", "subscription-limit-exceed-attempt", eventParams);
+    setShowSubscriptionLimitModal(true);
   };
 
   const renderAddBuilding = () => {
@@ -121,7 +139,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
             !isLoggedIn
               ? navigateToLogin()
               : atSubscriptionLimit
-              ? setShowSubscriptionLimitModal(true)
+              ? handleSubscriptionLimitReached()
               : subscribeToBuilding(addr);
           }}
         />
@@ -169,6 +187,11 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
             href={`https://form.typeform.com/to/ChJMCNYN#email=${user?.email}`}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() => {
+              const eventParams = { ...eventUserParams, limit: SUBSCRIPTION_LIMIT };
+              // logAmplitudeEvent("subscriptionLimitRequest", eventParams);
+              window.gtag("event", "subscription-limit-request", eventParams);
+            }}
           >
             request form
           </a>

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -79,6 +79,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
         onClick={() => {
           unsubscribe(addr.bbl);
           setJustSubscribed(false);
+          window.gtag("event", "unsubscribe-building", { from: "building page" });
         }}
       />
     </>

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -79,7 +79,8 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
         onClick={() => {
           unsubscribe(addr.bbl);
           setJustSubscribed(false);
-          window.gtag("event", "unsubscribe-building", { from: "building page" });
+          const params = { ...eventUserParams, from: "building page" };
+          window.gtag("event", "unsubscribe-building", { ...params });
         }}
       />
     </>

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -101,7 +101,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
           AuthClient.resendVerifyEmail();
           const eventParams = { ...eventUserParams, from: "building page" };
           // logAmplitudeEvent("emailVerifyResend", eventParams);
-          window.gtag("event", "email-verify-resend", eventParams);
+          window.gtag("event", "email-verify-resend", { ...eventParams });
         }}
       />
     </>

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -218,7 +218,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
               <button
                 className="button is-text ml-2"
                 onClick={() => {
-                  // logAmplitudeEvent("swapRegisterLogin", { ...eventParams(), to: "login" });
                   window.gtag("event", "swap-register-login", { ...eventParams(), to: "login" });
                   toggleLoginSignup(Step.Login);
                 }}
@@ -232,7 +231,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
               <button
                 className="button is-text ml-2 pt-6"
                 onClick={() => {
-                  // logAmplitudeEvent("swapRegisterLogin", { ...eventParams(), to: "register" });
                   window.gtag("event", "swap-register-login", { ...eventParams(), to: "register" });
                   toggleLoginSignup(Step.RegisterAccount);
                 }}
@@ -260,7 +258,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
           onClick={() => {
             AuthClient.resendVerifyEmail();
             const from = (!!addr ? "building page " : "nav ") + loginOrRegister;
-            // logAmplitudeEvent("emailVerifyResend", { ...eventParams(), from });
             window.gtag("event", "email-verify-resend", { ...eventParams(), from });
           }}
         />
@@ -270,10 +267,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
           <Link
             to={{ pathname: getAddrPageRoute(addr), state: { justSubscribed: true } }}
             component={JFCLLink}
-            onClick={() => {
-              // logAmplitudeEvent("registerReturnAddress");
-              window.gtag("event", "register-return-address");
-            }}
+            onClick={() => window.gtag("event", "register-return-address")}
           >
             <IconLinkInternal />
             Back to {formatAddr(addr)}
@@ -293,7 +287,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
   );
 
   const onEmailSubmit = async () => {
-    // logAmplitudeEvent("registerLoginEmail", gtagParams());
     window.gtag("event", "register-login-email", eventParams());
 
     if (!email || emailError) {
@@ -307,7 +300,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
   };
 
   const onLoginSubmit = async () => {
-    // logAmplitudeEvent("loginPassword", gtagParams());
     window.gtag("event", "login-password", eventParams());
 
     resetAlertErrorStates();
@@ -332,13 +324,11 @@ const LoginWithoutI18n = (props: withI18nProps) => {
       return;
     }
 
-    // logAmplitudeEvent("loginSuccess", gtagParams(resp.user));
     window.gtag("event", "login-success", eventParams(resp?.user));
 
     if (!!addr) {
       const subscribeEventParams = { ...eventParams(), via: "login" };
-      // logAmplitudeEvent("subscribeBuildingViaRegisterLogin", subscribeEventParams);
-      window.gtag("event", "subscribe-building-via-register-login", subscribeEventParams);
+      window.gtag("event", "subscribe-building-via-register-login", { ...subscribeEventParams });
     }
 
     if (!resp?.user?.verified) {
@@ -358,7 +348,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
   };
 
   const onAccountSubmit = async () => {
-    // logAmplitudeEvent("registerPassword", gtagParams());
     window.gtag("event", "register-password", eventParams());
 
     if (!email || emailError) {
@@ -369,14 +358,12 @@ const LoginWithoutI18n = (props: withI18nProps) => {
 
     const existingUser = await AuthClient.isEmailAlreadyUsed(email);
     if (existingUser) {
-      // logAmplitudeEvent("registerExistingserError", eventParams());
       window.gtag("event", "register-existing-user-error", eventParams());
       setExistingUserError(true);
       return;
     }
 
     if (!password || passwordError) {
-      // logAmplitudeEvent("registerPasswordError", eventParams());
       window.gtag("event", "register-password-error", eventParams());
       setPasswordError(true);
       setShowPasswordError(true);
@@ -387,7 +374,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
   };
 
   const onUserTypeSubmit = async () => {
-    // logAmplitudeEvent("registerUserType", gtagParams());
     window.gtag("event", "register-user-type", eventParams());
 
     if (!userType || userTypeError) {
@@ -404,13 +390,11 @@ const LoginWithoutI18n = (props: withI18nProps) => {
       return;
     }
 
-    // logAmplitudeEvent("registerSuccess", gtagParams(resp?.user));
     window.gtag("event", "register-success", eventParams(resp?.user));
 
     if (!!addr) {
       const subscribeEventParams = { ...eventParams(), via: "register" };
-      // logAmplitudeEvent("subscribeBuildingViaRegisterLogin", subscribeEventParams);
-      window.gtag("event", "subscribe-building-via-register-login", subscribeEventParams);
+      window.gtag("event", "subscribe-building-via-register-login", { ...subscribeEventParams });
     }
 
     setLoginOrRegister("register");

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -34,6 +34,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
   const { i18n } = props;
 
   const userContext = useContext(UserContext);
+  const { user } = userContext;
   const { home, account } = createWhoOwnsWhatRoutePaths();
   const history = useHistory();
   const location = useLocation();
@@ -258,7 +259,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
           onClick={() => {
             AuthClient.resendVerifyEmail();
             const from = (!!addr ? "building page " : "nav ") + loginOrRegister;
-            window.gtag("event", "email-verify-resend", { ...eventParams(), from });
+            window.gtag("event", "email-verify-resend", { ...eventParams(user), from });
           }}
         />
       </div>
@@ -267,7 +268,9 @@ const LoginWithoutI18n = (props: withI18nProps) => {
           <Link
             to={{ pathname: getAddrPageRoute(addr), state: { justSubscribed: true } }}
             component={JFCLLink}
-            onClick={() => window.gtag("event", "register-return-address")}
+            onClick={() =>
+              window.gtag("event", "register-return-address", { ...eventParams(user) })
+            }
           >
             <IconLinkInternal />
             Back to {formatAddr(addr)}
@@ -321,6 +324,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
 
     if (!!resp?.error) {
       setInvalidAuthError(true);
+      window.gtag("event", "login-password-invalid", eventParams());
       return;
     }
 

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -20,7 +20,6 @@ import { createRouteForAddressPage, createWhoOwnsWhatRoutePaths } from "routes";
 import { AddressRecord } from "./APIDataTypes";
 import { isLegacyPath } from "./WowzaToggle";
 import { Nobr } from "./Nobr";
-import { logAmplitudeEvent } from "./Amplitude";
 
 enum Step {
   CheckEmail,

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -327,7 +327,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
     window.gtag("event", "login-success", eventParams(resp?.user));
 
     if (!!addr) {
-      const subscribeEventParams = { ...eventParams(), via: "login" };
+      const subscribeEventParams = { ...eventParams(), from: "login" };
       window.gtag("event", "subscribe-building-via-register-login", { ...subscribeEventParams });
     }
 
@@ -393,7 +393,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
     window.gtag("event", "register-success", eventParams(resp?.user));
 
     if (!!addr) {
-      const subscribeEventParams = { ...eventParams(), via: "register" };
+      const subscribeEventParams = { ...eventParams(), from: "register" };
       window.gtag("event", "subscribe-building-via-register-login", { ...subscribeEventParams });
     }
 

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -120,7 +120,11 @@ const PasswordInputWithoutI18n = forwardRef<HTMLInputElement, PasswordInputProps
           <button
             type="button"
             className="show-hide-toggle"
-            onClick={() => setShowPassword(!showPassword)}
+            onClick={() => {
+              // logAmplitudeEvent("passwordVisibilityToggle");
+              window.gtag("event", "password-visibility-toggle");
+              setShowPassword(!showPassword);
+            }}
           >
             {showPassword ? <HideIcon /> : <ShowIcon />}
           </button>

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -121,7 +121,6 @@ const PasswordInputWithoutI18n = forwardRef<HTMLInputElement, PasswordInputProps
             type="button"
             className="show-hide-toggle"
             onClick={() => {
-              // logAmplitudeEvent("passwordVisibilityToggle");
               window.gtag("event", "password-visibility-toggle");
               setShowPassword(!showPassword);
             }}

--- a/client/src/components/SendNewLink.tsx
+++ b/client/src/components/SendNewLink.tsx
@@ -47,6 +47,6 @@ const SendNewLinkWithoutI18n = (props: SendNewLinkProps) => {
   );
 };
 
-const BuildingStatsTable = withI18n()(SendNewLinkWithoutI18n);
+const SendNewLink = withI18n()(SendNewLinkWithoutI18n);
 
-export default BuildingStatsTable;
+export default SendNewLink;

--- a/client/src/components/StandalonePage.tsx
+++ b/client/src/components/StandalonePage.tsx
@@ -9,12 +9,49 @@ import { createWhoOwnsWhatRoutePaths } from "routes";
 import { JFCLLocaleLink, LocaleLink } from "i18n";
 import { Trans } from "@lingui/macro";
 import { JFLogo } from "./JFLogo";
+import { useLocation } from "react-router-dom";
 
-export const StandalonePageFooter = () => {
+export const STANDALONE_PAGES = [
+  "forgot-password",
+  "login",
+  "verify-email",
+  "forgot-password",
+  "reset-password",
+  "unsubscribe",
+];
+
+export const JustFixLogoLink = (eventParams: any) => {
   const { home } = createWhoOwnsWhatRoutePaths();
+
+  return (
+    <LocaleLink
+      className="jf-logo"
+      to={home}
+      onClick={() => {
+        // logAmplitudeEvent("standaloneJustfixLogoClick", eventParams);
+        window.gtag("event", "standalone-justfix-logo-click", eventParams);
+      }}
+    >
+      <JFLogo />
+    </LocaleLink>
+  );
+};
+
+export const StandalonePageFooter = (eventParams: any) => {
+  const { home } = createWhoOwnsWhatRoutePaths();
+
   return (
     <Trans render="div" className="wow-footer">
-      <JFCLLocaleLink to={home}>Who Owns What</JFCLLocaleLink> by JustFix.
+      <JFCLLocaleLink
+        to={home}
+        onClick={() => {
+          // logAmplitudeEvent("standaloneWowLinkClick", eventParams);
+          window.gtag("event", "standalone-wow-link-click", eventParams);
+        }}
+      >
+        Who Owns What
+      </JFCLLocaleLink>{" "}
+      by JustFix.
       <br />
       Read our{" "}
       <JFCLLink
@@ -44,16 +81,17 @@ type StandalonePageProps = withI18nProps & {
 
 const StandalonePage = withI18n()((props: StandalonePageProps) => {
   const { title, className, children } = props;
-  const { home } = createWhoOwnsWhatRoutePaths();
+  const { pathname } = useLocation();
+  const pageName = STANDALONE_PAGES.find((x) => pathname.includes(x));
+  const eventParams = { from: pageName };
+
   return (
     <Page title={title}>
       <div className={classNames("StandalonePage Page", className)}>
         <div className="page-container">
-          <LocaleLink className="jf-logo" to={home}>
-            <JFLogo />
-          </LocaleLink>
+          <JustFixLogoLink eventParams={eventParams} />
           <div className="standalone-container">{children}</div>
-          <StandalonePageFooter />
+          <StandalonePageFooter eventParams={eventParams} />
         </div>
       </div>
     </Page>

--- a/client/src/components/StandalonePage.tsx
+++ b/client/src/components/StandalonePage.tsx
@@ -28,8 +28,7 @@ export const JustFixLogoLink = (eventParams: any) => {
       className="jf-logo"
       to={home}
       onClick={() => {
-        // logAmplitudeEvent("standaloneJustfixLogoClick", eventParams);
-        window.gtag("event", "standalone-justfix-logo-click", eventParams);
+        window.gtag("event", "standalone-justfix-logo-click", { ...eventParams });
       }}
     >
       <JFLogo />
@@ -45,8 +44,7 @@ export const StandalonePageFooter = (eventParams: any) => {
       <JFCLLocaleLink
         to={home}
         onClick={() => {
-          // logAmplitudeEvent("standaloneWowLinkClick", eventParams);
-          window.gtag("event", "standalone-wow-link-click", eventParams);
+          window.gtag("event", "standalone-wow-link-click", { ...eventParams });
         }}
       >
         Who Owns What

--- a/client/src/components/StandalonePage.tsx
+++ b/client/src/components/StandalonePage.tsx
@@ -20,7 +20,7 @@ export const STANDALONE_PAGES = [
   "unsubscribe",
 ];
 
-export const JustFixLogoLink = (eventParams: any) => {
+export const JustFixLogoLink = (props: { eventParams: any }) => {
   const { home } = createWhoOwnsWhatRoutePaths();
 
   return (
@@ -28,7 +28,7 @@ export const JustFixLogoLink = (eventParams: any) => {
       className="jf-logo"
       to={home}
       onClick={() => {
-        window.gtag("event", "standalone-justfix-logo-click", { ...eventParams });
+        window.gtag("event", "standalone-justfix-logo-click", { ...props.eventParams });
       }}
     >
       <JFLogo />
@@ -36,7 +36,7 @@ export const JustFixLogoLink = (eventParams: any) => {
   );
 };
 
-export const StandalonePageFooter = (eventParams: any) => {
+export const StandalonePageFooter = (props: { eventParams: any }) => {
   const { home } = createWhoOwnsWhatRoutePaths();
 
   return (
@@ -44,7 +44,7 @@ export const StandalonePageFooter = (eventParams: any) => {
       <JFCLLocaleLink
         to={home}
         onClick={() => {
-          window.gtag("event", "standalone-wow-link-click", { ...eventParams });
+          window.gtag("event", "standalone-wow-link-click", { ...props.eventParams });
         }}
       >
         Who Owns What
@@ -81,14 +81,15 @@ const StandalonePage = withI18n()((props: StandalonePageProps) => {
   const { title, className, children } = props;
   const { pathname } = useLocation();
   const pageName = STANDALONE_PAGES.find((x) => pathname.includes(x));
+  const eventParams = { from: pageName };
 
   return (
     <Page title={title}>
       <div className={classNames("StandalonePage Page", className)}>
         <div className="page-container">
-          <JustFixLogoLink eventParams={{ from: pageName }} />
+          <JustFixLogoLink eventParams={eventParams} />
           <div className="standalone-container">{children}</div>
-          <StandalonePageFooter eventParams={{ from: pageName }} />
+          <StandalonePageFooter eventParams={eventParams} />
         </div>
       </div>
     </Page>

--- a/client/src/components/StandalonePage.tsx
+++ b/client/src/components/StandalonePage.tsx
@@ -81,15 +81,14 @@ const StandalonePage = withI18n()((props: StandalonePageProps) => {
   const { title, className, children } = props;
   const { pathname } = useLocation();
   const pageName = STANDALONE_PAGES.find((x) => pathname.includes(x));
-  const eventParams = { from: pageName };
 
   return (
     <Page title={title}>
       <div className={classNames("StandalonePage Page", className)}>
         <div className="page-container">
-          <JustFixLogoLink eventParams={eventParams} />
+          <JustFixLogoLink eventParams={{ from: pageName }} />
           <div className="standalone-container">{children}</div>
-          <StandalonePageFooter eventParams={eventParams} />
+          <StandalonePageFooter eventParams={{ from: pageName }} />
         </div>
       </div>
     </Page>

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -22,7 +22,10 @@ type PasswordSettingFieldProps = withI18nProps & {
 const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
   const { i18n, onSubmit } = props;
   const userContext = useContext(UserContext);
-  const { email } = userContext.user as JustfixUser;
+  const user = userContext.user as JustfixUser;
+  const { email } = user;
+  const eventUserParams = { user_id: user.id, user_type: user.type };
+
   const {
     value: currentPassword,
     error: currentPasswordError,
@@ -67,6 +70,9 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
     }
 
     onSubmit(currentPassword, newPassword);
+
+    // logAmplitudeEvent("accountUpdatePassword", eventUserParams);
+    window.gtag("event", "account-update-password", eventUserParams);
   };
 
   return (
@@ -119,7 +125,8 @@ type EmailSettingFieldProps = withI18nProps & {
 const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
   const { i18n, currentValue, onSubmit } = props;
   const userContext = useContext(UserContext);
-  const { email: oldEmail, verified } = userContext.user as JustfixUser;
+  const user = userContext.user as JustfixUser;
+  const { email: oldEmail, verified } = user;
   const [isEmailResent, setIsEmailResent] = React.useState(false);
   const [existingUserError, setExistingUserError] = useState(false);
   const {
@@ -130,6 +137,8 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
     setShowError: setShowEmailError,
     onChange: onChangeEmail,
   } = useInput(oldEmail);
+
+  const eventUserParams = { user_id: user.id, user_type: user.type };
 
   const handleSubmit = async () => {
     setExistingUserError(false);
@@ -154,6 +163,9 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
     }
 
     onSubmit(email);
+
+    // logAmplitudeEvent("accountUpdateEmail", eventUserParams);
+    window.gtag("event", "account-update-email", eventUserParams);
   };
 
   const verifyCallout = !verified ? (
@@ -165,7 +177,12 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
       {!isEmailResent && <Trans render="p">Didn’t get the link?</Trans>}
       <SendNewLink
         setParentState={setIsEmailResent}
-        onClick={() => AuthClient.resendVerifyEmail()}
+        onClick={() => {
+          AuthClient.resendVerifyEmail();
+          const eventParams = { ...eventUserParams, from: "account settings" };
+          // logAmplitudeEvent("emailVerifyResend", eventParams);
+          window.gtag("event", "email-verify-resend", eventParams);
+        }}
       />
     </div>
   ) : undefined;

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -71,8 +71,7 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
 
     onSubmit(currentPassword, newPassword);
 
-    // logAmplitudeEvent("accountUpdatePassword", eventUserParams);
-    window.gtag("event", "account-update-password", eventUserParams);
+    window.gtag("event", "account-update-password", { ...eventUserParams });
   };
 
   return (
@@ -139,6 +138,7 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
   } = useInput(oldEmail);
 
   const eventUserParams = { user_id: user.id, user_type: user.type };
+  console.log({ user, eventUserParams });
 
   const handleSubmit = async () => {
     setExistingUserError(false);
@@ -164,8 +164,7 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
 
     onSubmit(email);
 
-    // logAmplitudeEvent("accountUpdateEmail", eventUserParams);
-    window.gtag("event", "account-update-email", eventUserParams);
+    window.gtag("event", "account-update-email", { ...eventUserParams });
   };
 
   const verifyCallout = !verified ? (
@@ -180,8 +179,7 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
         onClick={() => {
           AuthClient.resendVerifyEmail();
           const eventParams = { ...eventUserParams, from: "account settings" };
-          // logAmplitudeEvent("emailVerifyResend", eventParams);
-          window.gtag("event", "email-verify-resend", eventParams);
+          window.gtag("event", "email-verify-resend", { ...eventParams });
         }}
       />
     </div>

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -56,10 +56,19 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const userContext = useContext(UserContext);
   if (!userContext.user) return <div />;
-
-  const { email, subscriptions } = userContext.user as JustfixUser;
+  const user = userContext.user as JustfixUser;
+  const { email, subscriptions } = user;
   const subscriptionsNumber = !!subscriptions ? subscriptions.length : 0;
   const { home } = createWhoOwnsWhatRoutePaths();
+
+  const unsubscribeBuilding = (bbl: string) => {
+    userContext.unsubscribe(bbl);
+    window.gtag("event", "unsubscribe-building", {
+      user_id: user.id,
+      user_type: user.type,
+      from: "account settings",
+    });
+  };
 
   return (
     <Page title={i18n._(t`Account`)}>
@@ -90,7 +99,7 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
               {subscriptions?.length ? (
                 <>
                   {subscriptions.map((s) => (
-                    <SubscriptionField key={s.bbl} {...s} onRemoveClick={userContext.unsubscribe} />
+                    <SubscriptionField key={s.bbl} {...s} onRemoveClick={unsubscribeBuilding} />
                   ))}
                 </>
               ) : (

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -16,6 +16,7 @@ import {
   LocaleSwitcher,
   LocaleSwitcherWithFullLanguageName,
   JFCLLocaleLink,
+  removeLocalePrefix,
 } from "../i18n";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { createWhoOwnsWhatRoutePaths } from "../routes";
@@ -224,7 +225,7 @@ const getAccountNavLinks = (
         </LocaleNavLink>,
         <button
           onClick={() => {
-            window.gtag("event", "nav-logout", { from: fromPath });
+            window.gtag("event", "nav-logout", { from: removeLocalePrefix(fromPath) });
             handleLogout(fromPath);
           }}
           key="account-2"
@@ -236,7 +237,7 @@ const getAccountNavLinks = (
         <LocaleNavLink
           to={login}
           key="account-3"
-          onClick={() => window.gtag("event", "nav-login", { from: fromPath })}
+          onClick={() => window.gtag("event", "nav-login", { from: removeLocalePrefix(fromPath) })}
         >
           <Trans>Log in</Trans>
         </LocaleNavLink>,

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -49,6 +49,7 @@ import UnsubscribePage from "./UnsubscribePage";
 import LoginPage from "./LoginPage";
 import { JFLogo } from "components/JFLogo";
 import logoDivider from "../assets/img/logo-divider.svg";
+import { STANDALONE_PAGES } from "components/StandalonePage";
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -221,12 +222,26 @@ const getAccountNavLinks = (
         <LocaleNavLink to={settings} key="account-1">
           <Trans>Account</Trans>
         </LocaleNavLink>,
-        <button onClick={() => handleLogout(fromPath)} key="account-2">
+        <button
+          onClick={() => {
+            // logAmplitudeEvent("navLogout");
+            window.gtag("event", "nav-logout", { from: fromPath });
+            handleLogout(fromPath);
+          }}
+          key="account-2"
+        >
           <Trans>Log out</Trans>
         </button>,
       ]
     : [
-        <LocaleNavLink to={login} key="account-3">
+        <LocaleNavLink
+          to={login}
+          key="account-3"
+          onClick={() => {
+            // logAmplitudeEvent("navLogin");
+            window.gtag("event", "nav-login", { from: fromPath });
+          }}
+        >
           <Trans>Log in</Trans>
         </LocaleNavLink>,
       ];
@@ -264,15 +279,7 @@ const Navbar = () => {
 
   const userContext = useContext(UserContext);
 
-  const standalonePages = [
-    "forgot-password",
-    "login",
-    "verify-email",
-    "forgot-password",
-    "reset-password",
-    "unsubscribe",
-  ];
-  const hideNavbar = standalonePages.some((v) => pathname.includes(`account/${v}`));
+  const hideNavbar = STANDALONE_PAGES.some((v) => pathname.includes(`account/${v}`));
 
   return hideNavbar ? null : (
     <div

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -224,7 +224,6 @@ const getAccountNavLinks = (
         </LocaleNavLink>,
         <button
           onClick={() => {
-            // logAmplitudeEvent("navLogout");
             window.gtag("event", "nav-logout", { from: fromPath });
             handleLogout(fromPath);
           }}
@@ -237,10 +236,7 @@ const getAccountNavLinks = (
         <LocaleNavLink
           to={login}
           key="account-3"
-          onClick={() => {
-            // logAmplitudeEvent("navLogin");
-            window.gtag("event", "nav-login", { from: fromPath });
-          }}
+          onClick={() => window.gtag("event", "nav-login", { from: fromPath })}
         >
           <Trans>Log in</Trans>
         </LocaleNavLink>,

--- a/client/src/containers/ForgotPasswordPage.tsx
+++ b/client/src/containers/ForgotPasswordPage.tsx
@@ -39,7 +39,6 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
     }
     sendResetEmail();
     setRequestSent(true);
-    // logAmplitudeEvent("forgotPasswordRequest");
     window.gtag("event", "forgot-password-request");
   };
 
@@ -96,7 +95,6 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
               size="large"
               onClick={() => {
                 sendResetEmail();
-                // logAmplitudeEvent("forgotPasswordResend");
                 window.gtag("event", "forgot-password-resend");
               }}
             />

--- a/client/src/containers/ForgotPasswordPage.tsx
+++ b/client/src/containers/ForgotPasswordPage.tsx
@@ -39,6 +39,8 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
     }
     sendResetEmail();
     setRequestSent(true);
+    // logAmplitudeEvent("forgotPasswordRequest");
+    window.gtag("event", "forgot-password-request");
   };
 
   const sendResetEmail = async () => {
@@ -92,7 +94,11 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
             <SendNewLink
               setParentState={setRequestSentAgain}
               size="large"
-              onClick={sendResetEmail}
+              onClick={() => {
+                sendResetEmail();
+                // logAmplitudeEvent("forgotPasswordResend");
+                window.gtag("event", "forgot-password-resend");
+              }}
             />
           </div>
         </>

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -40,21 +40,17 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
       setTokenStatus(result.statusCode);
       switch (result.statusCode) {
         case ResetStatusCode.Expired:
-          // logAmplitudeEvent("forgotPasswordExpired");
           window.gtag("event", "forgot-password-expired");
           break;
         case ResetStatusCode.Invalid:
-          // logAmplitudeEvent("forgotPasswordInvalid");
           window.gtag("event", "forgot-password-invalid");
           break;
         case ResetStatusCode.Unknown:
-          // logAmplitudeEvent("forgotPasswordEmailLinkError");
           window.gtag("event", "forgot-password-email-link-error");
           break;
       }
     });
 
-    // logAmplitudeEvent("forgotPasswordEmailLink");
     window.gtag("event", "forgot-password-email-link");
   }, []);
 
@@ -70,10 +66,8 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
     const resp = await AuthClient.resetPassword(params.get("token") || "", password);
     setResetStatus(resp.statusCode);
     if (resp.statusCode === ResetStatusCode.Success) {
-      // logAmplitudeEvent("forgotPasswordResetSuccess");
       window.gtag("event", "forgot-password-reset-success");
     } else {
-      // logAmplitudeEvent("forgotPasswordResetError");
       window.gtag("event", "forgot-password-reset-error");
     }
   };
@@ -89,9 +83,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
       <SendNewLink
         setParentState={setEmailIsResent}
         size="large"
-        onClick={async () => {
-          setEmailIsResent(await AuthClient.resetPasswordRequest());
-        }}
+        onClick={async () => setEmailIsResent(await AuthClient.resetPasswordRequest())}
       />
     </>
   );
@@ -104,10 +96,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
         <LocaleLink
           className="jfcl-button jfcl-variant-primary jfcl-size-large"
           to={account.forgotPassword}
-          onClick={() => {
-            // logAmplitudeEvent("forgotPasswordResetResend");
-            window.gtag("event", "forgot-password-reset-resend");
-          }}
+          onClick={() => window.gtag("event", "forgot-password-reset-resend")}
         >
           <Trans>Request new link</Trans>
         </LocaleLink>
@@ -144,10 +133,7 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
       <div className="standalone-footer">
         <JFCLLocaleLink
           to={account.login}
-          onClick={() => {
-            // logAmplitudeEvent("forgotPasswordResetReturnLogin");
-            window.gtag("event", "forgot-password-reset-return-login");
-          }}
+          onClick={() => window.gtag("event", "forgot-password-reset-return-login")}
         >
           <Trans>Back to Log in</Trans>
         </JFCLLocaleLink>

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -38,7 +38,24 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
 
     asyncCheckToken().then((result) => {
       setTokenStatus(result.statusCode);
+      switch (result.statusCode) {
+        case ResetStatusCode.Expired:
+          // logAmplitudeEvent("forgotPasswordExpired");
+          window.gtag("event", "forgot-password-expired");
+          break;
+        case ResetStatusCode.Invalid:
+          // logAmplitudeEvent("forgotPasswordInvalid");
+          window.gtag("event", "forgot-password-invalid");
+          break;
+        case ResetStatusCode.Unknown:
+          // logAmplitudeEvent("forgotPasswordEmailLinkError");
+          window.gtag("event", "forgot-password-email-link-error");
+          break;
+      }
     });
+
+    // logAmplitudeEvent("forgotPasswordEmailLink");
+    window.gtag("event", "forgot-password-email-link");
   }, []);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -52,6 +69,13 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
 
     const resp = await AuthClient.resetPassword(params.get("token") || "", password);
     setResetStatus(resp.statusCode);
+    if (resp.statusCode === ResetStatusCode.Success) {
+      // logAmplitudeEvent("forgotPasswordResetSuccess");
+      window.gtag("event", "forgot-password-reset-success");
+    } else {
+      // logAmplitudeEvent("forgotPasswordResetError");
+      window.gtag("event", "forgot-password-reset-error");
+    }
   };
 
   const expiredPage = () => (
@@ -80,6 +104,10 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
         <LocaleLink
           className="jfcl-button jfcl-variant-primary jfcl-size-large"
           to={account.forgotPassword}
+          onClick={() => {
+            // logAmplitudeEvent("forgotPasswordResetResend");
+            window.gtag("event", "forgot-password-reset-resend");
+          }}
         >
           <Trans>Request new link</Trans>
         </LocaleLink>
@@ -114,7 +142,13 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
     <>
       <Trans render="h1">Password reset successful</Trans>
       <div className="standalone-footer">
-        <JFCLLocaleLink to={account.login}>
+        <JFCLLocaleLink
+          to={account.login}
+          onClick={() => {
+            // logAmplitudeEvent("forgotPasswordResetReturnLogin");
+            window.gtag("event", "forgot-password-reset-return-login");
+          }}
+        >
           <Trans>Back to Log in</Trans>
         </JFCLLocaleLink>
       </div>

--- a/client/src/containers/UnsubscribePage.tsx
+++ b/client/src/containers/UnsubscribePage.tsx
@@ -46,13 +46,13 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
   const handleUnsubscribeBuilding = async (bbl: string) => {
     const result = await AuthClient.emailUnsubscribeBuilding(bbl, token);
     if (!!result?.["subscriptions"]) setSubscriptions(result["subscriptions"]);
-    window.gtag("event", "unsubscribe-building", { from: "manage subscriptions page" });
+    window.gtag("event", "unsubscribe-building", { from: "manage subscriptions" });
   };
 
-  const handleUnsubscribeAll = async () => {
+  const handleUnsubscribeAll = async (from: string) => {
     const result = await AuthClient.emailUnsubscribeAll(token);
     if (!!result?.["subscriptions"]) setSubscriptions(result["subscriptions"]);
-    window.gtag("event", "unsubscribe-building-all", { from: "manage subscriptions page" });
+    window.gtag("event", "unsubscribe-building-all", { from: from });
   };
 
   const renderUnsubscribePage = () => (
@@ -67,7 +67,7 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
         variant="primary"
         size="large"
         labelText={i18n._(t`Unsubscribe from all`)}
-        onClick={handleUnsubscribeAll}
+        onClick={() => () => handleUnsubscribeAll("unsubscribe")}
       />
     </>
   );
@@ -88,7 +88,7 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
             variant="secondary"
             size="small"
             labelText={i18n._(t`Unsubscribe from all`)}
-            onClick={handleUnsubscribeAll}
+            onClick={() => handleUnsubscribeAll("manage subscriptions")}
           />
         </div>
       </div>

--- a/client/src/containers/UnsubscribePage.tsx
+++ b/client/src/containers/UnsubscribePage.tsx
@@ -37,10 +37,8 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
     asyncFetchSubscriptions();
 
     if (isEmailUnsubscribeAll) {
-      // logAmplitudeEvent("unsubscribeBuildingAllEmailLink");
       window.gtag("event", "unsubscribe-building-all-email-link");
     } else {
-      // logAmplitudeEvent("manageSubscriptionsEmailLink");
       window.gtag("event", "manage-subscriptions-email-link");
     }
   }, [token, isEmailUnsubscribeAll]);
@@ -48,17 +46,13 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
   const handleUnsubscribeBuilding = async (bbl: string) => {
     const result = await AuthClient.emailUnsubscribeBuilding(bbl, token);
     if (!!result?.["subscriptions"]) setSubscriptions(result["subscriptions"]);
-    const eventParams = { from: "manage subscriptions page" };
-    // logAmplitudeEvent("unsubscribeBuilding", eventParams);
-    window.gtag("event", "unsubscribe-building", eventParams);
+    window.gtag("event", "unsubscribe-building", { from: "manage subscriptions page" });
   };
 
   const handleUnsubscribeAll = async () => {
     const result = await AuthClient.emailUnsubscribeAll(token);
     if (!!result?.["subscriptions"]) setSubscriptions(result["subscriptions"]);
-    const eventParams = { from: "manage subscriptions page" };
-    // logAmplitudeEvent("unsubscribeBuildingAll", eventParams);
-    window.gtag("event", "unsubscribe-building-all", eventParams);
+    window.gtag("event", "unsubscribe-building-all", { from: "manage subscriptions page" });
   };
 
   const renderUnsubscribePage = () => (

--- a/client/src/containers/UnsubscribePage.tsx
+++ b/client/src/containers/UnsubscribePage.tsx
@@ -67,7 +67,7 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
         variant="primary"
         size="large"
         labelText={i18n._(t`Unsubscribe from all`)}
-        onClick={() => () => handleUnsubscribeAll("unsubscribe")}
+        onClick={() => handleUnsubscribeAll("unsubscribe")}
       />
     </>
   );

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -31,23 +31,19 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
       switch (result.statusCode) {
         case VerifyStatusCode.Success:
           setIsVerified(true);
-          // logAmplitudeEvent("emailVerifySuccess");
           window.gtag("event", "email-verify-success");
           break;
         case VerifyStatusCode.AlreadyVerified:
           setIsVerified(true);
           setIsAlreadyVerified(true);
-          // logAmplitudeEvent("emailVerifyAlready");
           window.gtag("event", "email-verify-already");
           break;
         case VerifyStatusCode.Expired:
           setIsExpired(true);
-          // logAmplitudeEvent("emailVerifyExpired");
           window.gtag("event", "email-verify-expired");
           break;
         default:
           setUnknownError(true);
-          // logAmplitudeEvent("emailV  erifyError");
           window.gtag("event", "email-verify-error");
       }
       setLoading(false);
@@ -67,9 +63,7 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
         size="large"
         onClick={async () => {
           setIsEmailResent(await AuthClient.resendVerifyEmail(token));
-          const eventParams = { from: "verify page" };
-          // logAmplitudeEvent("emailVerifyResend", eventParams);
-          window.gtag("event", "email-verify-resend", eventParams);
+          window.gtag("event", "email-verify-resend", { from: "verify page" });
         }}
       />
     </div>

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -31,16 +31,24 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
       switch (result.statusCode) {
         case VerifyStatusCode.Success:
           setIsVerified(true);
+          // logAmplitudeEvent("emailVerifySuccess");
+          window.gtag("event", "email-verify-success");
           break;
         case VerifyStatusCode.AlreadyVerified:
           setIsVerified(true);
           setIsAlreadyVerified(true);
+          // logAmplitudeEvent("emailVerifyAlready");
+          window.gtag("event", "email-verify-already");
           break;
         case VerifyStatusCode.Expired:
           setIsExpired(true);
+          // logAmplitudeEvent("emailVerifyExpired");
+          window.gtag("event", "email-verify-expired");
           break;
         default:
           setUnknownError(true);
+          // logAmplitudeEvent("emailV  erifyError");
+          window.gtag("event", "email-verify-error");
       }
       setLoading(false);
     });
@@ -59,6 +67,9 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
         size="large"
         onClick={async () => {
           setIsEmailResent(await AuthClient.resendVerifyEmail(token));
+          const eventParams = { from: "verify page" };
+          // logAmplitudeEvent("emailVerifyResend", eventParams);
+          window.gtag("event", "email-verify-resend", eventParams);
         }}
       />
     </div>

--- a/client/src/state-machine.ts
+++ b/client/src/state-machine.ts
@@ -120,6 +120,10 @@ export type JustfixUser = {
   email: string;
   /** Whether the user's email address has been verified */
   verified: boolean;
+  /** User id for passing to Google Analytics */
+  id: number;
+  /** User type for passing to Google Analytics */
+  type: string;
   /** All buildings the user is subscribed to (email alerts) */
   subscriptions: BuildingSubscription[];
 };


### PR DESCRIPTION
Adds all the Google Tag Manager (and Amplitude) events for our tracking in GA4. 
Also makes updates to accommodate the user `id` and `type` now sent from auth provider, which we pass as params in our analytics events. 
Corresponding auth-provider pr: https://github.com/JustFixNYC/auth-provider/pull/39

[sc-14433]