### PR TITLE
update copy/style for SMS social button

### DIFF
--- a/client/src/components/SocialShare.tsx
+++ b/client/src/components/SocialShare.tsx
@@ -119,15 +119,15 @@ const SocialShareWithoutI18n: React.FC<SocialShareProps> = ({
       />
       {isMobile && (
         <a
-          className="btn btn-steps"
+          className="sms-social jfcl-button jfcl-variant-secondary jfcl-size-small"
           onClick={() => {
-            window.gtag("event", "twitter-" + location);
+            window.gtag("event", "sms-" + location);
           }}
           href={"sms: " + (isAndroid ? "?" : "&") + "body=" + encodeURIComponent(url)}
           target="_blank"
           rel="noopener noreferrer"
         >
-          SMS
+          Text URL
         </a>
       )}
     </div>

--- a/client/src/styles/_button.scss
+++ b/client/src/styles/_button.scss
@@ -81,6 +81,7 @@
 }
 
 .btns-social {
+  row-gap: 0.5rem;
   .btn {
     &:nth-child(1) {
       @include button-special($facebook, #fff);
@@ -104,6 +105,11 @@
 
   .btn.btn-steps {
     flex: 1 0 0;
+  }
+
+  // sms link
+  .sms-social {
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
We missed the SMS social button when updating component library styles, so this makes that style change and also changes to "Text URL" instead of the previous "SMS". 

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/8e3e4490-c162-455c-af3f-40de2ccdb8e2)

TBD if in stead we want to use an icon so they match, since it currently forces wrapping in some places and looks awkward to me - waiting on Joel's approval 

[sc-14520]