### PR TITLE
update bbls of cofos with no longer existing bbls

### DIFF
--- a/sql/create_gce_common.sql
+++ b/sql/create_gce_common.sql
@@ -18,25 +18,56 @@ CREATE OR REPLACE AGGREGATE array_concat_agg(anyarray) (
 
 -- For each BBL, get the date of most recent certificate of occupancy, if there
 -- is one. Keep the BIN, date, and type for extra context and custom links.
+-- Because BBLs change over time, some older records might not match to any
+-- current BBLs, so we need to first join with PAD using either 
 
 CREATE TEMPORARY TABLE x_all_cofos AS (
-  SELECT
-    bbl,
-    bin,
-    coissuedate AS issue_date
-  FROM dob_certificate_occupancy
-  UNION
-  SELECT
-    bbl,
-    bin,
-    issuedate AS issue_date
-  FROM dob_foil_certificate_occupancy
-  UNION
-  SELECT
-    bbl,
-    bin,
-    cofoissuancedate::date AS issue_date
-  FROM dob_now_certificate_occupancy
+	WITH all_cofos AS (
+		SELECT
+		  bbl,
+		  bin,
+		  coissuedate AS issue_date
+		FROM dob_certificate_occupancy
+		UNION
+		SELECT
+		  bbl,
+		  bin,
+		  issuedate AS issue_date
+		FROM dob_foil_certificate_occupancy
+		UNION
+		SELECT
+		  bbl,
+		  bin,
+		  cofoissuancedate::date AS issue_date
+		FROM dob_now_certificate_occupancy
+	), pad_bin_bbl AS (
+		SELECT DISTINCT bin, bbl
+		FROM pad_adr
+	), all_cofos_w_id AS (
+		SELECT 
+			row_number() OVER() AS id,
+			*
+		FROM all_cofos
+	), cofo_old_bbl AS (
+		SELECT c.*
+		FROM all_cofos_w_id AS c
+		LEFT JOIN pad_bin_bbl AS p USING(bbl)
+		WHERE p.bbl IS NULL
+	), cofo_updated_bbl AS (
+		SELECT
+			c.id,
+			c.bin,
+			COALESCE(p.bbl, c.bbl) AS bbl,
+			c.issue_date
+		FROM cofo_old_bbl AS c
+		LEFT JOIN pad_bin_bbl AS p USING(bin)
+	)
+	SELECT 
+		c.bin,
+		COALESCE(u.bbl, c.bbl) AS bbl,
+		c.issue_date
+	FROM all_cofos_w_id AS c
+	LEFT JOIN cofo_updated_bbl AS u USING(id)
 );
 
 CREATE INDEX ON x_all_cofos (bbl, issue_date);

--- a/sql/create_gce_common.sql
+++ b/sql/create_gce_common.sql
@@ -41,19 +41,23 @@ CREATE TEMPORARY TABLE x_all_cofos AS (
 		  cofoissuancedate::date AS issue_date
 		FROM dob_now_certificate_occupancy
 	), pad_bin_bbl AS (
+    -- address level data has duplicates of bin-bbl
 		SELECT DISTINCT bin, bbl
 		FROM pad_adr
 	), all_cofos_w_id AS (
+    -- create ID to join back later
 		SELECT 
 			row_number() OVER() AS id,
 			*
 		FROM all_cofos
 	), cofo_old_bbl AS (
+    -- "anti-join" cOfOs with PAD using BBL to get CofO records with BBLs that no longer exist
 		SELECT c.*
 		FROM all_cofos_w_id AS c
 		LEFT JOIN pad_bin_bbl AS p USING(bbl)
 		WHERE p.bbl IS NULL
 	), cofo_updated_bbl AS (
+    -- Join the CofOs with outdated BBLs to PAD using BIN to get the current BBL for those buildings (BINs)
 		SELECT
 			c.id,
 			c.bin,


### PR DESCRIPTION
We got some feedback from a user on GoodCauseNYC about a case where a 2010 CofO that appears on the DOB site was not being found on GoodCauseNYC and so gave an incorrect "covered" result. We discovered that this is because for some older CofO records the BBL from the time no longer exists (since they change when lots of split/merged) but in many cases using the BIN you can join with [PAD](https://www.nyc.gov/content/planning/pages/resources/datasets/pad) to get the current BBL that the bin is associated with now. 

Can we confirmed that this works for the case they found:  `SELECT * FROM wow_indicators WHERE bbl = '4005660136';`

[sc-16412]