### PR TITLE
Remove congressional districts from area alerts

### DIFF
--- a/client/src/data/district-types.json
+++ b/client/src/data/district-types.json
@@ -13,10 +13,6 @@
       "value": "community_dist"
     },
     {
-      "label": "Congressional Districts",
-      "value": "cong_dist"
-    },
-    {
       "label": "City Council Districts",
       "value": "coun_dist"
     },

--- a/client/src/styles/DistrictAlertsPage.scss
+++ b/client/src/styles/DistrictAlertsPage.scss
@@ -165,6 +165,7 @@ div.DistrictAlertsPage {
       }
       .save-selection {
         @include body-standard;
+        font-weight: 500;
         font-size: 1.125rem;
         line-height: 120%;
         align-self: center;

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -67,7 +67,6 @@ export const shortDateOptions = { month: "short" };
 const areaTypeLabelTranslations = new Map([
   ["nta", t`Neighborhood`],
   ["census_tract", t`Census Tract`],
-  ["cong_dist", t`Congressional District`],
   ["coun_dist", t`City Council District`],
   ["community_dist", t`Community District`],
   ["assem_dist", t`State Assembly District`],

--- a/sql/create_districts_geom.sql
+++ b/sql/create_districts_geom.sql
@@ -23,14 +23,6 @@ CREATE TABLE wow_districts_geom AS (
 			'District '::text || stsendist AS arealabel,
 			geom
 		FROM nyss_25a
-	), congress AS (
-		SELECT 
-			'cong_dist'::text AS typevalue,
-			'Congressional District'::text AS typelabel,
-			congdist::text AS areavalue,
-			'District ' || congdist AS arealabel,
-			geom
-		FROM nycg_25a
 	), nta AS (
 		SELECT 
 			'nta'::text AS typevalue,
@@ -90,9 +82,6 @@ CREATE TABLE wow_districts_geom AS (
 	UNION
 	SELECT *
 	FROM state_senate
-	UNION
-	SELECT *
-	FROM congress
 	UNION
 	SELECT *
 	FROM nta

--- a/sql/create_indicators_table.sql
+++ b/sql/create_indicators_table.sql
@@ -301,7 +301,6 @@ CREATE TABLE wow_indicators AS
 		pld.coun_dist,
 		pld.assem_dist,
 		pld.stsen_dist,
-		pld.cong_dist,
 		pld.community_dist,
 		pld.zipcode, 
 		pld.boroct2020 AS census_tract,
@@ -328,7 +327,6 @@ create index on wow_indicators (bbl);
 create index on wow_indicators (coun_dist);
 create index on wow_indicators (assem_dist);
 create index on wow_indicators (stsen_dist);
-create index on wow_indicators (cong_dist);
 create index on wow_indicators (community_dist);
 create index on wow_indicators (zipcode);
 create index on wow_indicators (census_tract);

--- a/wow/forms.py
+++ b/wow/forms.py
@@ -81,7 +81,6 @@ def validate_district_types(value):
         "nta",
         "borough",
         "community_dist",
-        "cong_dist",
         "assem_dist",
         "stsen_dist",
         "zipcode",
@@ -102,7 +101,6 @@ class EmailAlertDistrict(forms.Form):
     nta = forms.CharField(required=False)
     borough = forms.CharField(required=False)
     community_dist = forms.CharField(required=False)
-    cong_dist = forms.CharField(required=False)
     assem_dist = forms.CharField(required=False)
     stsen_dist = forms.CharField(required=False)
     zipcode = forms.CharField(required=False)

--- a/wow/sql/alerts_district.sql
+++ b/wow/sql/alerts_district.sql
@@ -7,7 +7,6 @@ WHERE bbl IS NOT NULL
 	or borough = ANY(%(borough)s)
 	or census_tract = ANY(%(census_tract)s)
     OR community_dist = ANY(%(community_dist)s::int[])
-	or cong_dist = ANY(%(cong_dist)s)
 	or assem_dist = ANY(%(assem_dist)s)
 	or stsen_dist = ANY(%(stsen_dist)s)
 	or zipcode = ANY(%(zipcode)s))

--- a/wow/sql/alerts_district_litigation.sql
+++ b/wow/sql/alerts_district_litigation.sql
@@ -25,7 +25,6 @@ WHERE bbl IS NOT NULL
 		or x.borough = ANY(%(borough)s)
 		or x.census_tract = ANY(%(census_tract)s)
 		or x.community_dist = ANY(%(community_dist)s::int[])
-		or x.cong_dist = ANY(%(cong_dist)s)
 		or x.assem_dist = ANY(%(assem_dist)s)
 		or x.stsen_dist = ANY(%(stsen_dist)s)
 		or x.zipcode = ANY(%(zipcode)s)

--- a/wow/sql/alerts_district_sale.sql
+++ b/wow/sql/alerts_district_sale.sql
@@ -24,7 +24,6 @@ WHERE bbl IS NOT NULL
 		or borough = ANY(%(borough)s)
 		or census_tract = ANY(%(census_tract)s)
 		or community_dist = ANY(%(community_dist)s::int[])
-		or cong_dist = ANY(%(cong_dist)s)
 		or assem_dist = ANY(%(assem_dist)s)
 		or stsen_dist = ANY(%(stsen_dist)s)
 		or zipcode = ANY(%(zipcode)s)

--- a/wow/sql/alerts_district_vacate_order.sql
+++ b/wow/sql/alerts_district_vacate_order.sql
@@ -22,7 +22,6 @@ WHERE bbl IS NOT NULL
 		or borough = ANY(%(borough)s)
 		or census_tract = ANY(%(census_tract)s)
 	    or community_dist = ANY(%(community_dist)s::int[])
-		or cong_dist = ANY(%(cong_dist)s)
 		or assem_dist = ANY(%(assem_dist)s)
 		or stsen_dist = ANY(%(stsen_dist)s)
 		or zipcode = ANY(%(zipcode)s)

--- a/wow/views.py
+++ b/wow/views.py
@@ -385,7 +385,6 @@ def get_district_query_params(args: Dict[str, Any]):
         "nta": safe_literal_eval(args["nta"]),
         "borough": safe_literal_eval(args["borough"]),
         "community_dist": safe_literal_eval(args["community_dist"]),
-        "cong_dist": safe_literal_eval(args["cong_dist"]),
         "assem_dist": safe_literal_eval(args["assem_dist"]),
         "stsen_dist": safe_literal_eval(args["stsen_dist"]),
         "zipcode": safe_literal_eval(args["zipcode"]),


### PR DESCRIPTION
We decided they weren't a priority, and it's better to start with a smaller list of districts at launch and add more later if there's interest.

Also bumps up the font size on the save selections button