### PR TITLE
Area subscription toast

### DIFF
--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -2,8 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { Trans, t } from "@lingui/macro";
 import { useHistory, useLocation } from "react-router-dom";
-import { CSSTransition } from "react-transition-group";
-import { Button, Alert as JFCLAlert } from "@justfixnyc/component-library";
+import { Button } from "@justfixnyc/component-library";
 
 import "styles/EmailAlertSignup.css";
 import "styles/Card.css";
@@ -18,6 +17,7 @@ import Modal from "./Modal";
 import helpers from "util/helpers";
 import { AddressRecord } from "./APIDataTypes";
 import SendNewLink from "./SendNewLink";
+import { ToastAlert } from "./ToastAlert";
 
 const DEFAULT_SUBSCRIPTION_LIMIT = 15;
 const BRANCH_NAME = process.env.REACT_APP_BRANCH;
@@ -162,21 +162,16 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
           ? renderSubscribed()
           : renderAddBuilding()}
       </div>
-      <div className="login-subscribe-alert-container">
-        <CSSTransition
-          in={justSubscribed}
-          timeout={5000}
-          classNames="login-subscribe-alert"
-          onEntered={() => setJustSubscribed(false)}
-        >
-          <JFCLAlert
-            variant="primary"
-            type="success"
-            className="login-subscribe-alert"
-            text={i18n._(t`You are now logged in and we’ve added this building to your updates`)}
-          />
-        </CSSTransition>
-      </div>
+      <ToastAlert
+        showToast={justSubscribed}
+        setShowToast={setJustSubscribed}
+        i18n={i18n}
+        timeout={5000}
+        variant="primary"
+        type="success"
+        className="login-subscribe-alert"
+        text={i18n._(t`You are now logged in and we’ve added this building to your updates`)}
+      />
       <Modal
         key={1}
         showModal={showSubscriptionLimitModal}

