### PR TITLE
Document typecasting to resolve Issue #481

### DIFF
--- a/wow/views.py
+++ b/wow/views.py
@@ -46,6 +46,15 @@ def log_unsupported_request_args(request):
 
 
 def clean_addr_dict(addr):
+    """
+    ### Typecasting API Data
+    Some values returned by SQL queries (especially through NYCDB) are returned as strings, even when they represent numbers. This is due to:
+
+    - JSON serialization quirks (64-bit ints aren’t supported)
+    - Postgres behavior or schema ambiguity
+
+    To avoid unexpected bugs in the frontend, all API data is explicitly typecast to the correct types in the backend.
+    """
     return {
         **addr,
         "bin": str(addr["bin"]),

--- a/wow/views.py
+++ b/wow/views.py
@@ -47,7 +47,6 @@ def log_unsupported_request_args(request):
 
 def clean_addr_dict(addr):
     """
-    ### Typecasting API Data
     Some values returned by SQL queries (especially through NYCDB) are returned as strings, even when they represent numbers. This is due to:
 
     - JSON serialization quirks (64-bit ints aren’t supported)


### PR DESCRIPTION
This PR adds inline documentation explaining why certain SQL query results are typecast to numbers in the API responses. This addresses Issue #481.

 clean_addr_dict() modified to add the need for explicit typecasting.

Fixes: #481