### PR TITLE
use router redirect for account settings page 

### DIFF
--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -138,7 +138,6 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
   } = useInput(oldEmail);
 
   const eventUserParams = { user_id: user.id, user_type: user.type };
-  console.log({ user, eventUserParams });
 
   const handleSubmit = async () => {
     setExistingUserError(false);

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -12,8 +12,6 @@ import { JustfixUser } from "state-machine";
 import { createRouteForAddressPage, createWhoOwnsWhatRoutePaths } from "routes";
 import { Borough } from "components/APIDataTypes";
 import { LocaleNavLink } from "i18n";
-import { useHistory } from "react-router-dom";
-import { LoadingPage } from "components/Loader";
 
 type SubscriptionFieldProps = withI18nProps & {
   bbl: string;
@@ -56,15 +54,9 @@ export const SubscriptionField = withI18n()(SubscriptionFieldWithoutI18n);
 
 const AccountSettingsPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
-  const history = useHistory();
-  const { home, account } = createWhoOwnsWhatRoutePaths();
+  const { home } = createWhoOwnsWhatRoutePaths();
   const userContext = useContext(UserContext);
   const user = userContext.user as JustfixUser;
-
-  if (!user?.email) {
-    history.replace(account.login);
-    return <LoadingPage />;
-  }
 
   const { email, subscriptions } = user;
   const subscriptionsNumber = !!subscriptions ? subscriptions.length : 0;

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -52,6 +52,7 @@ import LoginPage from "./LoginPage";
 import { JFLogo } from "components/JFLogo";
 import logoDivider from "../assets/img/logo-divider.svg";
 import { STANDALONE_PAGES } from "components/StandalonePage";
+import { LoadingPage } from "components/Loader";
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
@@ -86,6 +87,7 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
   const [state, send] = useMachine(wowMachine);
   const machineProps = { state, send };
   const userContext = useContext(UserContext);
+  const fetchingUser = !userContext?.user;
   const isLoggedIn = !!userContext?.user?.email;
   const allowChangingPortfolioMethod =
     process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1";
@@ -188,7 +190,13 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
       <Route
         path={paths.account.settings}
         render={(props) =>
-          isLoggedIn ? <AccountSettingsPage /> : localizedRedirect(paths.account.login)
+          fetchingUser ? (
+            <LoadingPage />
+          ) : isLoggedIn ? (
+            <AccountSettingsPage />
+          ) : (
+            localizedRedirect(paths.account.login)
+          )
         }
       />
       <Route path={paths.account.forgotPassword} component={ForgotPasswordPage} />

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -17,6 +17,7 @@ import {
   LocaleSwitcherWithFullLanguageName,
   JFCLLocaleLink,
   removeLocalePrefix,
+  LocaleRedirect,
 } from "../i18n";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { createWhoOwnsWhatRoutePaths } from "../routes";
@@ -84,8 +85,15 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
   const paths = createWhoOwnsWhatRoutePaths("/:locale");
   const [state, send] = useMachine(wowMachine);
   const machineProps = { state, send };
+  const userContext = useContext(UserContext);
+  const isLoggedIn = !!userContext?.user?.email;
   const allowChangingPortfolioMethod =
     process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1";
+
+  const localizedRedirect = (pathname: string) => {
+    return <LocaleRedirect to={{ pathname: removeLocalePrefix(pathname) }} />;
+  };
+
   return (
     <Switch>
       <Route exact path={paths.legacy.home} component={HomePage} />
@@ -177,7 +185,12 @@ const WhoOwnsWhatRoutes: React.FC<{}> = () => {
       />
       <Route path={paths.account.login} component={LoginPage} />
       <Route path={paths.account.verifyEmail} component={VerifyEmailPage} />
-      <Route path={paths.account.settings} component={AccountSettingsPage} />
+      <Route
+        path={paths.account.settings}
+        render={(props) =>
+          isLoggedIn ? <AccountSettingsPage /> : localizedRedirect(paths.account.login)
+        }
+      />
       <Route path={paths.account.forgotPassword} component={ForgotPasswordPage} />
       <Route path={paths.account.resetPassword} component={ResetPasswordPage} />
       <Route path={paths.account.unsubscribe} component={UnsubscribePage} />


### PR DESCRIPTION
In #912 I added a redirect from Account Settings to Login when you're not already logged in. But I'm now seeing that there's a bug with how I was checking logged in state with the usercontext which made it appear not logged in when it was just still fetching the user. This made it work ok if you are logged in and navigte to the account page, but once there if you reload the page while it's fetching the user it thinks you're logged out and so immediately redirects. I've now reverted that commit of that previous PR, so this is a redo.

Additionally, when I first attempted this redirect I added it within the account setting page itself, but I think the better way to do this is using React Router's Redirect within the specification of the Route. So this PR switches to use that approach

I think I've solved this issue by using `!userContext.user` to indicate that it's still fetching the user because in this state the user object is just completely undefined. Then once it's been fetched there is a user object so `userContext.user` is truthy, even if you're logged out and all the values within the object are undefined (like email, verified, etc.). So then to test if you're logged in we use `!!userContext.user.email`. So now we can show a loading page while fetching before deciding to either show the account page (if logged in) or redirect to the login page. 

[sc-14498]