### PR TITLE
Add loan_status and loan_action to signature api

### DIFF
--- a/sql/create_signature_buildings.sql
+++ b/sql/create_signature_buildings.sql
@@ -11,6 +11,9 @@ CREATE TEMP TABLE IF NOT EXISTS signature_pluto_geos AS (
 		nullif(s.water_charges, '')::float AS water_charges,
 		nullif(s.origination_date, '')::date AS origination_date,
 		nullif(s.debt_total, '')::float AS debt_total,
+		-- temporarily adding these here, later they'll be included in the data from UNHP
+		'active' AS loan_status,
+		NULL AS loan_action,
 		p.borocode,
 		p.block,
 		p.lot,
@@ -391,6 +394,10 @@ CREATE TABLE IF NOT EXISTS signature_buildings AS (
 		sp.landlord_slug,
 		sp.lender,
 		sp.lender_slug,
+
+		-- LOAN
+		loan_status,
+ 		loan_action,
 		
 		-- FINANCIAL
 		acris_deed.last_sale_date,

--- a/wow/sql/signature_building.sql
+++ b/wow/sql/signature_building.sql
@@ -7,6 +7,8 @@ SELECT
     landlord_slug,
     lender,
     lender_slug,
+    loan_status,
+    loan_action,
     units_res,
     units_nonres,
     rs_units,


### PR DESCRIPTION
later these will be included in the file provided by UNHP, but for now they are all active with no actions so just setting that now so we have the api structure finalized. These are used for these pills on the building pages (though the values may change as we start seeing this kind of activity in coming months) 

![image](https://github.com/JustFixNYC/who-owns-what/assets/16906516/977cd9cd-66af-4998-8bdd-d8ac246924e2)


[sc-15043]