### PR TITLE
add dataset update tracker table to /dev page

### DIFF
--- a/client/src/components/APIClient.ts
+++ b/client/src/components/APIClient.ts
@@ -3,6 +3,8 @@ import {
   BuildingInfoResults,
   IndicatorsHistoryResults,
   WithBoroBlockLot,
+  DatasetTrackerInfoResults,
+  DatasetTrackerInfo,
 } from "./APIDataTypes";
 import { GeoSearchRequester } from "@justfixnyc/geosearch-requester";
 import {
@@ -102,6 +104,12 @@ function getBuildingInfo(bbl: string): Promise<BuildingInfoResults> {
   return getApiJson(`/api/address/buildinginfo?bbl=${bbl}`);
 }
 
+async function getDatasetInfo(): Promise<DatasetTrackerInfo[]> {
+  const apiData: Promise<DatasetTrackerInfoResults> = getApiJson("/api/dataset/tracker");
+  const rawDatasetInfo = (await apiData).result;
+  return rawDatasetInfo;
+}
+
 async function getIndicatorHistory(bbl: string): Promise<IndicatorsDataFromAPI> {
   const apiData: Promise<IndicatorsHistoryResults> = getApiJson(
     `/api/address/indicatorhistory?bbl=${bbl}`
@@ -175,6 +183,7 @@ const Client = {
   searchForBBL,
   getBuildingInfo,
   getIndicatorHistory,
+  getDatasetInfo,
 };
 
 export default Client;

--- a/client/src/components/APIDataTypes.ts
+++ b/client/src/components/APIDataTypes.ts
@@ -195,3 +195,15 @@ export type MonthlyTimelineData = {
 export type IndicatorsHistoryResults = {
   result: MonthlyTimelineData[];
 };
+
+export type DatasetTrackerInfo = {
+  dataset: string;
+  last_updated: string;
+  update_cadence: string;
+  alert_threshold: string;
+  is_late: boolean;
+};
+
+export type DatasetTrackerInfoResults = {
+  result: DatasetTrackerInfo[];
+};

--- a/client/src/components/DatasetTrackerTable.tsx
+++ b/client/src/components/DatasetTrackerTable.tsx
@@ -1,0 +1,100 @@
+import {
+  createColumnHelper,
+  filterFns,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { DatasetTrackerInfo } from "./APIDataTypes";
+import { inNumberRanges, isNonZero } from "./PortfolioTable";
+import classNames from "classnames";
+import "../styles/DatasetTrackerTable.scss";
+
+const columnHelper = createColumnHelper<DatasetTrackerInfo>();
+
+const columns = [
+  columnHelper.accessor("dataset", {
+    header: "Dataset",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("last_updated", {
+    header: "Last Updated",
+    cell: (info) => {
+      return new Date(info.getValue()).toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        hour12: true,
+      });
+    },
+  }),
+  columnHelper.accessor("update_cadence", {
+    header: "Update Cadence",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("alert_threshold", {
+    header: "Alert Threshold",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("is_late", {
+    header: "Status",
+    cell: (info) => (info.getValue() ? "Late" : info.getValue() === false ? "Up-to-date" : ""),
+  }),
+];
+
+const initialSorting = [
+  { id: "is_late", desc: true },
+  { id: "last_updated", desc: true },
+];
+
+export const DatasetTrackerTable: React.FC<{ data: DatasetTrackerInfo[] }> = ({ data }) => {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    state: {
+      sorting: initialSorting,
+    },
+    filterFns: {
+      arrIncludesSome: filterFns.arrIncludesSome,
+      inNumberRanges: inNumberRanges,
+      isNonZero: isNonZero,
+    },
+  });
+
+  return (
+    <table id="dataset-tracker-table">
+      <thead>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <th key={header.id}>
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(header.column.columnDef.header, header.getContext())}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getSortedRowModel().rows.map((row) => (
+          <tr
+            key={row.id}
+            className={classNames(
+              row.original.is_late ? "late" : row.original.is_late === false ? "up-to-date" : ""
+            )}
+          >
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/client/src/components/PortfolioTable.tsx
+++ b/client/src/components/PortfolioTable.tsx
@@ -54,10 +54,10 @@ const currencyFormater = new Intl.NumberFormat("en-us", {
   maximumFractionDigits: 0,
 });
 
-const isNonZero: FilterFn<any> = (row, columnId, value, addMeta) =>
+export const isNonZero: FilterFn<any> = (row, columnId, value, addMeta) =>
   value ? !!row.getValue(columnId) : true;
 
-const inNumberRanges: FilterFn<any> = (
+export const inNumberRanges: FilterFn<any> = (
   row,
   columnId,
   filterValue: FilterNumberRange[],

--- a/client/src/containers/DevPage.tsx
+++ b/client/src/containers/DevPage.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Page from "components/Page";
-import { SearchAddressWithoutBbl } from "components/APIDataTypes";
+import { DatasetTrackerInfo, SearchAddressWithoutBbl } from "components/APIDataTypes";
 import { Link } from "react-router-dom";
 import { createRouteForAddressPage, createRouteForFullBbl } from "routes";
+import APIClient from "components/APIClient";
+import { DatasetTrackerTable } from "components/DatasetTrackerTable";
 
 type AddressExampleProps = SearchAddressWithoutBbl & {
   desc: string;
@@ -54,6 +56,15 @@ const AddressExample: React.FC<AddressExampleProps> = (props: AddressExampleProp
 
 export const DevPage: React.FC<{}> = () => {
   const fullBllUrl = createRouteForFullBbl("3012380016");
+  const [datasetInfo, setDatasetInfo] = useState<DatasetTrackerInfo[]>();
+
+  useEffect(() => {
+    async function asyncGetDatasetInfo() {
+      const data = await APIClient.getDatasetInfo();
+      setDatasetInfo(data);
+    }
+    asyncGetDatasetInfo();
+  }, []);
 
   return (
     <Page title="Developer documentation">
@@ -91,6 +102,8 @@ export const DevPage: React.FC<{}> = () => {
           <p>
             <Link to={fullBllUrl}>{fullBllUrl}</Link>
           </p>
+          <h3 id="tracker">Dataset Update Tracker</h3>
+          {datasetInfo && <DatasetTrackerTable data={datasetInfo} />}
         </div>
       </div>
     </Page>

--- a/client/src/styles/DatasetTrackerTable.scss
+++ b/client/src/styles/DatasetTrackerTable.scss
@@ -1,0 +1,24 @@
+@import "_vars.scss";
+
+#dataset-tracker-table {
+  border-collapse: collapse;
+  thead {
+    font-size: 1rem;
+  }
+  tbody tr {
+    &.up-to-date {
+      background-color: rgba($justfix-green, 0.5);
+    }
+    &.late {
+      background-color: rgba($justfix-orange, 0.5);
+      font-weight: 700;
+    }
+    td {
+      border: 1px solid $justfix-black;
+    }
+  }
+  th,
+  td {
+    padding: 0.5rem;
+  }
+}

--- a/wow/sql/dataset_tracker.sql
+++ b/wow/sql/dataset_tracker.sql
@@ -3,6 +3,6 @@ SELECT
     to_char(t.value::timestamp, 'YYYY-MM-DD"T"HH24:MI:SS.US')  || 'Z' AS last_updated,
     expectedupdate::text AS update_cadence,
     alertthreshold::text AS alert_threshold,
-    -(CURRENT_DATE - t.value::timestamp) > alertthreshold AS is_late
+    ((CURRENT_DATE - expectedupdate) - t.value::timestamp) > alertthreshold AS is_late
 FROM dataset_tracker  AS t
 LEFT JOIN dataset_alerts AS a ON t.key = a.datasetname


### PR DESCRIPTION
Uses the new API endpoint (https://github.com/JustFixNYC/who-owns-what/pull/990) to add a simple table of all our datasets (nycdb and custom jobs) and when they were last updated and highlighting if any are late. 

I kept the table extremely simple for now, without any interactively or extra data aside from what's in the API response.

Later I think it would be nice to add the ability to click on a row and reveal an extra row with a list of all the tables that dataset includes, what projects it's used in (wow, signature, etc.), and links to the the NYCDB wiki documentation page the sources datasets so we can check for problems on the open data portal. Unfortunately all this meta data isn't accessible from the NYCDB code itself, so I think I might just build this out manually in a static file within NYCDB and incorporate this later on. 

(also fixes a bug in the api query for calculating if a dataset is late or not)

An id is added to the header so we can easily just bookmark https://whoownswhat.justfix.org/en/dev#tracker

![image](https://github.com/user-attachments/assets/b5833116-a179-4a59-9542-e0a2a023d6b8)

[sc-15804]