### PR TITLE
remove old api for address search

### DIFF
--- a/wow/sql/signature_bbls.sql
+++ b/wow/sql/signature_bbls.sql
@@ -1,2 +1,0 @@
-SELECT bbl
-FROM signature_buildings

--- a/wow/urls.py
+++ b/wow/urls.py
@@ -55,7 +55,6 @@ urlpatterns = [
         name="signature_collection_charts",
     ),
     path("signature/landlords", views.signature_landlords, name="signature_landlords"),
-    path("signature/bbls", views.signature_bbls, name="signature_bbls"),
     path(
         "signature/portfolios", views.signature_portfolios, name="signature_portfolios"
     ),

--- a/wow/views.py
+++ b/wow/views.py
@@ -376,19 +376,6 @@ def signature_landlords(request):
 
 
 @api
-def signature_bbls(request):
-    """
-    This API endpoint returns a list of all of the BBLs in the signature
-    portfolio, to use in limiting results from GeoSearch Autocomplete API for
-    the building search function.
-    """
-    authorize_for_signature(request)
-    result = exec_db_query(SQL_DIR / "signature_bbls.sql")
-    bbls = [x["bbl"] for x in result]
-    return JsonResponse({"result": list(bbls)})
-
-
-@api
 def signature_portfolios(request):
     """
     This API endpoint returns data on signature/lender portfolio for home page cards.


### PR DESCRIPTION
This removes the endpoint we thought we were going to use to filter Geosearch API results for signature BBLs. We are now using our Algolia to replace Geosearch completely for addresses and landlords