### PR TITLE
remove borough as area alerts option

### DIFF
--- a/client/src/data/district-types.json
+++ b/client/src/data/district-types.json
@@ -1,10 +1,6 @@
 {
   "options": [
     {
-      "label": "Boroughs",
-      "value": "borough"
-    },
-    {
       "label": "Census Tracts",
       "value": "census_tract"
     },

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -72,7 +72,6 @@ const areaTypeLabelTranslations = new Map([
   ["assem_dist", t`State Assembly District`],
   ["stsen_dist", t`State Senate District`],
   ["zipcode", t`Zip Code`],
-  ["borough", t`Borough`],
 ]);
 
 // https://www.geeksforgeeks.org/how-to-detect-the-user-browser-safari-chrome-ie-firefox-and-opera-using-javascript/

--- a/sql/create_districts_geom.sql
+++ b/sql/create_districts_geom.sql
@@ -31,14 +31,6 @@ CREATE TABLE wow_districts_geom AS (
 			ntaname AS arealabel,
 			geom
 		FROM nynta2020_25a
-	), borough AS (
-		SELECT 
-			'borough'::text AS typevalue,
-			'Borough'::text AS typelabel,
-			borocode::text AS areavalue,
-			boroname AS arealabel,
-			geom
-		FROM nybb_25a
 	), cd_names AS (
 		SELECT DISTINCT ON (cdta2020)
 		  borocode,
@@ -85,9 +77,6 @@ CREATE TABLE wow_districts_geom AS (
 	UNION
 	SELECT *
 	FROM nta
-	UNION
-	SELECT *
-	FROM borough
 	UNION
 	SELECT *
 	FROM community_district

--- a/sql/create_indicators_table.sql
+++ b/sql/create_indicators_table.sql
@@ -304,9 +304,7 @@ CREATE TABLE wow_indicators AS
 		pld.community_dist,
 		pld.zipcode, 
 		pld.boroct2020 AS census_tract,
-		pld.nta2020 AS nta,
-		pld.borough
-
+		pld.nta2020 AS nta
 		
 	FROM wow_bldgs AS x
 	LEFT JOIN hpd_viol USING(bbl)
@@ -331,5 +329,4 @@ create index on wow_indicators (community_dist);
 create index on wow_indicators (zipcode);
 create index on wow_indicators (census_tract);
 create index on wow_indicators (nta);
-create index on wow_indicators (borough);
 create index on wow_indicators (lastsaledate);

--- a/wow/forms.py
+++ b/wow/forms.py
@@ -79,7 +79,6 @@ def validate_district_types(value):
     VALID_DISTRICTS = [
         "coun_dist",
         "nta",
-        "borough",
         "community_dist",
         "assem_dist",
         "stsen_dist",
@@ -99,7 +98,6 @@ class DistrictTypeForm(forms.Form):
 class EmailAlertDistrict(forms.Form):
     coun_dist = forms.CharField(required=False)
     nta = forms.CharField(required=False)
-    borough = forms.CharField(required=False)
     community_dist = forms.CharField(required=False)
     assem_dist = forms.CharField(required=False)
     stsen_dist = forms.CharField(required=False)

--- a/wow/sql/alerts_district.sql
+++ b/wow/sql/alerts_district.sql
@@ -4,7 +4,6 @@ FROM wow_indicators
 WHERE bbl IS NOT NULL
 	and (coun_dist = ANY(%(coun_dist)s)
 	or nta = ANY(%(nta)s)
-	or borough = ANY(%(borough)s)
 	or census_tract = ANY(%(census_tract)s)
     OR community_dist = ANY(%(community_dist)s::int[])
 	or assem_dist = ANY(%(assem_dist)s)

--- a/wow/sql/alerts_district_litigation.sql
+++ b/wow/sql/alerts_district_litigation.sql
@@ -22,7 +22,6 @@ WHERE bbl IS NOT NULL
 	and (
 		x.coun_dist = ANY(%(coun_dist)s)
 		or x.nta = ANY(%(nta)s)
-		or x.borough = ANY(%(borough)s)
 		or x.census_tract = ANY(%(census_tract)s)
 		or x.community_dist = ANY(%(community_dist)s::int[])
 		or x.assem_dist = ANY(%(assem_dist)s)

--- a/wow/sql/alerts_district_sale.sql
+++ b/wow/sql/alerts_district_sale.sql
@@ -21,7 +21,6 @@ WHERE bbl IS NOT NULL
 	and (
 		coun_dist = ANY(%(coun_dist)s)
 		or nta = ANY(%(nta)s)
-		or borough = ANY(%(borough)s)
 		or census_tract = ANY(%(census_tract)s)
 		or community_dist = ANY(%(community_dist)s::int[])
 		or assem_dist = ANY(%(assem_dist)s)

--- a/wow/sql/alerts_district_vacate_order.sql
+++ b/wow/sql/alerts_district_vacate_order.sql
@@ -19,7 +19,6 @@ WHERE bbl IS NOT NULL
 	and (
 		coun_dist = ANY(%(coun_dist)s)
 		or nta = ANY(%(nta)s)
-		or borough = ANY(%(borough)s)
 		or census_tract = ANY(%(census_tract)s)
 	    or community_dist = ANY(%(community_dist)s::int[])
 		or assem_dist = ANY(%(assem_dist)s)

--- a/wow/views.py
+++ b/wow/views.py
@@ -383,7 +383,6 @@ def get_district_query_params(args: Dict[str, Any]):
     query_params = {
         "coun_dist": safe_literal_eval(args["coun_dist"]),
         "nta": safe_literal_eval(args["nta"]),
-        "borough": safe_literal_eval(args["borough"]),
         "community_dist": safe_literal_eval(args["community_dist"]),
         "assem_dist": safe_literal_eval(args["assem_dist"]),
         "stsen_dist": safe_literal_eval(args["stsen_dist"]),


### PR DESCRIPTION
We're trying to limit the number of area types in the dropdown, and boroughs seem so large they are unlikely to be used - but we can always add it back later upon request

[sc-16417]