### PR TITLE
add redirect login -> account when already logged in

### DIFF
--- a/client/src/containers/LoginPage.tsx
+++ b/client/src/containers/LoginPage.tsx
@@ -3,11 +3,31 @@ import { t } from "@lingui/macro";
 
 import StandalonePage from "components/StandalonePage";
 import Login from "components/Login";
+import { useContext, useEffect, useState } from "react";
+import { UserContext } from "components/UserContext";
+import { LocaleRedirect } from "i18n";
+import { createWhoOwnsWhatRoutePaths } from "routes";
+import { FixedLoadingLabel } from "components/Loader";
 
 const LoginPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
+  const { account } = createWhoOwnsWhatRoutePaths();
+  const userContext = useContext(UserContext);
+  const fetchingUser = !userContext?.user;
+  const isLoggedIn = !!userContext?.user?.email;
+  const [redirectToLogin, setRedirectToLogin] = useState<boolean>();
 
-  return (
+  useEffect(() => {
+    if (redirectToLogin === undefined && !fetchingUser) {
+      setRedirectToLogin(isLoggedIn);
+    }
+  }, [fetchingUser, redirectToLogin, isLoggedIn]);
+
+  return redirectToLogin === undefined ? (
+    <FixedLoadingLabel />
+  ) : redirectToLogin ? (
+    <LocaleRedirect to={{ pathname: account.settings }} />
+  ) : (
     <StandalonePage title={i18n._(t`Log in / sign up`)} className="LoginPage">
       <Login />
     </StandalonePage>


### PR DESCRIPTION
This adds a redirect from the Login page to Account settings if you are already logged in. Also it shows a loading page while fetching the user object until we can decide whether to redirect or not. It uses a useEffect and extra state variable to track the redirect decision to avoid the problem of redirecting at the end of your login process before you can see the verification message. 

[sc-14573]