### PR TITLE
use inspection date for hpd violations indicators

### DIFF
--- a/sql/create_signature_building_charts.sql
+++ b/sql/create_signature_building_charts.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS signature_building_charts AS
     hpdviolations AS (
         SELECT
             bbl,
-            to_char(coalesce(inspectiondate, novissueddate), 'YYYY-MM') AS month,
+            to_char(inspectiondate, 'YYYY-MM') AS month,
             count(*) FILTER (WHERE class = 'A') AS hpdviolations_class_a,
             count(*) FILTER (WHERE class = 'B') AS hpdviolations_class_b,
             count(*) FILTER (WHERE class = 'C') AS hpdviolations_class_c,
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS signature_building_charts AS
             count(*) FILTER (WHERE class IS NOT NULL) AS hpdviolations_total
         FROM hpd_violations
         INNER JOIN signature_unhp_data USING(bbl)
-        WHERE coalesce(inspectiondate, novissueddate) >= '2010-01-01'
+        WHERE inspectiondate >= '2010-01-01'
         GROUP BY bbl, month
     ),
 

--- a/sql/create_signature_buildings.sql
+++ b/sql/create_signature_buildings.sql
@@ -125,7 +125,7 @@ CREATE TABLE IF NOT EXISTS signature_buildings AS (
 	    FROM hpd_violations
 	    WHERE class = any('{B,C}') 
 			AND violationstatus = 'Open' 
-			AND novissueddate >= (CURRENT_DATE - interval '5' year)
+			AND inspectiondate >= (CURRENT_DATE - interval '5' year)
 	    GROUP BY bbl
 	), 
 
@@ -141,7 +141,7 @@ CREATE TABLE IF NOT EXISTS signature_buildings AS (
 			-- https://www.nyc.gov/assets/buildings/pdf/HousingMaintenanceCode.pdf#page=18
 			count(*) FILTER (WHERE novdescription ~* '27-[\d\s,]*?201[7-9]') AS hpd_viol_pests
 	    FROM hpd_violations
-	    WHERE novissueddate >= (CURRENT_DATE - interval '1' year)
+	    WHERE inspectiondate >= (CURRENT_DATE - interval '1' year)
 	    GROUP BY bbl
 	), 
 	


### PR DESCRIPTION
For HPD violations we are changing from notice of violation issue date to the inspection date, since that's the earliest date available and what we already use on WOW. This way we're minimizing the lag in data and we don't have to worry about a confusing lack of data on timeline graphs. 

[sc-15095]