### PR TITLE
add hpd active vacate orders

### DIFF
--- a/wow/sql/signature_building.sql
+++ b/wow/sql/signature_building.sql
@@ -32,6 +32,7 @@ SELECT
     hpd_comp_pests,
     hpd_comp_apts_pct,
     hpd_comp_apts,
+    hpd_active_vacate,
     last_rodent_date,
     last_rodent_result,
     in_aep,


### PR DESCRIPTION
We originally hoped to have DOB and FDNY as well, but FDNY hasn't updated their open data dataset for years, and after trying to sort out the DOB version I still don't have enough info to know which ones are still active. DOB has all vacate orders issues in the `dob_complaints` table (already in nycdb) with disposition code Y1 and Y3, but it seems those complaints get closed when the order is issued and there's no other dataset to find any further updates on those orders. I've put in questions about this and a request for more data via open data (dob is good at responding) but haven't heard back yet. 

So all that said, for now we are just using HPD vacate orders. For those we have the active status, and know if it's partial of entire building and the date it was issued. so we put those together in a single string value to use. 

[sc-14674]