### PR TITLE
Area alert API for sales and litigations for month relative to updated date

### DIFF
--- a/wow/sql/alerts_district_litigation.sql
+++ b/wow/sql/alerts_district_litigation.sql
@@ -1,3 +1,10 @@
+
+WITH last_updated AS (
+	SELECT 
+		(VALUE::date - interval '1' DAY) AS last_updated
+	FROM dataset_tracker
+	WHERE KEY = 'hpd_litigations'
+)
 SELECT 
 	bbl,
 	x.housenumber,
@@ -6,21 +13,25 @@ SELECT
 	l.caseopendate,
 	l.casetype,
 	l.respondent,
-	count(*) over () as total_litigations
-FROM wow_indicators AS x
+	count(*) over () as total_litigations,
+	d.last_updated
+FROM last_updated AS d, 
+	wow_indicators AS x
 LEFT JOIN hpd_litigations as l using(bbl)
 WHERE bbl IS NOT NULL
-	and (x.coun_dist = ANY(%(coun_dist)s)
-	or x.nta = ANY(%(nta)s)
-	or x.borough = ANY(%(borough)s)
-	or x.census_tract = ANY(%(census_tract)s)
-    OR x.community_dist = ANY(%(community_dist)s::int[])
-	or x.cong_dist = ANY(%(cong_dist)s)
-	or x.assem_dist = ANY(%(assem_dist)s)
-	or x.stsen_dist = ANY(%(stsen_dist)s)
-	or x.zipcode = ANY(%(zipcode)s))
+	and (
+		x.coun_dist = ANY(%(coun_dist)s)
+		or x.nta = ANY(%(nta)s)
+		or x.borough = ANY(%(borough)s)
+		or x.census_tract = ANY(%(census_tract)s)
+		or x.community_dist = ANY(%(community_dist)s::int[])
+		or x.cong_dist = ANY(%(cong_dist)s)
+		or x.assem_dist = ANY(%(assem_dist)s)
+		or x.stsen_dist = ANY(%(stsen_dist)s)
+		or x.zipcode = ANY(%(zipcode)s)
+	)
 	and l.casetype IN ('Tenant Action', 'Tenant Action/Harrassment', 'Heat and Hot Water')
-	and l.caseopendate > (CURRENT_DATE - interval '30' day) -- TODO FIX DATE LOGIC 
+	and l.caseopendate > (d.last_updated - interval '30' day)
 	and l.caseopendate < CURRENT_DATE
 ORDER BY l.caseopendate DESC
 LIMIT 10;

--- a/wow/sql/alerts_district_sale.sql
+++ b/wow/sql/alerts_district_sale.sql
@@ -1,3 +1,10 @@
+
+WITH last_updated AS (
+	SELECT 
+		(VALUE::date - interval '1' DAY) AS last_updated
+	FROM dataset_tracker
+	WHERE KEY = 'acris'
+)
 SELECT 
 	bbl,
 	housenumber,
@@ -6,10 +13,13 @@ SELECT
 	lastsaleacrisid,
 	lastsaleamount,
 	lastsaledate,
-	count(*) over () as total_sales
-FROM wow_indicators
+	count(*) over () as total_sales,
+	d.last_updated
+FROM last_updated AS d,
+	wow_indicators
 WHERE bbl IS NOT NULL
-	and (coun_dist = ANY(%(coun_dist)s)
+	and (
+		coun_dist = ANY(%(coun_dist)s)
 		or nta = ANY(%(nta)s)
 		or borough = ANY(%(borough)s)
 		or census_tract = ANY(%(census_tract)s)
@@ -17,10 +27,9 @@ WHERE bbl IS NOT NULL
 		or cong_dist = ANY(%(cong_dist)s)
 		or assem_dist = ANY(%(assem_dist)s)
 		or stsen_dist = ANY(%(stsen_dist)s)
-		or zipcode = ANY(%(zipcode)s))
-	and lastsaledate > (CURRENT_DATE - interval '7' day)
+		or zipcode = ANY(%(zipcode)s)
+	)
+	and lastsaledate > (d.last_updated - interval '30' day)
 	and lastsaleamount >= 10000
 ORDER BY lastsaledate DESC
 LIMIT 10;
-
-	

--- a/wow/sql/alerts_district_sale.sql
+++ b/wow/sql/alerts_district_sale.sql
@@ -23,7 +23,7 @@ WHERE bbl IS NOT NULL
 		or nta = ANY(%(nta)s)
 		or borough = ANY(%(borough)s)
 		or census_tract = ANY(%(census_tract)s)
-		OR community_dist = ANY(%(community_dist)s::int[])
+		or community_dist = ANY(%(community_dist)s::int[])
 		or cong_dist = ANY(%(cong_dist)s)
 		or assem_dist = ANY(%(assem_dist)s)
 		or stsen_dist = ANY(%(stsen_dist)s)

--- a/wow/sql/alerts_district_vacate_order.sql
+++ b/wow/sql/alerts_district_vacate_order.sql
@@ -8,6 +8,7 @@ SELECT
 	hpd_vacate_type,
 	hpd_vacate_units_affected,
 	hpd_vacate_reason,
+	hpd_link,
 	dob_vacate_date,
 	dob_vacate_type,
 	dob_vacate_complaint_number


### PR DESCRIPTION
For area alerts emails we now want to include the most recent month of data, based on when the dataset was last updated rather than the date we are sending the email. So this edits the api queries to use the table with datasets' last updated dates to create the date filer. 

Companion PR on auth-provider for email: https://github.com/JustFixNYC/auth-provider/pull/85

[sc-16374]