### PR TITLE
Add api endpoint for getting last updated date for datasets

### DIFF
--- a/wow/forms.py
+++ b/wow/forms.py
@@ -150,3 +150,7 @@ class EmailAlertMultiIndicatorForm(PaddedBBLForm):
 
 class SignatureCollectionForm(forms.Form):
     collection = forms.CharField()
+
+
+class DatasetLastUpdatedForm(forms.Form):
+    dataset = forms.CharField()

--- a/wow/sql/dataset_last_updated.sql
+++ b/wow/sql/dataset_last_updated.sql
@@ -1,0 +1,4 @@
+SELECT 
+    value::timestamp AS last_updated
+FROM dataset_tracker
+WHERE key = %(dataset)s

--- a/wow/urls.py
+++ b/wow/urls.py
@@ -59,4 +59,7 @@ urlpatterns = [
         "signature/portfolios", views.signature_portfolios, name="signature_portfolios"
     ),
     path("signature/map", views.signature_map, name="signature_map"),
+    path(
+        "dataset/last_updated", views.dataset_last_updated, name="dataset_last_updated"
+    ),
 ]

--- a/wow/views.py
+++ b/wow/views.py
@@ -396,6 +396,17 @@ def signature_map(request):
     return JsonResponse({"result": list(result)})
 
 
+@api
+def dataset_last_updated(request):
+    """
+    This API endpoint returns data on all properties in the signature portfolio
+    for the dedicated map page.
+    """
+    dataset = get_validated_form_data(EmailAlertViolationsForm, request.GET)["dataset"]
+    result = exec_db_query(SQL_DIR / "dataset_last_updated.sql", {dataset: dataset})
+    return JsonResponse({"result": list(result)})
+
+
 def _fixup_addr_for_csv(addr: Dict[str, Any]):
     addr["ownernames"] = csvutil.stringify_owners(addr["ownernames"] or [])
     addr["recentcomplaintsbytype"] = csvutil.stringify_complaints(


### PR DESCRIPTION
Pairs with https://github.com/JustFixNYC/nycdb-k8s-loader/pull/159 which adds a table with every dataset and when it was last updated in our db. This adds a simple endpoint that takes a dataset name and returns the date it was last updated. We'll use this to provide indicator-specific last updated dates in the Signature dashboard, and it should also help for general monitoring now that there are so many dataset in there and so many are now dependencies for wow/alerts/signature.

I haven't added tests yet because I would need to add a test data builder and ran out of time. I also need to add signature api tests, so I'll do all of this as a post mvp launch task.

[sc-15116]