### PR TITLE
overview stats table RS units drop to zero in red text

### DIFF
--- a/client/src/components/BuildingStatsTable.tsx
+++ b/client/src/components/BuildingStatsTable.tsx
@@ -180,7 +180,9 @@ const RsUnits = () => {
           <span>&#x21FE;</span>
           <span
             className={`${
-              addr.rsunits2007 !== null && addr.rsunitslatest !== null && addr.rsunitslatest < addr.rsunits2007
+              addr.rsunits2007 !== null &&
+              addr.rsunitslatest !== null &&
+              addr.rsunitslatest < addr.rsunits2007
                 ? "text-danger"
                 : ""
             }`}

--- a/client/src/components/BuildingStatsTable.tsx
+++ b/client/src/components/BuildingStatsTable.tsx
@@ -180,7 +180,7 @@ const RsUnits = () => {
           <span>&#x21FE;</span>
           <span
             className={`${
-              addr.rsunits2007 && addr.rsunitslatest && addr.rsunitslatest < addr.rsunits2007
+              addr.rsunits2007 !== null && addr.rsunitslatest !== null && addr.rsunitslatest < addr.rsunits2007
                 ? "text-danger"
                 : ""
             }`}


### PR DESCRIPTION
There was a bug in the condition where it short-circuited on 0 before testing for the drop - need to only exclude nulls first
![image](https://github.com/user-attachments/assets/0488124f-04e8-4807-b42e-0ad59bbaa42b)

[sc-15644]