### PR TITLE
user state not updating sometimes on account page after area alerts subscription

### DIFF
--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -179,7 +179,7 @@ export const UserContextProvider = ({ children }: { children: React.ReactNode })
   );
 
   const subscribeDistrict = useCallback(
-    (district: District, _user?: JustfixUser) => {
+    async (district: District, _user?: JustfixUser) => {
       const currentUser = !!user?.email ? user : _user;
       if (currentUser) {
         const asyncSubscribe = async () => {

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -186,7 +186,7 @@ export const UserContextProvider = ({ children }: { children: React.ReactNode })
           const response = await AuthClient.subscribeDistrict(district);
           setUser({ ...currentUser, districtSubscriptions: response["district_subscriptions"] });
         };
-        asyncSubscribe();
+        await asyncSubscribe();
       }
     },
     [user]


### PR DESCRIPTION
This only happens sometimes, but after subscribing to an area while logged in the user is automatically sent to the account settings page where all area subscriptions should be listed but sometimes it won't be there until the page is refreshed. 

This was because the api request to subscribe to the area was sent out but sometimes it wouldn't complete before the user got sent to the setting page. We confirmed this by looking at the devtools "waterfall" overview graph on the network tab and you can see the sequencing of the requests. This was because of a missing `await` within the `UserContext.subscribeDistrict`, and once that was added and the navigation to setting page is delayed ontil the subscription is complete every works as intended now.

[sc-16406]