### PR TITLE
Rs data fix

### DIFF
--- a/sql/create_bldgs_table.sql
+++ b/sql/create_bldgs_table.sql
@@ -32,7 +32,7 @@ rentstab as (
     coalesce(uc2022, 0) rsunitslatest,
     coalesce(uc2022, 0) - coalesce(unitsstab2007, 0) rsdiff
   from rentstab_summary
-  left join rentstab_v2 using(ucbbl)
+  full join rentstab_v2 using(ucbbl)
 ),
 
 complaints as (

--- a/wow/sql/address_indicatorhistory.sql
+++ b/wow/sql/address_indicatorhistory.sql
@@ -107,6 +107,8 @@ WITH TIME_SERIES AS (
       union
       select '2018-01' as month, uc2018 as RENTSTABILIZEDUNITS_TOTAL from RENTSTAB_DATA
       union
+      select '2019-01' as month, uc2019 as RENTSTABILIZEDUNITS_TOTAL from RENTSTAB_DATA
+      union
       select '2020-01' as month, uc2020 as RENTSTABILIZEDUNITS_TOTAL from RENTSTAB_DATA
       union
       select '2021-01' as month, uc2021 as RENTSTABILIZEDUNITS_TOTAL from RENTSTAB_DATA


### PR DESCRIPTION
From Praks:
>Noting that for [this building](https://whoownswhat.justfix.org/en/address/BROOKLYN/123/MELROSE%20STREET) while the overview tab says RS units is NA, the timeline tab shows all 468 units since 2020 (assuming because 421 a starts this year) 

Since it's a new building it's not in the old RS table, and we were doing a left join so all the later years were missing. 

Separate I also noticed a typo in the RS timeline query that was leaving out 2019

[sc-16095]