### PR TITLE
add branch name to GTM event params for A/B testing

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -19,9 +19,4 @@ REACT_APP_API_BASE_URL=http://localhost:8000
 
 REACT_APP_AMPLITUDE_API_KEY=d10d994e2e75ba2c60a5cbe82b03a55e
 
-# 5.28.24 we don't need this in the client dir
-# handled by outer .env 
-# we only need this on heroku!!!! 
-#REACT_APP_AUTH_SERVER_BASE_URL=http://127.0.0.1:8080
-
 REACT_APP_PORTFOLIO_FILTERS_ENABLED=1

--- a/client/.env
+++ b/client/.env
@@ -19,6 +19,9 @@ REACT_APP_API_BASE_URL=http://localhost:8000
 
 REACT_APP_AMPLITUDE_API_KEY=d10d994e2e75ba2c60a5cbe82b03a55e
 
-REACT_APP_AUTH_SERVER_BASE_URL=http://127.0.0.1:8080
+# 5.28.24 we don't need this in the client dir
+# handled by outer .env 
+# we only need this on heroku!!!! 
+#REACT_APP_AUTH_SERVER_BASE_URL=http://127.0.0.1:8080
 
 REACT_APP_PORTFOLIO_FILTERS_ENABLED=1

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "@amplitude/analytics-browser": "^1.2.3",
     "@babel/core": "^7.7.2",
     "@contentful/rich-text-react-renderer": "^15.0.0",
-    "@justfixnyc/component-library": "0.37",
+    "@justfixnyc/component-library": "^0.37.1",
     "@justfixnyc/contentful-common-strings": "^0.1.0",
     "@justfixnyc/geosearch-requester": "1.0.0",
     "@justfixnyc/util": "^0.4.1",

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -57,7 +57,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const [showSubscriptionLimitModal, setShowSubscriptionLimitModal] = useState(false);
 
   const navigateToLogin = () => {
-    window.gtag("event", `register-login-via-building_${process.env.BRANCH}`);
+    window.gtag("event", `register-login-via-building_${process.env.REACT_BRANCH}`);
     const loginRoute = `/${i18n.language}${account.login}`;
     history.push({ pathname: loginRoute, state: { addr } });
   };

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -57,7 +57,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const [showSubscriptionLimitModal, setShowSubscriptionLimitModal] = useState(false);
 
   const navigateToLogin = () => {
-    window.gtag("event", "register-login-via-building");
+    window.gtag("event", `register-login-via-building_${process.env.BRANCH}`);
     const loginRoute = `/${i18n.language}${account.login}`;
     history.push({ pathname: loginRoute, state: { addr } });
   };
@@ -131,7 +131,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
           variant="primary"
           size="small"
           className="is-full-width"