--- a/client/src/components/EmailAlertSignup.tsx
+++ b/client/src/components/EmailAlertSignup.tsx
@@ -38,7 +38,7 @@ const BuildingSubscribeWithoutI18n = (props: BuildingSubscribeProps) => {
 
   const { state: locationState } = useLocation();
   const [justSubscribed, setJustSubscribed] = React.useState(false);
-  // switch to regular state and clear location state since it othrwise persists after reloads
+  // switch to regular state and clear location state since it otherwise persists after reloads
   useEffect(() => {
     setJustSubscribed(!!locationState?.justSubscribed);
     window.history.replaceState({ state: undefined }, "");

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -368,7 +368,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
     if (!!addr || !!district) {
       const redirectTo = {
         pathname: !!addr ? getAddrPageRoute(addr) : `/${i18n.language}${account.settings}`,
-        state: { justSubscribed: true },
+        state: { justSubscribed: true, justLoggedIn: true },
       };
       history.push(redirectTo);
       return;

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -367,7 +367,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
 
     if (!!addr || !!district) {
       const redirectTo = {
-        pathname: !!addr ? getAddrPageRoute(addr) : account.settings,
+        pathname: !!addr ? getAddrPageRoute(addr) : `/${i18n.language}${account.settings}`,
         state: { justSubscribed: true },
       };
       history.push(redirectTo);

--- a/client/src/components/ToastAlert.tsx
+++ b/client/src/components/ToastAlert.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Alert, AlertProps } from "@justfixnyc/component-library";
+import { CSSTransition } from "react-transition-group";
+import { I18n } from "@lingui/core";
+// import classNames from "classnames";
+
+import "styles/_toastalert.scss";
+
+interface ToastAlertProps extends AlertProps {
+  active: boolean;
+  i18n: I18n;
+  timeout: number;
+}
+
+export const ToastAlert: React.FC<ToastAlertProps> = (props) => {
+  const { active, i18n, timeout, className, ...alertProps } = props;
+  const [showToast, setShowToast] = React.useState(active);
+
+  return (
+    <div className="toast-alert-container">
+      <CSSTransition
+        in={showToast}
+        timeout={timeout}
+        classNames="toast-alert"
+        // classNames={classNames(className, "toast-alert")}
+        onEntered={() => setShowToast(false)}
+      >
+        <Alert
+          {...alertProps}
+          className="toast-alert"
+          // className={classNames(className, "toast-alert")}
+        />
+      </CSSTransition>
+    </div>
+  );
+};

--- a/client/src/components/ToastAlert.tsx
+++ b/client/src/components/ToastAlert.tsx
@@ -2,34 +2,29 @@ import React from "react";
 import { Alert, AlertProps } from "@justfixnyc/component-library";
 import { CSSTransition } from "react-transition-group";
 import { I18n } from "@lingui/core";
-// import classNames from "classnames";
+import classNames from "classnames";
 
-import "styles/_toastalert.scss";
+import "styles/_toastalert.css";
 
 interface ToastAlertProps extends AlertProps {
-  active: boolean;
+  showToast: boolean;
+  setShowToast: (value: React.SetStateAction<boolean>) => void;
   i18n: I18n;
   timeout: number;
 }
 
 export const ToastAlert: React.FC<ToastAlertProps> = (props) => {
-  const { active, i18n, timeout, className, ...alertProps } = props;
-  const [showToast, setShowToast] = React.useState(active);
+  const { showToast, setShowToast, i18n, timeout, className, ...alertProps } = props;
 
   return (
     <div className="toast-alert-container">
       <CSSTransition
         in={showToast}
         timeout={timeout}
-        classNames="toast-alert"
-        // classNames={classNames(className, "toast-alert")}
+        classNames={classNames(className, "toast-alert")}
         onEntered={() => setShowToast(false)}
       >
-        <Alert
-          {...alertProps}
-          className="toast-alert"
-          // className={classNames(className, "toast-alert")}
-        />
+        <Alert {...alertProps} className={classNames(className, "toast-alert")} />
       </CSSTransition>
     </div>
   );

--- a/client/src/components/ToastAlert.tsx
+++ b/client/src/components/ToastAlert.tsx
@@ -4,7 +4,7 @@ import { CSSTransition } from "react-transition-group";
 import { I18n } from "@lingui/core";
 import classNames from "classnames";
 
-import "styles/_toastalert.css";
+import "styles/_toastalert.scss";
 
 interface ToastAlertProps extends AlertProps {
   showToast: boolean;

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useEffect } from "react";
 import { withI18n, withI18nProps } from "@lingui/react";
+import { useLocation } from "react-router-dom";
 import { t, Trans, Plural } from "@lingui/macro";
-import { Button, Alert as JFCLAlert } from "@justfixnyc/component-library";
-import { CSSTransition } from "react-transition-group";
+import { Button } from "@justfixnyc/component-library";
 
 import "styles/AccountSettingsPage.css";
 import "styles/UserSetting.css";
@@ -13,8 +13,8 @@ import { DistrictSubscription, JustfixUser } from "state-machine";
 import { createRouteForAddressPage, createWhoOwnsWhatRoutePaths } from "routes";
 import { Borough } from "components/APIDataTypes";
 import { LocaleNavLink } from "i18n";
-import { useLocation } from "react-router-dom";
 import helpers from "util/helpers";
+import { ToastAlert } from "components/ToastAlert";
 
 type BuildingSubscriptionFieldProps = withI18nProps & {
   bbl: string;
@@ -119,7 +119,18 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
     <Page title={i18n._(t`Account`)}>
       <div className="AccountSettingsPage Page">
         <div className="page-container">
-          <div className="login-subscribe-alert-container">
+          <ToastAlert
+            active={justSubscribed}
+            i18n={i18n}
+            timeout={500}
+            variant="primary"
+            type="success"
+            className="subscribe-success-alert"
+            text={i18n._(t`We’ve added your area to your weekly email updates`)}
+            actionLabel={i18n._(t`Manage`)}
+            actionHref="#area-alerts-section"
+          />
+          {/* <div className="login-subscribe-alert-container">
             <CSSTransition
               in={justSubscribed}
               timeout={5000}
@@ -135,17 +146,9 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
                 actionHref="#area-alerts-section"
               />
             </CSSTransition>
-          </div>
+          </div> */}
           <Trans render="h1">Email settings</Trans>
           <div className="settings-section">
-            <JFCLAlert
-              variant="primary"
-              type="success"
-              className="login-subscribe-alert"
-              text={i18n._(t`We’ve added your area to your weekly email updates`)}
-              actionLabel={i18n._(t`Manage`)}
-              actionHref="#area-alerts-section"
-            />
             <div className="log-in-out">
               <Trans render="h2">You are logged in</Trans>
               <Button

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -120,9 +120,10 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
       <div className="AccountSettingsPage Page">
         <div className="page-container">
           <ToastAlert
-            active={justSubscribed}
+            showToast={justSubscribed}
+            setShowToast={setJustSubscribed}
             i18n={i18n}
-            timeout={500}
+            timeout={5000}
             variant="primary"
             type="success"
             className="subscribe-success-alert"
@@ -130,23 +131,6 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
             actionLabel={i18n._(t`Manage`)}
             actionHref="#area-alerts-section"
           />
-          {/* <div className="login-subscribe-alert-container">
-            <CSSTransition
-              in={justSubscribed}
-              timeout={5000}
-              classNames="login-subscribe-alert"
-              onEntered={() => setJustSubscribed(false)}
-            >
-              <JFCLAlert
-                variant="primary"
-                type="success"
-                className="login-subscribe-alert"
-                text={i18n._(t`We’ve added your area to your weekly email updates`)}
-                actionLabel={i18n._(t`Manage`)}
-                actionHref="#area-alerts-section"
-              />
-            </CSSTransition>
-          </div> */}
           <Trans render="h1">Email settings</Trans>
           <div className="settings-section">
             <div className="log-in-out">

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -92,6 +92,7 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
   const districtSubscriptionsNumber = districtSubscriptions?.length || 0;
 
   const [justSubscribed, setJustSubscribed] = React.useState(false);
+  const [justLoggedIn, setJustLoggedIn] = React.useState(false);
   // NOTE: when using location state you must navigate directly to the
   // language-prefixed route (/en/account/settings), otherwise the state is lost
   // during the redirect
@@ -99,6 +100,7 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
     // switch to regular state and clear location state since it otherwise
     // persists after reloads
     setJustSubscribed(!!locationState?.justSubscribed);
+    setJustLoggedIn(!!locationState?.justLoggedIn);
     window.history.replaceState({ state: undefined }, "");
   }, [locationState]);
 
@@ -133,7 +135,13 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
             variant="primary"
             type="success"
             className="subscribe-success-alert"
-            text={i18n._(t`We’ve added your area to your weekly email updates`)}
+            text={
+              justLoggedIn
+                ? i18n._(
+                    t`You are now logged in and we’ve added your area to your weekly email updates`
+                  )
+                : i18n._(t`We’ve added your area to your weekly email updates`)
+            }
             actionLabel={i18n._(t`Manage`)}
             action={() => alertSectionRef.current?.scrollIntoView({ behavior: "smooth" })}
           />

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useRef } from "react";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { useLocation } from "react-router-dom";
 import { t, Trans, Plural } from "@lingui/macro";
@@ -102,6 +102,8 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
     window.history.replaceState({ state: undefined }, "");
   }, [locationState]);
 
+  const alertSectionRef = useRef<HTMLDivElement>(null);
+
   const unsubscribeBuilding = (bbl: string) => {
     userContext.unsubscribeBuilding(bbl);
     window.gtag("event", "unsubscribe-building", {
@@ -133,7 +135,7 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
             className="subscribe-success-alert"
             text={i18n._(t`We’ve added your area to your weekly email updates`)}
             actionLabel={i18n._(t`Manage`)}
-            actionHref="#area-alerts-section"
+            action={() => alertSectionRef.current?.scrollIntoView({ behavior: "smooth" })}
           />
           <Trans render="h1">Email settings</Trans>
           <div className="settings-section">
@@ -201,7 +203,7 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
               )}
             </Trans>
             <div
-              id="area-alerts-section"
+              ref={alertSectionRef}
               className="subscriptions-container district-subscriptions-container"
             >
               {districtSubscriptions?.length ? (

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -92,8 +92,12 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
   const districtSubscriptionsNumber = districtSubscriptions?.length || 0;
 
   const [justSubscribed, setJustSubscribed] = React.useState(false);
-  // switch to regular state and clear location state since it otherwise persists after reloads
+  // NOTE: when using location state you must navigate directly to the
+  // language-prefixed route (/en/account/settings), otherwise the state is lost
+  // during the redirect 
   useEffect(() => {
+    // switch to regular state and clear location state since it otherwise
+    // persists after reloads
     setJustSubscribed(!!locationState?.justSubscribed);
     window.history.replaceState({ state: undefined }, "");
   }, [locationState]);

--- a/client/src/containers/AccountSettingsPage.tsx
+++ b/client/src/containers/AccountSettingsPage.tsx
@@ -94,7 +94,7 @@ const AccountSettingsPage = withI18n()((props: withI18nProps) => {
   const [justSubscribed, setJustSubscribed] = React.useState(false);
   // NOTE: when using location state you must navigate directly to the
   // language-prefixed route (/en/account/settings), otherwise the state is lost
-  // during the redirect 
+  // during the redirect
   useEffect(() => {
     // switch to regular state and clear location state since it otherwise
     // persists after reloads

--- a/client/src/containers/DistrictAlertsPage.tsx
+++ b/client/src/containers/DistrictAlertsPage.tsx
@@ -75,7 +75,7 @@ const DistrictCreation = withI18n()((props: withI18nProps) => {
   const isLoggedIn = !!userContext?.user?.email;
 
   const history = useHistory();
-  const { account } = createWhoOwnsWhatRoutePaths();
+  const { account } = createWhoOwnsWhatRoutePaths(i18n.language);
 
   const defaultAreaType = areaTypeOptions.filter((area) => area.value === "zipcode")[0];
   const [areaType, setAreaType] = useState<AreaTypeOption>(defaultAreaType);
@@ -155,7 +155,11 @@ const DistrictCreation = withI18n()((props: withI18nProps) => {
     }
 
     await userContext.subscribeDistrict(district);
-    history.push(account.settings);
+    const redirectTo = {
+      pathname: `/${account.settings}`,
+      state: { justSubscribed: true },
+    };
+    history.push(redirectTo);
   };
 
   areaTypeOptions = areaTypeOptions.sort((a, b) => collator.compare(a.label, b.label));

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -78,7 +78,7 @@ msgstr "<0/><1>Success</1>"
 #~ msgid "<0> {delaySeconds}</0> seconds"
 #~ msgstr "<0> {delaySeconds}</0> seconds"
 
-#: src/containers/AccountSettingsPage.tsx:107
+#: src/containers/AccountSettingsPage.tsx:120
 msgid "<0>Add another area alert</0>"
 msgstr "<0>Add another area alert</0>"
 
@@ -90,7 +90,7 @@ msgstr "<0>Add another area alert</0>"
 #~ msgid "<0>Create a district</0> to add to your weekly emails"
 #~ msgstr "<0>Create a district</0> to add to your weekly emails"
 
-#: src/containers/AccountSettingsPage.tsx:112
+#: src/containers/AccountSettingsPage.tsx:125
 msgid "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
 msgstr "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
 
@@ -106,7 +106,7 @@ msgstr "<0>If the landlord doesn't reside here, this property should be register
 msgid "<0>Rent stabilization</0> protects tenants by limiting rent increases and providing the right to lease renewals. Landlords register rent-stabilized units each year with NYS Homes and Community Renewal (HCR). Though the agency does not directly make this data available, the number of registered rent-stabilized units appears on public city property tax bills. JustFix and open-source community projects have extracted these numbers to compile a <1>dataset of building-level counts of rent-stabilized units</1> from 2007 to 2023.<2/><3/>A significant limitation of the data is that <4>landlords will sometimes fail to register the units</4> or do so late, and in the tax bills, it appears there are no rent-stabilized units. For this reason, you may see a sudden drop of registered units to zero, but this doesn’t necessarily reflect an actual loss of stabilized units. If you see a gradual decline in the number of stabilized units that is more likely to represent a true destabilization of units, especially if before 2019 when the passage of the Housing Stability and Tenant Protection Act of 2019 (HSTPA) greatly limited the ways units could be legally destabilized. Even when units are actually destabilized by landlords it does not mean that this was done legally. The only way to know for sure whether your apartment is rent stabilized, was illegally destabilized, or if you are being overcharged is to <5>request your rent history</5> from HCR. Once you receive it, you can use <6>this Learning Center article</6> to guide you in reading your rent history document."
 msgstr "<0>Rent stabilization</0> protects tenants by limiting rent increases and providing the right to lease renewals. Landlords register rent-stabilized units each year with NYS Homes and Community Renewal (HCR). Though the agency does not directly make this data available, the number of registered rent-stabilized units appears on public city property tax bills. JustFix and open-source community projects have extracted these numbers to compile a <1>dataset of building-level counts of rent-stabilized units</1> from 2007 to 2023.<2/><3/>A significant limitation of the data is that <4>landlords will sometimes fail to register the units</4> or do so late, and in the tax bills, it appears there are no rent-stabilized units. For this reason, you may see a sudden drop of registered units to zero, but this doesn’t necessarily reflect an actual loss of stabilized units. If you see a gradual decline in the number of stabilized units that is more likely to represent a true destabilization of units, especially if before 2019 when the passage of the Housing Stability and Tenant Protection Act of 2019 (HSTPA) greatly limited the ways units could be legally destabilized. Even when units are actually destabilized by landlords it does not mean that this was done legally. The only way to know for sure whether your apartment is rent stabilized, was illegally destabilized, or if you are being overcharged is to <5>request your rent history</5> from HCR. Once you receive it, you can use <6>this Learning Center article</6> to guide you in reading your rent history document."
 
-#: src/containers/AccountSettingsPage.tsx:90
+#: src/containers/AccountSettingsPage.tsx:103
 msgid "<0>Search an address</0> to add to your Building Alerts"
 msgstr "<0>Search an address</0> to add to your Building Alerts"
 
@@ -205,7 +205,7 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 
-#: src/containers/AccountSettingsPage.tsx:67
+#: src/containers/AccountSettingsPage.tsx:74
 msgid "Account"
 msgstr "Account"
 
@@ -305,8 +305,8 @@ msgstr "Are you having issues in this development?"
 #~ msgid "Area"
 #~ msgstr "Area"
 
-#: src/containers/AccountSettingsPage.tsx:97
-#: src/containers/DistrictAlertsPage.tsx:148
+#: src/containers/AccountSettingsPage.tsx:110
+#: src/containers/DistrictAlertsPage.tsx:152
 msgid "Area Alerts"
 msgstr "Area Alerts"
 
@@ -318,11 +318,11 @@ msgstr "Area Alerts"
 #~ msgid "Area maps"
 #~ msgstr "Area maps"
 
-#: src/containers/DistrictAlertsPage.tsx:116
+#: src/containers/DistrictAlertsPage.tsx:120
 msgid "Area selection"
 msgstr "Area selection"
 
-#: src/containers/DistrictAlertsPage.tsx:111
+#: src/containers/DistrictAlertsPage.tsx:115
 msgid "Area type selection"
 msgstr "Area type selection"
 
@@ -365,7 +365,7 @@ msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
 #: src/components/EmailAlertSignup.tsx:139
-#: src/containers/AccountSettingsPage.tsx:80
+#: src/containers/AccountSettingsPage.tsx:93
 msgid "Building Alerts"
 msgstr "Building Alerts"
 
@@ -580,7 +580,7 @@ msgstr "Complaints to 311"
 #~ msgid "Congressional District"
 #~ msgstr "Congressional District"
 
-#: src/containers/AccountSettingsPage.tsx:124
+#: src/containers/AccountSettingsPage.tsx:137
 msgid "Contact support@justfix.org to delete your account or get help"
 msgstr "Contact support@justfix.org to delete your account or get help"
 
@@ -740,12 +740,12 @@ msgstr "Email address"
 msgid "Email address verified"
 msgstr "Email address verified"
 
-#: src/containers/AccountSettingsPage.tsx:70
+#: src/containers/AccountSettingsPage.tsx:82
 #: src/containers/App.tsx:124
 msgid "Email settings"
 msgstr "Email settings"
 
-#: src/containers/DistrictAlertsPage.tsx:105
+#: src/containers/DistrictAlertsPage.tsx:109
 msgid "Emails will include data on HPD & DOB complaints and violations, eviction filings, litigations, vacate orders, and building sales."
 msgstr "Emails will include data on HPD & DOB complaints and violations, eviction filings, litigations, vacate orders, and building sales."
 
@@ -935,7 +935,7 @@ msgstr "Get a weekly email alert on complaints, violations, and eviction filings
 #~ msgid "Get a weekly email that identifies buildings and landlord portfolios where tenants are at risk of displacement."
 #~ msgstr "Get a weekly email that identifies buildings and landlord portfolios where tenants are at risk of displacement."
 
-#: src/containers/DistrictAlertsPage.tsx:101
+#: src/containers/DistrictAlertsPage.tsx:105
 msgid "Get a weekly email that identifies buildings and portfolios where tenants are at an elevated risk of displacement."
 msgstr "Get a weekly email that identifies buildings and portfolios where tenants are at an elevated risk of displacement."
 
@@ -1266,7 +1266,7 @@ msgstr "Log in to subscribe to Area Alerts"
 #~ msgid "Login details"
 #~ msgstr "Login details"
 
-#: src/containers/AccountSettingsPage.tsx:74
+#: src/containers/AccountSettingsPage.tsx:87
 msgid "Logout"
 msgstr "Logout"
 
@@ -1317,6 +1317,11 @@ msgstr "Make a selection from the list or clear search text"
 #: src/components/Multiselect.tsx:450
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
+
+#: src/containers/AccountSettingsPage.tsx:79
+#: src/containers/AccountSettingsPage.tsx:84
+msgid "Manage"
+msgstr "Manage"
 
 #: src/containers/UnsubscribePage.tsx:77
 msgid "Manage Subscriptions"
@@ -1403,7 +1408,7 @@ msgstr "MyNYCHA App"
 msgid "NON-CONSTRUCTION"
 msgstr "NON-CONSTRUCTION"
 
-#: src/containers/DistrictAlertsPage.tsx:100
+#: src/containers/DistrictAlertsPage.tsx:104
 msgid "NYC Area Alerts"
 msgstr "NYC Area Alerts"
 
@@ -1702,8 +1707,8 @@ msgstr "Read more in our Methodology section"
 msgid "Registration expired:"
 msgstr "Registration expired:"
 
-#: src/containers/AccountSettingsPage.tsx:26
-#: src/containers/AccountSettingsPage.tsx:36
+#: src/containers/AccountSettingsPage.tsx:27
+#: src/containers/AccountSettingsPage.tsx:37
 msgid "Remove"
 msgstr "Remove"
 
@@ -1807,11 +1812,11 @@ msgstr "STAIRS"
 msgid "Save"
 msgstr "Save"
 
-#: src/containers/DistrictAlertsPage.tsx:122
+#: src/containers/DistrictAlertsPage.tsx:126
 msgid "Save or add more areas"
 msgstr "Save or add more areas"
 
-#: src/containers/DistrictAlertsPage.tsx:130
+#: src/containers/DistrictAlertsPage.tsx:134
 msgid "Save selections"
 msgstr "Save selections"
 
@@ -1845,11 +1850,11 @@ msgstr "See Building Profile"
 msgid "See the most common complaints reported by tenants to 311, now on the Overview and Portfolio tabs."
 msgstr "See the most common complaints reported by tenants to 311, now on the Overview and Portfolio tabs."
 
-#: src/containers/DistrictAlertsPage.tsx:128
+#: src/containers/DistrictAlertsPage.tsx:132
 msgid "Select an area"
 msgstr "Select an area"
 
-#: src/containers/DistrictAlertsPage.tsx:109
+#: src/containers/DistrictAlertsPage.tsx:113
 msgid "Select an area to get started:"
 msgstr "Select an area to get started:"
 
@@ -1857,7 +1862,7 @@ msgstr "Select an area to get started:"
 msgid "Select one or more ranges of building units, or set a custom range, then apply selections to filter the list of portfolio properties."
 msgstr "Select one or more ranges of building units, or set a custom range, then apply selections to filter the list of portfolio properties."
 
-#: src/containers/DistrictAlertsPage.tsx:116
+#: src/containers/DistrictAlertsPage.tsx:120
 msgid "Select or type a"
 msgstr "Select or type a"
 
@@ -2214,7 +2219,7 @@ msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this bui
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
-#: src/containers/AccountSettingsPage.tsx:81
+#: src/containers/AccountSettingsPage.tsx:94
 msgid "There {buildingSubscriptionsNumber, plural, one {is} other {are}} {buildingSubscriptionsNumber} {buildingSubscriptionsNumber, plural, one {building} other {buildings}} in your weekly emails"
 msgstr "There {buildingSubscriptionsNumber, plural, one {is} other {are}} {buildingSubscriptionsNumber} {buildingSubscriptionsNumber, plural, one {building} other {buildings}} in your weekly emails"
 
@@ -2573,6 +2578,11 @@ msgstr "We sent a reset link to {email}. Please check your inbox and spam."
 msgid "We’re having trouble verifying your email at this time."
 msgstr "We’re having trouble verifying your email at this time."
 
+#: src/containers/AccountSettingsPage.tsx:79
+#: src/containers/AccountSettingsPage.tsx:84
+msgid "We’ve added your area to your weekly email updates"
+msgstr "We’ve added your area to your weekly email updates"
+
 #: src/components/BigPortfolioWarning.tsx:61
 #~ msgid "We’ve improved Who Owns What to dig deeper into the data and offer you a more complete picture of buildings associated with your landlord. <0>Read more in our Medium article</0>"
 #~ msgstr "We’ve improved Who Owns What to dig deeper into the data and offer you a more complete picture of buildings associated with your landlord. <0>Read more in our Medium article</0>"
@@ -2675,7 +2685,7 @@ msgid "Yes"
 msgstr "Yes"
 
 #: src/components/Login.tsx:192
-#: src/containers/AccountSettingsPage.tsx:73
+#: src/containers/AccountSettingsPage.tsx:86
 msgid "You are logged in"
 msgstr "You are logged in"
 
@@ -2962,7 +2972,7 @@ msgstr "{0, plural, one {unit} other {units}}"
 
 #: src/components/BuildingStatsTable.tsx:34
 #: src/components/BuildingStatsTable.tsx:35
-#: src/containers/AccountSettingsPage.tsx:98
+#: src/containers/AccountSettingsPage.tsx:111
 #: src/containers/VerifyEmailPage.tsx:92
 msgid "{0}"
 msgstr "{0}"
@@ -2979,7 +2989,7 @@ msgstr "{0} of {numberOfEntries}"
 #~ msgid "{areaTypeLabel}: {areaLabel}"
 #~ msgstr "{areaTypeLabel}: {areaLabel}"
 
-#: src/containers/AccountSettingsPage.tsx:101
+#: src/containers/AccountSettingsPage.tsx:114
 msgid "{districtSubscriptionsNumber, plural, one {a weekly email for 1 area} other {weekly emails for {districtSubscriptionsNumber} areas}}"
 msgstr "{districtSubscriptionsNumber, plural, one {a weekly email for 1 area} other {weekly emails for {districtSubscriptionsNumber} areas}}"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -78,7 +78,7 @@ msgstr "<0/><1>Success</1>"
 #~ msgid "<0> {delaySeconds}</0> seconds"
 #~ msgstr "<0> {delaySeconds}</0> seconds"
 
-#: src/containers/AccountSettingsPage.tsx:115
+#: src/containers/AccountSettingsPage.tsx:124
 msgid "<0>Add another area alert</0>"
 msgstr "<0>Add another area alert</0>"
 
@@ -90,7 +90,7 @@ msgstr "<0>Add another area alert</0>"
 #~ msgid "<0>Create a district</0> to add to your weekly emails"
 #~ msgstr "<0>Create a district</0> to add to your weekly emails"
 
-#: src/containers/AccountSettingsPage.tsx:120
+#: src/containers/AccountSettingsPage.tsx:129
 msgid "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
 msgstr "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
 
@@ -106,7 +106,7 @@ msgstr "<0>If the landlord doesn't reside here, this property should be register
 msgid "<0>Rent stabilization</0> protects tenants by limiting rent increases and providing the right to lease renewals. Landlords register rent-stabilized units each year with NYS Homes and Community Renewal (HCR). Though the agency does not directly make this data available, the number of registered rent-stabilized units appears on public city property tax bills. JustFix and open-source community projects have extracted these numbers to compile a <1>dataset of building-level counts of rent-stabilized units</1> from 2007 to 2023.<2/><3/>A significant limitation of the data is that <4>landlords will sometimes fail to register the units</4> or do so late, and in the tax bills, it appears there are no rent-stabilized units. For this reason, you may see a sudden drop of registered units to zero, but this doesn’t necessarily reflect an actual loss of stabilized units. If you see a gradual decline in the number of stabilized units that is more likely to represent a true destabilization of units, especially if before 2019 when the passage of the Housing Stability and Tenant Protection Act of 2019 (HSTPA) greatly limited the ways units could be legally destabilized. Even when units are actually destabilized by landlords it does not mean that this was done legally. The only way to know for sure whether your apartment is rent stabilized, was illegally destabilized, or if you are being overcharged is to <5>request your rent history</5> from HCR. Once you receive it, you can use <6>this Learning Center article</6> to guide you in reading your rent history document."
 msgstr "<0>Rent stabilization</0> protects tenants by limiting rent increases and providing the right to lease renewals. Landlords register rent-stabilized units each year with NYS Homes and Community Renewal (HCR). Though the agency does not directly make this data available, the number of registered rent-stabilized units appears on public city property tax bills. JustFix and open-source community projects have extracted these numbers to compile a <1>dataset of building-level counts of rent-stabilized units</1> from 2007 to 2023.<2/><3/>A significant limitation of the data is that <4>landlords will sometimes fail to register the units</4> or do so late, and in the tax bills, it appears there are no rent-stabilized units. For this reason, you may see a sudden drop of registered units to zero, but this doesn’t necessarily reflect an actual loss of stabilized units. If you see a gradual decline in the number of stabilized units that is more likely to represent a true destabilization of units, especially if before 2019 when the passage of the Housing Stability and Tenant Protection Act of 2019 (HSTPA) greatly limited the ways units could be legally destabilized. Even when units are actually destabilized by landlords it does not mean that this was done legally. The only way to know for sure whether your apartment is rent stabilized, was illegally destabilized, or if you are being overcharged is to <5>request your rent history</5> from HCR. Once you receive it, you can use <6>this Learning Center article</6> to guide you in reading your rent history document."
 
-#: src/containers/AccountSettingsPage.tsx:98
+#: src/containers/AccountSettingsPage.tsx:107
 msgid "<0>Search an address</0> to add to your Building Alerts"
 msgstr "<0>Search an address</0> to add to your Building Alerts"
 
@@ -205,7 +205,7 @@ msgstr "About"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 
-#: src/containers/AccountSettingsPage.tsx:74
+#: src/containers/AccountSettingsPage.tsx:81
 msgid "Account"
 msgstr "Account"
 
@@ -305,7 +305,7 @@ msgstr "Are you having issues in this development?"
 #~ msgid "Area"
 #~ msgstr "Area"
 
-#: src/containers/AccountSettingsPage.tsx:105
+#: src/containers/AccountSettingsPage.tsx:114
 #: src/containers/DistrictAlertsPage.tsx:152
 msgid "Area Alerts"
 msgstr "Area Alerts"
@@ -365,7 +365,7 @@ msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
 #: src/components/EmailAlertSignup.tsx:135
-#: src/containers/AccountSettingsPage.tsx:88
+#: src/containers/AccountSettingsPage.tsx:97
 msgid "Building Alerts"
 msgstr "Building Alerts"
 
@@ -580,7 +580,7 @@ msgstr "Complaints to 311"
 #~ msgid "Congressional District"
 #~ msgstr "Congressional District"
 
-#: src/containers/AccountSettingsPage.tsx:132
+#: src/containers/AccountSettingsPage.tsx:141
 msgid "Contact support@justfix.org to delete your account or get help"
 msgstr "Contact support@justfix.org to delete your account or get help"
 
@@ -740,7 +740,7 @@ msgstr "Email address"
 msgid "Email address verified"
 msgstr "Email address verified"
 
-#: src/containers/AccountSettingsPage.tsx:78
+#: src/containers/AccountSettingsPage.tsx:87
 #: src/containers/App.tsx:124
 msgid "Email settings"
 msgstr "Email settings"
@@ -1266,7 +1266,7 @@ msgstr "Log in to subscribe to Area Alerts"
 #~ msgid "Login details"
 #~ msgstr "Login details"
 
-#: src/containers/AccountSettingsPage.tsx:82
+#: src/containers/AccountSettingsPage.tsx:91
 msgid "Logout"
 msgstr "Logout"
 
@@ -1318,7 +1318,7 @@ msgstr "Make a selection from the list or clear search text"
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
 
-#: src/containers/AccountSettingsPage.tsx:77
+#: src/containers/AccountSettingsPage.tsx:86
 msgid "Manage"
 msgstr "Manage"
 
@@ -2218,7 +2218,7 @@ msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this bui
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
-#: src/containers/AccountSettingsPage.tsx:89
+#: src/containers/AccountSettingsPage.tsx:98
 msgid "There {buildingSubscriptionsNumber, plural, one {is} other {are}} {buildingSubscriptionsNumber} {buildingSubscriptionsNumber, plural, one {building} other {buildings}} in your weekly emails"
 msgstr "There {buildingSubscriptionsNumber, plural, one {is} other {are}} {buildingSubscriptionsNumber} {buildingSubscriptionsNumber, plural, one {building} other {buildings}} in your weekly emails"
 
@@ -2577,7 +2577,7 @@ msgstr "We sent a reset link to {email}. Please check your inbox and spam."
 msgid "We’re having trouble verifying your email at this time."
 msgstr "We’re having trouble verifying your email at this time."
 
-#: src/containers/AccountSettingsPage.tsx:77
+#: src/containers/AccountSettingsPage.tsx:86
 msgid "We’ve added your area to your weekly email updates"
 msgstr "We’ve added your area to your weekly email updates"
 
@@ -2683,7 +2683,7 @@ msgid "Yes"
 msgstr "Yes"
 
 #: src/components/Login.tsx:192
-#: src/containers/AccountSettingsPage.tsx:81
+#: src/containers/AccountSettingsPage.tsx:90
 msgid "You are logged in"
 msgstr "You are logged in"
 
@@ -2698,6 +2698,10 @@ msgstr "You are not subscribed to any Building or Area Alerts"
 #: src/components/EmailAlertSignup.tsx:112
 msgid "You are now logged in and we’ve added this building to your updates"
 msgstr "You are now logged in and we’ve added this building to your updates"
+
+#: src/containers/AccountSettingsPage.tsx:85
+msgid "You are now logged in and we’ve added your area to your weekly email updates"
+msgstr "You are now logged in and we’ve added your area to your weekly email updates"
 
 #: src/containers/VerifyEmailPage.tsx:86
 #~ msgid "You are now signed up for weekly Data Updates."
@@ -2970,7 +2974,7 @@ msgstr "{0, plural, one {unit} other {units}}"
 
 #: src/components/BuildingStatsTable.tsx:34
 #: src/components/BuildingStatsTable.tsx:35
-#: src/containers/AccountSettingsPage.tsx:106
+#: src/containers/AccountSettingsPage.tsx:115
 #: src/containers/VerifyEmailPage.tsx:92
 msgid "{0}"
 msgstr "{0}"
@@ -2987,7 +2991,7 @@ msgstr "{0} of {numberOfEntries}"
 #~ msgid "{areaTypeLabel}: {areaLabel}"
 #~ msgstr "{areaTypeLabel}: {areaLabel}"
 
-#: src/containers/AccountSettingsPage.tsx:109
+#: src/containers/AccountSettingsPage.tsx:118
 msgid "{districtSubscriptionsNumber, plural, one {a weekly email for 1 area} other {weekly emails for {districtSubscriptionsNumber} areas}}"
 msgstr "{districtSubscriptionsNumber, plural, one {a weekly email for 1 area} other {weekly emails for {districtSubscriptionsNumber} areas}}"
 

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -78,7 +78,7 @@ msgstr "<0/><1>Success</1>"
 #~ msgid "<0> {delaySeconds}</0> seconds"
 #~ msgstr "<0> {delaySeconds}</0> seconds"
 
-#: src/containers/AccountSettingsPage.tsx:120
+#: src/containers/AccountSettingsPage.tsx:115
 msgid "<0>Add another area alert</0>"
 msgstr "<0>Add another area alert</0>"
 
@@ -90,7 +90,7 @@ msgstr "<0>Add another area alert</0>"
 #~ msgid "<0>Create a district</0> to add to your weekly emails"
 #~ msgstr "<0>Create a district</0> to add to your weekly emails"
 
-#: src/containers/AccountSettingsPage.tsx:125
+#: src/containers/AccountSettingsPage.tsx:120
 msgid "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
 msgstr "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
 
@@ -106,7 +106,7 @@ msgstr "<0>If the landlord doesn't reside here, this property should be register
 msgid "<0>Rent stabilization</0> protects tenants by limiting rent increases and providing the right to lease renewals. Landlords register rent-stabilized units each year with NYS Homes and Community Renewal (HCR). Though the agency does not directly make this data available, the number of registered rent-stabilized units appears on public city property tax bills. JustFix and open-source community projects have extracted these numbers to compile a <1>dataset of building-level counts of rent-stabilized units</1> from 2007 to 2023.<2/><3/>A significant limitation of the data is that <4>landlords will sometimes fail to register the units</4> or do so late, and in the tax bills, it appears there are no rent-stabilized units. For this reason, you may see a sudden drop of registered units to zero, but this doesn’t necessarily reflect an actual loss of stabilized units. If you see a gradual decline in the number of stabilized units that is more likely to represent a true destabilization of units, especially if before 2019 when the passage of the Housing Stability and Tenant Protection Act of 2019 (HSTPA) greatly limited the ways units could be legally destabilized. Even when units are actually destabilized by landlords it does not mean that this was done legally. The only way to know for sure whether your apartment is rent stabilized, was illegally destabilized, or if you are being overcharged is to <5>request your rent history</5> from HCR. Once you receive it, you can use <6>this Learning Center article</6> to guide you in reading your rent history document."
 msgstr "<0>Rent stabilization</0> protects tenants by limiting rent increases and providing the right to lease renewals. Landlords register rent-stabilized units each year with NYS Homes and Community Renewal (HCR). Though the agency does not directly make this data available, the number of registered rent-stabilized units appears on public city property tax bills. JustFix and open-source community projects have extracted these numbers to compile a <1>dataset of building-level counts of rent-stabilized units</1> from 2007 to 2023.<2/><3/>A significant limitation of the data is that <4>landlords will sometimes fail to register the units</4> or do so late, and in the tax bills, it appears there are no rent-stabilized units. For this reason, you may see a sudden drop of registered units to zero, but this doesn’t necessarily reflect an actual loss of stabilized units. If you see a gradual decline in the number of stabilized units that is more likely to represent a true destabilization of units, especially if before 2019 when the passage of the Housing Stability and Tenant Protection Act of 2019 (HSTPA) greatly limited the ways units could be legally destabilized. Even when units are actually destabilized by landlords it does not mean that this was done legally. The only way to know for sure whether your apartment is rent stabilized, was illegally destabilized, or if you are being overcharged is to <5>request your rent history</5> from HCR. Once you receive it, you can use <6>this Learning Center article</6> to guide you in reading your rent history document."
 
-#: src/containers/AccountSettingsPage.tsx:103
+#: src/containers/AccountSettingsPage.tsx:98
 msgid "<0>Search an address</0> to add to your Building Alerts"
 msgstr "<0>Search an address</0> to add to your Building Alerts"
 
@@ -305,7 +305,7 @@ msgstr "Are you having issues in this development?"
 #~ msgid "Area"
 #~ msgstr "Area"
 
-#: src/containers/AccountSettingsPage.tsx:110
+#: src/containers/AccountSettingsPage.tsx:105
 #: src/containers/DistrictAlertsPage.tsx:152
 msgid "Area Alerts"
 msgstr "Area Alerts"
@@ -334,7 +334,7 @@ msgstr "Associated names/entities: {0}"
 #~ msgid "At this time we can only support {SUBSCRIPTION_LIMIT} buildings in each email. Please visit your <0>account</0> to manage the buildings in your email. If you would like to track more buildings, please let us know by submiting a <1>request form</1>."
 #~ msgstr "At this time we can only support {SUBSCRIPTION_LIMIT} buildings in each email. Please visit your <0>account</0> to manage the buildings in your email. If you would like to track more buildings, please let us know by submiting a <1>request form</1>."
 
-#: src/components/EmailAlertSignup.tsx:119
+#: src/components/EmailAlertSignup.tsx:115
 msgid "At this time we can only support {subscriptionLimit} buildings in each email. Please visit your <0>account</0> to manage the buildings in your email. If you would like to track more buildings, please let us know by submiting a <1>request form</1>."
 msgstr "At this time we can only support {subscriptionLimit} buildings in each email. Please visit your <0>account</0> to manage the buildings in your email. If you would like to track more buildings, please let us know by submiting a <1>request form</1>."
 
@@ -364,8 +364,8 @@ msgstr "Borough"
 msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
-#: src/components/EmailAlertSignup.tsx:139
-#: src/containers/AccountSettingsPage.tsx:93
+#: src/components/EmailAlertSignup.tsx:135
+#: src/containers/AccountSettingsPage.tsx:88
 msgid "Building Alerts"
 msgstr "Building Alerts"
 
@@ -580,7 +580,7 @@ msgstr "Complaints to 311"
 #~ msgid "Congressional District"
 #~ msgstr "Congressional District"
 
-#: src/containers/AccountSettingsPage.tsx:137
+#: src/containers/AccountSettingsPage.tsx:132
 msgid "Contact support@justfix.org to delete your account or get help"
 msgstr "Contact support@justfix.org to delete your account or get help"
 
@@ -740,7 +740,7 @@ msgstr "Email address"
 msgid "Email address verified"
 msgstr "Email address verified"
 
-#: src/containers/AccountSettingsPage.tsx:82
+#: src/containers/AccountSettingsPage.tsx:78
 #: src/containers/App.tsx:124
 msgid "Email settings"
 msgstr "Email settings"
@@ -1266,7 +1266,7 @@ msgstr "Log in to subscribe to Area Alerts"
 #~ msgid "Login details"
 #~ msgstr "Login details"
 
-#: src/containers/AccountSettingsPage.tsx:87
+#: src/containers/AccountSettingsPage.tsx:82
 msgid "Logout"
 msgstr "Logout"
 
@@ -1318,8 +1318,7 @@ msgstr "Make a selection from the list or clear search text"
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
 
-#: src/containers/AccountSettingsPage.tsx:79
-#: src/containers/AccountSettingsPage.tsx:84
+#: src/containers/AccountSettingsPage.tsx:77
 msgid "Manage"
 msgstr "Manage"
 
@@ -2219,7 +2218,7 @@ msgstr "The {0, plural, one {} other {average}} age of {1, plural, one {this bui
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 
-#: src/containers/AccountSettingsPage.tsx:94
+#: src/containers/AccountSettingsPage.tsx:89
 msgid "There {buildingSubscriptionsNumber, plural, one {is} other {are}} {buildingSubscriptionsNumber} {buildingSubscriptionsNumber, plural, one {building} other {buildings}} in your weekly emails"
 msgstr "There {buildingSubscriptionsNumber, plural, one {is} other {are}} {buildingSubscriptionsNumber} {buildingSubscriptionsNumber, plural, one {building} other {buildings}} in your weekly emails"
 
@@ -2578,8 +2577,7 @@ msgstr "We sent a reset link to {email}. Please check your inbox and spam."
 msgid "We’re having trouble verifying your email at this time."
 msgstr "We’re having trouble verifying your email at this time."
 
-#: src/containers/AccountSettingsPage.tsx:79
-#: src/containers/AccountSettingsPage.tsx:84
+#: src/containers/AccountSettingsPage.tsx:77
 msgid "We’ve added your area to your weekly email updates"
 msgstr "We’ve added your area to your weekly email updates"
 
@@ -2685,7 +2683,7 @@ msgid "Yes"
 msgstr "Yes"
 
 #: src/components/Login.tsx:192
-#: src/containers/AccountSettingsPage.tsx:86
+#: src/containers/AccountSettingsPage.tsx:81
 msgid "You are logged in"
 msgstr "You are logged in"
 
@@ -2697,7 +2695,7 @@ msgstr "You are not subscribed to any Building or Area Alerts"
 #~ msgid "You are not subscribed to any buildings"
 #~ msgstr "You are not subscribed to any buildings"
 
-#: src/components/EmailAlertSignup.tsx:114
+#: src/components/EmailAlertSignup.tsx:112
 msgid "You are now logged in and we’ve added this building to your updates"
 msgstr "You are now logged in and we’ve added this building to your updates"
 
@@ -2778,7 +2776,7 @@ msgstr "You can now close this window, <0>search for another building</0> to fol
 #~ msgid "You can now start receiving Building Updates"
 #~ msgstr "You can now start receiving Building Updates"
 
-#: src/components/EmailAlertSignup.tsx:118
+#: src/components/EmailAlertSignup.tsx:114
 msgid "You have reached the maximum number of Building Alerts"
 msgstr "You have reached the maximum number of Building Alerts"
 
@@ -2972,7 +2970,7 @@ msgstr "{0, plural, one {unit} other {units}}"
 
 #: src/components/BuildingStatsTable.tsx:34
 #: src/components/BuildingStatsTable.tsx:35
-#: src/containers/AccountSettingsPage.tsx:111
+#: src/containers/AccountSettingsPage.tsx:106
 #: src/containers/VerifyEmailPage.tsx:92
 msgid "{0}"
 msgstr "{0}"
@@ -2989,7 +2987,7 @@ msgstr "{0} of {numberOfEntries}"
 #~ msgid "{areaTypeLabel}: {areaLabel}"
 #~ msgstr "{areaTypeLabel}: {areaLabel}"
 
-#: src/containers/AccountSettingsPage.tsx:114
+#: src/containers/AccountSettingsPage.tsx:109
 msgid "{districtSubscriptionsNumber, plural, one {a weekly email for 1 area} other {weekly emails for {districtSubscriptionsNumber} areas}}"
 msgstr "{districtSubscriptionsNumber, plural, one {a weekly email for 1 area} other {weekly emails for {districtSubscriptionsNumber} areas}}"
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -83,7 +83,7 @@ msgstr ""
 #~ msgid "<0> {delaySeconds}</0> seconds"
 #~ msgstr "<0> {delaySeconds}</0> seconds"
 
-#: src/containers/AccountSettingsPage.tsx:120
+#: src/containers/AccountSettingsPage.tsx:115
 msgid "<0>Add another area alert</0>"
 msgstr ""
 
@@ -95,7 +95,7 @@ msgstr ""
 #~ msgid "<0>Create a district</0> to add to your weekly emails"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:125
+#: src/containers/AccountSettingsPage.tsx:120
 msgid "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
 msgstr ""
 
@@ -111,7 +111,7 @@ msgstr "<0>Si el dueño no reside aquí, esta propiedad debería estar registrad
 msgid "<0>Rent stabilization</0> protects tenants by limiting rent increases and providing the right to lease renewals. Landlords register rent-stabilized units each year with NYS Homes and Community Renewal (HCR). Though the agency does not directly make this data available, the number of registered rent-stabilized units appears on public city property tax bills. JustFix and open-source community projects have extracted these numbers to compile a <1>dataset of building-level counts of rent-stabilized units</1> from 2007 to 2023.<2/><3/>A significant limitation of the data is that <4>landlords will sometimes fail to register the units</4> or do so late, and in the tax bills, it appears there are no rent-stabilized units. For this reason, you may see a sudden drop of registered units to zero, but this doesn’t necessarily reflect an actual loss of stabilized units. If you see a gradual decline in the number of stabilized units that is more likely to represent a true destabilization of units, especially if before 2019 when the passage of the Housing Stability and Tenant Protection Act of 2019 (HSTPA) greatly limited the ways units could be legally destabilized. Even when units are actually destabilized by landlords it does not mean that this was done legally. The only way to know for sure whether your apartment is rent stabilized, was illegally destabilized, or if you are being overcharged is to <5>request your rent history</5> from HCR. Once you receive it, you can use <6>this Learning Center article</6> to guide you in reading your rent history document."
 msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:103
+#: src/containers/AccountSettingsPage.tsx:98
 msgid "<0>Search an address</0> to add to your Building Alerts"
 msgstr ""
 
@@ -310,7 +310,7 @@ msgstr "¿Tienes problemas en tu edificio?"
 #~ msgid "Area"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:110
+#: src/containers/AccountSettingsPage.tsx:105
 #: src/containers/DistrictAlertsPage.tsx:152
 msgid "Area Alerts"
 msgstr ""
@@ -339,7 +339,7 @@ msgstr "Nombres/entidades asociados: {0}"
 #~ msgid "At this time we can only support {SUBSCRIPTION_LIMIT} buildings in each email. Please visit your <0>account</0> to manage the buildings in your email. If you would like to track more buildings, please let us know by submiting a <1>request form</1>."
 #~ msgstr "En este momento solamente podemos admitir {SUBSCRIPTION_LIMIT} edificios en cada correo electrónico. Por favor, visite su <0>cuenta</0> para gestionar los edificios en su correo electrónico. Si desea seguir más edificios, por favor háganoslo saber enviando un <1>formulario de solicitud</1>."
 
-#: src/components/EmailAlertSignup.tsx:119
+#: src/components/EmailAlertSignup.tsx:115
 msgid "At this time we can only support {subscriptionLimit} buildings in each email. Please visit your <0>account</0> to manage the buildings in your email. If you would like to track more buildings, please let us know by submiting a <1>request form</1>."
 msgstr ""
 
@@ -369,8 +369,8 @@ msgstr "Municipio"
 msgid "Borough Management Office:"
 msgstr "Oficina de Gestión Municipal:"
 
-#: src/components/EmailAlertSignup.tsx:139
-#: src/containers/AccountSettingsPage.tsx:93
+#: src/components/EmailAlertSignup.tsx:135
+#: src/containers/AccountSettingsPage.tsx:88
 msgid "Building Alerts"
 msgstr "Alertas de edificios"
 
@@ -585,7 +585,7 @@ msgstr "Quejas al 311"
 #~ msgid "Congressional District"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:137
+#: src/containers/AccountSettingsPage.tsx:132
 msgid "Contact support@justfix.org to delete your account or get help"
 msgstr "Contacte a support@justfix.org para borrar su cuenta u obtener ayuda"
 
@@ -745,7 +745,7 @@ msgstr "Correo electrónico"
 msgid "Email address verified"
 msgstr "Correo electrónico verificado"
 
-#: src/containers/AccountSettingsPage.tsx:82
+#: src/containers/AccountSettingsPage.tsx:78
 #: src/containers/App.tsx:124
 msgid "Email settings"
 msgstr "Configuración del correo electrónico"
@@ -1271,7 +1271,7 @@ msgstr ""
 #~ msgid "Login details"
 #~ msgstr "Login details"
 
-#: src/containers/AccountSettingsPage.tsx:87
+#: src/containers/AccountSettingsPage.tsx:82
 msgid "Logout"
 msgstr "Cerrar sesión"
 
@@ -1323,8 +1323,7 @@ msgstr "Hacer una selección de la lista o borrar el texto de búsqueda"
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
 
-#: src/containers/AccountSettingsPage.tsx:79
-#: src/containers/AccountSettingsPage.tsx:84
+#: src/containers/AccountSettingsPage.tsx:77
 msgid "Manage"
 msgstr ""
 
@@ -2224,7 +2223,7 @@ msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este e
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
-#: src/containers/AccountSettingsPage.tsx:94
+#: src/containers/AccountSettingsPage.tsx:89
 msgid "There {buildingSubscriptionsNumber, plural, one {is} other {are}} {buildingSubscriptionsNumber} {buildingSubscriptionsNumber, plural, one {building} other {buildings}} in your weekly emails"
 msgstr ""
 
@@ -2583,8 +2582,7 @@ msgstr "Hemos enviado un enlace de reinicio a {email}. Por favor, comprueba su b
 msgid "We’re having trouble verifying your email at this time."
 msgstr "Estamos teniendo problemas para verificar su correo electrónico en este momento."
 
-#: src/containers/AccountSettingsPage.tsx:79
-#: src/containers/AccountSettingsPage.tsx:84
+#: src/containers/AccountSettingsPage.tsx:77
 msgid "We’ve added your area to your weekly email updates"
 msgstr ""
 
@@ -2690,7 +2688,7 @@ msgid "Yes"
 msgstr "Sí"
 
 #: src/components/Login.tsx:192
-#: src/containers/AccountSettingsPage.tsx:86
+#: src/containers/AccountSettingsPage.tsx:81
 msgid "You are logged in"
 msgstr "Ha iniciado sesión"
 
@@ -2702,7 +2700,7 @@ msgstr ""
 #~ msgid "You are not subscribed to any buildings"
 #~ msgstr "No está suscrito a ningún edificio"
 
-#: src/components/EmailAlertSignup.tsx:114
+#: src/components/EmailAlertSignup.tsx:112
 msgid "You are now logged in and we’ve added this building to your updates"
 msgstr "Ha iniciado sesión y hemos añadido este edificio a sus actualizaciones"
 
@@ -2783,7 +2781,7 @@ msgstr ""
 #~ msgid "You can now start receiving Building Updates"
 #~ msgstr "You can now start receiving Building Updates"
 
-#: src/components/EmailAlertSignup.tsx:118
+#: src/components/EmailAlertSignup.tsx:114
 msgid "You have reached the maximum number of Building Alerts"
 msgstr "Ha alcanzado el número máximo de Alertas de Edificios"
 
@@ -2977,7 +2975,7 @@ msgstr "{0, plural, one {unidad} other {unidades}}"
 
 #: src/components/BuildingStatsTable.tsx:34
 #: src/components/BuildingStatsTable.tsx:35
-#: src/containers/AccountSettingsPage.tsx:111
+#: src/containers/AccountSettingsPage.tsx:106
 #: src/containers/VerifyEmailPage.tsx:92
 msgid "{0}"
 msgstr "{0}"
@@ -2994,7 +2992,7 @@ msgstr "{0} de {numberOfEntries}"
 #~ msgid "{areaTypeLabel}: {areaLabel}"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:114
+#: src/containers/AccountSettingsPage.tsx:109
 msgid "{districtSubscriptionsNumber, plural, one {a weekly email for 1 area} other {weekly emails for {districtSubscriptionsNumber} areas}}"
 msgstr ""
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -83,7 +83,7 @@ msgstr ""
 #~ msgid "<0> {delaySeconds}</0> seconds"
 #~ msgstr "<0> {delaySeconds}</0> seconds"
 
-#: src/containers/AccountSettingsPage.tsx:115
+#: src/containers/AccountSettingsPage.tsx:124
 msgid "<0>Add another area alert</0>"
 msgstr ""
 
@@ -95,7 +95,7 @@ msgstr ""
 #~ msgid "<0>Create a district</0> to add to your weekly emails"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:120
+#: src/containers/AccountSettingsPage.tsx:129
 msgid "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
 msgstr ""
 
@@ -111,7 +111,7 @@ msgstr "<0>Si el dueño no reside aquí, esta propiedad debería estar registrad
 msgid "<0>Rent stabilization</0> protects tenants by limiting rent increases and providing the right to lease renewals. Landlords register rent-stabilized units each year with NYS Homes and Community Renewal (HCR). Though the agency does not directly make this data available, the number of registered rent-stabilized units appears on public city property tax bills. JustFix and open-source community projects have extracted these numbers to compile a <1>dataset of building-level counts of rent-stabilized units</1> from 2007 to 2023.<2/><3/>A significant limitation of the data is that <4>landlords will sometimes fail to register the units</4> or do so late, and in the tax bills, it appears there are no rent-stabilized units. For this reason, you may see a sudden drop of registered units to zero, but this doesn’t necessarily reflect an actual loss of stabilized units. If you see a gradual decline in the number of stabilized units that is more likely to represent a true destabilization of units, especially if before 2019 when the passage of the Housing Stability and Tenant Protection Act of 2019 (HSTPA) greatly limited the ways units could be legally destabilized. Even when units are actually destabilized by landlords it does not mean that this was done legally. The only way to know for sure whether your apartment is rent stabilized, was illegally destabilized, or if you are being overcharged is to <5>request your rent history</5> from HCR. Once you receive it, you can use <6>this Learning Center article</6> to guide you in reading your rent history document."
 msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:98
+#: src/containers/AccountSettingsPage.tsx:107
 msgid "<0>Search an address</0> to add to your Building Alerts"
 msgstr ""
 
@@ -210,7 +210,7 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha recibido un total de <0>{totalviolations}</0> violaciones."
 
-#: src/containers/AccountSettingsPage.tsx:74
+#: src/containers/AccountSettingsPage.tsx:81
 msgid "Account"
 msgstr "Cuenta"
 
@@ -310,7 +310,7 @@ msgstr "¿Tienes problemas en tu edificio?"
 #~ msgid "Area"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:105
+#: src/containers/AccountSettingsPage.tsx:114
 #: src/containers/DistrictAlertsPage.tsx:152
 msgid "Area Alerts"
 msgstr ""
@@ -370,7 +370,7 @@ msgid "Borough Management Office:"
 msgstr "Oficina de Gestión Municipal:"
 
 #: src/components/EmailAlertSignup.tsx:135
-#: src/containers/AccountSettingsPage.tsx:88
+#: src/containers/AccountSettingsPage.tsx:97
 msgid "Building Alerts"
 msgstr "Alertas de edificios"
 
@@ -585,7 +585,7 @@ msgstr "Quejas al 311"
 #~ msgid "Congressional District"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:132
+#: src/containers/AccountSettingsPage.tsx:141
 msgid "Contact support@justfix.org to delete your account or get help"
 msgstr "Contacte a support@justfix.org para borrar su cuenta u obtener ayuda"
 
@@ -745,7 +745,7 @@ msgstr "Correo electrónico"
 msgid "Email address verified"
 msgstr "Correo electrónico verificado"
 
-#: src/containers/AccountSettingsPage.tsx:78
+#: src/containers/AccountSettingsPage.tsx:87
 #: src/containers/App.tsx:124
 msgid "Email settings"
 msgstr "Configuración del correo electrónico"
@@ -1271,7 +1271,7 @@ msgstr ""
 #~ msgid "Login details"
 #~ msgstr "Login details"
 
-#: src/containers/AccountSettingsPage.tsx:82
+#: src/containers/AccountSettingsPage.tsx:91
 msgid "Logout"
 msgstr "Cerrar sesión"
 
@@ -1323,7 +1323,7 @@ msgstr "Hacer una selección de la lista o borrar el texto de búsqueda"
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
 
-#: src/containers/AccountSettingsPage.tsx:77
+#: src/containers/AccountSettingsPage.tsx:86
 msgid "Manage"
 msgstr ""
 
@@ -2223,7 +2223,7 @@ msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este e
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
-#: src/containers/AccountSettingsPage.tsx:89
+#: src/containers/AccountSettingsPage.tsx:98
 msgid "There {buildingSubscriptionsNumber, plural, one {is} other {are}} {buildingSubscriptionsNumber} {buildingSubscriptionsNumber, plural, one {building} other {buildings}} in your weekly emails"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr "Hemos enviado un enlace de reinicio a {email}. Por favor, comprueba su b
 msgid "We’re having trouble verifying your email at this time."
 msgstr "Estamos teniendo problemas para verificar su correo electrónico en este momento."
 
-#: src/containers/AccountSettingsPage.tsx:77
+#: src/containers/AccountSettingsPage.tsx:86
 msgid "We’ve added your area to your weekly email updates"
 msgstr ""
 
@@ -2688,7 +2688,7 @@ msgid "Yes"
 msgstr "Sí"
 
 #: src/components/Login.tsx:192
-#: src/containers/AccountSettingsPage.tsx:81
+#: src/containers/AccountSettingsPage.tsx:90
 msgid "You are logged in"
 msgstr "Ha iniciado sesión"
 
@@ -2703,6 +2703,10 @@ msgstr ""
 #: src/components/EmailAlertSignup.tsx:112
 msgid "You are now logged in and we’ve added this building to your updates"
 msgstr "Ha iniciado sesión y hemos añadido este edificio a sus actualizaciones"
+
+#: src/containers/AccountSettingsPage.tsx:85
+msgid "You are now logged in and we’ve added your area to your weekly email updates"
+msgstr ""
 
 #: src/containers/VerifyEmailPage.tsx:86
 #~ msgid "You are now signed up for weekly Data Updates."
@@ -2975,7 +2979,7 @@ msgstr "{0, plural, one {unidad} other {unidades}}"
 
 #: src/components/BuildingStatsTable.tsx:34
 #: src/components/BuildingStatsTable.tsx:35
-#: src/containers/AccountSettingsPage.tsx:106
+#: src/containers/AccountSettingsPage.tsx:115
 #: src/containers/VerifyEmailPage.tsx:92
 msgid "{0}"
 msgstr "{0}"
@@ -2992,7 +2996,7 @@ msgstr "{0} de {numberOfEntries}"
 #~ msgid "{areaTypeLabel}: {areaLabel}"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:109
+#: src/containers/AccountSettingsPage.tsx:118
 msgid "{districtSubscriptionsNumber, plural, one {a weekly email for 1 area} other {weekly emails for {districtSubscriptionsNumber} areas}}"
 msgstr ""
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -83,7 +83,7 @@ msgstr ""
 #~ msgid "<0> {delaySeconds}</0> seconds"
 #~ msgstr "<0> {delaySeconds}</0> seconds"
 
-#: src/containers/AccountSettingsPage.tsx:107
+#: src/containers/AccountSettingsPage.tsx:120
 msgid "<0>Add another area alert</0>"
 msgstr ""
 
@@ -95,7 +95,7 @@ msgstr ""
 #~ msgid "<0>Create a district</0> to add to your weekly emails"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:112
+#: src/containers/AccountSettingsPage.tsx:125
 msgid "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
 msgstr ""
 
@@ -111,7 +111,7 @@ msgstr "<0>Si el dueño no reside aquí, esta propiedad debería estar registrad
 msgid "<0>Rent stabilization</0> protects tenants by limiting rent increases and providing the right to lease renewals. Landlords register rent-stabilized units each year with NYS Homes and Community Renewal (HCR). Though the agency does not directly make this data available, the number of registered rent-stabilized units appears on public city property tax bills. JustFix and open-source community projects have extracted these numbers to compile a <1>dataset of building-level counts of rent-stabilized units</1> from 2007 to 2023.<2/><3/>A significant limitation of the data is that <4>landlords will sometimes fail to register the units</4> or do so late, and in the tax bills, it appears there are no rent-stabilized units. For this reason, you may see a sudden drop of registered units to zero, but this doesn’t necessarily reflect an actual loss of stabilized units. If you see a gradual decline in the number of stabilized units that is more likely to represent a true destabilization of units, especially if before 2019 when the passage of the Housing Stability and Tenant Protection Act of 2019 (HSTPA) greatly limited the ways units could be legally destabilized. Even when units are actually destabilized by landlords it does not mean that this was done legally. The only way to know for sure whether your apartment is rent stabilized, was illegally destabilized, or if you are being overcharged is to <5>request your rent history</5> from HCR. Once you receive it, you can use <6>this Learning Center article</6> to guide you in reading your rent history document."
 msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:90
+#: src/containers/AccountSettingsPage.tsx:103
 msgid "<0>Search an address</0> to add to your Building Alerts"
 msgstr ""
 
@@ -210,7 +210,7 @@ msgstr "Acerca de"
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
 msgstr "Según los datos del HPD disponibles, este portafolio de edificios ha recibido un total de <0>{totalviolations}</0> violaciones."
 
-#: src/containers/AccountSettingsPage.tsx:67
+#: src/containers/AccountSettingsPage.tsx:74
 msgid "Account"
 msgstr "Cuenta"
 
@@ -310,8 +310,8 @@ msgstr "¿Tienes problemas en tu edificio?"
 #~ msgid "Area"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:97
-#: src/containers/DistrictAlertsPage.tsx:148
+#: src/containers/AccountSettingsPage.tsx:110
+#: src/containers/DistrictAlertsPage.tsx:152
 msgid "Area Alerts"
 msgstr ""
 
@@ -323,11 +323,11 @@ msgstr ""
 #~ msgid "Area maps"
 #~ msgstr ""
 
-#: src/containers/DistrictAlertsPage.tsx:116
+#: src/containers/DistrictAlertsPage.tsx:120
 msgid "Area selection"
 msgstr ""
 
-#: src/containers/DistrictAlertsPage.tsx:111
+#: src/containers/DistrictAlertsPage.tsx:115
 msgid "Area type selection"
 msgstr ""
 
@@ -370,7 +370,7 @@ msgid "Borough Management Office:"
 msgstr "Oficina de Gestión Municipal:"
 
 #: src/components/EmailAlertSignup.tsx:139
-#: src/containers/AccountSettingsPage.tsx:80
+#: src/containers/AccountSettingsPage.tsx:93
 msgid "Building Alerts"
 msgstr "Alertas de edificios"
 
@@ -585,7 +585,7 @@ msgstr "Quejas al 311"
 #~ msgid "Congressional District"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:124
+#: src/containers/AccountSettingsPage.tsx:137
 msgid "Contact support@justfix.org to delete your account or get help"
 msgstr "Contacte a support@justfix.org para borrar su cuenta u obtener ayuda"
 
@@ -745,12 +745,12 @@ msgstr "Correo electrónico"
 msgid "Email address verified"
 msgstr "Correo electrónico verificado"
 
-#: src/containers/AccountSettingsPage.tsx:70
+#: src/containers/AccountSettingsPage.tsx:82
 #: src/containers/App.tsx:124
 msgid "Email settings"
 msgstr "Configuración del correo electrónico"
 
-#: src/containers/DistrictAlertsPage.tsx:105
+#: src/containers/DistrictAlertsPage.tsx:109
 msgid "Emails will include data on HPD & DOB complaints and violations, eviction filings, litigations, vacate orders, and building sales."
 msgstr ""
 
@@ -940,7 +940,7 @@ msgstr "Reciba por correo electrónico una alerta semanal de las quejas, infracc
 #~ msgid "Get a weekly email that identifies buildings and landlord portfolios where tenants are at risk of displacement."
 #~ msgstr ""
 
-#: src/containers/DistrictAlertsPage.tsx:101
+#: src/containers/DistrictAlertsPage.tsx:105
 msgid "Get a weekly email that identifies buildings and portfolios where tenants are at an elevated risk of displacement."
 msgstr ""
 
@@ -1271,7 +1271,7 @@ msgstr ""
 #~ msgid "Login details"
 #~ msgstr "Login details"
 
-#: src/containers/AccountSettingsPage.tsx:74
+#: src/containers/AccountSettingsPage.tsx:87
 msgid "Logout"
 msgstr "Cerrar sesión"
 
@@ -1322,6 +1322,11 @@ msgstr "Hacer una selección de la lista o borrar el texto de búsqueda"
 #: src/components/Multiselect.tsx:450
 #~ msgid "Make a selection."
 #~ msgstr "Make a selection."
+
+#: src/containers/AccountSettingsPage.tsx:79
+#: src/containers/AccountSettingsPage.tsx:84
+msgid "Manage"
+msgstr ""
 
 #: src/containers/UnsubscribePage.tsx:77
 msgid "Manage Subscriptions"
@@ -1408,7 +1413,7 @@ msgstr "App MyNYCHA"
 msgid "NON-CONSTRUCTION"
 msgstr "NO CONSTRUCCIÓN"
 
-#: src/containers/DistrictAlertsPage.tsx:100
+#: src/containers/DistrictAlertsPage.tsx:104
 msgid "NYC Area Alerts"
 msgstr ""
 
@@ -1707,8 +1712,8 @@ msgstr "Más información sobre nuestra metodología"
 msgid "Registration expired:"
 msgstr "El registro ha caducado:"
 
-#: src/containers/AccountSettingsPage.tsx:26
-#: src/containers/AccountSettingsPage.tsx:36
+#: src/containers/AccountSettingsPage.tsx:27
+#: src/containers/AccountSettingsPage.tsx:37
 msgid "Remove"
 msgstr "Eliminar"
 
@@ -1812,11 +1817,11 @@ msgstr "ESCALERAS"
 msgid "Save"
 msgstr "Guardar"
 
-#: src/containers/DistrictAlertsPage.tsx:122
+#: src/containers/DistrictAlertsPage.tsx:126
 msgid "Save or add more areas"
 msgstr ""
 
-#: src/containers/DistrictAlertsPage.tsx:130
+#: src/containers/DistrictAlertsPage.tsx:134
 msgid "Save selections"
 msgstr ""
 
@@ -1850,11 +1855,11 @@ msgstr "Ver perfil del edificio"
 msgid "See the most common complaints reported by tenants to 311, now on the Overview and Portfolio tabs."
 msgstr "Vea las quejas más comunes reportadas por inquilinos al 311, ahora en las pestañas General y Portafolio."
 
-#: src/containers/DistrictAlertsPage.tsx:128
+#: src/containers/DistrictAlertsPage.tsx:132
 msgid "Select an area"
 msgstr ""
 
-#: src/containers/DistrictAlertsPage.tsx:109
+#: src/containers/DistrictAlertsPage.tsx:113
 msgid "Select an area to get started:"
 msgstr ""
 
@@ -1862,7 +1867,7 @@ msgstr ""
 msgid "Select one or more ranges of building units, or set a custom range, then apply selections to filter the list of portfolio properties."
 msgstr "Seleccione uno o varios rangos de unidades de edificios o establezca un rango personalizado y, a continuación, aplique las selecciones para filtrar la lista de propiedades de la cartera."
 
-#: src/containers/DistrictAlertsPage.tsx:116
+#: src/containers/DistrictAlertsPage.tsx:120
 msgid "Select or type a"
 msgstr ""
 
@@ -2219,7 +2224,7 @@ msgstr "La {0, plural, one {edad} other {edad media}} de {1, plural, one {este e
 msgid "There {0, plural, one {<0>is <1>1</1> building</0>} other {<2>are <3>{1}</3> buildings</2>}} in this portfolio with a total of {2, plural, one {1 unit} other {# units}}."
 msgstr "Hay {0, plural, one {<0><1>1</1> edificio</0>} other {<2><3>{1}</3> edificios</2>}} en este portafolio de edificios, con un total de {2, plural, one {una unidad residencial} other {# unidades residenciales}}."
 
-#: src/containers/AccountSettingsPage.tsx:81
+#: src/containers/AccountSettingsPage.tsx:94
 msgid "There {buildingSubscriptionsNumber, plural, one {is} other {are}} {buildingSubscriptionsNumber} {buildingSubscriptionsNumber, plural, one {building} other {buildings}} in your weekly emails"
 msgstr ""
 
@@ -2578,6 +2583,11 @@ msgstr "Hemos enviado un enlace de reinicio a {email}. Por favor, comprueba su b
 msgid "We’re having trouble verifying your email at this time."
 msgstr "Estamos teniendo problemas para verificar su correo electrónico en este momento."
 
+#: src/containers/AccountSettingsPage.tsx:79
+#: src/containers/AccountSettingsPage.tsx:84
+msgid "We’ve added your area to your weekly email updates"
+msgstr ""
+
 #: src/components/BigPortfolioWarning.tsx:61
 #~ msgid "We’ve improved Who Owns What to dig deeper into the data and offer you a more complete picture of buildings associated with your landlord. <0>Read more in our Medium article</0>"
 #~ msgstr "We’ve improved Who Owns What to dig deeper into the data and offer you a more complete picture of buildings associated with your landlord. <0>Read more in our Medium article</0>"
@@ -2680,7 +2690,7 @@ msgid "Yes"
 msgstr "Sí"
 
 #: src/components/Login.tsx:192
-#: src/containers/AccountSettingsPage.tsx:73
+#: src/containers/AccountSettingsPage.tsx:86
 msgid "You are logged in"
 msgstr "Ha iniciado sesión"
 
@@ -2967,7 +2977,7 @@ msgstr "{0, plural, one {unidad} other {unidades}}"
 
 #: src/components/BuildingStatsTable.tsx:34
 #: src/components/BuildingStatsTable.tsx:35
-#: src/containers/AccountSettingsPage.tsx:98
+#: src/containers/AccountSettingsPage.tsx:111
 #: src/containers/VerifyEmailPage.tsx:92
 msgid "{0}"
 msgstr "{0}"
@@ -2984,7 +2994,7 @@ msgstr "{0} de {numberOfEntries}"
 #~ msgid "{areaTypeLabel}: {areaLabel}"
 #~ msgstr ""
 
-#: src/containers/AccountSettingsPage.tsx:101
+#: src/containers/AccountSettingsPage.tsx:114
 msgid "{districtSubscriptionsNumber, plural, one {a weekly email for 1 area} other {weekly emails for {districtSubscriptionsNumber} areas}}"
 msgstr ""
 

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -7,6 +7,40 @@
     padding-top: 1.5rem;
   }
 
+  .login-subscribe-alert-container {
+    position: fixed;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    top: 0;
+    left: 0;
+    width: 100%;
+
+    .login-subscribe-alert {
+      position: relative;
+
+      transform: translateY(-100%);
+      &-enter {
+        transform: translateY(-100%);
+      }
+      &-enter-active {
+        transform: translatey(215%);
+        transition: transform 500ms ease-in-out;
+      }
+      &-enter-done {
+        transform: translateY(215%);
+      }
+      &-exit {
+        transform: translateY(215%);
+      }
+      &-exit-active {
+        transform: translateY(-100%);
+        transition: transform 500ms ease-in-out;
+      }
+    }
+  }
+
   h1 {
     font-size: 1.5rem;
     font-weight: 400;

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -7,39 +7,39 @@
     padding-top: 1.5rem;
   }
 
-  .login-subscribe-alert-container {
-    position: fixed;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    top: 0;
-    left: 0;
-    width: 100%;
+  // .login-subscribe-alert-container {
+  //   position: fixed;
+  //   display: flex;
+  //   align-items: center;
+  //   justify-content: center;
+  //   flex-direction: column;
+  //   top: 0;
+  //   left: 0;
+  //   width: 100%;
 
-    .login-subscribe-alert {
-      position: relative;
+  //   .login-subscribe-alert {
+  //     position: relative;
 
-      transform: translateY(-100%);
-      &-enter {
-        transform: translateY(-100%);
-      }
-      &-enter-active {
-        transform: translatey(215%);
-        transition: transform 500ms ease-in-out;
-      }
-      &-enter-done {
-        transform: translateY(215%);
-      }
-      &-exit {
-        transform: translateY(215%);
-      }
-      &-exit-active {
-        transform: translateY(-100%);
-        transition: transform 500ms ease-in-out;
-      }
-    }
-  }
+  //     transform: translateY(-100%);
+  //     &-enter {
+  //       transform: translateY(-100%);
+  //     }
+  //     &-enter-active {
+  //       transform: translatey(215%);
+  //       transition: transform 500ms ease-in-out;
+  //     }
+  //     &-enter-done {
+  //       transform: translateY(215%);
+  //     }
+  //     &-exit {
+  //       transform: translateY(215%);
+  //     }
+  //     &-exit-active {
+  //       transform: translateY(-100%);
+  //       transition: transform 500ms ease-in-out;
+  //     }
+  //   }
+  // }
 
   h1 {
     font-size: 1.5rem;

--- a/client/src/styles/AccountSettingsPage.scss
+++ b/client/src/styles/AccountSettingsPage.scss
@@ -7,39 +7,39 @@
     padding-top: 1.5rem;
   }
 
-  // .login-subscribe-alert-container {
-  //   position: fixed;
-  //   display: flex;
-  //   align-items: center;
-  //   justify-content: center;
-  //   flex-direction: column;
-  //   top: 0;
-  //   left: 0;
-  //   width: 100%;
+  .login-subscribe-alert-container {
+    position: fixed;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    top: 0;
+    left: 0;
+    width: 100%;
 
-  //   .login-subscribe-alert {
-  //     position: relative;
+    .login-subscribe-alert {
+      position: relative;
 
-  //     transform: translateY(-100%);
-  //     &-enter {
-  //       transform: translateY(-100%);
-  //     }
-  //     &-enter-active {
-  //       transform: translatey(215%);
-  //       transition: transform 500ms ease-in-out;
-  //     }
-  //     &-enter-done {
-  //       transform: translateY(215%);
-  //     }
-  //     &-exit {
-  //       transform: translateY(215%);
-  //     }
-  //     &-exit-active {
-  //       transform: translateY(-100%);
-  //       transition: transform 500ms ease-in-out;
-  //     }
-  //   }
-  // }
+      transform: translateY(-100%);
+      &-enter {
+        transform: translateY(-100%);
+      }
+      &-enter-active {
+        transform: translatey(215%);
+        transition: transform 500ms ease-in-out;
+      }
+      &-enter-done {
+        transform: translateY(215%);
+      }
+      &-exit {
+        transform: translateY(215%);
+      }
+      &-exit-active {
+        transform: translateY(-100%);
+        transition: transform 500ms ease-in-out;
+      }
+    }
+  }
 
   h1 {
     font-size: 1.5rem;

--- a/client/src/styles/EmailAlertSignup.scss
+++ b/client/src/styles/EmailAlertSignup.scss
@@ -4,41 +4,6 @@
 .EmailAlertSignup {
   margin-top: 1.25rem;
 
-  .login-subscribe-alert-container {
-    position: fixed;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    top: 0;
-    left: 0;
-    width: 100%;
-    pointer-events: none;
-
-    .login-subscribe-alert {
-      position: relative;
-
-      transform: translateY(-100%);
-      &-enter {
-        transform: translateY(-100%);
-      }
-      &-enter-active {
-        transform: translatey(215%);
-        transition: transform 500ms ease-in-out;
-      }
-      &-enter-done {
-        transform: translateY(215%);
-      }
-      &-exit {
-        transform: translateY(215%);
-      }
-      &-exit-active {
-        transform: translateY(-100%);
-        transition: transform 500ms ease-in-out;
-      }
-    }
-  }
-
   .building-subscribe {
     display: flex;
     flex-direction: column;

--- a/client/src/styles/_toastalert.scss
+++ b/client/src/styles/_toastalert.scss
@@ -1,0 +1,33 @@
+.toast-alert-container {
+  position: fixed;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  top: 0;
+  left: 0;
+  width: 100%;
+
+  .toast-alert {
+    position: relative;
+
+    transform: translateY(-100%);
+    &-enter {
+      transform: translateY(-100%);
+    }
+    &-enter-active {
+      transform: translatey(215%);
+      transition: transform 500ms ease-in-out;
+    }
+    &-enter-done {
+      transform: translateY(215%);
+    }
+    &-exit {
+      transform: translateY(215%);
+    }
+    &-exit-active {
+      transform: translateY(-100%);
+      transition: transform 500ms ease-in-out;
+    }
+  }
+}


### PR DESCRIPTION
Adds a alert "toast" to the top of the account settings page that appears/disappears from the top when you are directed to the settings page after completing an area alerts subscription. The copy of the alert differs if you are already logged in vs when you start the signup from a logged out state and complete registration/login to complete the subscription flow. There is also a text button in the alert to "manage" subscriptions that scrolls down to the area alerts section of the page, since it's sometimes out of view if you have a bunch of building alert subscriptions already. This uses a ref and `scrollIntoView` instead of an anchor link as originally planned because that was breaking on safari.

This copies the existing implementation we used for the toast alert on building pages when you follow a building via login/register flow. 

Since we are now using it in two places and there's a decent chunk of styles needed to manage the animation, I've created a component for it.

[sc-16470]