### PR TITLE
add back temporarily removed gce eligibility tables

### DIFF
--- a/sql/create_gce_eligibility.sql
+++ b/sql/create_gce_eligibility.sql
@@ -86,7 +86,7 @@ CREATE TABLE gce_eligibility AS (
         LEFT JOIN x_latest_cofos AS co USING(bbl)
         LEFT JOIN x_portfolio_bbls AS wb USING(bbl)
         LEFT JOIN x_portfolio_size AS wp USING(portfolio_id)
-        LEFT JOIN pluto_latest_districts_25a AS pd USING(bbl)
+        LEFT JOIN pluto_latest_districts AS pd USING(bbl)
     )
     SELECT
         bbl,

--- a/who-owns-what.yml
+++ b/who-owns-what.yml
@@ -57,6 +57,8 @@ signature_post_sql:
 good_cause_sql:
   - create_gce_common.sql
   - create_gce_screener.sql
+  - create_gce_eligibility.sql
+  - create_gce_eligibility_maps.sql
 wow_pre_sql:
   # These SQL scripts must be executed in order, as
   # some of them depend on others.


### PR DESCRIPTION
In #1007 we temporarily had to remove the GCE eligibility and map tables because they rely on `pluto_latest_districts` which was a one-off table we created directly on the DB outside of our usual nycdb process and that broke tests. We have since updated nycdb to add this dataset with a new pattern for datasets without source data and with dependencies on other nycdb datasets in https://github.com/nycdb/nycdb/pull/386. So now we can add these tables back to the goodcause job to run on k8s.

Companion PR: https://github.com/JustFixNYC/nycdb-k8s-loader/pull/216

[sc-16362]