### PR TITLE
indicator dropdown shows correct timeline visualized

### DIFF
--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -230,7 +230,6 @@ class IndicatorsWithoutI18n extends Component<IndicatorsWithRouterProps, Indicat
       const { state, send } = this.props;
       const { detailAddr } = state.context.portfolioData;
       const {
-        defaultVis,
         activeVis,
         activeTimeSpan,
         monthsInGroup,

--- a/client/src/components/Indicators.tsx
+++ b/client/src/components/Indicators.tsx
@@ -312,7 +312,7 @@ class IndicatorsWithoutI18n extends Component<IndicatorsWithRouterProps, Indicat
                       classNamePrefix="select"
                       aria-labelledby="indicator-dropdown-title"
                       name="indicator-type"
-                      defaultValue={indicatorOptions.find((i) => i.value === defaultVis)}
+                      defaultValue={indicatorOptions.find((i) => i.value === activeVis)}
                       options={indicatorOptions}
                       onChange={this.handleVisChange}
                     />


### PR DESCRIPTION
a small bug we never noticed -- it was showing the default visualization name in the dropdown rather than the active visualization. current buggy behavior is recorded in this loom [link](https://www.loom.com/share/f6cf355a4ce441b5a8b1b24fda0db8c8) and the fixed behavior is in this loom [link](https://www.loom.com/share/bdb62e7a3c65409e9a087fb88f5172bf).

unfortunately the timespan dropdown's inaccuracy for rent stab units (showing "quarter" or "month" as selected when the graph is showing the "year" view) is not fixed by this