### PR TITLE
remove streetview image from building pages (mobile) and summary tab (mobile/desktop)

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -179,8 +179,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;500;600&display=swap" rel="stylesheet">
 
-    <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_STREETVIEW_API_KEY%&libraries=places,geometry"></script>
-
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->

--- a/client/src/components/DetailView.tsx
+++ b/client/src/components/DetailView.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import { CSSTransition } from "react-transition-group";
-import { LazyLoadWhenVisible } from "./LazyLoadWhenVisible";
 import Helpers, { longDateOptions } from "../util/helpers";
 import Browser from "../util/browser";
 import Modal from "../components/Modal";
@@ -23,7 +22,6 @@ import { HpdContactAddress, HpdFullContact } from "./APIDataTypes";
 import { isLegacyPath } from "./WowzaToggle";
 import { logAmplitudeEvent } from "./Amplitude";
 import EmailAlertSignup from "./EmailAlertSignup";
-import { StreetViewStatic } from "./StreetView";
 import GetRepairs from "./GetRepairs";
 
 type Props = withI18nProps &
@@ -184,29 +182,6 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     if (wrapper) wrapper.scrollTop = 0;
   }
 
-  renderStreetView(
-    streetViewAddr: string,
-    streetViewCoords: {
-      lat: number;
-      lng: number;
-    } | null
-  ) {
-    if (!(streetViewAddr && streetViewCoords)) return <></>;
-
-    return (
-      <LazyLoadWhenVisible>
-        <figure className="figure">
-          <StreetViewStatic
-            lat={streetViewCoords.lat}
-            lng={streetViewCoords.lng}
-            imgHeight={(width, _height) => ((width || 0) < 900 ? 200 : 400)}
-            imgWidth={(width, _height) => ((width || 0) < 900 ? 500 : 600)}
-          />
-        </figure>
-      </LazyLoadWhenVisible>
-    );
-  }
-
   render() {
     const isMobile = Browser.isMobile();
     const { i18n, state } = this.props;
@@ -215,21 +190,13 @@ class DetailViewWithoutI18n extends Component<Props, State> {
     const { assocAddrs, detailAddr, searchAddr } = portfolioData;
 
     // Let's save some variables that will be helpful in rendering the front-end component
-    let formattedRegEndDate, streetViewCoords, streetViewAddr, ownernames, userOwnernames;
+    let formattedRegEndDate, streetViewAddr, ownernames, userOwnernames;
 
     formattedRegEndDate = Helpers.formatDate(
       detailAddr.registrationenddate,
       longDateOptions,
       locale
     );
-
-    streetViewCoords =
-      detailAddr.lat && detailAddr.lng
-        ? {
-            lat: detailAddr.lat,
-            lng: detailAddr.lng,
-          }
-        : null;
 
     streetViewAddr = encodeURIComponent(
       `${detailAddr.housenumber} ${detailAddr.streetname}, ${detailAddr.boro}, NY ${detailAddr.zip}`
@@ -251,9 +218,6 @@ class DetailViewWithoutI18n extends Component<Props, State> {
                   <button onClick={() => this.props.onCloseDetail()}>
                     <Trans render="span">View portfolio map</Trans>
                   </button>
-                </div>
-                <div className="card-image show-lg">
-                  {this.renderStreetView(streetViewAddr, streetViewCoords)}
                 </div>
                 <div className="columns main-content-columns">
                   <div className="column col-lg-12 col-7 detail-column-left">

--- a/client/src/components/PropertiesSummary.tsx
+++ b/client/src/components/PropertiesSummary.tsx
@@ -13,7 +13,6 @@ import { StringifyListWithConjunction } from "./StringifyList";
 import { SocialShareAddressPage } from "./SocialShare";
 import { withMachineInStateProps } from "state-machine";
 import { ComplaintsSummary } from "./ComplaintsSummary";
-import { StreetViewStatic } from "./StreetView";
 
 type Props = withMachineInStateProps<"portfolioFound"> & {
   isVisible: boolean;
@@ -68,31 +67,6 @@ export default class PropertiesSummary extends Component<Props, {}> {
                   </Trans>
                 )}
               </p>
-              <aside>
-                {agg.violationsaddr.lat && agg.violationsaddr.lng && (
-                  <figure className="figure">
-                    <StreetViewStatic
-                      lat={agg.violationsaddr.lat}
-                      lng={agg.violationsaddr.lng}
-                      imgHeight={() => 800}
-                      imgWidth={() => 500}
-                      className="img-responsive"
-                    />
-                    <figcaption className="figure-caption text-center text-italic">
-                      <Trans>
-                        {agg.violationsaddr.housenumber} {agg.violationsaddr.streetname},{" "}
-                        {agg.violationsaddr.boro} currently has{" "}
-                        <Plural
-                          value={agg.violationsaddr.openviolations || 0}
-                          one="one open HPD violation"
-                          other="# open HPD violations"
-                        />{" "}
-                        - the most in this portfolio.
-                      </Trans>
-                    </figcaption>
-                  </figure>
-                )}
-              </aside>
               <Trans render="h6">Building info</Trans>
               <p>
                 <Trans>
@@ -129,42 +103,42 @@ export default class PropertiesSummary extends Component<Props, {}> {
               <EvictionsSummary {...agg} />
               <Trans render="h6">Rent stabilization</Trans>
               <RentstabSummary {...agg} />
-              <aside>
-                <div className="PropertiesSummary__links">
-                  <span className="PropertiesSummary__linksTitle">
-                    <Trans render="em">Additional links</Trans>
-                  </span>
-                  <div>
-                    <h6 className="PropertiesSummary__linksSubtitle">
-                      <Trans>Questions or feedback?</Trans>
-                    </h6>
-                    <Link
-                      href="mailto:support@justfix.org"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      icon="external"
-                    >
-                      support@justfix.org
-                    </Link>
-                  </div>
-                  <div>
-                    <h6 className="PropertiesSummary__linksSubtitle">
-                      <Trans>Share with your neighbors</Trans>
-                    </h6>
-                    <SocialShareAddressPage
-                      location="summary-tab"
-                      customContent={{
-                        tweet: t`This landlord owns ${agg.bldgs} buildings, and according to @NYCHousing, has received a total of ${agg.totalviolations} violations. Can you guess which landlord it is? Find their name and more data analysis here: `,
-                        tweetCloseout: t`#WhoOwnsWhat via @JustFixOrg`,
-                        emailSubject: t` This landlord’s buildings average ${agg.openviolationsperresunit} open HPD violations per apartment`,
-                        getEmailBody: (url: string) =>
-                          t`I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: ${url}`,
-                      }}
-                    />
-                  </div>
-                </div>
-              </aside>
             </div>
+            <aside>
+              <div className="PropertiesSummary__links">
+                <span className="PropertiesSummary__linksTitle">
+                  <Trans render="em">Additional links</Trans>
+                </span>
+                <div>
+                  <h6 className="PropertiesSummary__linksSubtitle">
+                    <Trans>Questions or feedback?</Trans>
+                  </h6>
+                  <Link
+                    href="mailto:support@justfix.org"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    icon="external"
+                  >
+                    support@justfix.org
+                  </Link>
+                </div>
+                <div>
+                  <h6 className="PropertiesSummary__linksSubtitle">
+                    <Trans>Share with your neighbors</Trans>
+                  </h6>
+                  <SocialShareAddressPage
+                    location="summary-tab"
+                    customContent={{
+                      tweet: t`This landlord owns ${agg.bldgs} buildings, and according to @NYCHousing, has received a total of ${agg.totalviolations} violations. Can you guess which landlord it is? Find their name and more data analysis here: `,
+                      tweetCloseout: t`#WhoOwnsWhat via @JustFixOrg`,
+                      emailSubject: t` This landlord’s buildings average ${agg.openviolationsperresunit} open HPD violations per apartment`,
+                      getEmailBody: (url: string) =>
+                        t`I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: ${url}`,
+                    }}
+                  />
+                </div>
+              </div>
+            </aside>
           </div>
           <LegalFooter />
         </div>

--- a/client/src/components/StreetView.tsx
+++ b/client/src/components/StreetView.tsx
@@ -4,6 +4,10 @@ import Browser from "../util/browser";
 import Helpers from "../util/helpers";
 import { FixedLoadingLabel } from "./Loader";
 
+// The API for these streetview images is quite expensive, and the quality has
+// been declining (now common to get images inside businesses etc) so we've
+// decided to completely remove it from the site for now.
+
 export type StreetViewAddr = {
   lat: number;
   lng: number;

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -25,24 +25,24 @@ msgstr ""
 #~ msgid "#WhoOwnsWhat via @JustFixNYC"
 #~ msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/components/PropertiesSummary.tsx:108
+#: src/components/PropertiesSummary.tsx:95
 msgid "#WhoOwnsWhat via @JustFixOrg"
 msgstr "#WhoOwnsWhat via @JustFixOrg"
 
-#: src/util/helpers.ts:275
+#: src/util/helpers.ts:274
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
-#: src/components/DetailView.tsx:240
+#: src/components/DetailView.tsx:219
 msgid "(as part of a group sale)"
 msgstr "(as part of a group sale)"
 
-#: src/components/DetailView.tsx:222
+#: src/components/DetailView.tsx:201
 #: src/containers/NotRegisteredPage.tsx:104
 msgid "(expired {formattedRegEndDate})"
 msgstr "(expired {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:225
+#: src/components/DetailView.tsx:204
 msgid "(expires {formattedRegEndDate})"
 msgstr "(expires {formattedRegEndDate})"
 
@@ -159,7 +159,7 @@ msgstr "<0>This property is not required to register with HPD</0> because it doe
 msgid "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 msgstr "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 
-#: src/components/DetailView.tsx:65
+#: src/components/DetailView.tsx:63
 msgid "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 msgstr "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 
@@ -215,7 +215,7 @@ msgstr "Account"
 #~ msgid "Account settings"
 #~ msgstr "Account settings"
 
-#: src/components/PropertiesSummary.tsx:38
+#: src/components/PropertiesSummary.tsx:37
 msgid "Across owners and management staff, the most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "Across owners and management staff, the most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 
@@ -227,7 +227,7 @@ msgstr "Across owners and management staff, the most common {0, plural, one {nam
 #~ msgid "Add to Building Updates"
 #~ msgstr "Add to Building Updates"
 
-#: src/components/PropertiesSummary.tsx:92
+#: src/components/PropertiesSummary.tsx:79
 msgid "Additional links"
 msgstr "Additional links"
 
@@ -342,7 +342,7 @@ msgstr "At this time we can only support {subscriptionLimit} buildings in each e
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "BELL/BUZZER/INTERCOM"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:143
 msgid "BUILDING:"
 msgstr "BUILDING:"
 
@@ -357,7 +357,6 @@ msgstr "Boro-Block-Lot (BBL)"
 
 #: src/components/PortfolioTable.tsx:94
 #: src/containers/NychaPage.tsx:83
-#: src/util/helpers.ts:68
 msgid "Borough"
 msgstr "Borough"
 
@@ -387,7 +386,7 @@ msgstr "Building Size"
 #~ msgid "Building Updates"
 #~ msgstr "Building Updates"
 
-#: src/components/PropertiesSummary.tsx:63
+#: src/components/PropertiesSummary.tsx:49
 msgid "Building info"
 msgstr "Building info"
 
@@ -403,13 +402,13 @@ msgstr "Buildings without valid property registration are subject to the followi
 msgid "Built"
 msgstr "Built"
 
-#: src/components/DetailView.tsx:304
-#: src/components/DetailView.tsx:313
+#: src/components/DetailView.tsx:283
+#: src/components/DetailView.tsx:292
 msgid "Business Addresses"
 msgstr "Business Addresses"
 
-#: src/components/DetailView.tsx:284
-#: src/components/DetailView.tsx:293
+#: src/components/DetailView.tsx:263
+#: src/components/DetailView.tsx:272
 msgid "Business Entities"
 msgstr "Business Entities"
 
@@ -445,7 +444,7 @@ msgstr "Change in rent stabilized units"
 msgid "Change in rent stabilized units"
 msgstr "Change in rent stabilized units"
 
-#: src/components/DetailView.tsx:29
+#: src/components/DetailView.tsx:27
 msgid "Check out the issues in this building"
 msgstr "Check out the issues in this building"
 
@@ -556,7 +555,7 @@ msgstr "Click the link we sent to {0}. It may take a few minutes to arrive."
 #~ msgstr "Click the link we sent to {email}. It may take a few minutes to arrive."
 
 #: src/components/CloseButton.tsx:10
-#: src/components/DetailView.tsx:60
+#: src/components/DetailView.tsx:58
 #: src/components/FeatureCalloutWidget.tsx:61
 msgid "Close"
 msgstr "Close"
@@ -814,7 +813,7 @@ msgstr "Eviction cases filed in Housing Court since 2017. This data comes from t
 msgid "Eviction cases filed in Housing Court since 2017. This data comes from the Office of Court Administration via the OCA Data Collective in collaboration with the Right to Counsel Coalition."
 msgstr "Eviction cases filed in Housing Court since 2017. This data comes from the Office of Court Administration via the OCA Data Collective in collaboration with the Right to Counsel Coalition."
 
-#: src/components/PropertiesSummary.tsx:85
+#: src/components/PropertiesSummary.tsx:71
 #: src/containers/NychaPage.tsx:91
 msgid "Evictions"
 msgstr "Evictions"
@@ -1017,7 +1016,7 @@ msgstr "Hide legend"
 msgid "How are the results calculated?"
 msgstr "How are the results calculated?"
 
-#: src/components/DetailView.tsx:89
+#: src/components/DetailView.tsx:87
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
@@ -1026,15 +1025,15 @@ msgstr "How is this building associated to this portfolio?"
 msgid "How to use"
 msgstr "How to use"
 
-#: src/components/DetailView.tsx:30
+#: src/components/DetailView.tsx:28
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "I just looked up this building on Who Owns What, a free tool built by JustFix to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 
-#: src/components/DetailView.tsx:28
+#: src/components/DetailView.tsx:26
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 
-#: src/components/PropertiesSummary.tsx:110
+#: src/components/PropertiesSummary.tsx:97
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 
@@ -1163,16 +1162,16 @@ msgstr "Last Sale"
 msgid "Last Sale Unknown"
 msgstr "Last Sale Unknown"
 
-#: src/components/DetailView.tsx:217
+#: src/components/DetailView.tsx:196
 #: src/containers/NotRegisteredPage.tsx:99
 msgid "Last registered:"
 msgstr "Last registered:"
 
-#: src/components/DetailView.tsx:230
+#: src/components/DetailView.tsx:209
 msgid "Last sold:"
 msgstr "Last sold:"
 
-#: src/components/DetailView.tsx:60
+#: src/components/DetailView.tsx:58
 msgid "Learn more"
 msgstr "Learn more"
 
@@ -1380,7 +1379,7 @@ msgstr "Min must be less than {maxOption}"
 msgid "More Mobile Friendly"
 msgstr "More Mobile Friendly"
 
-#: src/components/DetailView.tsx:174
+#: src/components/DetailView.tsx:153
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Most Common 311 Complaints, Last 3 Years"
 
@@ -1498,7 +1497,7 @@ msgstr "Non-ECB"
 msgid "Non-Emergency"
 msgstr "Non-Emergency"
 
-#: src/components/DetailView.tsx:182
+#: src/components/DetailView.tsx:161
 msgid "None"
 msgstr "None"
 
@@ -1622,8 +1621,8 @@ msgstr "Password"
 msgid "Password reset successful"
 msgstr "Password reset successful"
 
-#: src/components/DetailView.tsx:324
-#: src/components/DetailView.tsx:334
+#: src/components/DetailView.tsx:303
+#: src/components/DetailView.tsx:313
 msgid "People"
 msgstr "People"
 
@@ -1681,7 +1680,7 @@ msgstr "Privacy policy"
 msgid "Public Housing Development"
 msgstr "Public Housing Development"
 
-#: src/components/PropertiesSummary.tsx:96
+#: src/components/PropertiesSummary.tsx:83
 msgid "Questions or feedback?"
 msgstr "Questions or feedback?"
 
@@ -1730,7 +1729,7 @@ msgstr "Rent Stabilized Units registered since 2007"
 #~ msgid "Rent Stabilized Units registered since 2010"
 #~ msgstr "Rent Stabilized Units registered since 2010"
 
-#: src/components/PropertiesSummary.tsx:87
+#: src/components/PropertiesSummary.tsx:73
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
@@ -1894,9 +1893,9 @@ msgstr "Send new link"
 #~ msgid "Share this page with your neighbors"
 #~ msgstr "Share this page with your neighbors"
 
-#: src/components/DetailView.tsx:255
+#: src/components/DetailView.tsx:234
 #: src/components/EngagementPanel.tsx:11
-#: src/components/PropertiesSummary.tsx:104
+#: src/components/PropertiesSummary.tsx:91
 #: src/containers/NotRegisteredPage.tsx:19
 msgid "Share with your neighbors"
 msgstr "Share with your neighbors"
@@ -2152,7 +2151,7 @@ msgstr "The email and/or password you entered is incorrect."
 #~ msgid "The link sent to you has timed out."
 #~ msgstr "The link sent to you has timed out."
 
-#: src/components/PropertiesSummary.tsx:44
+#: src/components/PropertiesSummary.tsx:43
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 
@@ -2207,11 +2206,11 @@ msgstr "The verification link that we sent you is no longer valid."
 msgid "The year that this building was originally constructed, according to the Dept. of Finance"
 msgstr "The year that this building was originally constructed, according to the Dept. of Finance"
 
-#: src/components/PropertiesSummary.tsx:76
+#: src/components/PropertiesSummary.tsx:62
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 
-#: src/components/PropertiesSummary.tsx:65
+#: src/components/PropertiesSummary.tsx:51
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
@@ -2259,11 +2258,11 @@ msgstr "This is <0>worse</0> than the citywide average of {VIOLATIONS_AVG} per r
 #~ msgid "This is the old version of Who Owns What. <0>Check out the new version here.</0>"
 #~ msgstr "This is the old version of Who Owns What. <0>Check out the new version here.</0>"
 
-#: src/components/PropertiesSummary.tsx:107
+#: src/components/PropertiesSummary.tsx:94
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 
-#: src/components/PropertiesSummary.tsx:109
+#: src/components/PropertiesSummary.tsx:96
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "This landlord’s buildings average {0} open HPD violations per apartment"
 
@@ -2497,7 +2496,7 @@ msgstr "View on Google Maps"
 msgid "View portfolio"
 msgstr "View portfolio"
 
-#: src/components/DetailView.tsx:154
+#: src/components/DetailView.tsx:136
 msgid "View portfolio map"
 msgstr "View portfolio map"
 
@@ -2530,11 +2529,11 @@ msgstr "WINDOWS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:209
+#: src/components/DetailView.tsx:188
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 
-#: src/components/DetailView.tsx:93
+#: src/components/DetailView.tsx:91
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
@@ -2657,7 +2656,7 @@ msgstr "Who owns what"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 
-#: src/components/DetailView.tsx:189
+#: src/components/DetailView.tsx:168
 msgid "Who’s the landlord of this building?"
 msgstr "Who’s the landlord of this building?"
 
@@ -2913,7 +2912,7 @@ msgstr "buildings"
 #~ msgid "districts"
 #~ msgstr "districts"
 
-#: src/components/DetailView.tsx:234
+#: src/components/DetailView.tsx:213
 msgid "for ${0}"
 msgstr "for ${0}"
 
@@ -2973,8 +2972,8 @@ msgid "{0} of {numberOfEntries}"
 msgstr "{0} of {numberOfEntries}"
 
 #: src/components/PropertiesSummary.tsx:54
-msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
-msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
+#~ msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
+#~ msgstr "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
 
 #: src/containers/DistrictAlertsPage.tsx:124
 #~ msgid "{areaTypeLabel}: {areaLabel}"

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -30,24 +30,24 @@ msgstr ""
 #~ msgid "#WhoOwnsWhat via @JustFixNYC"
 #~ msgstr "#WhoOwnsWhat via @JustFixNYC"
 
-#: src/components/PropertiesSummary.tsx:108
+#: src/components/PropertiesSummary.tsx:95
 msgid "#WhoOwnsWhat via @JustFixOrg"
 msgstr "#QuiénEsElDueño por @JustFixOrg"
 
-#: src/util/helpers.ts:275
+#: src/util/helpers.ts:274
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
-#: src/components/DetailView.tsx:240
+#: src/components/DetailView.tsx:219
 msgid "(as part of a group sale)"
 msgstr "(como parte de una venta en grupo)"
 
-#: src/components/DetailView.tsx:222
+#: src/components/DetailView.tsx:201
 #: src/containers/NotRegisteredPage.tsx:104
 msgid "(expired {formattedRegEndDate})"
 msgstr "(caducado {formattedRegEndDate})"
 
-#: src/components/DetailView.tsx:225
+#: src/components/DetailView.tsx:204
 msgid "(expires {formattedRegEndDate})"
 msgstr "(caduca {formattedRegEndDate})"
 
@@ -164,7 +164,7 @@ msgstr "<0>Esta propiedad no necesita estar registrada con en HPD</0> porque no 
 msgid "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 msgstr "<0>Esta propiedad debe estar registrada con en HPD</0> porque tiene más de 2 unidades residenciales."
 
-#: src/components/DetailView.tsx:65
+#: src/components/DetailView.tsx:63
 msgid "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 msgstr "<0>Mientras el dueño legal de un edificio es, con frecuencia, una compañía (se llama muchas veces un “LLC”), estos nombres y direcciones de negocio registrado con HPD se ofrecen una idea más clara de quién controla el edificio.</0><1>Las personas enumeradas aquí como “Oficial Principal” o “Dueño” normalmente tienen una conexión con la propiedad del edificio, mientras que los \"Administradores del Sitio\" formen parte de la gerencia. Dicho eso, estos nombres son autoinformados por el dueño, y entonces pueden ser engañosos.</1><2>Aprende más acerca de registros de HPD y cómo esta información impulsa la herramienta en la <3>página “Acerca de”</3>.</2>"
 
@@ -220,7 +220,7 @@ msgstr "Cuenta"
 #~ msgid "Account settings"
 #~ msgstr "Account settings"
 
-#: src/components/PropertiesSummary.tsx:38
+#: src/components/PropertiesSummary.tsx:37
 msgid "Across owners and management staff, the most common {0, plural, one {name that appears in this portfolio is} other {names that appear in this portfolio are}} <0/>."
 msgstr "En todos los dueños y administradores, {0, plural, one {el nombre más común que aparece en esta cartera de edificios es} other {los nombres más comunes que aparecen en esta cartera de edificios son}} <0/>."
 
@@ -232,7 +232,7 @@ msgstr "En todos los dueños y administradores, {0, plural, one {el nombre más 
 #~ msgid "Add to Building Updates"
 #~ msgstr "Add to Building Updates"
 
-#: src/components/PropertiesSummary.tsx:92
+#: src/components/PropertiesSummary.tsx:79
 msgid "Additional links"
 msgstr "Enlaces adicionales"
 
@@ -347,7 +347,7 @@ msgstr ""
 msgid "BELL/BUZZER/INTERCOM"
 msgstr "TIMBRE/INTERCOMUNICADOR"
 
-#: src/components/DetailView.tsx:164
+#: src/components/DetailView.tsx:143
 msgid "BUILDING:"
 msgstr "EDIFICIO:"
 
@@ -362,7 +362,6 @@ msgstr ""
 
 #: src/components/PortfolioTable.tsx:94
 #: src/containers/NychaPage.tsx:83
-#: src/util/helpers.ts:68
 msgid "Borough"
 msgstr "Municipio"
 
@@ -392,7 +391,7 @@ msgstr "Tamaño del Edificio"
 #~ msgid "Building Updates"
 #~ msgstr "Building Updates"
 
-#: src/components/PropertiesSummary.tsx:63
+#: src/components/PropertiesSummary.tsx:49
 msgid "Building info"
 msgstr "Información de edificios"
 
@@ -408,13 +407,13 @@ msgstr "Edificios sin registro de propiedad válido están sujetos a las siguien
 msgid "Built"
 msgstr "Construido"
 
-#: src/components/DetailView.tsx:304
-#: src/components/DetailView.tsx:313
+#: src/components/DetailView.tsx:283
+#: src/components/DetailView.tsx:292
 msgid "Business Addresses"
 msgstr "Dirección Comercial"
 
-#: src/components/DetailView.tsx:284
-#: src/components/DetailView.tsx:293
+#: src/components/DetailView.tsx:263
+#: src/components/DetailView.tsx:272
 msgid "Business Entities"
 msgstr "Entidades Comerciales"
 
@@ -450,7 +449,7 @@ msgstr ""
 msgid "Change in rent stabilized units"
 msgstr ""
 
-#: src/components/DetailView.tsx:29
+#: src/components/DetailView.tsx:27
 msgid "Check out the issues in this building"
 msgstr "Mira los problemas en este edificio"
 
@@ -561,7 +560,7 @@ msgstr "Haga clic en el enlace que le enviamos a {0}. Puede tardar unos minutos 
 #~ msgstr "Click the link we sent to {email}. It may take a few minutes to arrive."
 
 #: src/components/CloseButton.tsx:10
-#: src/components/DetailView.tsx:60
+#: src/components/DetailView.tsx:58
 #: src/components/FeatureCalloutWidget.tsx:61
 msgid "Close"
 msgstr "Cerrar"
@@ -819,7 +818,7 @@ msgstr "Casos de desalojo presentados en la Corte de Vivienda desde 2017. Estos 
 msgid "Eviction cases filed in Housing Court since 2017. This data comes from the Office of Court Administration via the OCA Data Collective in collaboration with the Right to Counsel Coalition."
 msgstr ""
 
-#: src/components/PropertiesSummary.tsx:85
+#: src/components/PropertiesSummary.tsx:71
 #: src/containers/NychaPage.tsx:91
 msgid "Evictions"
 msgstr "Desalojos"
@@ -1022,7 +1021,7 @@ msgstr "Esconder leyenda"
 msgid "How are the results calculated?"
 msgstr "¿Cómo se calculan los resultados?"
 
-#: src/components/DetailView.tsx:89
+#: src/components/DetailView.tsx:87
 msgid "How is this building associated to this portfolio?"
 msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 
@@ -1031,15 +1030,15 @@ msgstr "¿Cómo se asocia este edificio a este portafolio de edificios?"
 msgid "How to use"
 msgstr "Cómo se usa"
 
-#: src/components/DetailView.tsx:30
+#: src/components/DetailView.tsx:28
 msgid "I just looked up this building on Who Owns What, a free tool built by JustFix to make data on landlords and evictors more transparent to tenants. You might want to look up your building. Check it out here: {url}"
 msgstr "Justo busqué este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix que hace que la información sobre los dueños de edificios sea más transparente para los inquilinos. Sería bueno si buscaras tu edificio también. Míralo aquí: {url}"
 
-#: src/components/DetailView.tsx:28
+#: src/components/DetailView.tsx:26
 msgid "I used #WhoOwnsWhat (built by @JustFixNYC) to see not only the open violations in this building, but also rent stabilized losses, evictions, and more. This website is a wealth of info and costs nothing to use. Savvy New Yorkers need this info:"
 msgstr "Usé #QuiénEsElDueño (construido por @JustFixNYC) para ver no solo las violaciones del código de vivienda, sino también cuántos apartamentos con renta estabilizada se han perdido, desalojos, y más. Este sitio web no cuesta nada para usar. Ojo, neoyorquinos:"
 
-#: src/components/PropertiesSummary.tsx:110
+#: src/components/PropertiesSummary.tsx:97
 msgid "I was checking out this building on Who Owns What, a free landlord research tool from JustFix. It’s a remarkable website that every tenant and housing advocate should know about! Can you guess how many total violations this landlord portfolio has? Check it out here: {url}"
 msgstr "Estaba revisando este edificio en Quién Es El Dueño, una herramienta gratuita construida por JustFix. ¡Es un sitio web extraordinario que cada inquilino y defensor de viviendas debería saber sobre! ¿Puedes adivinar cuántas violaciones totales tiene este portafolio de este dueño? Míralo aquí: {url}"
 
@@ -1168,16 +1167,16 @@ msgstr "Última venta"
 msgid "Last Sale Unknown"
 msgstr "Última venta desconocida"
 
-#: src/components/DetailView.tsx:217
+#: src/components/DetailView.tsx:196
 #: src/containers/NotRegisteredPage.tsx:99
 msgid "Last registered:"
 msgstr "Registrado por última vez:"
 
-#: src/components/DetailView.tsx:230
+#: src/components/DetailView.tsx:209
 msgid "Last sold:"
 msgstr "Vendido por última vez:"
 
-#: src/components/DetailView.tsx:60
+#: src/components/DetailView.tsx:58
 msgid "Learn more"
 msgstr "Aprende más"
 
@@ -1385,7 +1384,7 @@ msgstr "Mín debe ser menor que {maxOption}"
 msgid "More Mobile Friendly"
 msgstr "Más útil para dispositivos móviles"
 
-#: src/components/DetailView.tsx:174
+#: src/components/DetailView.tsx:153
 msgid "Most Common 311 Complaints, Last 3 Years"
 msgstr "Las quejas más comunes de 311, los últimos 3 años"
 
@@ -1503,7 +1502,7 @@ msgstr "No ECB"
 msgid "Non-Emergency"
 msgstr "No Emergencia"
 
-#: src/components/DetailView.tsx:182
+#: src/components/DetailView.tsx:161
 msgid "None"
 msgstr "Ninguna"
 
@@ -1627,8 +1626,8 @@ msgstr "Contraseña"
 msgid "Password reset successful"
 msgstr "Contraseña restablecida con éxito"
 
-#: src/components/DetailView.tsx:324
-#: src/components/DetailView.tsx:334
+#: src/components/DetailView.tsx:303
+#: src/components/DetailView.tsx:313
 msgid "People"
 msgstr "Personas"
 
@@ -1686,7 +1685,7 @@ msgstr "Política de privacidad"
 msgid "Public Housing Development"
 msgstr "Complejo de Vivienda Pública"
 
-#: src/components/PropertiesSummary.tsx:96
+#: src/components/PropertiesSummary.tsx:83
 msgid "Questions or feedback?"
 msgstr "¿preguntas o comentarios?"
 
@@ -1735,7 +1734,7 @@ msgstr "Unidades de Renta Estabilizada registradas desde 2007"
 #~ msgid "Rent Stabilized Units registered since 2010"
 #~ msgstr "Rent Stabilized Units registered since 2010"
 
-#: src/components/PropertiesSummary.tsx:87
+#: src/components/PropertiesSummary.tsx:73
 msgid "Rent stabilization"
 msgstr "Renta estabilizada"
 
@@ -1899,9 +1898,9 @@ msgstr "Enviarme otro enlace"
 #~ msgid "Share this page with your neighbors"
 #~ msgstr "Share this page with your neighbors"
 
-#: src/components/DetailView.tsx:255
+#: src/components/DetailView.tsx:234
 #: src/components/EngagementPanel.tsx:11
-#: src/components/PropertiesSummary.tsx:104
+#: src/components/PropertiesSummary.tsx:91
 #: src/containers/NotRegisteredPage.tsx:19
 msgid "Share with your neighbors"
 msgstr "Comparte esta página con sus vecinos"
@@ -2157,7 +2156,7 @@ msgstr "El correo electrónico y/o la contraseña introducidos son incorrectos."
 #~ msgid "The link sent to you has timed out."
 #~ msgstr "The link sent to you has timed out."
 
-#: src/components/PropertiesSummary.tsx:44
+#: src/components/PropertiesSummary.tsx:43
 msgid "The most common corporate entity is <0>{0}</0> and the most common business address is <1>{1}</1>."
 msgstr "La entidad corporativa más común es <0>{0}</0> y la dirección administrativa más común es <1>{1}</1>."
 
@@ -2212,11 +2211,11 @@ msgstr "El enlace de verificación que le enviamos ya no es válido."
 msgid "The year that this building was originally constructed, according to the Dept. of Finance"
 msgstr ""
 
-#: src/components/PropertiesSummary.tsx:76
+#: src/components/PropertiesSummary.tsx:62
 msgid "The {0, plural, one {} other {average}} age of {1, plural, one {this building} other {these buildings}} is <0>{2}</0> years old."
 msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este edificio} other {estos edificios}} es de <0>{2}</0> años."
 
-#: src/components/PropertiesSummary.tsx:65
+#: src/components/PropertiesSummary.tsx:51
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
@@ -2264,11 +2263,11 @@ msgstr "Esto es <0>peor</0> que el promedio de la ciudad de {VIOLATIONS_AVG} por
 #~ msgid "This is the old version of Who Owns What. <0>Check out the new version here.</0>"
 #~ msgstr "This is the old version of Who Owns What. <0>Check out the new version here.</0>"
 
-#: src/components/PropertiesSummary.tsx:107
+#: src/components/PropertiesSummary.tsx:94
 msgid "This landlord owns {0} buildings, and according to @NYCHousing, has received a total of {1} violations. Can you guess which landlord it is? Find their name and more data analysis here:"
 msgstr "Este dueño de edificio posee {0} edificios, y según @NYCHousing, ha recibido un total de {1} violaciones del código de vivienda. ¿Puedes adivinar como se llama el dueño? Encuentra su nombre y ve más estadísticas aquí:"
 
-#: src/components/PropertiesSummary.tsx:109
+#: src/components/PropertiesSummary.tsx:96
 msgid "This landlord’s buildings average {0} open HPD violations per apartment"
 msgstr "Los edificios de este dueño tienen un promedio de {0} violaciones abiertas de HPD por cada apartamento"
 
@@ -2502,7 +2501,7 @@ msgstr "Ver en Google Maps"
 msgid "View portfolio"
 msgstr "Ver portafolio de edificios"
 
-#: src/components/DetailView.tsx:154
+#: src/components/DetailView.tsx:136
 msgid "View portfolio map"
 msgstr "Ver mapa de la cartera de edificios"
 
@@ -2535,11 +2534,11 @@ msgstr "VENTANAS"
 #~ msgid "Warning"
 #~ msgstr "Warning"
 
-#: src/components/DetailView.tsx:209
+#: src/components/DetailView.tsx:188
 msgid "Warning: This building has an expired registration and was sold after the expiration date. The landlord info listed here may be outdated."
 msgstr "Aviso: Este edificio tiene un registro vencido y se vendió después del vencimiento del registro. La información del dueño que se incluye aquí puede estar desactualizada."
 
-#: src/components/DetailView.tsx:93
+#: src/components/DetailView.tsx:91
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
@@ -2662,7 +2661,7 @@ msgstr "Quién es el dueño en NY"
 msgid "Who’s responsible for issues in your apartment & building? #WhoOwnsWhat helps you research NYC property owners using public, open data. A free tool built by @JustFixNYC, it works on any device with an internet connection! Search your address here:"
 msgstr "¿Quién es responsable por los problemas en tu apartamento y edificio? #QuiénEsElDueño te ayuda investigar los dueños de edificios de NYC usando data pública y abierta. Un sitio web gratis construido por @JustFixNYC, ¡funciona en cualquier aparato con internet! Úsalo ahorita:"
 
-#: src/components/DetailView.tsx:189
+#: src/components/DetailView.tsx:168
 msgid "Who’s the landlord of this building?"
 msgstr "¿Quién es el dueño de este edificio?"
 
@@ -2918,7 +2917,7 @@ msgstr "edificios"
 #~ msgid "districts"
 #~ msgstr ""
 
-#: src/components/DetailView.tsx:234
+#: src/components/DetailView.tsx:213
 msgid "for ${0}"
 msgstr "por ${0}"
 
@@ -2978,8 +2977,8 @@ msgid "{0} of {numberOfEntries}"
 msgstr "{0} de {numberOfEntries}"
 
 #: src/components/PropertiesSummary.tsx:54
-msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
-msgstr "{0} {1}, {2} tiene {3, plural, one {una violación del HPD actual} other {# violaciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
+#~ msgid "{0} {1}, {2} currently has {3, plural, one {one open HPD violation} other {# open HPD violations}} - the most in this portfolio."
+#~ msgstr "{0} {1}, {2} tiene {3, plural, one {una violación del HPD actual} other {# violaciones del HPD actuales}} - la major cantidad en este portafolio de edificios."
 
 #: src/containers/DistrictAlertsPage.tsx:124
 #~ msgid "{areaTypeLabel}: {areaLabel}"

--- a/client/src/styles/DetailView.scss
+++ b/client/src/styles/DetailView.scss
@@ -114,7 +114,7 @@
     }
 
     .DetailView__mobilePortfolioView {
-      padding: 0.8125rem 1.25rem;
+      padding: 0.8125rem 1.25rem 0;
 
       display: none;
       @include for-phone-only() {
@@ -138,6 +138,10 @@
 
       .card-title {
         margin-bottom: 0;
+        @include for-phone-only {
+          font-weight: 700;
+          font-size: 1.35rem;
+        }
       }
 
       // how is this bldg assoc

--- a/client/src/styles/PropertiesSummary.scss
+++ b/client/src/styles/PropertiesSummary.scss
@@ -4,14 +4,13 @@
 
 .PropertiesSummary {
   position: relative;
-  // @include for-phone-only() {
-  //   padding-right: 30px;
-  // };
 
   .PropertiesSummary__content {
     padding: 30px 45px 104px 30px;
 
     @include for-tablet-portrait-up() {
+      display: grid;
+      grid-template-columns: 2fr 1fr;
       padding: 45px 45px 104px 45px;
     }
 
@@ -31,14 +30,14 @@
       margin-bottom: 1.5rem;
     }
 
-    aside {
-      @include for-tablet-landscape-up() {
-        width: 32%;
-        margin-left: 40px;
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-    }
+    // aside {
+    //   @include for-tablet-landscape-up() {
+    //     width: 32%;
+    //     margin-left: 40px;
+    //     margin-top: 0;
+    //     margin-bottom: 0;
+    //   }
+    // }
 
     .network-legend {
       // position: absolute;
@@ -133,7 +132,12 @@
     }
   }
 
+  aside {
+    width: unset;
+  }
+
   .PropertiesSummary__links {
+    width: unset;
     border: 1px solid $gray;
     padding: 1.25rem 0.94rem;
     position: relative;


### PR DESCRIPTION
 The API for these streetview images is quite expensive, and the quality has been declining (now common to get images inside businesses etc) so we've decided to completely remove it from the site for now. We have already done so for the desktop building page, so now we are removing it from mobile building pages and the summary tab for desktop and mobile.

[sc-16440]