### PR TITLE
add eviction filings to building stats table on mobile

### DIFF
--- a/client/src/components/BuildingStatsTable.tsx
+++ b/client/src/components/BuildingStatsTable.tsx
@@ -236,14 +236,14 @@ const BuildingStatsTableWithoutI18n = (props: { addr: AddressRecord; timelineUrl
     <div className="BuildingStatsTable card-body-table show-sm">
       <div className="table-row">
         <BBL />
+        <YearBuilt />
       </div>
       <div className="table-row">
-        <YearBuilt />
         <UnitsRes />
         <RsUnits />
+        <OpenViolations />
       </div>
       <div className="table-row">
-        <OpenViolations />
         <TotalViolations />
         <EvictionsExecuted />
       </div>


### PR DESCRIPTION
For some reason this indicator was not included in the mobile version of the table. We should add it in, and adjust the rows a bit (just for mobile) since the 4 in one row is too squished.

| before | after |
|--------|--------|
| ![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/5fe02d1b-3133-48c2-bd61-8d2777432c95) | ![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/4ca686b0-51a8-4e5f-995f-7a55ef04b9fc) |

[sc-14649]