### PR TITLE
add API endpoint for dataset tracker info for sending alerts

### DIFF
--- a/wow/sql/dataset_tracker.sql
+++ b/wow/sql/dataset_tracker.sql
@@ -1,0 +1,8 @@
+SELECT
+    t.key AS dataset,
+    to_char(t.value::timestamp, 'YYYY-MM-DD"T"HH24:MI:SS.US')  || 'Z' AS last_updated,
+    expectedupdate::text AS update_cadence,
+    alertthreshold::text AS alert_threshold,
+    -(CURRENT_DATE - t.value::timestamp) > alertthreshold AS is_late
+FROM dataset_tracker  AS t
+LEFT JOIN dataset_alerts AS a ON t.key = a.datasetname

--- a/wow/urls.py
+++ b/wow/urls.py
@@ -55,5 +55,6 @@ urlpatterns = [
     path(
         "dataset/last_updated", views.dataset_last_updated, name="dataset_last_updated"
     ),
+    path("dataset/tracker", views.dataset_tracker, name="dataset_tracker"),
     path("gce/screener", views.gce_screener, name="gce_screener"),
 ]

--- a/wow/views.py
+++ b/wow/views.py
@@ -331,6 +331,7 @@ def dataset_last_updated(request):
         result = exec_db_query(SQL_DIR / "dataset_last_updated_all.sql")
     return JsonResponse({"result": list(result)})
 
+
 @api
 def dataset_tracker(request):
     """

--- a/wow/views.py
+++ b/wow/views.py
@@ -331,6 +331,16 @@ def dataset_last_updated(request):
         result = exec_db_query(SQL_DIR / "dataset_last_updated_all.sql")
     return JsonResponse({"result": list(result)})
 
+@api
+def dataset_tracker(request):
+    """
+    This API endpoint returns data on all datasets loaded in the database via
+    our nycdb-k8s-loader, including when the dataset was last updated and the
+    expected update schedule.
+    """
+    result = exec_db_query(SQL_DIR / "dataset_tracker.sql")
+    return JsonResponse({"result": list(result)})
+
 
 @api
 def gce_screener(request):


### PR DESCRIPTION
We want to set up a dashboard display dataset update status and daily cron job script to check for out-of-date datasets, so this API endpoint returns all the information about datasets recorded via nycdb-k8s-loader and the manually created/maintained table of expected dataset schedules. 

They may be some changes to this set up, but just wanted to get a first pass of this up and running now.

[sc-15800]