### PR TITLE
send utm_source param to auth-provider api [base: cta-ab-test] 

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -168,6 +168,8 @@ const userAuthenticated = async () => {
  */
 const verifyEmail = async () => {
   const params = new URLSearchParams(window.location.search);
+  const code = params.get("code");
+  const utm_source = params.get("utm_source") || "";
 
   let result: VerifyEmailResponse = {
     statusCode: VerifyStatusCode.Unknown,
@@ -175,9 +177,10 @@ const verifyEmail = async () => {
   };
 
   try {
-    const response = await postAuthRequest(
-      `${BASE_URL}auth/verify_email?code=${params.get("code")}`
-    );
+    let url = `${BASE_URL}auth/verify_email?code=${code}`;
+    if (utm_source) url += `&utm_source=${utm_source}`;
+
+    const response = await postAuthRequest(url);
     result.statusCode = response.status_code;
     result.statusText = response.status_text;
   } catch (e) {

--- a/jfauthprovider/views.py
+++ b/jfauthprovider/views.py
@@ -106,6 +106,7 @@ def verify_email(request):
     try:
         post_data = {
             "code": request.GET.get("code"),
+            "utm_source": request.GET.get("utm_source"),
             "origin": request.headers["Origin"],
         }
         return auth_server_request(


### PR DESCRIPTION
two identical PRs to send the `utm_source` param

related prs:
https://github.com/JustFixNYC/auth-provider/pull/47
https://github.com/JustFixNYC/who-owns-what/pull/940

[sc-14837]