### PR TITLE
Revert change of CTA to get alerts

### DIFF
--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -132,7 +132,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
           variant="primary"
           size="small"
           className="is-full-width"
-          labelText={i18n._(t`Get alerts`)}
+          labelText={i18n._(t`Follow building`)}
           labelIcon="circlePlus"
           onClick={() => {
             !isLoggedIn

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -773,8 +773,8 @@ msgstr "Find other buildings your landlord might own in NYC:"
 #~ msgstr "Find other buildings your landlord might own:"
 
 #: src/components/EmailAlertSignup.tsx:91
-#~ msgid "Follow building"
-#~ msgstr "Follow building"
+msgid "Follow building"
+msgstr "Follow building"
 
 #: src/components/Login.tsx:143
 msgid "Forgot your password?"
@@ -799,10 +799,6 @@ msgstr "Get a weekly email alert on complaints, violations, and eviction filings
 #: src/components/EmailAlertSignup.tsx:86
 #~ msgid "Get a weekly email update on complaints, violations, and eviction filings for this building."
 #~ msgstr "Get a weekly email update on complaints, violations, and eviction filings for this building."
-
-#: src/components/EmailAlertSignup.tsx:91
-msgid "Get alerts"
-msgstr "Get alerts"
 
 #: src/components/EmailAlertSignup.tsx:50
 #: src/components/EmailAlertSignup.tsx:51

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -778,8 +778,8 @@ msgstr "Encuentre otros edificios que su dueño pueda tener en NYC:"
 #~ msgstr "Find other buildings your landlord might own:"
 
 #: src/components/EmailAlertSignup.tsx:91
-#~ msgid "Follow building"
-#~ msgstr "Seguir edifico"
+msgid "Follow building"
+msgstr "Seguir edifico"
 
 #: src/components/Login.tsx:143
 msgid "Forgot your password?"
@@ -804,10 +804,6 @@ msgstr "Reciba por correo electrónico una alerta semanal de las quejas, infracc
 #: src/components/EmailAlertSignup.tsx:86
 #~ msgid "Get a weekly email update on complaints, violations, and eviction filings for this building."
 #~ msgstr "Reciba por correo electrónico una actualización semanal de las quejas, infracciones y expedientes de desalojo de este edificio."
-
-#: src/components/EmailAlertSignup.tsx:91
-msgid "Get alerts"
-msgstr "Recibir alertas"
 
 #: src/components/EmailAlertSignup.tsx:50
 #: src/components/EmailAlertSignup.tsx:51


### PR DESCRIPTION
After running the a/b test of "get alerts" against "follow building" we're sticking with "follow building" so reverting this change

This reverts commit 259fb1a2bb0bc8ec3db03bfc1318b7349433e6cd.