### PR TITLE
Lingui fixes

### DIFF
--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -72,7 +72,7 @@ const PasswordInputWithoutI18n = forwardRef<HTMLInputElement, PasswordInputProps
     return (
       <div className="password-input-field">
         <div className="password-input-label mb-4">
-          <label htmlFor={id ?? "password-input"}>{i18n._(t`${labelText}`)}</label>
+          <label htmlFor={id ?? "password-input"}>{labelText}</label>
         </div>
         {showPasswordRules ? (
           <div className="password-input-rules">

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -261,9 +261,7 @@ const UserSettingFieldWithoutI18n = (props: UserSettingFieldProps) => {
           </>
         ) : (
           <>
-            <Trans render="label" className="user-setting-label">
-              {title}
-            </Trans>
+            <label className="user-setting-label">{title}</label>
             <div>
               <span>{preview}</span>
               <Button

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -592,7 +592,7 @@ msgstr "ELEVATOR"
 #~ msgid "Each weekly email includes HPD Complaints, HPD Violations, and Eviction Filings."
 #~ msgstr "Each weekly email includes HPD Complaints, HPD Violations, and Eviction Filings."
 
-#: src/components/UserSettingField.tsx:144
+#: src/components/UserSettingField.tsx:142
 msgid "Edit"
 msgstr "Edit"
 
@@ -2627,8 +2627,8 @@ msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} othe
 #~ msgstr "{header}"
 
 #: src/components/PasswordInput.tsx:43
-msgid "{labelText}"
-msgstr "{labelText}"
+#~ msgid "{labelText}"
+#~ msgstr "{labelText}"
 
 #: src/components/LandlordSearch.tsx:65
 msgid "{numberOfHits} {numberOfHits, plural, one {search result} other {search results}}."
@@ -2639,8 +2639,8 @@ msgstr "{numberOfHits} {numberOfHits, plural, one {search result} other {search 
 #~ msgstr "{subheader}"
 
 #: src/components/UserSettingField.tsx:139
-msgid "{title}"
-msgstr "{title}"
+#~ msgid "{title}"
+#~ msgstr "{title}"
 
 #: src/components/IndicatorsViz.tsx:467
 msgid "{unitsres, plural, one {1 unit total} other {# units total}}"

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -144,7 +144,7 @@ msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:138
+#: src/containers/App.tsx:134
 msgid "About"
 msgstr "About"
 
@@ -154,7 +154,6 @@ msgstr "According to available HPD data, this portfolio has received <0>{totalvi
 
 #: src/containers/AccountSettingsPage.tsx:47
 #: src/containers/AccountSettingsPage.tsx:50
-#: src/containers/App.tsx:118
 msgid "Account"
 msgstr "Account"
 
@@ -537,7 +536,7 @@ msgstr "DOORS"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:162
+#: src/containers/App.tsx:158
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -569,7 +568,7 @@ msgid "Don't have an account?"
 msgstr "Don't have an account?"
 
 #: src/components/LegalFooter.tsx:35
-#: src/containers/App.tsx:147
+#: src/containers/App.tsx:143
 msgid "Donate"
 msgstr "Donate"
 
@@ -616,6 +615,10 @@ msgstr "Email address not verified. Click the link we sent to {email} start rece
 msgid "Email address verified"
 msgstr "Email address verified"
 
+#: src/containers/App.tsx:120
+msgid "Email settings"
+msgstr "Email settings"
+
 #: src/components/IndicatorsViz.tsx:170
 msgid "Emergency"
 msgstr "Emergency"
@@ -625,8 +628,12 @@ msgstr "Emergency"
 #~ msgstr "Enter NYC ZIP CODE"
 
 #: src/containers/HomePage.tsx:87
-msgid "Enter an NYC address and find other buildings your landlord might own:"
-msgstr "Enter an NYC address and find other buildings your landlord might own:"
+#~ msgid "Enter an NYC address and find other buildings your landlord might own:"
+#~ msgstr "Enter an NYC address and find other buildings your landlord might own:"
+
+#: src/containers/HomePage.tsx:87
+msgid "Enter an address and find other buildings your landlord might own in NYC:"
+msgstr "Enter an address and find other buildings your landlord might own in NYC:"
 
 #: src/components/Subscribe.tsx:80
 #: src/containers/ForgotPasswordPage.tsx:53
@@ -751,8 +758,12 @@ msgstr "Filters"
 #~ msgstr "Filter <0/>for"
 
 #: src/containers/HomePage.tsx:88
-msgid "Find other buildings your landlord might own:"
-msgstr "Find other buildings your landlord might own:"
+msgid "Find other buildings your landlord might own in NYC:"
+msgstr "Find other buildings your landlord might own in NYC:"
+
+#: src/containers/HomePage.tsx:88
+#~ msgid "Find other buildings your landlord might own:"
+#~ msgstr "Find other buildings your landlord might own:"
 
 #: src/components/Login.tsx:139
 msgid "Forgot your password?"
@@ -851,7 +862,7 @@ msgstr "How are the results calculated?"
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:144
+#: src/containers/App.tsx:140
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -1057,12 +1068,12 @@ msgstr "Location"
 #: src/components/Login.tsx:148
 #: src/components/Login.tsx:294
 #: src/components/Login.tsx:297
-#: src/containers/App.tsx:129
+#: src/containers/App.tsx:125
 msgid "Log in"
 msgstr "Log in"
 
 #: src/components/Login.tsx:285
-#: src/containers/LoginPage.tsx:7
+#: src/containers/LoginPage.tsx:23
 msgid "Log in / sign up"
 msgstr "Log in / sign up"
 
@@ -1079,8 +1090,8 @@ msgstr "Log in to add {0} to your Building Updates"
 #~ msgstr "Log in to start getting updates for this building."
 
 #: src/containers/App.tsx:124
-msgid "Log out"
-msgstr "Log out"
+#~ msgid "Log out"
+#~ msgstr "Log out"
 
 #: src/containers/AccountSettingsPage.tsx:43
 #~ msgid "Login details"
@@ -1603,7 +1614,7 @@ msgid "Save"
 msgstr "Save"
 
 #: src/components/Multiselect.tsx:71
-#: src/containers/App.tsx:109
+#: src/containers/App.tsx:111
 msgid "Search"
 msgstr "Search"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -149,7 +149,7 @@ msgid "APPLIANCE"
 msgstr "MEDIO DOMÉSTICO"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:138
+#: src/containers/App.tsx:134
 msgid "About"
 msgstr "Acerca de"
 
@@ -159,7 +159,6 @@ msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha re
 
 #: src/containers/AccountSettingsPage.tsx:47
 #: src/containers/AccountSettingsPage.tsx:50
-#: src/containers/App.tsx:118
 msgid "Account"
 msgstr ""
 
@@ -542,7 +541,7 @@ msgstr "PUERTAS"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/containers/App.tsx:162
+#: src/containers/App.tsx:158
 msgid "Demo Site"
 msgstr "Sitio Demo"
 
@@ -574,7 +573,7 @@ msgid "Don't have an account?"
 msgstr ""
 
 #: src/components/LegalFooter.tsx:35
-#: src/containers/App.tsx:147
+#: src/containers/App.tsx:143
 msgid "Donate"
 msgstr "Donar"
 
@@ -625,6 +624,10 @@ msgstr ""
 msgid "Email address verified"
 msgstr ""
 
+#: src/containers/App.tsx:120
+msgid "Email settings"
+msgstr ""
+
 #: src/components/EmailAlertSignup.tsx:22
 #~ msgid "Email updates will be sent to {email}"
 #~ msgstr ""
@@ -642,8 +645,12 @@ msgstr "Emergencia"
 #~ msgstr "Enter NYC ZIP CODE"
 
 #: src/containers/HomePage.tsx:87
-msgid "Enter an NYC address and find other buildings your landlord might own:"
-msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
+#~ msgid "Enter an NYC address and find other buildings your landlord might own:"
+#~ msgstr "Introduce una dirección de NYC para encontrar otros edificios que tu propietario podría poseer:"
+
+#: src/containers/HomePage.tsx:87
+msgid "Enter an address and find other buildings your landlord might own in NYC:"
+msgstr ""
 
 #: src/components/Subscribe.tsx:80
 #: src/containers/ForgotPasswordPage.tsx:53
@@ -768,8 +775,12 @@ msgstr "Filtros"
 #~ msgstr "Filter <0/>for"
 
 #: src/containers/HomePage.tsx:88
-msgid "Find other buildings your landlord might own:"
-msgstr "Encuentra otros edificios que su dueño podría poseer:"
+msgid "Find other buildings your landlord might own in NYC:"
+msgstr ""
+
+#: src/containers/HomePage.tsx:88
+#~ msgid "Find other buildings your landlord might own:"
+#~ msgstr "Encuentra otros edificios que su dueño podría poseer:"
 
 #: src/components/Login.tsx:139
 msgid "Forgot your password?"
@@ -868,7 +879,7 @@ msgstr "¿Cómo se calculan los resultados?"
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
-#: src/containers/App.tsx:144
+#: src/containers/App.tsx:140
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "Cómo se usa"
@@ -1074,12 +1085,12 @@ msgstr "Ubicación"
 #: src/components/Login.tsx:148
 #: src/components/Login.tsx:294
 #: src/components/Login.tsx:297
-#: src/containers/App.tsx:129
+#: src/containers/App.tsx:125
 msgid "Log in"
 msgstr ""
 
 #: src/components/Login.tsx:285
-#: src/containers/LoginPage.tsx:7
+#: src/containers/LoginPage.tsx:23
 msgid "Log in / sign up"
 msgstr ""
 
@@ -1096,8 +1107,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/containers/App.tsx:124
-msgid "Log out"
-msgstr ""
+#~ msgid "Log out"
+#~ msgstr ""
 
 #: src/containers/AccountSettingsPage.tsx:43
 #~ msgid "Login details"
@@ -1620,7 +1631,7 @@ msgid "Save"
 msgstr ""
 
 #: src/components/Multiselect.tsx:71
-#: src/containers/App.tsx:109
+#: src/containers/App.tsx:111
 msgid "Search"
 msgstr "Buscar"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -620,6 +620,10 @@ msgstr "Correo electrónico no verificado. Haga clic al enlace que le enviamos a
 msgid "Email address verified"
 msgstr "Correo electrónico verificado"
 
+#: src/containers/App.tsx:120
+msgid "Email settings"
+msgstr ""
+
 #: src/components/IndicatorsViz.tsx:170
 msgid "Emergency"
 msgstr "Emergencia"
@@ -1091,8 +1095,8 @@ msgstr "Inicia sesión para añadir {0} a sus Actualizaciones de edificios"
 #~ msgstr "Log in to start getting updates for this building."
 
 #: src/containers/App.tsx:124
-msgid "Log out"
-msgstr "Cerrar sesión"
+#~ msgid "Log out"
+#~ msgstr "Cerrar sesión"
 
 #: src/containers/AccountSettingsPage.tsx:43
 #~ msgid "Login details"
@@ -2674,4 +2678,3 @@ msgstr "{value, plural, one {Una Queja del HPD emitida desde el 2012} other {# Q
 #: src/components/IndicatorsDatasets.tsx:36
 msgid "{value, plural, one {One HPD Violation Issued since 2012} other {# HPD Violations Issued since 2012}}"
 msgstr "{value, plural, one {Una Violación del HPD emitida desde el 2012} other {# Violaciones del HPD emitidas desde el 2012}}"
-

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -597,7 +597,7 @@ msgstr "ASCENSOR"
 #~ msgid "Each weekly email includes HPD Complaints, HPD Violations, and Eviction Filings."
 #~ msgstr ""
 
-#: src/components/UserSettingField.tsx:144
+#: src/components/UserSettingField.tsx:142
 msgid "Edit"
 msgstr ""
 
@@ -2644,16 +2644,16 @@ msgstr "{0} {1}, {2} tiene {3, plural, one {una violación del HPD actual} other
 #~ msgstr ""
 
 #: src/components/PasswordInput.tsx:43
-msgid "{labelText}"
-msgstr ""
+#~ msgid "{labelText}"
+#~ msgstr ""
 
 #: src/components/LandlordSearch.tsx:65
 msgid "{numberOfHits} {numberOfHits, plural, one {search result} other {search results}}."
 msgstr "{numberOfHits} {numberOfHits, plural, one {resultado de búsqueda} other {resultados de búsqueda}}."
 
 #: src/components/UserSettingField.tsx:139
-msgid "{title}"
-msgstr ""
+#~ msgid "{title}"
+#~ msgstr ""
 
 #: src/components/IndicatorsViz.tsx:467
 msgid "{unitsres, plural, one {1 unit total} other {# units total}}"


### PR DESCRIPTION
The messages.po file was a bit out of date before translations were just merged in, so this updates that. 

Also, there are some places where we have string vars that already come from i18n._() passed like: <Trans>{stringVar}</Trans> and the double lingui wrapping like this seems to break things when extracting the text for messages.po. So we should just rely on the string vars already having the translations and those get fixed there and then can be input into non-Trans tags

