### PR TITLE
remove rows without bbl from gce_screener related properties

### DIFF
--- a/sql/create_gce_screener.sql
+++ b/sql/create_gce_screener.sql
@@ -226,14 +226,14 @@ CREATE INDEX ON x_wow_related_bbls (ref_bbl, bbl);
 -- their details.
 
 CREATE TEMPORARY TABLE x_all_related_bbls AS (
-  SELECT
-    w.ref_bbl,
-    w.bbl,
-    coalesce(o.match_ownername, false) AS match_ownername,
-    coalesce(m.match_multidoc, false) AS match_multidoc,
-    coalesce(w.match_wow, false) AS match_wow,
-    p.unitsres,
-    p.address || ', ' || CASE 
+	SELECT
+		w.ref_bbl,
+		w.bbl,
+		coalesce(o.match_ownername, false) AS match_ownername,
+		coalesce(m.match_multidoc, false) AS match_multidoc,
+		coalesce(w.match_wow, false) AS match_wow,
+		p.unitsres,
+		p.address || ', ' || CASE 
 			WHEN p.borough = 'MN' THEN 'Manhattan'
 			WHEN p.borough = 'BX' THEN 'Bronx'
 			WHEN p.borough = 'BK' THEN 'Brooklyn'
@@ -244,14 +244,17 @@ CREATE TEMPORARY TABLE x_all_related_bbls AS (
 		w.wow_match_name,
 		w.wow_match_bizaddr_unit,
 		coalesce(aref.party_names && a.party_names, false) AS party_name_match,
-    coalesce(a.acris_docs, '[]'::json) AS acris_docs
-  FROM x_wow_related_bbls AS w
-  FULL JOIN x_ownername_related_bbls AS o USING(ref_bbl, bbl)
-  FULL JOIN x_multi_doc_related_bbls AS m  USING(ref_bbl, bbl)
-  LEFT JOIN pluto_latest AS p USING(bbl)
-  LEFT JOIN x_bbl_acris_docs AS a USING(bbl)
+		coalesce(a.acris_docs, '[]'::json) AS acris_docs
+	FROM x_wow_related_bbls AS w
+	FULL JOIN x_ownername_related_bbls AS o USING(ref_bbl, bbl)
+	FULL JOIN x_multi_doc_related_bbls AS m  USING(ref_bbl, bbl)
+	LEFT JOIN pluto_latest AS p USING(bbl)
+	LEFT JOIN x_bbl_acris_docs AS a USING(bbl)
 	LEFT JOIN x_bbl_acris_docs AS aref ON w.ref_bbl = aref.bbl
   WHERE p.unitsres > 0
+	-- TODO: still not clear on how records with no bbl are created, it only happens on the last join here
+	AND w.ref_bbl IS NOT NULL
+	AND w.bbl IS NOT NULL
 );
 
 CREATE INDEX ON x_all_related_bbls (ref_bbl);


### PR DESCRIPTION
Somehow there were a ton of rows getting created that had no bbl, and so when aggregating all the related properties data by bbl (in the temp table immediately after this one being edited) there is one row for the null bbl that had an array being aggregated with millions of elements and it broke everything. Unfortunately I'm still not totally sure how these additional rows were getting created, but there are no duplicates among the other non-null bbl records. I could trace it down to this one join, and left a comment about it, but I don't see how this could happening, because when I do the same query without that last join there are no null-bbl rows, and the table being joined has no null-bbl rows, yet somehow after adding in that final join the result has a lot of null-bbl rows. Even more strange, is that this job was working just fine for a month or so then started failing just this weekend, though the null-bbl rows could have always been there but only recently did there become so many that it overflowed the maximum array length to raise an error.

But for now since the whole job is failing and GCE data isn't getting updated I wanted to get this fix in and can revisit later to try to better understand what's happening. 