### PR TITLE
Fix invalid html syntax for building stats table table

### DIFF
--- a/client/src/components/BuildingStatsTable.tsx
+++ b/client/src/components/BuildingStatsTable.tsx
@@ -350,14 +350,16 @@ const BuildingStatsTableWithoutI18n = (props: { addr: AddressRecord; timelineUrl
       </Modal>
       <div className="BuildingStatsTable card-body-table">
         <table>
-          <BBL />
-          <YearBuilt />
-          <UnitsRes />
-          <RsUnits />
-          <OpenViolations />
-          <TotalViolations />
-          <EvictionFilings />
-          <EvictionsExecuted />
+          <tbody>
+            <BBL />
+            <YearBuilt />
+            <UnitsRes />
+            <RsUnits />
+            <OpenViolations />
+            <TotalViolations />
+            <EvictionFilings />
+            <EvictionsExecuted />
+          </tbody>
         </table>
         <div className="table-row timeline-link">
           <TimelineLink url={props.timelineUrl} />

--- a/client/src/components/PropertiesMap.tsx
+++ b/client/src/components/PropertiesMap.tsx
@@ -69,7 +69,7 @@ const MAP_CONFIGURABLES = {
   fitBoundsOptions: {
     padding: { top: 50, bottom: 50, left: 50, right: 50 },
     maxZoom: 20,
-    offset: [0, Browser.isMobile() ? -25 : 0],
+    offset: [0, Browser.isMobile() ? -25 : 0] as [number, number],
   },
 };
 


### PR DESCRIPTION
I noticed that we're getting console errors about invalid html syntax for the new buildn stats table on overview page. It was missing a `<tbody>` within the `<table>`.

Also I've added a type for a mapbox option that is needed to avoid errors when we make a change to the version for district-maps  (doing it now just helps when switching back and forth between wow main and district-alerts for local development)

[sc-16155]