### PR TITLE
exclude portfolio to watch buildings with no values

### DIFF
--- a/wow/sql/alerts_district.sql
+++ b/wow/sql/alerts_district.sql
@@ -436,6 +436,13 @@ shared_portfolio_top_3 AS (
     FROM x_indicators_final
     WHERE portfolio_id = (SELECT portfolio_id FROM first_shared_portfolio)
       AND rank_final > 5  -- Exclude any from top 5 to avoid dupes
+      AND ( -- Exclude any with no values to display
+        hpd_comp__6mo > 0
+        OR hpd_viol__6mo > 0
+        OR dob_ecb_viol__6mo > 0
+        OR dob_comp__6mo > 0
+        OR evictions_filed__6mo > 0
+      )
     ORDER BY rank_final
     LIMIT 3
 ),


### PR DESCRIPTION
Updates our main Area Alerts API to exclude buildings from the Portfolio to Watch section if they don't have any data values to display. They are still included in the `area_bbls` count, but the building objects are included in the result.

Related to changes for the portfolio section messages in < PR TBA >