### PR TITLE
add logout buton to account settings, update styles

### DIFF
--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -12,6 +12,7 @@ import { JustfixUser } from "state-machine";
 import { createRouteForAddressPage, createWhoOwnsWhatRoutePaths } from "routes";
 import { Borough } from "components/APIDataTypes";
 import { LocaleNavLink } from "i18n";
+import { useLocation } from "react-router-dom";
 
 type SubscriptionFieldProps = withI18nProps & {
   bbl: string;
@@ -54,6 +55,7 @@ export const SubscriptionField = withI18n()(SubscriptionFieldWithoutI18n);
 
 const AccountSettingsPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
+  const { pathname } = useLocation();
   const userContext = useContext(UserContext);
   if (!userContext.user) return <div />;
   const user = userContext.user as JustfixUser;

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -12,7 +12,7 @@ import { JustfixUser } from "state-machine";
 import { createRouteForAddressPage, createWhoOwnsWhatRoutePaths } from "routes";
 import { Borough } from "components/APIDataTypes";
 import { LocaleNavLink } from "i18n";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { LoadingPage } from "components/Loader";
 
 type SubscriptionFieldProps = withI18nProps & {
@@ -57,6 +57,7 @@ export const SubscriptionField = withI18n()(SubscriptionFieldWithoutI18n);
 const AccountSettingsPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const history = useHistory();
+  const { pathname } = useLocation();
   const { home, account } = createWhoOwnsWhatRoutePaths();
   const userContext = useContext(UserContext);
   const user = userContext.user as JustfixUser;
@@ -84,7 +85,16 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
         <div className="page-container">
           <Trans render="h1">Account</Trans>
           <div className="settings-section">
-            <Trans render="h2">Log in</Trans>
+            <div className="log-in-out">
+              <Trans render="h2">You are logged in</Trans>
+              <Button
+                type="button"
+                variant="tertiary"
+                size="small"
+                labelText={i18n._(t`Logout`)}
+                onClick={() => userContext.logout(pathname)}
+              />
+            </div>
             <EmailSettingField
               currentValue={email}
               onSubmit={(newEmail: string) => userContext.updateEmail(newEmail)}

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -17,6 +17,19 @@
   .settings-section {
     margin-bottom: 3rem;
 
+    &:first-of-type {
+      border-top: 1px solid #c5ccd1; // new grey in figma, unnamed
+      border-bottom: 1px solid #c5ccd1; // new grey in figma, unnamed
+      padding-bottom: 3rem;
+    }
+
+    .log-in-out {
+      display: flex;
+      justify-content: space-between;
+      padding: 1rem 0 3rem 0;
+      align-items: baseline;
+    }
+
     h2 {
       font-size: 1rem;
       font-style: normal;


### PR DESCRIPTION
Adds a Logout button to the account settings page, and makes a few minor spacing/style changes:
- Adding a page rule under the "Account" label (to help provide some structure).
- Adding "You are logged in" message with a "Log out" button.
- Removing the "Log In" label that currently lives above the user email address.
- Adding a page rule above the "Building Updates" label (to more clearly separate the contact details section from the buildings section).

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/bd0afc09-365b-4448-bbf4-063fb39abdb2)
![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/a8aba142-b16d-408c-8235-705a91b4e0d8)

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/91ced2dc-1d52-43aa-8365-2e39f07ad937)
