### PR TITLE
add CofO type to gce_eligibility table

### DIFF
--- a/sql/create_gce_eligibility.sql
+++ b/sql/create_gce_eligibility.sql
@@ -41,6 +41,7 @@ CREATE TABLE gce_eligibility AS (
 
             co.co_bin,
             co.co_issued,
+            co.co_type,
             
             (   co.co_issued IS NULL 
                 OR co.co_issued <= '2009-01-01'
@@ -104,6 +105,7 @@ CREATE TABLE gce_eligibility AS (
         bldgclass,
         co_bin,
         co_issued,
+        co_type,
         subsidy_name,
         active_421a,
         active_j51,


### PR DESCRIPTION
For some internal analysis of GCE responses we wanted to see how often users were ineligible for GCE because of a recent CofO that was for an Alteration rather than new building, which was a technical mistake in the way the law was written. So to do this it's easiest to add the CofO type to the `gce_eligibility` table we often use for analysis (not used for the actual website).

Analysis code where this is used https://github.com/JustFixNYC/requests/blob/main/gce-internal/gce-responses-analytics.R#L159-L214