### PR TITLE
ensure selected geosearch result matched on borough

### DIFF
--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -36,7 +36,6 @@ function searchForAddressWithGeosearch(
         reject(new NetworkError(e.message));
       },
       onResults(results) {
-        console.log({ results, addr });
         const firstBoroResult = results.features.filter(
           (bldg) => bldg.properties.borough.toUpperCase() === q.boro.toUpperCase()
         )[0];

--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -36,15 +36,18 @@ function searchForAddressWithGeosearch(
         reject(new NetworkError(e.message));
       },
       onResults(results) {
-        const firstResult = results.features[0];
-        if (!firstResult)
+        console.log({ results, addr });
+        const firstBoroResult = results.features.filter(
+          (bldg) => bldg.properties.borough.toUpperCase() === q.boro.toUpperCase()
+        )[0];
+        if (!firstBoroResult)
           return resolve({
             addrs: [],
             geosearch: undefined,
           });
         resolve(
           searchForBBL(
-            helpers.splitBBL(firstResult.properties.addendum.pad.bbl),
+            helpers.splitBBL(firstBoroResult.properties.addendum.pad.bbl),
             useNewPortfolioMethod
           )
         );


### PR DESCRIPTION
For all addresses pages the URL has the street address, and we first input those into a request to Geosearch to get the BBL, then use the BBL for a request to our own WOW api for the data to populate the page. This happens for every load of an address page, and it completely separate from our use of Geosearch for the address autocomplete/search bar on the home page. 

Since we always have the complete address (boro, number, streetname) in the URL for an address page we had just taken all of that and put that into the Geosearch api (eg. `101 MANHATTAN AVENUE, MANHATTAN`) and take the first property in the response. However, in some rare cases the first result option is incorrect. For example for this address the first result given is for the same address but in brooklyn, and so we populate the page with data for the wrong property. 

![image](https://github.com/user-attachments/assets/a9b070ba-f3d7-48ec-8005-2d849f5d8cb9)


To fix this, without completely removing this geosearch step (which we will consider separately), we can just check the geosearch result list and confirm that the borough matches before taking the first result. 

Before: https://whoownswhat.justfix.org/en/address/BROOKLYN/103/MANHATTAN%20AVENUE shows the brooklyn results (note the bbl starting with 3)
![image](https://github.com/user-attachments/assets/8c04079b-477b-48c3-88c4-387e8b4af08b)


After: https://deploy-preview-981--wow-django.netlify.app/en/address/MANHATTAN/103/MANHATTAN%20AVENUE it shows the correct manhattan address page

This also still works if you use the BBL url: https://deploy-preview-981--wow-django.netlify.app/en/bbl/1018400014

[sc-15871]