### PR TITLE
add note for delayed hpd reg data

### DIFF
--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -10,7 +10,7 @@ import { withI18n, withI18nProps, I18n } from "@lingui/react";
 import { t, Trans } from "@lingui/macro";
 import { SocialShareAddressPage } from "./SocialShare";
 import { isPartOfGroupSale } from "./PortfolioTable";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { LocaleLink } from "../i18n";
 import BuildingStatsTable from "./BuildingStatsTable";
 import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
@@ -344,8 +344,8 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                             <Trans>
                               Public data on registrations has not been updated by HPD since June 1,
                               2024. We're working with HPD to resolve the issue. See{" "}
-                              <Link
-                                to={
+                              <a
+                                href={
                                   !!hpdbuildingid && hpdbuildings === 1
                                     ? `https://hpdonline.nyc.gov/hpdonline/building/${hpdbuildingid}/overview`
                                     : `https://hpdonline.nyc.gov/hpdonline/building/search-results?boroId=${boro}&block=${block}&lot=${lot}`
@@ -354,7 +354,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                                 rel="noopener noreferrer"
                               >
                                 <Trans>HPD Online</Trans>
-                              </Link>{" "}
+                              </a>{" "}
                               for latest information.
                             </Trans>
                           </span>

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -10,7 +10,7 @@ import { withI18n, withI18nProps, I18n } from "@lingui/react";
 import { t, Trans } from "@lingui/macro";
 import { SocialShareAddressPage } from "./SocialShare";
 import { isPartOfGroupSale } from "./PortfolioTable";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { LocaleLink } from "../i18n";
 import BuildingStatsTable from "./BuildingStatsTable";
 import { createWhoOwnsWhatRoutePaths, AddressPageRoutes } from "../routes";
@@ -40,7 +40,7 @@ type State = {
 
 const NUM_COMPLAINT_TYPES_TO_SHOW = 3;
 
-const getTodaysDate = () => new Date();
+// const getTodaysDate = () => new Date();
 
 const SocialShareDetailView = () => (
   <SocialShareAddressPage
@@ -214,14 +214,17 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const { portfolioData } = state.context;
     const { assocAddrs, detailAddr, searchAddr } = portfolioData;
 
-    // Let's save some variables that will be helpful in rendering the front-end component
-    let formattedRegEndDate, streetViewCoords, streetViewAddr, ownernames, userOwnernames;
+    const { bbl, hpdbuildingid, hpdbuildings } = detailAddr;
+    const { boro, block, lot } = Helpers.splitBBL(bbl);
 
-    formattedRegEndDate = Helpers.formatDate(
-      detailAddr.registrationenddate,
-      longDateOptions,
-      locale
-    );
+    // Let's save some variables that will be helpful in rendering the front-end component
+    let streetViewCoords, streetViewAddr, ownernames, userOwnernames; //formattedRegEndDate
+
+    // formattedRegEndDate = Helpers.formatDate(
+    //   detailAddr.registrationenddate,
+    //   longDateOptions,
+    //   locale
+    // );
 
     streetViewCoords =
       detailAddr.lat && detailAddr.lng
@@ -335,6 +338,27 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                       <div className="card-body-registration">
                         <p>
                           <b>
+                            <Trans>Note:</Trans>
+                          </b>{" "}
+                          <span className="text-danger">
+                            <Trans>
+                              Public data on registrations has not been updated by HPD since June 1,
+                              2024. We're working with HPD to resolve the issue. See{" "}
+                              <Link
+                                to={
+                                  !!hpdbuildingid && hpdbuildings === 1
+                                    ? `https://hpdonline.nyc.gov/hpdonline/building/${hpdbuildingid}/overview`
+                                    : `https://hpdonline.nyc.gov/hpdonline/building/search-results?boroId=${boro}&block=${block}&lot=${lot}`
+                                }
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <Trans>HPD Online</Trans>
+                              </Link>{" "}
+                              for latest information.
+                            </Trans>
+                          </span>
+                          {/* <b>
                             <Trans>Last registered:</Trans>
                           </b>{" "}
                           {Helpers.formatDate(
@@ -352,7 +376,7 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                               {" "}
                               <Trans>(expires {formattedRegEndDate})</Trans>
                             </span>
-                          )}
+                          )} */}
                         </p>
                         {detailAddr.lastsaledate && detailAddr.lastsaleamount && (
                           <p>

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -6,8 +6,7 @@ import { Trans } from "@lingui/macro";
 import Modal from "../components/Modal";
 import LegalFooter from "../components/LegalFooter";
 import { withI18n, withI18nProps } from "@lingui/react";
-import Helpers, { longDateOptions } from "../util/helpers";
-import { defaultLocale, SupportedLocale } from "../i18n-base";
+import Helpers from "../util/helpers";
 import SocialShare from "../components/SocialShare";
 import { Nobr } from "../components/Nobr";
 import { withMachineInStateProps } from "state-machine";
@@ -43,12 +42,12 @@ class NotRegisteredPageWithoutI18n extends Component<Props, State> {
   }
 
   render() {
-    const { state, i18n } = this.props;
+    const { state } = this.props; //i18n
     const { searchAddrParams, searchAddrBbl, buildingInfo } = state.context;
 
     const { boro, block, lot } = Helpers.splitBBL(searchAddrBbl);
 
-    const locale = (i18n.language as SupportedLocale) || defaultLocale;
+    // const locale = (i18n.language as SupportedLocale) || defaultLocale;
 
     /**
      * This is the address that will show up in the top header of the page.
@@ -132,43 +131,43 @@ class NotRegisteredPageWithoutI18n extends Component<Props, State> {
       );
     }
 
-    const formattedLastRegDate = Helpers.formatDate(
-      buildingInfo.lastregistrationdate,
-      longDateOptions,
-      locale
-    );
+    // const formattedLastRegDate = Helpers.formatDate(
+    //   buildingInfo.lastregistrationdate,
+    //   longDateOptions,
+    //   locale
+    // );
 
-    const formattedRegEndDate = Helpers.formatDate(
-      buildingInfo.registrationenddate,
-      longDateOptions,
-      locale
-    );
+    // const formattedRegEndDate = Helpers.formatDate(
+    //   buildingInfo.registrationenddate,
+    //   longDateOptions,
+    //   locale
+    // );
 
-    const lastRegisteredDates = buildingInfo.registrationenddate ? (
-      <div className="card-body-registration text-center">
-        {buildingInfo.lastregistrationdate ? (
-          <p>
-            <b>
-              <Trans>Last registered:</Trans>
-            </b>{" "}
-            {formattedLastRegDate}
-            <span className="text-danger">
-              {" "}
-              <Trans>(expired {formattedRegEndDate})</Trans>
-            </span>
-          </p>
-        ) : (
-          <p>
-            <b>
-              <Trans>Registration expired:</Trans>
-            </b>{" "}
-            <span className="text-danger"> {formattedRegEndDate}</span>
-          </p>
-        )}
-      </div>
-    ) : (
-      <></>
-    );
+    // const lastRegisteredDates = buildingInfo.registrationenddate ? (
+    //   <div className="card-body-registration text-center">
+    //     {buildingInfo.lastregistrationdate ? (
+    //       <p>
+    //         <b>
+    //           <Trans>Last registered:</Trans>
+    //         </b>{" "}
+    //         {formattedLastRegDate}
+    //         <span className="text-danger">
+    //           {" "}
+    //           <Trans>(expired {formattedRegEndDate})</Trans>
+    //         </span>
+    //       </p>
+    //     ) : (
+    //       <p>
+    //         <b>
+    //           <Trans>Registration expired:</Trans>
+    //         </b>{" "}
+    //         <span className="text-danger"> {formattedRegEndDate}</span>
+    //       </p>
+    //     )}
+    //   </div>
+    // ) : (
+    //   <></>
+    // );
 
     const failedToRegisterLink = (
       <div className="text-center">
@@ -201,7 +200,26 @@ class NotRegisteredPageWithoutI18n extends Component<Props, State> {
               )}
               {registrationMissingOrExpired && buildingInfo.unitsres > 0 && (
                 <>
-                  {lastRegisteredDates}
+                  {/* {lastRegisteredDates} */}
+                  <p>
+                    <b>
+                      <Trans>Note:</Trans>
+                    </b>{" "}
+                    <span className="text-danger">
+                      <Trans>
+                        Public data on registrations has not been updated by HPD since June 1, 2024.
+                        We're working with HPD to resolve the issue. See{" "}
+                        <Link
+                          to={`https://hpdonline.nyc.gov/hpdonline/building/search-results?boroId=${boro}&block=${block}&lot=${lot}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <Trans>HPD Online</Trans>
+                        </Link>{" "}
+                        for latest information.
+                      </Trans>
+                    </span>
+                  </p>
                   {failedToRegisterLink}
                 </>
               )}

--- a/client/src/containers/NotRegisteredPage.tsx
+++ b/client/src/containers/NotRegisteredPage.tsx
@@ -209,13 +209,13 @@ class NotRegisteredPageWithoutI18n extends Component<Props, State> {
                       <Trans>
                         Public data on registrations has not been updated by HPD since June 1, 2024.
                         We're working with HPD to resolve the issue. See{" "}
-                        <Link
-                          to={`https://hpdonline.nyc.gov/hpdonline/building/search-results?boroId=${boro}&block=${block}&lot=${lot}`}
+                        <a
+                          href={`https://hpdonline.nyc.gov/hpdonline/building/search-results?boroId=${boro}&block=${block}&lot=${lot}`}
                           target="_blank"
                           rel="noopener noreferrer"
                         >
                           <Trans>HPD Online</Trans>
-                        </Link>{" "}
+                        </a>{" "}
                         for latest information.
                       </Trans>
                     </span>

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -33,18 +33,18 @@ msgstr "#WhoOwnsWhat via @JustFixOrg"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
-#: src/components/DetailView.tsx:240
+#: src/components/DetailView.tsx:269
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
 #: src/components/DetailView.tsx:222
 #: src/containers/NotRegisteredPage.tsx:104
-msgid "(expired {formattedRegEndDate})"
-msgstr "(expired {formattedRegEndDate})"
+#~ msgid "(expired {formattedRegEndDate})"
+#~ msgstr "(expired {formattedRegEndDate})"
 
 #: src/components/DetailView.tsx:225
-msgid "(expires {formattedRegEndDate})"
-msgstr "(expires {formattedRegEndDate})"
+#~ msgid "(expires {formattedRegEndDate})"
+#~ msgstr "(expires {formattedRegEndDate})"
 
 #: src/components/BuildingStatsTable.tsx:135
 #~ msgid "(hover over a box to learn more)"
@@ -74,7 +74,7 @@ msgstr "311 Complaints Data"
 #~ msgid "<0>Click to log in</0> if you are not redirected"
 #~ msgstr "<0>Click to log in</0> if you are not redirected"
 
-#: src/containers/NotRegisteredPage.tsx:81
+#: src/containers/NotRegisteredPage.tsx:80
 msgid "<0>If the landlord doesn't reside here, this property should be registered with HPD</0> because it has fewer than 3 residential units."
 msgstr "<0>If the landlord doesn't reside here, this property should be registered with HPD</0> because it has fewer than 3 residential units."
 
@@ -114,11 +114,11 @@ msgstr "<0>Search for an address</0> to add to your Building Alerts"
 msgid "<0>Search for an address</0> to add to your Building Updates, or visit your <1>email settings</1> page to manage subscriptions."
 msgstr "<0>Search for an address</0> to add to your Building Updates, or visit your <1>email settings</1> page to manage subscriptions."
 
-#: src/containers/NotRegisteredPage.tsx:73
+#: src/containers/NotRegisteredPage.tsx:72
 msgid "<0>This property is not required to register with HPD</0> because it doesn't have any residential units."
 msgstr "<0>This property is not required to register with HPD</0> because it doesn't have any residential units."
 
-#: src/containers/NotRegisteredPage.tsx:89
+#: src/containers/NotRegisteredPage.tsx:88
 msgid "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 msgstr "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 
@@ -276,7 +276,7 @@ msgstr "At this time we can only support {SUBSCRIPTION_LIMIT} buildings in each 
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:170
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -328,7 +328,7 @@ msgstr "Building info"
 msgid "Building size: {0}"
 msgstr "Building size: {0}"
 
-#: src/containers/NotRegisteredPage.tsx:163
+#: src/containers/NotRegisteredPage.tsx:193
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Buildings without valid property registration are subject to the following:"
 
@@ -336,13 +336,13 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:304
-#: src/components/DetailView.tsx:313
+#: src/components/DetailView.tsx:333
+#: src/components/DetailView.tsx:342
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:284
-#: src/components/DetailView.tsx:293
+#: src/components/DetailView.tsx:313
+#: src/components/DetailView.tsx:322
 msgid "Business Entities"
 msgstr "Business Entities"
 
@@ -390,7 +390,7 @@ msgstr "Check your email"
 #~ msgid "Check your email inbox {email} to verify your email address. Once you’ve done that, you’ll start getting email updates."
 #~ msgstr "Check your email inbox {email} to verify your email address. Once you’ve done that, you’ll start getting email updates."
 
-#: src/containers/NotRegisteredPage.tsx:167
+#: src/containers/NotRegisteredPage.tsx:197
 msgid "Civil penalties of $250-$500"
 msgstr "Civil penalties of $250-$500"
 
@@ -448,7 +448,7 @@ msgstr "Click below to unsubscribe from all and stop receiving Building Alerts."
 #~ msgid "Click below to unsubscribe from all and stop receiving Building Updates."
 #~ msgstr "Click below to unsubscribe from all and stop receiving Building Updates."
 
-#: src/containers/NotRegisteredPage.tsx:176
+#: src/containers/NotRegisteredPage.tsx:206
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
@@ -768,7 +768,7 @@ msgstr "FLOOR"
 msgid "FLOORING/STAIRS"
 msgstr "FLOORING/STAIRS"
 
-#: src/containers/NotRegisteredPage.tsx:162
+#: src/containers/NotRegisteredPage.tsx:192
 msgid "Failure to register a building with HPD"
 msgstr "Failure to register a building with HPD"
 
@@ -978,7 +978,7 @@ msgstr "If you already added a building, you will get your first Building Update
 msgid "In March 2023 this version will be discontinued. Switch to the new version or learn more."
 msgstr "In March 2023 this version will be discontinued. Switch to the new version or learn more."
 
-#: src/containers/NotRegisteredPage.tsx:64
+#: src/containers/NotRegisteredPage.tsx:63
 msgid "Incomplete registration for {usersInputAddressFragment}."
 msgstr "Incomplete registration for {usersInputAddressFragment}."
 
@@ -986,7 +986,7 @@ msgstr "Incomplete registration for {usersInputAddressFragment}."
 msgid "Individual Owner"
 msgstr "Individual Owner"
 
-#: src/containers/NotRegisteredPage.tsx:169
+#: src/containers/NotRegisteredPage.tsx:199
 msgid "Ineligible to certify violations"
 msgstr "Ineligible to certify violations"
 
@@ -1061,10 +1061,10 @@ msgstr "Last Sale Unknown"
 
 #: src/components/DetailView.tsx:217
 #: src/containers/NotRegisteredPage.tsx:99
-msgid "Last registered:"
-msgstr "Last registered:"
+#~ msgid "Last registered:"
+#~ msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:230
+#: src/components/DetailView.tsx:259
 msgid "Last sold:"
 msgstr "Last sold:"
 
@@ -1228,7 +1228,7 @@ msgstr "Max must be greater than {minOption}"
 #~ msgid "Maximum"
 #~ msgstr "Maximum"
 
-#: src/containers/NotRegisteredPage.tsx:168
+#: src/containers/NotRegisteredPage.tsx:198
 msgid "May be issued official Orders"
 msgstr "May be issued official Orders"
 
@@ -1261,7 +1261,7 @@ msgstr "Min must be less than {maxOption}"
 msgid "More Mobile Friendly"
 msgstr "More Mobile Friendly"
 
-#: src/components/DetailView.tsx:174
+#: src/components/DetailView.tsx:180
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -1351,11 +1351,11 @@ msgstr "No address found"
 msgid "No landlords match your search."
 msgstr "No landlords match your search."
 
-#: src/containers/NotRegisteredPage.tsx:67
+#: src/containers/NotRegisteredPage.tsx:66
 msgid "No registration found for {usersInputAddressFragment}."
 msgstr "No registration found for {usersInputAddressFragment}."
 
-#: src/containers/NotRegisteredPage.tsx:59
+#: src/containers/NotRegisteredPage.tsx:58
 msgid "No registration found."
 msgstr "No registration found."
 
@@ -1367,13 +1367,18 @@ msgstr "Non-ECB"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:182
+#: src/components/DetailView.tsx:188
 msgid "None"
 msgstr "None"
 
 #: src/containers/NotFoundPage.tsx:23
 msgid "Not found"
 msgstr "Not found"
+
+#: src/components/DetailView.tsx:223
+#: src/containers/NotRegisteredPage.tsx:151
+msgid "Note:"
+msgstr "Note:"
 
 #: src/components/PortfolioFilters.tsx:88
 #~ msgid "Notice an inaccuracy? Click here."
@@ -1491,8 +1496,8 @@ msgstr "Password"
 msgid "Password reset successful"
 msgstr "Password reset successful"
 
-#: src/components/DetailView.tsx:324
-#: src/components/DetailView.tsx:334
+#: src/components/DetailView.tsx:353
+#: src/components/DetailView.tsx:363
 msgid "People"
 msgstr "People"
 
@@ -1550,6 +1555,11 @@ msgstr "Privacy policy"
 msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
+#: src/components/DetailView.tsx:226
+#: src/containers/NotRegisteredPage.tsx:154
+msgid "Public data on registrations has not been updated by HPD since June 1, 2024. We're working with HPD to resolve the issue. See <0>HPD Online</0> for latest information."
+msgstr "Public data on registrations has not been updated by HPD since June 1, 2024. We're working with HPD to resolve the issue. See <0>HPD Online</0> for latest information."
+
 #: src/components/PropertiesSummary.tsx:130
 msgid "Questions or feedback?"
 msgstr "Questions or feedback?"
@@ -1569,8 +1579,8 @@ msgid "Read more in our Methodology section"
 msgstr "Read more in our Methodology section"
 
 #: src/containers/NotRegisteredPage.tsx:108
-msgid "Registration expired:"
-msgstr "Registration expired:"
+#~ msgid "Registration expired:"
+#~ msgstr "Registration expired:"
 
 #: src/containers/AccountSettingsPage.tsx:25
 msgid "Remove"
@@ -1689,7 +1699,7 @@ msgstr "Search by your landlord's name"
 msgid "Search by:"
 msgstr "Search by:"
 
-#: src/containers/NotRegisteredPage.tsx:158
+#: src/containers/NotRegisteredPage.tsx:188
 #: src/containers/NychaPage.tsx:200
 msgid "Search for a different address"
 msgstr "Search for a different address"
@@ -1742,10 +1752,10 @@ msgstr "Send us a data request"
 #~ msgid "Share this page with your neighbors"
 #~ msgstr "Share this page with your neighbors"
 
-#: src/components/DetailView.tsx:255
+#: src/components/DetailView.tsx:284
 #: src/components/EngagementPanel.tsx:11
 #: src/components/PropertiesSummary.tsx:138
-#: src/containers/NotRegisteredPage.tsx:19
+#: src/containers/NotRegisteredPage.tsx:18
 msgid "Share with your neighbors"
 msgstr "Share with your neighbors"
 
@@ -2021,7 +2031,7 @@ msgstr "The number of residential units in this building, according to the Dept.
 msgid "The password reset link that we sent you is no longer valid."
 msgstr "The password reset link that we sent you is no longer valid."
 
-#: src/containers/NotRegisteredPage.tsx:124
+#: src/containers/NotRegisteredPage.tsx:139
 msgid "The registration for this property is missing details for owner name or businesses address, which are required to link the property to a portfolio."
 msgstr "The registration for this property is missing details for owner name or businesses address, which are required to link the property to a portfolio."
 
@@ -2163,11 +2173,11 @@ msgstr "Try adjusting or clearing the filters to show more than 0 results."
 #~ msgid "Try adjusting or clearing the filters to yield more than 0 results."
 #~ msgstr "Try adjusting or clearing the filters to yield more than 0 results."
 
-#: src/containers/NotRegisteredPage.tsx:171
+#: src/containers/NotRegisteredPage.tsx:201
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "Unable to initiate a court action for nonpayment of rent."
 
-#: src/containers/NotRegisteredPage.tsx:170
+#: src/containers/NotRegisteredPage.tsx:200
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Unable to request Code Violation Dismissals"
 
@@ -2305,11 +2315,11 @@ msgstr "View on Google Maps"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:154
+#: src/components/DetailView.tsx:160
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
-#: src/components/BuildingStatsTable.tsx:187
+#: src/components/BuildingStatsTable.tsx:189
 msgid "View trends over time"
 msgstr "View trends over time"
 
@@ -2338,7 +2348,7 @@ msgstr "WINDOWS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:209
+#: src/components/DetailView.tsx:215
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 
@@ -2394,7 +2404,7 @@ msgstr "We’ve improved Who Owns What to dig deeper into the data and offer you
 msgid "What are {0}?"
 msgstr "What are {0}?"
 
-#: src/containers/NotRegisteredPage.tsx:115
+#: src/containers/NotRegisteredPage.tsx:130
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 
@@ -2461,7 +2471,7 @@ msgstr "Who owns what"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:189
+#: src/components/DetailView.tsx:195
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -2675,7 +2685,7 @@ msgstr "buildings"
 #~ msgid "contact support@justfix.org"
 #~ msgstr "contact support@justfix.org"
 
-#: src/components/DetailView.tsx:234
+#: src/components/DetailView.tsx:263
 msgid "for ${0}"
 msgstr "for ${0}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -38,18 +38,18 @@ msgstr "#QuiénEsElDueño por @JustFixOrg"
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
-#: src/components/DetailView.tsx:240
+#: src/components/DetailView.tsx:269
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
 #: src/components/DetailView.tsx:222
 #: src/containers/NotRegisteredPage.tsx:104
-msgid "(expired {formattedRegEndDate})"
-msgstr "(caducado {formattedRegEndDate})"
+#~ msgid "(expired {formattedRegEndDate})"
+#~ msgstr "(caducado {formattedRegEndDate})"
 
 #: src/components/DetailView.tsx:225
-msgid "(expires {formattedRegEndDate})"
-msgstr "(caduca {formattedRegEndDate})"
+#~ msgid "(expires {formattedRegEndDate})"
+#~ msgstr "(caduca {formattedRegEndDate})"
 
 #: src/components/BuildingStatsTable.tsx:135
 #~ msgid "(hover over a box to learn more)"
@@ -79,7 +79,7 @@ msgstr "Datos de quejas al 311"
 #~ msgid "<0>Click to log in</0> if you are not redirected"
 #~ msgstr "<0>Click to log in</0> if you are not redirected"
 
-#: src/containers/NotRegisteredPage.tsx:81
+#: src/containers/NotRegisteredPage.tsx:80
 msgid "<0>If the landlord doesn't reside here, this property should be registered with HPD</0> because it has fewer than 3 residential units."
 msgstr "<0>Si el dueño no reside aquí, esta propiedad debería estar registrado con el HPD</0> porque tiene menos de 3 unidades residenciales."
 
@@ -119,11 +119,11 @@ msgstr "<0>Busca una dirección</0> para añadir a Alertas de Edificios"
 msgid "<0>Search for an address</0> to add to your Building Updates, or visit your <1>email settings</1> page to manage subscriptions."
 msgstr "<0>Busca una dirección</0> para añadir a sus actualizaciones de edificios, o visite su página de <1>configuración del correo electrónico</1> para administrar sus suscripciones."
 
-#: src/containers/NotRegisteredPage.tsx:73
+#: src/containers/NotRegisteredPage.tsx:72
 msgid "<0>This property is not required to register with HPD</0> because it doesn't have any residential units."
 msgstr "<0>Esta propiedad no necesita estar registrada con en HPD</0> porque no tiene ninguna unidad residencial."
 
-#: src/containers/NotRegisteredPage.tsx:89
+#: src/containers/NotRegisteredPage.tsx:88
 msgid "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 msgstr "<0>Esta propiedad debe estar registrada con en HPD</0> porque tiene más de 2 unidades residenciales."
 
@@ -281,7 +281,7 @@ msgstr "En este momento solamente podemos admitir {SUBSCRIPTION_LIMIT} edificios
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:170
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -333,7 +333,7 @@ msgstr "Información de edificios"
 msgid "Building size: {0}"
 msgstr "Tamaño del edificio: {0}"
 
-#: src/containers/NotRegisteredPage.tsx:163
+#: src/containers/NotRegisteredPage.tsx:193
 msgid "Buildings without valid property registration are subject to the following:"
 msgstr "Edificios sin registro de propiedad válido están sujetos a las siguientes obligaciones:"
 
@@ -341,13 +341,13 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:304
-#: src/components/DetailView.tsx:313
+#: src/components/DetailView.tsx:333
+#: src/components/DetailView.tsx:342
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:284
-#: src/components/DetailView.tsx:293
+#: src/components/DetailView.tsx:313
+#: src/components/DetailView.tsx:322
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
@@ -395,7 +395,7 @@ msgstr "Revise su correo electrónico"
 #~ msgid "Check your email inbox {email} to verify your email address. Once you’ve done that, you’ll start getting email updates."
 #~ msgstr "Check your email inbox {email} to verify your email address. Once you’ve done that, you’ll start getting email updates."
 
-#: src/containers/NotRegisteredPage.tsx:167
+#: src/containers/NotRegisteredPage.tsx:197
 msgid "Civil penalties of $250-$500"
 msgstr "Sanciones civiles de $250-$500"
 
@@ -453,7 +453,7 @@ msgstr "Haga clic a continuación para desuscribirse de todo y dejar de recibir 
 #~ msgid "Click below to unsubscribe from all and stop receiving Building Updates."
 #~ msgstr "Click below to unsubscribe from all and stop receiving Building Updates."
 
-#: src/containers/NotRegisteredPage.tsx:176
+#: src/containers/NotRegisteredPage.tsx:206
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
@@ -773,7 +773,7 @@ msgstr "PISO"
 msgid "FLOORING/STAIRS"
 msgstr "PISO/ESCALERAS"
 
-#: src/containers/NotRegisteredPage.tsx:162
+#: src/containers/NotRegisteredPage.tsx:192
 msgid "Failure to register a building with HPD"
 msgstr "Si no se registra un edificio con el HPD"
 
@@ -983,7 +983,7 @@ msgstr "Si ya ha añadido un edificio, recibirá la primera actualización de ed
 msgid "In March 2023 this version will be discontinued. Switch to the new version or learn more."
 msgstr "En marzo de 2023 esta versión dejará de funcionar. Cambie a la nueva versión u obtenga más información."
 
-#: src/containers/NotRegisteredPage.tsx:64
+#: src/containers/NotRegisteredPage.tsx:63
 msgid "Incomplete registration for {usersInputAddressFragment}."
 msgstr "Registro incompleto para {usersInputAddressFragment}."
 
@@ -991,7 +991,7 @@ msgstr "Registro incompleto para {usersInputAddressFragment}."
 msgid "Individual Owner"
 msgstr "Dueño Individual"
 
-#: src/containers/NotRegisteredPage.tsx:169
+#: src/containers/NotRegisteredPage.tsx:199
 msgid "Ineligible to certify violations"
 msgstr "Inelegible para certificar violaciones"
 
@@ -1066,10 +1066,10 @@ msgstr "Última venta desconocida"
 
 #: src/components/DetailView.tsx:217
 #: src/containers/NotRegisteredPage.tsx:99
-msgid "Last registered:"
-msgstr "Registrado por última vez:"
+#~ msgid "Last registered:"
+#~ msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:230
+#: src/components/DetailView.tsx:259
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
@@ -1233,7 +1233,7 @@ msgstr "Máx debe ser mayor que {minOption}"
 #~ msgid "Maximum"
 #~ msgstr "Maximum"
 
-#: src/containers/NotRegisteredPage.tsx:168
+#: src/containers/NotRegisteredPage.tsx:198
 msgid "May be issued official Orders"
 msgstr "Pueden emitirse órdenes oficiales"
 
@@ -1266,7 +1266,7 @@ msgstr "Mín debe ser menor que {maxOption}"
 msgid "More Mobile Friendly"
 msgstr "Más útil para dispositivos móviles"
 
-#: src/components/DetailView.tsx:174
+#: src/components/DetailView.tsx:180
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -1356,11 +1356,11 @@ msgstr "No se encontraron direcciones"
 msgid "No landlords match your search."
 msgstr "No hay nombres de dueños coincidan con su búsqueda."
 
-#: src/containers/NotRegisteredPage.tsx:67
+#: src/containers/NotRegisteredPage.tsx:66
 msgid "No registration found for {usersInputAddressFragment}."
 msgstr "No se ha encontrado ningún registro para {usersInputAddressFragment}."
 
-#: src/containers/NotRegisteredPage.tsx:59
+#: src/containers/NotRegisteredPage.tsx:58
 msgid "No registration found."
 msgstr "No se ha encontrado nigún registro."
 
@@ -1372,13 +1372,18 @@ msgstr "No ECB"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:182
+#: src/components/DetailView.tsx:188
 msgid "None"
 msgstr "Ninguna"
 
 #: src/containers/NotFoundPage.tsx:23
 msgid "Not found"
 msgstr "No encontrado"
+
+#: src/components/DetailView.tsx:223
+#: src/containers/NotRegisteredPage.tsx:151
+msgid "Note:"
+msgstr ""
 
 #: src/components/PortfolioFilters.tsx:88
 #~ msgid "Notice an inaccuracy? Click here."
@@ -1496,8 +1501,8 @@ msgstr "Contraseña"
 msgid "Password reset successful"
 msgstr "Contraseña restablecida con éxito"
 
-#: src/components/DetailView.tsx:324
-#: src/components/DetailView.tsx:334
+#: src/components/DetailView.tsx:353
+#: src/components/DetailView.tsx:363
 msgid "People"
 msgstr "Personas"
 
@@ -1555,6 +1560,11 @@ msgstr "Política de privacidad"
 msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
+#: src/components/DetailView.tsx:226
+#: src/containers/NotRegisteredPage.tsx:154
+msgid "Public data on registrations has not been updated by HPD since June 1, 2024. We're working with HPD to resolve the issue. See <0>HPD Online</0> for latest information."
+msgstr ""
+
 #: src/components/PropertiesSummary.tsx:130
 msgid "Questions or feedback?"
 msgstr "¿preguntas o comentarios?"
@@ -1574,8 +1584,8 @@ msgid "Read more in our Methodology section"
 msgstr "Más información sobre nuestra metodología"
 
 #: src/containers/NotRegisteredPage.tsx:108
-msgid "Registration expired:"
-msgstr "El registro ha caducado:"
+#~ msgid "Registration expired:"
+#~ msgstr "El registro ha caducado:"
 
 #: src/containers/AccountSettingsPage.tsx:25
 msgid "Remove"
@@ -1694,7 +1704,7 @@ msgstr "Busca por el nombre de tu dueño"
 msgid "Search by:"
 msgstr "Buscar por:"
 
-#: src/containers/NotRegisteredPage.tsx:158
+#: src/containers/NotRegisteredPage.tsx:188
 #: src/containers/NychaPage.tsx:200
 msgid "Search for a different address"
 msgstr "Buscar otra dirección"
@@ -1747,10 +1757,10 @@ msgstr "Envíanos una solicitud de datos"
 #~ msgid "Share this page with your neighbors"
 #~ msgstr "Share this page with your neighbors"
 
-#: src/components/DetailView.tsx:255
+#: src/components/DetailView.tsx:284
 #: src/components/EngagementPanel.tsx:11
 #: src/components/PropertiesSummary.tsx:138
-#: src/containers/NotRegisteredPage.tsx:19
+#: src/containers/NotRegisteredPage.tsx:18
 msgid "Share with your neighbors"
 msgstr "Comparte esta página con sus vecinos"
 
@@ -2026,7 +2036,7 @@ msgstr ""
 msgid "The password reset link that we sent you is no longer valid."
 msgstr "El enlace para restablecer la contraseña que le hemos enviado no es válido."
 
-#: src/containers/NotRegisteredPage.tsx:124
+#: src/containers/NotRegisteredPage.tsx:139
 msgid "The registration for this property is missing details for owner name or businesses address, which are required to link the property to a portfolio."
 msgstr "El registro de esta propiedad faltan detalles sobre el nombre del dueño o la dirección comercial, que son necesarios a vincular la propiedad a un portafolio."
 
@@ -2168,11 +2178,11 @@ msgstr "Intente ajustar o borrar los filtros para mostrar más de 0 resultados."
 #~ msgid "Try adjusting or clearing the filters to yield more than 0 results."
 #~ msgstr "Try adjusting or clearing the filters to yield more than 0 results."
 
-#: src/containers/NotRegisteredPage.tsx:171
+#: src/containers/NotRegisteredPage.tsx:201
 msgid "Unable to initiate a court action for nonpayment of rent."
 msgstr "No es possible iniciar una acción judicial por falta de pago del alquiler."
 
-#: src/containers/NotRegisteredPage.tsx:170
+#: src/containers/NotRegisteredPage.tsx:200
 msgid "Unable to request Code Violation Dismissals"
 msgstr "Imposible solicitar el despido de una Infracción del Código de Vivienda"
 
@@ -2310,11 +2320,11 @@ msgstr "Ver en Google Maps"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:154
+#: src/components/DetailView.tsx:160
 msgid "View portfolio map"
 msgstr "Ver mapa de la cartera de edificios"
 
-#: src/components/BuildingStatsTable.tsx:187
+#: src/components/BuildingStatsTable.tsx:189
 msgid "View trends over time"
 msgstr ""
 
@@ -2343,7 +2353,7 @@ msgstr "VENTANAS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:209
+#: src/components/DetailView.tsx:215
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Aviso: Este edificio tiene un registro vencido y se vendió después del vencimiento del registro. La información del dueño que se incluye aquí puede estar desactualizada."
 
@@ -2399,7 +2409,7 @@ msgstr "Hemos mejorado ¿Quién es el Dueño en NY? para profundizar en los dato
 msgid "What are {0}?"
 msgstr "¿Qué son {0}?"
 
-#: src/containers/NotRegisteredPage.tsx:115
+#: src/containers/NotRegisteredPage.tsx:130
 msgid "What happens if the landlord has failed to register?"
 msgstr "¿Qué pasa si el propietario no ha registrado el edificio?"
 
@@ -2466,7 +2476,7 @@ msgstr "Quién es el dueño en NY"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:189
+#: src/components/DetailView.tsx:195
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
@@ -2680,7 +2690,7 @@ msgstr "edificios"
 #~ msgid "contact support@justfix.org"
 #~ msgstr "contact support@justfix.org"
 
-#: src/components/DetailView.tsx:234
+#: src/components/DetailView.tsx:263
 msgid "for ${0}"
 msgstr "por ${0}"
 


### PR DESCRIPTION
The HPD registration datasets on the Open Data portal haven't been updated since June 1, but are supposed to be automatically each month. We are talking with HPD about getting things updated, but in the meantime we wanted to put a note on the WOW building pages where we usually put the latest registration date explaining that we don't have the data and to look on HPD Online where they have the up-to-date info. Hopefully we'll have the data updated soon and then we can just revert this commit. See [slack thread](https://justfixnyc.slack.com/archives/CCWHGAR9C/p1729525389206699) for discussion with Joel. 

[sc-15724]