### PR TITLE
fix to api query for signature portfolio cards

### DIFF
--- a/sql/create_signature_collections.sql
+++ b/sql/create_signature_collections.sql
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS signature_collections AS (
 			loan_pool AS collection_name,
 			'loan_pool' AS collection_type,
 
-			NULL::text AS loan_pool_name,
+			max(loan_pool) AS loan_pool_name,
 
 			-- All copied from above
 			count(*)::int AS buildings_agg,
@@ -164,4 +164,5 @@ CREATE TABLE IF NOT EXISTS signature_collections AS (
 );
 
 CREATE INDEX ON signature_collections (collection_slug);
+CREATE INDEX ON signature_collections (collection_type);
 

--- a/wow/sql/signature_portfolios.sql
+++ b/wow/sql/signature_portfolios.sql
@@ -1,14 +1,34 @@
+WITH buildings AS (
+	SELECT
+		loan_pool_slug as collection_slug,
+		sum(buildings_agg) AS buildings_agg
+	FROM signature.signature_collections
+	WHERE collection_type = 'loan_pool'
+	GROUP BY loan_pool_slug
+	UNION
+	SELECT
+		'all' AS collection_slug,
+		buildings_agg
+	FROM signature.signature_collections
+	WHERE collection_type = 'all'
+), 
+landlords AS (
+	SELECT 
+		loan_pool_slug AS collection_slug,
+		count(distinct collection_name) AS landlords
+	FROM signature.signature_collections
+	WHERE collection_type = 'landlord'
+	GROUP BY loan_pool_slug
+	UNION
+	SELECT
+		'all' AS collection_slug,
+		count(distinct collection_name) AS landlords
+	FROM signature.signature_collections
+	WHERE collection_type = 'landlord'
+)
 SELECT 
-	loan_pool_slug AS collection_slug,
-	count(*) AS landlords,
-	sum(buildings_agg) AS buildings_agg
-FROM signature.signature_collections
-WHERE collection_type = 'landlord'
-GROUP BY loan_pool_slug
-UNION
-SELECT
-	'all' AS collection_slug,
-	count(*) AS landlords,
-	sum(buildings_agg) AS buildings_agg
-FROM signature.signature_collections
-WHERE collection_type = 'landlord'
+	collection_slug,
+	landlords,
+	buildings_agg
+FROM buildings
+LEFT JOIN landlords USING(collection_slug)


### PR DESCRIPTION
While updating the UNHP data I noticed that the count of buildings was not correct because of an error in the query (forgot we don't have landlords assigned for all buildings, so was excluding those).
This fixes that query and fills in the loan_pool for those collection type records. 

[sc-15425]