### PR TITLE
Various small updates to the building page

### DIFF
--- a/client/src/components/BuildingStatsTable.tsx
+++ b/client/src/components/BuildingStatsTable.tsx
@@ -212,6 +212,9 @@ const BuildingStatsTableWithoutI18n = (props: { addr: AddressRecord; timelineUrl
       getBuildingStats: () => props.addr,
     }}
   >
+    <div className="hover-info">
+      <Trans render="i">hover over a box to learn more</Trans>
+    </div>
     <div className="BuildingStatsTable card-body-table hide-sm">
       <div className="table-row">
         <BBL />

--- a/client/src/components/BuildingStatsTable.tsx
+++ b/client/src/components/BuildingStatsTable.tsx
@@ -9,6 +9,7 @@ import { Trans } from "@lingui/macro";
 import JFCLLinkInternal from "./JFCLLinkInternal";
 import { Link } from "react-router-dom";
 import "styles/BuildingStatsTable.css";
+import { removeIndicatorSuffix } from "routes";
 
 interface BuildingStatsAddrContext {
   getBuildingStats(): AddressRecord;
@@ -195,7 +196,7 @@ const RsUnits = () => {
 const TimelineLink = (props: { url: string }) => {
   return (
     <Link
-      to={props.url}
+      to={removeIndicatorSuffix(props.url)}
       onClick={() => {
         window.gtag("event", "view-data-over-time-overview-tab");
       }}

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -4,6 +4,7 @@ import { LazyLoadWhenVisible } from "./LazyLoadWhenVisible";
 import Helpers, { longDateOptions } from "../util/helpers";
 import Browser from "../util/browser";
 import Modal from "../components/Modal";
+import { Link as JFCLLink } from "@justfixnyc/component-library";
 
 import "styles/DetailView.css";
 import { withI18n, withI18nProps, I18n } from "@lingui/react";
@@ -184,6 +185,44 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     if (wrapper) wrapper.scrollTop = 0;
   }
 
+  renderStreetView(
+    streetViewAddr: string,
+    streetViewCoords: {
+      lat: number;
+      lng: number;
+    } | null,
+    isMobile: boolean
+  ) {
+    if (!(streetViewAddr && streetViewCoords)) return <></>;
+
+    const googleMapLink = (
+      <figcaption className="figure-caption">
+        <JFCLLink
+          href={`https://www.google.com/maps/place/${streetViewAddr}`}
+          target="blank"
+          icon="external"
+        >
+          <Trans>View on Google Maps</Trans>
+        </JFCLLink>
+      </figcaption>
+    );
+
+    return (
+      <LazyLoadWhenVisible>
+        {!isMobile && googleMapLink}
+        <figure className="figure">
+          <StreetViewStatic
+            lat={streetViewCoords.lat}
+            lng={streetViewCoords.lng}
+            imgHeight={(width, _height) => ((width || 0) < 900 ? 200 : 400)}
+            imgWidth={(width, _height) => ((width || 0) < 900 ? 500 : 600)}
+          />
+        </figure>
+        {isMobile && googleMapLink}
+      </LazyLoadWhenVisible>
+    );
+  }
+
   render() {
     const isMobile = Browser.isMobile();
     const { i18n, state } = this.props;
@@ -218,27 +257,6 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     if (searchAddr.ownernames && searchAddr.ownernames.length)
       userOwnernames = Helpers.uniq(searchAddr.ownernames);
 
-    const streetView =
-      streetViewAddr && streetViewCoords ? (
-        <LazyLoadWhenVisible>
-          <figure className="figure">
-            <StreetViewStatic
-              lat={streetViewCoords.lat}
-              lng={streetViewCoords.lng}
-              imgHeight={(width, _height) => ((width || 0) < 900 ? 200 : 400)}
-              imgWidth={(width, _height) => ((width || 0) < 900 ? 500 : 600)}
-            />
-            <figcaption className="figure-caption">
-              <a href={`https://www.google.com/maps/place/${streetViewAddr}`} target="blank">
-                <Trans>View on Google Maps</Trans>
-              </a>
-            </figcaption>
-          </figure>
-        </LazyLoadWhenVisible>
-      ) : (
-        <></>
-      );
-
     return (
       <CSSTransition in={!isMobile || this.props.mobileShow} timeout={500} classNames="DetailView">
         <div className={`DetailView`}>
@@ -247,10 +265,12 @@ class DetailViewWithoutI18n extends Component<Props, State> {
               <div className="DetailView__card card">
                 <div className="DetailView__mobilePortfolioView">
                   <button onClick={() => this.props.onCloseDetail()}>
-                    <Trans render="span">View map</Trans>
+                    <Trans render="span">View portfolio map</Trans>
                   </button>
                 </div>
-                <div className="card-image show-lg">{streetView}</div>
+                <div className="card-image show-lg">
+                  {this.renderStreetView(streetViewAddr, streetViewCoords, isMobile)}
+                </div>
                 <div className="columns main-content-columns">
                   <div className="column col-lg-12 col-7 detail-column-left">
                     <div className="card-header">
@@ -394,14 +414,16 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                     <GetRepairs />
                     <div className="card-body-links column-right">
                       <UsefulLinks addrForLinks={detailAddr} location="overview-tab" />
-                      <div className="card-body-social social-group">
-                        <h6 className="DetailView__subtitle">
-                          <Trans>Share with your neighbors</Trans>
-                        </h6>
-                        <SocialShareDetailView />
-                      </div>
                     </div>
-                    <div className="card-image hide-lg">{streetView}</div>
+                    <div className="card-image hide-lg">
+                      {this.renderStreetView(streetViewAddr, streetViewCoords, isMobile)}
+                    </div>
+                    <div className="card-body-social social-group">
+                      <h6 className="DetailView__subtitle">
+                        <Trans>Share with your neighbors</Trans>
+                      </h6>
+                      <SocialShareDetailView />
+                    </div>
                   </div>
                 </div>
               </div>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -252,7 +252,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                 </div>
                 <div className="card-image show-lg">{streetView}</div>
                 <div className="columns main-content-columns">
-                  <div className="column col-lg-12 col-7">
+                  <div className="column col-lg-12 col-7 detail-column-left">
                     <div className="card-header">
                       <h4 className="card-title">
                         <Trans>BUILDING:</Trans> {detailAddr.housenumber}{" "}
@@ -389,7 +389,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                       </div>
                     </div>
                   </div>
-                  <div className="column col-lg-12 col-5">
+                  <div className="column col-lg-12 col-5 detail-column-right">
                     <EmailAlertSignup addr={detailAddr} />
                     <GetRepairs />
                     <div className="card-body-links column-right">

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -208,9 +208,6 @@ const EmailAlertSignupWithoutI18n = (props: EmailAlertProps) => (
     <div className="table-row">
       <div className="table-small-font">
         <label className="card-label-container">
-          <span className="pill-new">
-            <Trans>NEW</Trans>
-          </span>
           <Trans>Building Updates</Trans>
         </label>
         <div className="table-content">

--- a/client/src/components/GetRepairs.tsx
+++ b/client/src/components/GetRepairs.tsx
@@ -21,7 +21,7 @@ const GetRepairsWithoutI18n = () => {
                 </label>
                 <div className="table-content">
                   <Trans render="div" className="card-description">
-                    Send a free, legally vetted letter to notify your landlord of repair issues
+                    Send a free, legally vetted letter to notify your landlord of repair issues.
                   </Trans>
 
                   <JFCLLink

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -173,13 +173,21 @@
       }
     }
 
+    .hover-info {
+      display: flex;
+      i {
+        margin-left: auto;
+      }
+    }
+
     .card-body {
       padding-top: 0;
 
-      &:last-child {
-        @include for-phone-only() {
+      @include for-phone-only() {
+        &:last-child {
           padding: 0.63rem;
         }
+        padding-top: 0 !important;
       }
 
       @include for-tablet-portrait-up() {

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -6,6 +6,7 @@
   $detailWidth: 70vw;
   $detailAnimLength: 300;
   $detailAnimLengthMs: 300 + 0ms;
+  $rightColumnMaxWidth: 336px;
 
   position: relative;
   display: inline-block;
@@ -16,6 +17,17 @@
   z-index: 10;
   background-color: #ffffff;
   border-left: 1px solid $dark;
+
+  @include for-tablet-landscape-up() {
+    // detail left column and property map split the remaining width after left column max
+    width: calc(((100vw - #{$rightColumnMaxWidth}) / 2) + #{$rightColumnMaxWidth});
+    .detail-column-right {
+      max-width: $rightColumnMaxWidth;
+    }
+    .detail-column-left {
+      flex-grow: 1 !important;
+    }
+  }
 
   @include for-phone-only() {
     position: absolute;

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -175,12 +175,18 @@
       }
       figcaption {
         margin: 0;
+        padding-top: 1.5rem;
+        padding-bottom: 0.5rem;
         @include for-tablet-landscape-down {
           padding-left: 1.56rem;
         }
         @include for-phone-only {
+          padding-top: 0;
           padding-right: 1.25rem;
           text-align: right;
+          a {
+            font-size: 0.875rem;
+          }
         }
       }
     }

--- a/client/src/styles/PropertiesMap.scss
+++ b/client/src/styles/PropertiesMap.scss
@@ -5,6 +5,10 @@
   width: 30vw;
   // height: 100%;
 
+  @include for-tablet-landscape-up() {
+    flex-grow: 1;
+  }
+
   @include for-phone-only() {
     width: 100%;
   }


### PR DESCRIPTION
* add back "hover for info" above building table [[sc-13591]](https://app.shortcut.com/justfixnyc/story/13591)
* right detail column max-width [[sc-14239]](https://app.shortcut.com/justfixnyc/story/14239)
  * the right column max-width is 336px (per leslie in shortcut) and the map and left details column share the leftover screen width. This change only applies to screen width of tablet-landscape and up.
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/7a43434e-fbb4-45ec-829f-2ad239d720d6)
* copy update in LOC box [[sc-14480]](https://app.shortcut.com/justfixnyc/story/14480)
* view on google maps link style/placement [[sc-14241]](https://app.shortcut.com/justfixnyc/story/14241)
* remove "new" pill from building updates box [[sc-14478]](https://app.shortcut.com/justfixnyc/story/14478)
* removeIndicatorSuffix on timeline link [[sc-14352]](https://app.shortcut.com/justfixnyc/story/14352)