### PR TITLE
update manage subscriptions via email for area alerts

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -292,14 +292,14 @@ const unsubscribeAllBuilding = async (bbl: string) => {
  * Sends an unauthenticated request to unsubscribe the user from the building
  */
 const emailUnsubscribeBuilding = async (bbl: string, token: string) => {
-  return await postAuthRequest(`${BASE_URL}auth/unsubscribe/${bbl}?u=${token}`);
-};
+  return await postAuthRequest(`${BASE_URL}auth/email/unsubscribe/building/${bbl}?u=${token}`);
+}; /**
 
 /**
  * Sends an unauthenticated request to unsubscribe the user from all buildings
  */
 const emailUnsubscribeAllBuilding = async (token: string) => {
-  return await postAuthRequest(`${BASE_URL}auth/email/unsubscribe?u=${token}`);
+  return await postAuthRequest(`${BASE_URL}auth/email/unsubscribe_all/building?u=${token}`);
 };
 
 /**
@@ -347,7 +347,7 @@ const emailUnsubscribeDistrict = async (subscription_id: string, token: string) 
  * Sends an unauthenticated request to unsubscribe the user from all districts
  */
 const emailUnsubscribeAllDistrict = async (token: string) => {
-  return await postAuthRequest(`${BASE_URL}auth/email/unsubscribe/district?u=${token}`);
+  return await postAuthRequest(`${BASE_URL}auth/email/unsubscribe_all/district?u=${token}`);
 };
 
 /**

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -304,9 +304,9 @@ const LoginWithoutI18n = (props: withI18nProps) => {
       ) : (
         <Trans render="h2">
           <JFCLLocaleLink to={home}>Search for an address</JFCLLocaleLink> to add to your Building
-          Alerts, <JFCLLocaleLink to={districtPage}>subscribe to District Alerts</JFCLLocaleLink>,
-          or visit your <JFCLLocaleLink to={account.settings}>email settings</JFCLLocaleLink> page
-          to manage subscriptions.
+          Alerts, <JFCLLocaleLink to={districtPage}>subscribe to Area Alerts</JFCLLocaleLink>, or
+          visit your <JFCLLocaleLink to={account.settings}>email settings</JFCLLocaleLink> page to
+          manage subscriptions.
         </Trans>
       )}
     </>

--- a/client/src/containers/UnsubscribePage.tsx
+++ b/client/src/containers/UnsubscribePage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { t, Trans } from "@lingui/macro";
@@ -11,30 +11,24 @@ import AuthClient from "../components/AuthClient";
 import { BuildingSubscriptionField, DistrictSubscriptionField } from "./AccountSettingsPage";
 import { createWhoOwnsWhatRoutePaths } from "routes";
 import { JFCLLocaleLink } from "i18n";
-import { BuildingSubscription, DistrictSubscription, JustfixUser } from "state-machine";
+import { BuildingSubscription, DistrictSubscription } from "state-machine";
 import { FixedLoadingLabel } from "components/Loader";
 import { STANDALONE_PAGES, StandalonePageFooter } from "components/StandalonePage";
-import { UserContext } from "components/UserContext";
 
 const BRANCH_NAME = process.env.REACT_APP_BRANCH;
 
 const UnsubscribePage = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
   const { search, pathname } = useLocation();
-  const { home } = createWhoOwnsWhatRoutePaths();
+  const { home, account, districtPage } = createWhoOwnsWhatRoutePaths();
   const params = new URLSearchParams(search);
   const token = params.get("u") || "";
-  const isEmailUnsubscribeAll = !!params.get("all");
 
-  const [buildingSubscriptions, setBuildingSubscriptions] = React.useState<BuildingSubscription[]>(
-    []
-  );
-  const buildingSubscriptionsNumber = buildingSubscriptions?.length;
+  const [buildingSubs, setBuildingSubs] = React.useState<BuildingSubscription[]>();
+  const buildingSubsNumber = buildingSubs?.length;
 
-  const [districtSubscriptions, setDistrictSubscriptions] = React.useState<DistrictSubscription[]>(
-    []
-  );
-  const districtSubscriptionsNumber = districtSubscriptions?.length;
+  const [districtSubs, setDistrictSubs] = React.useState<DistrictSubscription[]>();
+  const districtSubsNumber = districtSubs?.length;
 
   const pageName = STANDALONE_PAGES.find((x) => pathname.includes(x));
   const standalonePageEventParams = { from: pageName };
@@ -42,23 +36,16 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
   useEffect(() => {
     const asyncFetchSubscriptions = async () => {
       const response = await AuthClient.emailUserSubscriptions(token);
-      setBuildingSubscriptions(response["building_subscriptions"]);
-      setDistrictSubscriptions(response["district_subscriptions"]);
+      setBuildingSubs(response["building_subscriptions"]);
+      setDistrictSubs(response["district_subscriptions"]);
     };
     asyncFetchSubscriptions();
-
-    if (isEmailUnsubscribeAll) {
-      window.gtag("event", "unsubscribe-building-all-email-link", { branch: BRANCH_NAME });
-    } else {
-      window.gtag("event", "manage-subscriptions-email-link", { branch: BRANCH_NAME });
-    }
-  }, [token, isEmailUnsubscribeAll]);
+    window.gtag("event", "manage-subscriptions-email-link", { branch: BRANCH_NAME });
+  }, [token]);
 
   const handleUnsubscribeBuilding = async (bbl: string) => {
     const result = await AuthClient.emailUnsubscribeBuilding(bbl, token);
-    if (!!result?.["building_subscriptions"]) {
-      setBuildingSubscriptions(result["building_subscriptions"]);
-    }
+    if (!!result?.["building_subscriptions"]) setBuildingSubs(result["building_subscriptions"]);
     window.gtag("event", "unsubscribe-building", {
       from: "manage subscriptions",
       branch: BRANCH_NAME,
@@ -67,9 +54,7 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
 
   const handleUnsubscribeDistrict = async (subscriptionId: string) => {
     const result = await AuthClient.emailUnsubscribeDistrict(subscriptionId, token);
-    if (!!result?.["district_subscriptions"]) {
-      setDistrictSubscriptions(result["district_subscriptions"]);
-    }
+    if (!!result?.["district_subscriptions"]) setDistrictSubs(result["district_subscriptions"]);
     window.gtag("event", "unsubscribe-district", {
       from: "manage subscriptions",
       branch: BRANCH_NAME,
@@ -78,102 +63,80 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
 
   const handleUnsubscribeAllBuilding = async (from: string) => {
     const result = await AuthClient.emailUnsubscribeAllBuilding(token);
-    if (!!result?.["district_subscriptions"]) setBuildingSubscriptions(result["subscriptions"]);
+    if (!!result?.["building_subscriptions"]) setBuildingSubs(result["building_subscriptions"]);
     window.gtag("event", "unsubscribe-building-all", { from: from, branch: BRANCH_NAME });
   };
 
   const handleUnsubscribeAllDistrict = async (from: string) => {
     const result = await AuthClient.emailUnsubscribeAllDistrict(token);
-    if (!!result?.["district_subscriptions"]) setBuildingSubscriptions(result["subscriptions"]);
-    window.gtag("event", "unsubscribe-building-all", { from: from, branch: BRANCH_NAME });
+    if (!!result?.["district_subscriptions"]) setDistrictSubs(result["district_subscriptions"]);
+    window.gtag("event", "unsubscribe-district-all", { from: from, branch: BRANCH_NAME });
   };
-
-  const renderUnsubscribePage = () => (
-    <>
-      <Trans render="h1">Unsubscribe</Trans>
-      <h2>
-        <Trans>You are signed up for Building Alerts for</Trans> {buildingSubscriptionsNumber}{" "}
-        {buildingSubscriptionsNumber! === 1 ? <Trans>building</Trans> : <Trans>buildings</Trans>}.{" "}
-        <Trans>Click below to unsubscribe from all and stop receiving Building Alerts.</Trans>
-      </h2>
-      <Button
-        variant="primary"
-        size="large"
-        labelText={i18n._(t`Unsubscribe from all`)}
-        onClick={() => handleUnsubscribeAllBuilding("unsubscribe")}
-      />
-    </>
-  );
 
   const renderManageSubscriptionsPage = () => (
     <>
       <Trans render="h1">Manage Subscriptions</Trans>
       <h2 className="settings-section">
-        <Trans>You are signed up for Building Alerts for</Trans> {buildingSubscriptionsNumber}{" "}
-        {buildingSubscriptionsNumber! === 1 ? <Trans>building</Trans> : <Trans>buildings</Trans>}
+        <Trans>You are signed up for Building Alerts for</Trans> {buildingSubsNumber}{" "}
+        {buildingSubsNumber! === 1 ? <Trans>building</Trans> : <Trans>buildings</Trans>}
       </h2>
       <div className="subscriptions-container">
-        {buildingSubscriptions!.map((s) => (
+        {buildingSubs?.map((s) => (
           <BuildingSubscriptionField key={s.bbl} {...s} onRemoveClick={handleUnsubscribeBuilding} />
         ))}
-        <div className="unsubscribe-all-field">
-          <Button
-            variant="secondary"
-            size="small"
-            labelText={i18n._(t`Unsubscribe from all buildings`)}
-            onClick={() => handleUnsubscribeAllBuilding("manage subscriptions")}
-          />
-        </div>
+        {!!buildingSubsNumber && (
+          <div className="unsubscribe-all-field">
+            <Button
+              variant="secondary"
+              size="small"
+              labelText={i18n._(t`Unsubscribe from all buildings`)}
+              onClick={() => handleUnsubscribeAllBuilding("manage subscriptions")}
+            />
+          </div>
+        )}
       </div>
       <h2 className="settings-section">
-        <Trans>You are signed up for District Alerts for</Trans> {districtSubscriptionsNumber}{" "}
-        {districtSubscriptionsNumber! === 1 ? <Trans>district</Trans> : <Trans>districts</Trans>}
+        <Trans>You are signed up for Area Alerts for</Trans> {districtSubsNumber}{" "}
+        {districtSubsNumber! === 1 ? <Trans>area</Trans> : <Trans>areas</Trans>}
       </h2>
       <div className="subscriptions-container">
-        {districtSubscriptions!.map((s) => (
+        {districtSubs?.map((s) => (
           <DistrictSubscriptionField key={s.pk} {...s} onRemoveClick={handleUnsubscribeDistrict} />
         ))}
-        <div className="unsubscribe-all-field">
-          <Button
-            variant="secondary"
-            size="small"
-            labelText={i18n._(t`Unsubscribe from all districts`)}
-            onClick={() => handleUnsubscribeAllDistrict("manage subscriptions")}
-          />
-        </div>
+        {!!districtSubsNumber && (
+          <div className="unsubscribe-all-field">
+            <Button
+              variant="secondary"
+              size="small"
+              labelText={i18n._(t`Unsubscribe from all areas`)}
+              onClick={() => handleUnsubscribeAllDistrict("manage subscriptions")}
+            />
+          </div>
+        )}
       </div>
     </>
   );
 
   const renderNoSubscriptionsPage = () => (
     <>
-      <Trans render="h1">You are not subscribed to any buildings</Trans>
+      <Trans render="h1">You are not subscribed to any Building or Area Alerts</Trans>
       <Trans render="h2">
-        <JFCLLocaleLink to={home}>Search for an address</JFCLLocaleLink> to add to Building Alerts
+        <JFCLLocaleLink to={home}>Search for an address</JFCLLocaleLink> to add to your Building
+        Alerts, <JFCLLocaleLink to={districtPage}>subscribe to Area Alerts</JFCLLocaleLink>, or
+        visit your <JFCLLocaleLink to={account.settings}>email settings</JFCLLocaleLink> page to
+        manage subscriptions.
       </Trans>
     </>
   );
 
   return (
-    <Page title={isEmailUnsubscribeAll ? i18n._(t`Unsubscribe`) : i18n._(t`Manage subscriptions`)}>
+    <Page title={i18n._(t`Manage subscriptions`)}>
       <div className="UnsubscribePage Page">
         <div className="page-container">
-          <Button
-            labelText="district unsubscribe all"
-            onClick={async () => {
-              await AuthClient.emailUnsubscribeAllDistrict(token);
-            }}
-          />
-          <DistrictSubscriptionsList />
-
-          <hr />
-
-          {buildingSubscriptions === undefined ? (
+          {buildingSubs === undefined || districtSubs === undefined ? (
             <FixedLoadingLabel />
-          ) : buildingSubscriptionsNumber === 0 ? (
+          ) : buildingSubsNumber === 0 && districtSubsNumber === 0 ? (
             renderNoSubscriptionsPage()
-          ) : isEmailUnsubscribeAll ? (
-            renderUnsubscribePage()
           ) : (
             renderManageSubscriptionsPage()
           )}
@@ -183,39 +146,5 @@ const UnsubscribePage = withI18n()((props: withI18nProps) => {
     </Page>
   );
 });
-
-const DistrictSubscriptionsList: React.FC = () => {
-  const userContext = useContext(UserContext);
-  if (!userContext.user) return <div />;
-
-  const user = userContext.user as JustfixUser;
-  const { districtSubscriptions } = user;
-
-  return (
-    <div className="district-subscriptions-list">
-      {!districtSubscriptions || !districtSubscriptions.length ? (
-        <div className="district-subscription">No subscriptions</div>
-      ) : (
-        <>
-          {districtSubscriptions.map((subscription, i) => {
-            return (
-              <div className="district-subscription">
-                <h3>Subscription {i + 1}</h3>
-                <pre>{JSON.stringify(subscription.district, null, 2)}</pre>
-                <Button
-                  labelText="Unsubscribe"
-                  onClick={() => {
-                    userContext.unsubscribeDistrict(subscription.pk);
-                    window.location.reload();
-                  }}
-                />
-              </div>
-            );
-          })}
-        </>
-      )}
-    </div>
-  );
-};
 
 export default UnsubscribePage;

--- a/jfauthprovider/views.py
+++ b/jfauthprovider/views.py
@@ -368,7 +368,7 @@ def email_unsubscribe_building(request, bbl):
 
         return auth_server_request(
             "POST",
-            f"user/unsubscribe/building/{str(bbl)}/",
+            f"user/email/unsubscribe/building/{str(bbl)}/",
             post_data,
         )
     except KeyError:
@@ -378,7 +378,7 @@ def email_unsubscribe_building(request, bbl):
 @api
 def email_unsubscribe_district(request, subscription_id):
     try:
-        post_data = {"token": request.POST.get("u")}
+        post_data = {"token": request.GET.get("u")}
 
         return auth_server_request(
             "POST",


### PR DESCRIPTION
No longer have a separate version of the page for "unsubscribe all", only the multipurpose "manage subscriptions". Includes building and area alert subscriptions, with buttons to unsubscribe from individual buildings/areas and to unsubscribe from all. Still waiting on the final design of the area alerts subscription field (how to display the area components), but that will be updated separately later.

This also fixes a couple mistakes in API from the initial addition of districts - in AuthClient and jfauthprovider views. 

Once the other PRs are all merged in I'll update this to point to `feature/district-alerts`