### PR TITLE
add dob_now_cofo data and remove jobtype (unused)

### DIFF
--- a/sql/create_gce_common.sql
+++ b/sql/create_gce_common.sql
@@ -14,16 +14,19 @@ CREATE TEMPORARY TABLE x_all_cofos AS (
   SELECT
     bbl,
     bin,
-    coissuedate AS issue_date,
-    jobtype AS job_type
+    coissuedate AS issue_date
   FROM dob_certificate_occupancy
   UNION
   SELECT
     bbl,
     bin,
-    issuedate AS issue_date,
-    jobtype AS job_type
+    issuedate AS issue_date
   FROM dob_foil_certificate_occupancy
+  SELECT
+    bbl,
+    bin,
+    cofoissuancedate::date AS issue_date
+  FROM dob_now_certificate_occupancy
 );
 
 CREATE INDEX ON x_all_cofos (bbl, issue_date);
@@ -32,10 +35,9 @@ CREATE TEMPORARY TABLE x_latest_cofos AS (
   SELECT DISTINCT ON (bbl)
     bbl,
     bin AS co_bin,
-    issue_date AS co_issued,
-    job_type AS co_type
+    issue_date AS co_issued
   FROM x_all_cofos
-  WHERE job_type IN ('NB', 'A1') AND issue_date IS NOT NULL
+  WHERE issue_date IS NOT NULL
   ORDER BY bbl, issue_date desc
 );
 

--- a/sql/create_gce_screener.sql
+++ b/sql/create_gce_screener.sql
@@ -250,7 +250,6 @@ CREATE TABLE gce_screener AS (
 
       co.co_bin,
       co.co_issued,
-      co.co_type,
 
       coalesce(r.uc2019, 0) AS rs_units_2019,
       coalesce(r.uc2020, 0) AS rs_units_2020, 


### PR DESCRIPTION
Add Certificate of Occupancy records from DOB NOW system (added to nycdb in https://github.com/nycdb/nycdb/pull/371) to the Good Cause tables

[sc-16216]