### PR TITLE
update type styles to work with jfcl better

### DIFF
--- a/client/src/styles/Card.scss
+++ b/client/src/styles/Card.scss
@@ -49,6 +49,10 @@
   }
 
   .card-description {
+    font-size: 0.875rem;
+    @include for-phone-only {
+      font-size: 1rem;
+    }
     text-align: left;
     line-height: 117%;
   }

--- a/client/src/styles/_datatable.scss
+++ b/client/src/styles/_datatable.scss
@@ -51,7 +51,10 @@
         > label {
           display: block;
           line-height: 1.1;
-          font-size: 0.8125rem;
+          font-size: 0.875rem;
+          @include for-phone-only() {
+            font-size: 1rem;
+          }
           padding: 1px 0;
           // background-color: $background;
           border-bottom: 1px solid $gray-dark;
@@ -79,7 +82,10 @@
       }
 
       .table-small-font {
-        font-size: 0.8125rem;
+        font-size: 0.875rem;
+        @include for-phone-only() {
+          font-size: 1rem;
+        }
       }
     }
   }

--- a/client/src/styles/_jfcl_overrides.scss
+++ b/client/src/styles/_jfcl_overrides.scss
@@ -1,0 +1,9 @@
+// Temporary until we can better align WOW type styles with desig sytem
+.jfcl-button,
+.jfcl-link {
+  font-size: 1rem;
+  svg:not(.jf-logo) {
+    height: 1rem;
+    width: 1rem;
+  }
+}

--- a/client/src/styles/index.scss
+++ b/client/src/styles/index.scss
@@ -1,5 +1,6 @@
 @import "_vars.scss";
 @import "_spacing.scss";
+@import "_jfcl_overrides.scss";
 
 html,
 body {


### PR DESCRIPTION
Make some small adjustments to type styles so that the new component library elements work within the unique wow style.

* reduces JFCL button and link text size
* Increases body text elsewhere

[sc-14387]