-          labelText={i18n._(t`Add building`)}
+          labelText={i18n._(t`Follow building`)}
           labelIcon="circlePlus"
           onClick={() => {
             !isLoggedIn

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -132,7 +132,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
           variant="primary"
           size="small"
           className="is-full-width"
-          labelText={i18n._(t`Follow building`)}
+          labelText={i18n._(t`Add building`)}
           labelIcon="circlePlus"
           onClick={() => {
             !isLoggedIn

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -57,7 +57,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const [showSubscriptionLimitModal, setShowSubscriptionLimitModal] = useState(false);
 
   const navigateToLogin = () => {
-    window.gtag("event", `register-login-via-building_${process.env.REACT_BRANCH}`);
+    window.gtag("event", `register-login-via-building_${process.env.REACT_APP_BRANCH}`);
     const loginRoute = `/${i18n.language}${account.login}`;
     history.push({ pathname: loginRoute, state: { addr } });
   };

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -194,7 +194,6 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
               };
               window.gtag("event", "subscription-limit-request", {
                 ...eventParams,
-                branch: BRANCH_NAME,
               });
             }}
           >

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -20,6 +20,7 @@ import { AddressRecord } from "./APIDataTypes";
 import SendNewLink from "./SendNewLink";
 
 const SUBSCRIPTION_LIMIT = 15;
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
 
 /**
  * edge case: adding building as a result of successful login shows a flicker
@@ -57,7 +58,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   const [showSubscriptionLimitModal, setShowSubscriptionLimitModal] = useState(false);
 
   const navigateToLogin = () => {
-    window.gtag("event", `register-login-via-building_${process.env.REACT_APP_BRANCH}`);
+    window.gtag("event", "register-login-via-building", { branch: BRANCH_NAME });
     const loginRoute = `/${i18n.language}${account.login}`;
     history.push({ pathname: loginRoute, state: { addr } });
   };
@@ -79,7 +80,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
         onClick={() => {
           unsubscribe(addr.bbl);
           setJustSubscribed(false);
-          const params = { ...eventUserParams, from: "building page" };
+          const params = { ...eventUserParams, from: "building page", branch: BRANCH_NAME };
           window.gtag("event", "unsubscribe-building", { ...params });
         }}
       />
@@ -100,7 +101,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
         className="is-full-width"
         onClick={() => {
           AuthClient.resendVerifyEmail();
-          const params = { ...eventUserParams, from: "building page" };
+          const params = { ...eventUserParams, from: "building page", branch: BRANCH_NAME };
           window.gtag("event", "email-verify-resend", { ...params });
         }}
       />
@@ -108,7 +109,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
   );
 
   const subscribeToBuilding = (addr: AddressRecord) => {
-    window.gtag("event", "subscribe-building-page", { ...eventUserParams });
+    window.gtag("event", "subscribe-building-page", { ...eventUserParams, branch: BRANCH_NAME });
     subscribe(addr.bbl, addr.housenumber, addr.streetname, addr.zip ?? "", addr.boro);
   };
 
@@ -186,8 +187,15 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => {
-              const eventParams = { ...eventUserParams, limit: SUBSCRIPTION_LIMIT };
-              window.gtag("event", "subscription-limit-request", { ...eventParams });
+              const eventParams = {
+                ...eventUserParams,
+                limit: SUBSCRIPTION_LIMIT,
+                branch: BRANCH_NAME,
+              };
+              window.gtag("event", "subscription-limit-request", {
+                ...eventParams,
+                branch: BRANCH_NAME,
+              });
             }}
           >
             request form

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -91,7 +91,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
   const eventParams = (user?: JustfixUser) => {
     const customParams = {
       from: !!addr ? "building page" : "nav",
-      branch: process.env.REACT_BRANCH,
+      branch: process.env.REACT_APP_BRANCH,
     };
     const params = !!user?.id
       ? {

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -89,14 +89,17 @@ const LoginWithoutI18n = (props: withI18nProps) => {
   const [existingUserError, setExistingUserError] = useState(false);
 
   const eventParams = (user?: JustfixUser) => {
-    const fromParam = { from: !!addr ? "building page" : "nav" };
+    const customParams = {
+      from: !!addr ? "building page" : "nav",
+      branch: process.env.REACT_BRANCH,
+    };
     const params = !!user?.id
       ? {
-          ...fromParam,
+          ...customParams,
           user_id: user.id,
           user_type: user.type,
         }
-      : fromParam;
+      : customParams;
 
     return params;
   };

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -288,7 +288,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
 
   const onEmailSubmit = async () => {
     window.gtag("event", "register-login-email", eventParams());
-
+    console.log(process.env.REACT_BRANCH);
     if (!email || emailError) {
       setEmailError(true);
       setShowEmailError(true);

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -21,6 +21,8 @@ import { AddressRecord } from "./APIDataTypes";
 import { isLegacyPath } from "./WowzaToggle";
 import { Nobr } from "./Nobr";
 
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
+
 enum Step {
   CheckEmail,
   Login,
@@ -91,7 +93,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
   const eventParams = (user?: JustfixUser) => {
     const customParams = {
       from: !!addr ? "building page" : "nav",
-      branch: process.env.REACT_APP_BRANCH,
+      branch: BRANCH_NAME,
     };
     const params = !!user?.id
       ? {
@@ -288,7 +290,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
 
   const onEmailSubmit = async () => {
     window.gtag("event", "register-login-email", eventParams());
-    console.log(process.env.REACT_BRANCH);
     if (!email || emailError) {
       setEmailError(true);
       setShowEmailError(true);

--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -11,6 +11,8 @@ import { DotIcon, HideIcon, ShowIcon } from "./Icons";
 import classNames from "classnames";
 import { Icon } from "@justfixnyc/component-library";
 
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
+
 type PasswordRule = {
   regex: RegExp;
   label: string;
@@ -122,7 +124,7 @@ const PasswordInputWithoutI18n = forwardRef<HTMLInputElement, PasswordInputProps
             type="button"
             className="show-hide-toggle"
             onClick={() => {
-              window.gtag("event", "password-visibility-toggle");
+              window.gtag("event", "password-visibility-toggle", { branch: BRANCH_NAME });
               setShowPassword(!showPassword);
             }}
           >

--- a/client/src/components/StandalonePage.tsx
+++ b/client/src/components/StandalonePage.tsx
@@ -10,6 +10,8 @@ import { Trans } from "@lingui/macro";
 import { JFLogo } from "./JFLogo";
 import { useLocation } from "react-router-dom";
 
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
+
 export const STANDALONE_PAGES = [
   "forgot-password",
   "login",
@@ -27,7 +29,10 @@ export const JustFixLogoLink = (props: { eventParams: any }) => {
       className="jf-logo"
       to={home}
       onClick={() => {
-        window.gtag("event", "standalone-justfix-logo-click", { ...props.eventParams });
+        window.gtag("event", "standalone-justfix-logo-click", {
+          ...props.eventParams,
+          branch: BRANCH_NAME,
+        });
       }}
     >
       <JFLogo />
@@ -43,7 +48,10 @@ export const StandalonePageFooter = (props: { eventParams: any }) => {
       <JFCLLocaleLink
         to={home}
         onClick={() => {
-          window.gtag("event", "standalone-wow-link-click", { ...props.eventParams });
+          window.gtag("event", "standalone-wow-link-click", {
+            ...props.eventParams,
+            branch: BRANCH_NAME,
+          });
         }}
       >
         Who Owns What

--- a/client/src/components/UserSettingField.tsx
+++ b/client/src/components/UserSettingField.tsx
@@ -15,6 +15,8 @@ import { Alert } from "./Alert";
 import SendNewLink from "./SendNewLink";
 import { Button, Icon } from "@justfixnyc/component-library";
 
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
+
 type PasswordSettingFieldProps = withI18nProps & {
   onSubmit: (currentPassword: string, newPassword: string) => void;
 };
@@ -71,7 +73,7 @@ const PasswordSettingFieldWithoutI18n = (props: PasswordSettingFieldProps) => {
 
     onSubmit(currentPassword, newPassword);
 
-    window.gtag("event", "account-update-password", { ...eventUserParams });
+    window.gtag("event", "account-update-password", { ...eventUserParams, branch: BRANCH_NAME });
   };
 
   return (
@@ -163,7 +165,7 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
 
     onSubmit(email);
 
-    window.gtag("event", "account-update-email", { ...eventUserParams });
+    window.gtag("event", "account-update-email", { ...eventUserParams, branch: BRANCH_NAME });
   };
 
   const verifyCallout = !verified ? (
@@ -178,7 +180,7 @@ const EmailSettingFieldWithoutI18n = (props: EmailSettingFieldProps) => {
         onClick={() => {
           AuthClient.resendVerifyEmail();
           const eventParams = { ...eventUserParams, from: "account settings" };
-          window.gtag("event", "email-verify-resend", { ...eventParams });
+          window.gtag("event", "email-verify-resend", { ...eventParams, branch: BRANCH_NAME });
         }}
       />
     </div>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -54,6 +54,8 @@ import { STANDALONE_PAGES } from "components/StandalonePage";
 import { JFLogoDivider } from "components/JFLogoDivider";
 import { LoadingPage } from "components/Loader";
 
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
+
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const title = i18n._(t`Who owns what`);
@@ -243,7 +245,12 @@ const getAccountNavLinks = (fromPath: string, isSignedIn?: boolean) => {
         <LocaleNavLink
           to={login}
           key="account-3"
-          onClick={() => window.gtag("event", "nav-login", { from: removeLocalePrefix(fromPath) })}
+          onClick={() =>
+            window.gtag("event", "nav-login", {
+              from: removeLocalePrefix(fromPath),
+              branch: BRANCH_NAME,
+            })
+          }
         >
           <Trans>Log in</Trans>
         </LocaleNavLink>,

--- a/client/src/containers/ForgotPasswordPage.tsx
+++ b/client/src/containers/ForgotPasswordPage.tsx
@@ -12,6 +12,8 @@ import StandalonePage from "components/StandalonePage";
 import { JFCLLocaleLink } from "i18n";
 import { createWhoOwnsWhatRoutePaths } from "routes";
 
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
+
 const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const { search } = useLocation();
@@ -39,7 +41,7 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
     }
     sendResetEmail();
     setRequestSent(true);
-    window.gtag("event", "forgot-password-request");
+    window.gtag("event", "forgot-password-request", { branch: BRANCH_NAME });
   };
 
   const sendResetEmail = async () => {
@@ -95,7 +97,7 @@ const ForgotPasswordPage = withI18n()((props: withI18nProps) => {
               size="large"
               onClick={() => {
                 sendResetEmail();
-                window.gtag("event", "forgot-password-resend");
+                window.gtag("event", "forgot-password-resend", { branch: BRANCH_NAME });
               }}
             />
           </div>

--- a/client/src/containers/ResetPasswordPage.tsx
+++ b/client/src/containers/ResetPasswordPage.tsx
@@ -13,6 +13,8 @@ import { JFCLLocaleLink, LocaleLink } from "i18n";
 import SendNewLink from "components/SendNewLink";
 import StandalonePage from "components/StandalonePage";
 
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
+
 const ResetPasswordPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const { search } = useLocation();
@@ -40,18 +42,18 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
       setTokenStatus(result.statusCode);
       switch (result.statusCode) {
         case ResetStatusCode.Expired:
-          window.gtag("event", "forgot-password-expired");
+          window.gtag("event", "forgot-password-expired", { branch: BRANCH_NAME });
           break;
         case ResetStatusCode.Invalid:
-          window.gtag("event", "forgot-password-invalid");
+          window.gtag("event", "forgot-password-invalid", { branch: BRANCH_NAME });
           break;
         case ResetStatusCode.Unknown:
-          window.gtag("event", "forgot-password-email-link-error");
+          window.gtag("event", "forgot-password-email-link-error", { branch: BRANCH_NAME });
           break;
       }
     });
 
-    window.gtag("event", "forgot-password-email-link");
+    window.gtag("event", "forgot-password-email-link", { branch: BRANCH_NAME });
   }, []);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -66,9 +68,9 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
     const resp = await AuthClient.resetPassword(params.get("token") || "", password);
     setResetStatus(resp.statusCode);
     if (resp.statusCode === ResetStatusCode.Success) {
-      window.gtag("event", "forgot-password-reset-success");
+      window.gtag("event", "forgot-password-reset-success", { branch: BRANCH_NAME });
     } else {
-      window.gtag("event", "forgot-password-reset-error");
+      window.gtag("event", "forgot-password-reset-error", { branch: BRANCH_NAME });
     }
   };
 
@@ -96,7 +98,9 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
         <LocaleLink
           className="jfcl-button jfcl-variant-primary jfcl-size-large"
           to={account.forgotPassword}
-          onClick={() => window.gtag("event", "forgot-password-reset-resend")}
+          onClick={() =>
+            window.gtag("event", "forgot-password-reset-resend", { branch: BRANCH_NAME })
+          }
         >
           <Trans>Request new link</Trans>
         </LocaleLink>
@@ -133,7 +137,9 @@ const ResetPasswordPage = withI18n()((props: withI18nProps) => {
       <div className="standalone-footer">
         <JFCLLocaleLink
           to={account.login}
-          onClick={() => window.gtag("event", "forgot-password-reset-return-login")}
+          onClick={() =>
+            window.gtag("event", "forgot-password-reset-return-login", { branch: BRANCH_NAME })
+          }
         >
           <Trans>Back to Log in</Trans>
         </JFCLLocaleLink>

--- a/client/src/containers/UnsubscribePage.tsx
+++ b/client/src/containers/UnsubscribePage.tsx
@@ -15,6 +15,8 @@ import { BuildingSubscription } from "state-machine";
 import { FixedLoadingLabel } from "components/Loader";
 import { STANDALONE_PAGES, StandalonePageFooter } from "components/StandalonePage";
 
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
+
 const UnsubscribePage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const { search, pathname } = useLocation();
@@ -37,22 +39,25 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
     asyncFetchSubscriptions();
 
     if (isEmailUnsubscribeAll) {
-      window.gtag("event", "unsubscribe-building-all-email-link");
+      window.gtag("event", "unsubscribe-building-all-email-link", { branch: BRANCH_NAME });
     } else {
-      window.gtag("event", "manage-subscriptions-email-link");
+      window.gtag("event", "manage-subscriptions-email-link", { branch: BRANCH_NAME });
     }
   }, [token, isEmailUnsubscribeAll]);
 
   const handleUnsubscribeBuilding = async (bbl: string) => {
     const result = await AuthClient.emailUnsubscribeBuilding(bbl, token);
     if (!!result?.["subscriptions"]) setSubscriptions(result["subscriptions"]);
-    window.gtag("event", "unsubscribe-building", { from: "manage subscriptions" });
+    window.gtag("event", "unsubscribe-building", {
+      from: "manage subscriptions",
+      branch: BRANCH_NAME,
+    });
   };
 
   const handleUnsubscribeAll = async (from: string) => {
     const result = await AuthClient.emailUnsubscribeAll(token);
     if (!!result?.["subscriptions"]) setSubscriptions(result["subscriptions"]);
-    window.gtag("event", "unsubscribe-building-all", { from: from });
+    window.gtag("event", "unsubscribe-building-all", { from: from, branch: BRANCH_NAME });
   };
 
   const renderUnsubscribePage = () => (

--- a/client/src/containers/VerifyEmailPage.tsx
+++ b/client/src/containers/VerifyEmailPage.tsx
@@ -9,6 +9,8 @@ import StandalonePage from "components/StandalonePage";
 import { JFCLLocaleLink } from "i18n";
 import { createWhoOwnsWhatRoutePaths } from "routes";
 
+const BRANCH_NAME = process.env.REACT_APP_BRANCH;
+
 const VerifyEmailPage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const { search } = useLocation();
@@ -31,20 +33,20 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
       switch (result.statusCode) {
         case VerifyStatusCode.Success:
           setIsVerified(true);
-          window.gtag("event", "email-verify-success");
+          window.gtag("event", "email-verify-success", { branch: BRANCH_NAME });
           break;
         case VerifyStatusCode.AlreadyVerified:
           setIsVerified(true);
           setIsAlreadyVerified(true);
-          window.gtag("event", "email-verify-already");
+          window.gtag("event", "email-verify-already", { branch: BRANCH_NAME });
           break;
         case VerifyStatusCode.Expired:
           setIsExpired(true);
-          window.gtag("event", "email-verify-expired");
+          window.gtag("event", "email-verify-expired", { branch: BRANCH_NAME });
           break;
         default:
           setUnknownError(true);
-          window.gtag("event", "email-verify-error");
+          window.gtag("event", "email-verify-error", { branch: BRANCH_NAME });
       }
       setLoading(false);
     });
@@ -63,7 +65,7 @@ const VerifyEmailPage = withI18n()((props: withI18nProps) => {
         size="large"
         onClick={async () => {
           setIsEmailResent(await AuthClient.resendVerifyEmail(token));
-          window.gtag("event", "email-verify-resend", { from: "verify page" });
+          window.gtag("event", "email-verify-resend", { from: "verify page", branch: BRANCH_NAME });
         }}
       />
     </div>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2802,10 +2802,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@justfixnyc/component-library@0.37":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.37.0.tgz#61839745f369a0c4fa5c4eeeee1adf7739cd1f1c"
-  integrity sha512-Hyn1pUq78FQbNgplGr8s2bAyVsDM8ZH/GXRSyH62qtmceLo3Uem5cAypImax5za/D+dZHyDb86yf2oSDcDQn7A==
+"@justfixnyc/component-library@^0.37.1":
+  version "0.37.1"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.37.1.tgz#47c00d69c093f26ca4b5036380b04eb12af6220c"
+  integrity sha512-9Ld6hYYTWoSz/Toal2+EAfbJsfLGzPI+EwleLDsajIVkYjdpFdHMcdAX/gwYzY2yzI5XsXiWEAN/R7FqESsVwA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@fortawesome/fontawesome-svg-core" "6.5.1"

--- a/project/settings.py
+++ b/project/settings.py
@@ -100,8 +100,8 @@ CORS_ALLOWED_ORIGINS = [
     "https://demo-whoownswhat.justfix.org",
 ]
 CORS_ALLOWED_ORIGIN_REGEXES = [
-    r"https://\w+\.deploy-preview-(?:\d{1,4})--wow-django-dev\.netlify\.app",
     r"https://deploy-preview-(?:\d{1,4})--wow-django-dev\.netlify\.app",
+    r"https://deploy-preview-(?:\d{1,4})--wow-django\.netlify\.app",
 ]
 
 # This is based off the default Django logging configuration:


### PR DESCRIPTION
edit: the CTA change will be on `cta-ab-test` branch ONLY. the event param changes are what need to be merged into `master` so that our GA4 is logging the updated event param variables from the currently live split testing `master` branch. 

---

this PR adds branch name to the `eventModel` data layer variable in GTM / GA4 [sc-14639]

ideally the branch name should've been accessible at build time with `process.env.BRANCH` (see comments in [sc-14639]) but this kept returning `undefined` even after branch and deploy preview builds. I also tried accessing via `process.env.REACT_APP_BRANCH`, appending `REACT_APP_` as convention requires for apps created with `create_react_app`.  

since the out-of-the-box env variable was not accessible, I just manually set the branch variables via netlify. see configuration below. once we do away with split testing, `eventModel.branch` will always pass in `production`. 

<img width="955" alt="Screenshot 2024-05-29 at 4 54 32 PM" src="https://github.com/JustFixNYC/who-owns-what/assets/17574626/d084c449-fa62-487c-b35a-83b6b15aadb4">
