### PR TITLE
add acris party name match to gce related property data

### DIFF
--- a/sql/create_gce_common.sql
+++ b/sql/create_gce_common.sql
@@ -3,6 +3,15 @@
 -- of duplicate table warnings when running the job in k8s-loader we'll define
 -- those here and run this first so they are available in the other two
 
+--- Array concatenate aggregate function 
+--- ------------------------------------
+-- This is used when preparing ACRIS party names to look for matches
+-- for use in prioritization of related properties on GCE portfolio size guide page
+CREATE OR REPLACE AGGREGATE array_concat_agg(anyarray) (
+   SFUNC = array_cat,
+   STYPE = anyarray
+);
+
 
 --- Certificates of Occupancy
 --- -------------------------


### PR DESCRIPTION
We now get all the owner party names from acris for the 5 documents we find for each property, and compare the names between the search address and the related properties to look for common names, and then use this flag to help prioritize/sort the related properties on the portfolio guide page. 

frontend companion PR: https://github.com/JustFixNYC/gce-screener/pull/118