### PR TITLE
remove GCE eligibility tables with unmet table dependency

### DIFF
--- a/who-owns-what.yml
+++ b/who-owns-what.yml
@@ -48,8 +48,6 @@ signature_post_sql:
 good_cause_sql:
   - create_gce_common.sql
   - create_gce_screener.sql
-  - create_gce_eligibility.sql
-  - create_gce_eligibility_maps.sql
 sql:
   # These SQL scripts must be executed in order, as
   # some of them depend on others.


### PR DESCRIPTION
The tables for good cause eligibility (not used in the screener website, but for data analysis and sharing with partners) aren't working because they depend on the table `pluto_latest_districts` which is a one-off table we've created in the DB but isn't an nycdb or other k8s-loader recognized job so it fails tests. So for now I'm just removing these tables from the list that are created, and later I think we'll need to add the sql for creating `pluto_latest_districts` to an nycdb dataset or another k8s-loader job in the who-owns-what repo like goodcause itself. 