### PR TITLE
add bbl event param to wow address search GA4 tag

### DIFF
--- a/client/src/containers/HomePage.tsx
+++ b/client/src/containers/HomePage.tsx
@@ -78,7 +78,7 @@ const HomePage: React.FC<HomePageProps> = ({ useNewPortfolioMethod }) => {
 
   const handleFormSubmit = (searchAddress: SearchAddress, error: any) => {
     logAmplitudeEvent("searchByAddress");
-    window.gtag("event", "search");
+    window.gtag("event", "search", { bbl: searchAddress.bbl });
 
     if (error) {
       window.gtag("event", "search-error");


### PR DESCRIPTION
A while back we needed to get data on all the addresses searched on WOW and we needed to geocode all the addresses which was a pain. This adds BBL as an event param to the wow address search GA4 tag so we can skip that step in future. 

[sc-16168]