### PR TITLE
restrict time period for eviction charts to >=2017

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -94,6 +94,8 @@ CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:3000",
     "http://localhost:3000",
+    "http://127.0.0.1:5173",
+    "http://localhost:5173",
     "https://wowserver.justfix.org",
     "https://demo-wowserver.justfix.org",
     "https://wow-django.herokuapp.com",

--- a/sql/create_signature_building_charts.sql
+++ b/sql/create_signature_building_charts.sql
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS signature_building_charts AS
             AND i.propertytype = 'Residential'
             AND a.bbl IS NOT NULL
             AND coalesce(p.unitsres, 0) > 10
-            AND i.fileddate >= '2010-01-01'
+            AND i.fileddate >= '2017-01-01'
         GROUP BY a.bbl, TO_CHAR(i.fileddate, 'YYYY')
     ),
 
@@ -86,7 +86,7 @@ CREATE TABLE IF NOT EXISTS signature_building_charts AS
             count(*) AS evictions_executed
         FROM marshal_evictions_all
         INNER JOIN signature_unhp_data USING(bbl)   
-        WHERE executeddate >= '2010-01-01'
+        WHERE executeddate >= '2017-01-01'
         GROUP BY bbl, TO_CHAR(executeddate, 'YYYY')
     ),
 


### PR DESCRIPTION
All our other charts go back to 2010, but we only have eviction data back to 2016/2017 (filings, executions) so we need to stop this chart here. this is also done on the front end, but wanted to do it here as well. 

https://github.com/JustFixNYC/signature-dashboard/pull/62

Also, I added the localhost for signature dashboard to the cors origins for local dev

[sc-15406]