### PR TITLE
Capture user phone number (optionally) during account registration

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -67,11 +67,17 @@ const clearUser = () => (_user = undefined);
  * Authenticates a user with the given email and password.
  * Creates an account for this user if one does not already exist.
  */
-const register = async (username: string, password: string, userType: string) => {
+const register = async (
+  username: string,
+  password: string,
+  userType: string,
+  phoneNumber?: string
+) => {
   const json = await postAuthRequest(`${BASE_URL}auth/register`, {
     username: username.toLowerCase(),
     password,
     user_type: userType,
+    ...(phoneNumber ? { phone_number: phoneNumber } : undefined),
   });
   fetchUser();
   return json;

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -4,7 +4,6 @@ import { withI18n, withI18nProps } from "@lingui/react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { Button, Icon, Link as JFCLLink } from "@justfixnyc/component-library";
 
-import "styles/UserTypeInput.css";
 import "styles/_input.scss";
 import AuthClient from "./AuthClient";
 import { JustfixUser } from "state-machine";
@@ -28,8 +27,8 @@ enum Step {
   CheckEmail,
   Login,
   RegisterAccount,
-  RegisterUserType,
   RegisterPhoneNumber,
+  RegisterUserType,
   VerifyEmail,
   LoginSuccess,
 }
@@ -411,7 +410,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
       return;
     }
 
-    setStep(Step.RegisterUserType);
+    setStep(Step.RegisterPhoneNumber);
   };
 
   const onUserTypeSubmit = async () => {
@@ -420,24 +419,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
     if (!userType || userTypeError) {
       setUserTypeError(true);
       setShowUserTypeError(true);
-      return;
-    }
-
-    setLoginOrRegister("register");
-    setStep(Step.RegisterPhoneNumber);
-  };
-
-  const onChangePhoneNumber = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const formatted = helpers.formatPhoneNumber(e.target.value);
-    setPhoneNumber(formatted);
-    setShowPhoneNumberError(false);
-  };
-
-  const onPhoneNumberSubmit = async () => {
-    window.gtag("event", "register-phone-number", eventParams());
-
-    if (phoneNumberError) {
-      setShowPhoneNumberError(true);
       return;
     }
 
@@ -468,6 +449,25 @@ const LoginWithoutI18n = (props: withI18nProps) => {
     setStep(Step.VerifyEmail);
   };
 
+  const onChangePhoneNumber = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const formatted = helpers.formatPhoneNumber(e.target.value);
+    setPhoneNumber(formatted);
+    setShowPhoneNumberError(false);
+  };
+
+  const onPhoneNumberSubmit = async () => {
+    window.gtag("event", "register-phone-number", eventParams());
+
+    if (phoneNumberError) {
+      setShowPhoneNumberError(true);
+      return;
+    }
+
+    setLoginOrRegister("register");
+    setStep(Step.RegisterUserType);
+  };
+
+  let stepProgress = "";
   let headerText: any;
   let subHeaderText: any;
   let onSubmit = async () => {};
@@ -501,22 +501,25 @@ const LoginWithoutI18n = (props: withI18nProps) => {
       submitButtonText = i18n._(t`Log in`);
       break;
     case Step.RegisterAccount:
+      stepProgress = i18n._(t`Step 1 of 3`);
       headerText = i18n._(t`Sign up for Email Alerts`);
       onSubmit = onAccountSubmit;
       submitButtonText = i18n._(t`Next`);
       break;
-    case Step.RegisterUserType:
-      headerText = i18n._(t`Sign up for Email Alerts`);
-      subHeaderText = i18n._(t`Which best describes you?`);
-      onSubmit = onUserTypeSubmit;
-      submitButtonText = i18n._(t`Next`);
-      break;
     case Step.RegisterPhoneNumber:
+      stepProgress = i18n._(t`Step 2 of 3`);
       headerText = i18n._(t`Sign up for Email Alerts`);
       subHeaderText = i18n._(
         t`We’ll text you in a few months to ask how we can improve this free service`
       );
       onSubmit = onPhoneNumberSubmit;
+      submitButtonText = i18n._(t`Next`);
+      break;
+    case Step.RegisterUserType:
+      stepProgress = i18n._(t`Step 3 of 3`);
+      headerText = i18n._(t`Sign up for Email Alerts`);
+      subHeaderText = i18n._(t`Which best describes you?`);
+      onSubmit = onUserTypeSubmit;
       submitButtonText = i18n._(t`Sign up`);
       break;
     case Step.VerifyEmail:
@@ -533,6 +536,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
 
   return (
     <div className="Login">
+      {stepProgress && <span className="step-progress">{stepProgress}</span>}
       {renderAlert()}
       {!!headerText && <h1>{headerText}</h1>}
       {!!subHeaderText && <h2>{subHeaderText}</h2>}

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -510,7 +510,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
       stepProgress = i18n._(t`Step 2 of 3`);
       headerText = i18n._(t`Sign up for Email Alerts`);
       subHeaderText = i18n._(
-        t`We’ll text you in a few months to ask how we can improve this free service`
+        t`We’ll text you in a few months to ask how we can improve this free service.`
       );
       onSubmit = onPhoneNumberSubmit;
       submitButtonText = i18n._(t`Next`);

--- a/client/src/components/PhoneNumberInput.tsx
+++ b/client/src/components/PhoneNumberInput.tsx
@@ -1,0 +1,70 @@
+import { ChangeEvent, forwardRef } from "react";
+import { t } from "@lingui/macro";
+import { I18n } from "@lingui/core";
+import { withI18n } from "@lingui/react";
+
+import "styles/PhoneNumberInput.css";
+import "styles/_input.scss";
+import classNames from "classnames";
+import { Icon } from "@justfixnyc/component-library";
+
+interface PhoneNumberInputProps extends React.ComponentPropsWithoutRef<"input"> {
+  i18n: I18n;
+  phone: string;
+  error: boolean;
+  setError: React.Dispatch<React.SetStateAction<boolean>>;
+  showError: boolean;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  i18nHash?: string;
+  labelText?: string;
+}
+
+const PhoneNumberInputWithoutI18n = forwardRef<HTMLInputElement, PhoneNumberInputProps>(
+  ({ i18n, i18nHash, phone, error, setError, showError, onChange, labelText, ...props }, ref) => {
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      onChange(e);
+      const VALID_PHONE_NUMBER_LENGTH = 10;
+      const cleaned = e.target.value.replace(/\D/g, "");
+      if (cleaned.length > 0 && cleaned.length !== VALID_PHONE_NUMBER_LENGTH) {
+        setError(true);
+      } else {
+        setError(false);
+      }
+    };
+
+    return (
+      <div className="phone-input-field">
+        {!!labelText && (
+          <div className="phone-input-label mb-4">
+            <label htmlFor="phone-input">{labelText}</label>
+          </div>
+        )}
+        {showError && error && (
+          <div className="phone-input-errors mb-4">
+            <span id="input-field-error">
+              <div>
+                <Icon icon="circleExclamation" className="mr-3" />
+              </div>
+              {i18n._(t`Please enter a valid phone number.`)}
+            </span>
+          </div>
+        )}
+        <div className="phone-input">
+          <input
+            type="tel"
+            id="phone-input"
+            maxLength={14} // 10 + formatting
+            className={classNames("input", { invalid: showError && error })}
+            onChange={handleChange}
+            value={phone}
+            {...props}
+          />
+        </div>
+      </div>
+    );
+  }
+);
+
+const PhoneNumberInput = withI18n({ withHash: false })(PhoneNumberInputWithoutI18n);
+
+export default PhoneNumberInput;

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -15,6 +15,7 @@ export type UserContextProps = {
     username: string,
     password: string,
     userType: string,
+    phoneNumber?: string,
     onSuccess?: (user: JustfixUser) => void
   ) => Promise<UserOrError | void>;
   login: (
@@ -45,6 +46,7 @@ const initialState: UserContextProps = {
     username: string,
     password: string,
     userType: string,
+    phoneNumber?: string,
     onSuccess?: (user: JustfixUser) => void
   ) => {},
   login: async (username: string, password: string, onSuccess?: (user: JustfixUser) => void) => {},
@@ -101,9 +103,10 @@ export const UserContextProvider = ({ children }: { children: React.ReactNode })
       username: string,
       password: string,
       userType: string,
+      phoneNumber?: string,
       onSuccess?: (user: JustfixUser) => void
     ) => {
-      const response = await AuthClient.register(username, password, userType);
+      const response = await AuthClient.register(username, password, userType, phoneNumber);
       if (response.error || !response.user) {
         return { error: response.error_description };
       }

--- a/client/src/components/UserTypeInput.tsx
+++ b/client/src/components/UserTypeInput.tsx
@@ -3,6 +3,7 @@ import { Trans, t } from "@lingui/macro";
 import { I18n } from "@lingui/core";
 import { withI18n } from "@lingui/react";
 
+import "styles/UserTypeInput.scss";
 import { Icon, RadioButton, TextInput } from "@justfixnyc/component-library";
 
 type UserTypeInputProps = {

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -29,7 +29,7 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixOrg"
 msgstr "#WhoOwnsWhat via @JustFixOrg"
 
-#: src/util/helpers.ts:274
+#: src/util/helpers.ts:295
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" in English)"
 
@@ -126,7 +126,7 @@ msgstr "<0>Search an address</0> to add to your Building Alerts"
 #~ msgid "<0>Search for an address</0> to add to your Building Alerts"
 #~ msgstr "<0>Search for an address</0> to add to your Building Alerts"
 
-#: src/components/Login.tsx:197
+#: src/components/Login.tsx:200
 #: src/containers/UnsubscribePage.tsx:101
 msgid "<0>Search for an address</0> to add to your Building Alerts, <1>subscribe to Area Alerts</1>, or visit your <2>email settings</2> page to manage subscriptions."
 msgstr "<0>Search for an address</0> to add to your Building Alerts, <1>subscribe to Area Alerts</1>, or visit your <2>email settings</2> page to manage subscriptions."
@@ -256,7 +256,7 @@ msgstr "All the public info on your landlord"
 #~ msgid "Almost done. Verify your email to start receiving updates."
 #~ msgstr "Almost done. Verify your email to start receiving updates."
 
-#: src/components/Login.tsx:148
+#: src/components/Login.tsx:151
 msgid "Already have an account?"
 msgstr "Already have an account?"
 
@@ -448,7 +448,7 @@ msgstr "Change in rent stabilized units"
 msgid "Check out the issues in this building"
 msgstr "Check out the issues in this building"
 
-#: src/components/Login.tsx:332
+#: src/components/Login.tsx:359
 msgid "Check your email"
 msgstr "Check your email"
 
@@ -526,7 +526,7 @@ msgstr "Clearer Landlord Contact Info"
 msgid "Click here to learn more."
 msgstr "Click here to learn more."
 
-#: src/components/Login.tsx:333
+#: src/components/Login.tsx:360
 msgid "Click the link we sent to <0>{email}</0> to verify your email. It may take a few minutes to arrive. If you can't find it, check your spam and promotions folders for an email from <1>no-reply@justfix.org</1>."
 msgstr "Click the link we sent to <0>{email}</0> to verify your email. It may take a few minutes to arrive. If you can't find it, check your spam and promotions folders for an email from <1>no-reply@justfix.org</1>."
 
@@ -612,7 +612,7 @@ msgstr "Create a password"
 #~ msgid "Create a password to start receiving Data Updates"
 #~ msgstr "Create a password to start receiving Data Updates"
 
-#: src/components/Login.tsx:353
+#: src/components/Login.tsx:381
 msgid "Create password"
 msgstr "Create password"
 
@@ -661,7 +661,7 @@ msgid "Demo Site"
 msgstr "Demo Site"
 
 #: src/components/EmailAlertSignup.tsx:70
-#: src/components/Login.tsx:169
+#: src/components/Login.tsx:172
 #: src/components/UserSettingField.tsx:104
 msgid "Didn’t get the link?"
 msgstr "Didn’t get the link?"
@@ -688,7 +688,7 @@ msgstr "Display:"
 #~ msgid "District Alerts"
 #~ msgstr "District Alerts"
 
-#: src/components/Login.tsx:156
+#: src/components/Login.tsx:159
 msgid "Don't have an account?"
 msgstr "Don't have an account?"
 
@@ -725,7 +725,7 @@ msgstr "Edit"
 msgid "Email"
 msgstr "Email"
 
-#: src/components/Login.tsx:352
+#: src/components/Login.tsx:380
 #: src/components/UserSettingField.tsx:111
 #: src/components/UserSettingField.tsx:116
 #: src/containers/ForgotPasswordPage.tsx:54
@@ -791,7 +791,7 @@ msgstr "Enter new email address"
 #~ msgid "Enter your old password"
 #~ msgstr "Enter your old password"
 
-#: src/components/Login.tsx:353
+#: src/components/Login.tsx:381
 msgid "Enter your password"
 msgstr "Enter your password"
 
@@ -911,7 +911,7 @@ msgstr "Follow building"
 msgid "Follow this building to add it to your weekly email alert."
 msgstr "Follow this building to add it to your weekly email alert."
 
-#: src/components/Login.tsx:144
+#: src/components/Login.tsx:147
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -962,7 +962,7 @@ msgstr "Get a weekly email that identifies buildings and portfolios where tenant
 #~ msgid "Government Worker (Non-Lawyer)"
 #~ msgstr "Government Worker (Non-Lawyer)"
 
-#: src/components/UserTypeInput.tsx:14
+#: src/components/UserTypeInput.tsx:15
 msgid "Government Worker (non-lawyer)"
 msgstr "Government Worker (non-lawyer)"
 
@@ -1191,7 +1191,7 @@ msgstr "Learn more."
 #~ msgid "Legal Worker"
 #~ msgstr "Legal Worker"
 
-#: src/components/UserTypeInput.tsx:13
+#: src/components/UserTypeInput.tsx:14
 msgid "Legal Worker/Lawyer"
 msgstr "Legal Worker/Lawyer"
 
@@ -1222,15 +1222,15 @@ msgstr "Loading {0} rows"
 msgid "Location"
 msgstr "Location"
 
-#: src/components/Login.tsx:112
-#: src/components/Login.tsx:153
-#: src/components/Login.tsx:315
-#: src/components/Login.tsx:318
+#: src/components/Login.tsx:115
+#: src/components/Login.tsx:156
+#: src/components/Login.tsx:333
+#: src/components/Login.tsx:336
 #: src/containers/App.tsx:132
 msgid "Log in"
 msgstr "Log in"
 
-#: src/components/Login.tsx:306
+#: src/components/Login.tsx:324
 msgid "Log in / Sign up"
 msgstr "Log in / Sign up"
 
@@ -1238,7 +1238,7 @@ msgstr "Log in / Sign up"
 msgid "Log in / sign up"
 msgstr "Log in / sign up"
 
-#: src/components/Login.tsx:316
+#: src/components/Login.tsx:334
 msgid "Log in to add {0} to your Building Alerts"
 msgstr "Log in to add {0} to your Building Alerts"
 
@@ -1254,7 +1254,7 @@ msgstr "Log in to add {0} to your Building Alerts"
 #~ msgid "Log in to start getting updates for this building."
 #~ msgstr "Log in to start getting updates for this building."
 
-#: src/components/Login.tsx:316
+#: src/components/Login.tsx:334
 msgid "Log in to subscribe to Area Alerts"
 msgstr "Log in to subscribe to Area Alerts"
 
@@ -1456,7 +1456,8 @@ msgid "New password"
 msgstr "New password"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/Login.tsx:323
+#: src/components/Login.tsx:342
+#: src/components/Login.tsx:349
 msgid "Next"
 msgstr "Next"
 
@@ -1568,7 +1569,7 @@ msgstr "Opens in a new window"
 #~ msgid "Organizer"
 #~ msgstr "Organizer"
 
-#: src/components/UserTypeInput.tsx:15
+#: src/components/UserTypeInput.tsx:16
 msgid "Other"
 msgstr "Other"
 
@@ -1635,6 +1636,10 @@ msgstr "People"
 msgid "Person/Entity"
 msgstr "Person/Entity"
 
+#: src/components/Login.tsx:383
+msgid "Phone number (optional)"
+msgstr "Phone number (optional)"
+
 #: src/components/UserTypeInput.tsx:56
 #~ msgid "Please enter a response."
 #~ msgstr "Please enter a response."
@@ -1642,6 +1647,10 @@ msgstr "Person/Entity"
 #: src/components/EmailInput.tsx:43
 msgid "Please enter a valid email address."
 msgstr "Please enter a valid email address."
+
+#: src/components/PhoneNumberInput.tsx:41
+msgid "Please enter a valid phone number."
+msgstr "Please enter a valid phone number."
 
 #: src/components/Subscribe.tsx:26
 msgid "Please enter an email address!"
@@ -1651,7 +1660,7 @@ msgstr "Please enter an email address!"
 msgid "Please enter password."
 msgstr "Please enter password."
 
-#: src/components/UserTypeInput.tsx:36
+#: src/components/UserTypeInput.tsx:37
 msgid "Please select an option."
 msgstr "Please select an option."
 
@@ -1948,7 +1957,8 @@ msgstr "Showing {0} {1, plural, one {result} other {results}}"
 #~ msgid "Sign out"
 #~ msgstr "Sign out"
 
-#: src/components/Login.tsx:161
+#: src/components/Login.tsx:164
+#: src/components/Login.tsx:356
 #: src/components/Subscribe.tsx:81
 msgid "Sign up"
 msgstr "Sign up"
@@ -1967,8 +1977,9 @@ msgstr "Sign up"
 #~ msgid "Sign up for Data Updates on the buildings you choose:"
 #~ msgstr "Sign up for Data Updates on the buildings you choose:"
 
-#: src/components/Login.tsx:321
-#: src/components/Login.tsx:326
+#: src/components/Login.tsx:340
+#: src/components/Login.tsx:346
+#: src/components/Login.tsx:353
 msgid "Sign up for Email Alerts"
 msgstr "Sign up for Email Alerts"
 
@@ -2053,7 +2064,19 @@ msgstr "State Assembly District"
 msgid "State Senate District"
 msgstr "State Senate District"
 
-#: src/components/Login.tsx:312
+#: src/components/Login.tsx:339
+msgid "Step 1 of 3"
+msgstr "Step 1 of 3"
+
+#: src/components/Login.tsx:345
+msgid "Step 2 of 3"
+msgstr "Step 2 of 3"
+
+#: src/components/Login.tsx:352
+msgid "Step 3 of 3"
+msgstr "Step 3 of 3"
+
+#: src/components/Login.tsx:330
 msgid "Submit"
 msgstr "Submit"
 
@@ -2085,15 +2108,15 @@ msgstr "Take action on JustFix.org!"
 msgid "Tax Exemptions"
 msgstr "Tax Exemptions"
 
-#: src/components/UserTypeInput.tsx:10
+#: src/components/UserTypeInput.tsx:11
 msgid "Tenant"
 msgstr "Tenant"
 
-#: src/components/UserTypeInput.tsx:12
+#: src/components/UserTypeInput.tsx:13
 msgid "Tenant Advocate"
 msgstr "Tenant Advocate"
 
-#: src/components/UserTypeInput.tsx:11
+#: src/components/UserTypeInput.tsx:12
 msgid "Tenant Organizer"
 msgstr "Tenant Organizer"
 
@@ -2106,7 +2129,7 @@ msgstr "Tenants in this portfolio have reported a total of <0>{totalhpdcomplaint
 msgid "Terms of use"
 msgstr "Terms of use"
 
-#: src/components/Login.tsx:123
+#: src/components/Login.tsx:126
 #: src/components/UserSettingField.tsx:114
 msgid "That email is already used."
 msgstr "That email is already used."
@@ -2147,7 +2170,7 @@ msgstr "The city’s fifth <0>worst evictor</0> in 2018, A&E is a prime example 
 msgid "The current password you entered is incorrect"
 msgstr "The current password you entered is incorrect"
 
-#: src/components/Login.tsx:120
+#: src/components/Login.tsx:123
 msgid "The email and/or password you entered is incorrect."
 msgstr "The email and/or password you entered is incorrect."
 
@@ -2387,7 +2410,7 @@ msgstr "Use the tab key to navigate. Press the enter key to select."
 msgid "Use this free tool from JustFix to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Use this free tool from JustFix to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 
-#: src/components/Login.tsx:307
+#: src/components/Login.tsx:325
 msgid "Use your account to get weekly email alerts on {0}"
 msgstr "Use your account to get weekly email alerts on {0}"
 
@@ -2541,7 +2564,7 @@ msgstr "Warning: This building has an expired registration and was sold after th
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 
-#: src/components/Login.tsx:193
+#: src/components/Login.tsx:196
 msgid "We have added Area Alerts to your weekly emails. Visit your <0>email settings</0> to manage Area Alerts."
 msgstr "We have added Area Alerts to your weekly emails. Visit your <0>email settings</0> to manage Area Alerts."
 
@@ -2572,6 +2595,10 @@ msgstr "We send Building Alerts to this email."
 #: src/containers/ForgotPasswordPage.tsx:63
 msgid "We sent a reset link to {email}. Please check your inbox and spam."
 msgstr "We sent a reset link to {email}. Please check your inbox and spam."
+
+#: src/components/Login.tsx:347
+msgid "We’ll text you in a few months to ask how we can improve this free service."
+msgstr "We’ll text you in a few months to ask how we can improve this free service."
 
 #: src/containers/VerifyEmailPage.tsx:81
 msgid "We’re having trouble verifying your email at this time."
@@ -2618,7 +2645,7 @@ msgstr "What’s the difference between a landlord, an owner, and head officer?"
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "When two parties share the same business address, we group them as part of the same portfolio."
 
-#: src/components/Login.tsx:327
+#: src/components/Login.tsx:354
 msgid "Which best describes you?"
 msgstr "Which best describes you?"
 
@@ -2682,7 +2709,7 @@ msgstr "Year Built"
 msgid "Yes"
 msgstr "Yes"
 
-#: src/components/Login.tsx:192
+#: src/components/Login.tsx:195
 #: src/containers/AccountSettingsPage.tsx:90
 msgid "You are logged in"
 msgstr "You are logged in"
@@ -2832,7 +2859,7 @@ msgstr "Your email is already verified"
 #~ msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Service</1>."
 #~ msgstr "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Service</1>."
 
-#: src/components/Login.tsx:131
+#: src/components/Login.tsx:134
 msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Use</1>."
 msgstr "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Use</1>."
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "#WhoOwnsWhat via @JustFixOrg"
 msgstr "#QuiénEsElDueño por @JustFixOrg"
 
-#: src/util/helpers.ts:274
+#: src/util/helpers.ts:295
 msgid "(\"{textInEnglish}\" in English)"
 msgstr "(\"{textInEnglish}\" en inglés)"
 
@@ -131,7 +131,7 @@ msgstr ""
 #~ msgid "<0>Search for an address</0> to add to your Building Alerts"
 #~ msgstr "<0>Busca una dirección</0> para añadir a Alertas de Edificios"
 
-#: src/components/Login.tsx:197
+#: src/components/Login.tsx:200
 #: src/containers/UnsubscribePage.tsx:101
 msgid "<0>Search for an address</0> to add to your Building Alerts, <1>subscribe to Area Alerts</1>, or visit your <2>email settings</2> page to manage subscriptions."
 msgstr ""
@@ -261,7 +261,7 @@ msgstr "Toda la información pública sobre el dueño/a de tu edificio"
 #~ msgid "Almost done. Verify your email to start receiving updates."
 #~ msgstr "Almost done. Verify your email to start receiving updates."
 
-#: src/components/Login.tsx:148
+#: src/components/Login.tsx:151
 msgid "Already have an account?"
 msgstr "¿Ya tiene una cuenta?"
 
@@ -453,7 +453,7 @@ msgstr ""
 msgid "Check out the issues in this building"
 msgstr "Mira los problemas en este edificio"
 
-#: src/components/Login.tsx:332
+#: src/components/Login.tsx:359
 msgid "Check your email"
 msgstr "Revise su correo electrónico"
 
@@ -531,7 +531,7 @@ msgstr "Información de contacto del dueño más clara"
 msgid "Click here to learn more."
 msgstr "HaZ clic aquí para obtener más información."
 
-#: src/components/Login.tsx:333
+#: src/components/Login.tsx:360
 msgid "Click the link we sent to <0>{email}</0> to verify your email. It may take a few minutes to arrive. If you can't find it, check your spam and promotions folders for an email from <1>no-reply@justfix.org</1>."
 msgstr "Haga clic en el enlace que le enviamos a <0>{email}</0> para verificar su correo electrónico. Puede tardar unos minutos en llegar. Si no lo encuentras, busque en sus carpetas de spam y promociones un correo electrónico de <1>no-reply@justfix.org</1>."
 
@@ -617,7 +617,7 @@ msgstr "Crear una contraseña"
 #~ msgid "Create a password to start receiving Data Updates"
 #~ msgstr "Create a password to start receiving Data Updates"
 
-#: src/components/Login.tsx:353
+#: src/components/Login.tsx:381
 msgid "Create password"
 msgstr "Crear contraseña"
 
@@ -666,7 +666,7 @@ msgid "Demo Site"
 msgstr "Sitio Demo"
 
 #: src/components/EmailAlertSignup.tsx:70
-#: src/components/Login.tsx:169
+#: src/components/Login.tsx:172
 #: src/components/UserSettingField.tsx:104
 msgid "Didn’t get the link?"
 msgstr "¿No recibió el enlace?"
@@ -693,7 +693,7 @@ msgstr "Mostrar:"
 #~ msgid "District Alerts"
 #~ msgstr ""
 
-#: src/components/Login.tsx:156
+#: src/components/Login.tsx:159
 msgid "Don't have an account?"
 msgstr "¿No tiene una cuenta?"
 
@@ -730,7 +730,7 @@ msgstr "Editar"
 msgid "Email"
 msgstr "Email"
 
-#: src/components/Login.tsx:352
+#: src/components/Login.tsx:380
 #: src/components/UserSettingField.tsx:111
 #: src/components/UserSettingField.tsx:116
 #: src/containers/ForgotPasswordPage.tsx:54
@@ -796,7 +796,7 @@ msgstr "Ingrese un nuevo correo electrónico"
 #~ msgid "Enter your old password"
 #~ msgstr "Enter your old password"
 
-#: src/components/Login.tsx:353
+#: src/components/Login.tsx:381
 msgid "Enter your password"
 msgstr "Ingrese su contraseña"
 
@@ -916,7 +916,7 @@ msgstr "Seguir edifico"
 msgid "Follow this building to add it to your weekly email alert."
 msgstr "Sigue este edificio para añadirlo a su alerta semanal electrónica."
 
-#: src/components/Login.tsx:144
+#: src/components/Login.tsx:147
 msgid "Forgot your password?"
 msgstr "¿Olvidó su contraseña?"
 
@@ -967,7 +967,7 @@ msgstr ""
 #~ msgid "Government Worker (Non-Lawyer)"
 #~ msgstr "Government Worker (Non-Lawyer)"
 
-#: src/components/UserTypeInput.tsx:14
+#: src/components/UserTypeInput.tsx:15
 msgid "Government Worker (non-lawyer)"
 msgstr "Trabajador del gobierno (no abogado)"
 
@@ -1196,7 +1196,7 @@ msgstr "Aprende más."
 #~ msgid "Legal Worker"
 #~ msgstr "Legal Worker"
 
-#: src/components/UserTypeInput.tsx:13
+#: src/components/UserTypeInput.tsx:14
 msgid "Legal Worker/Lawyer"
 msgstr "Trabajador del gobierno /Abogado"
 
@@ -1227,15 +1227,15 @@ msgstr "Cargando {0} filas"
 msgid "Location"
 msgstr "Ubicación"
 
-#: src/components/Login.tsx:112
-#: src/components/Login.tsx:153
-#: src/components/Login.tsx:315
-#: src/components/Login.tsx:318
+#: src/components/Login.tsx:115
+#: src/components/Login.tsx:156
+#: src/components/Login.tsx:333
+#: src/components/Login.tsx:336
 #: src/containers/App.tsx:132
 msgid "Log in"
 msgstr "Iniciar sesión"
 
-#: src/components/Login.tsx:306
+#: src/components/Login.tsx:324
 msgid "Log in / Sign up"
 msgstr ""
 
@@ -1243,7 +1243,7 @@ msgstr ""
 msgid "Log in / sign up"
 msgstr "Iniciar sesión / Registrarse"
 
-#: src/components/Login.tsx:316
+#: src/components/Login.tsx:334
 msgid "Log in to add {0} to your Building Alerts"
 msgstr "Inicia sesión para añadir {0} a sus Alertas de Edificios"
 
@@ -1259,7 +1259,7 @@ msgstr "Inicia sesión para añadir {0} a sus Alertas de Edificios"
 #~ msgid "Log in to start getting updates for this building."
 #~ msgstr "Log in to start getting updates for this building."
 
-#: src/components/Login.tsx:316
+#: src/components/Login.tsx:334
 msgid "Log in to subscribe to Area Alerts"
 msgstr ""
 
@@ -1461,7 +1461,8 @@ msgid "New password"
 msgstr "Contraseña nueva"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/Login.tsx:323
+#: src/components/Login.tsx:342
+#: src/components/Login.tsx:349
 msgid "Next"
 msgstr "Siguiente"
 
@@ -1573,7 +1574,7 @@ msgstr "Abre en una nueva ventana"
 #~ msgid "Organizer"
 #~ msgstr "Organizer"
 
-#: src/components/UserTypeInput.tsx:15
+#: src/components/UserTypeInput.tsx:16
 msgid "Other"
 msgstr "Otro"
 
@@ -1640,6 +1641,10 @@ msgstr "Personas"
 msgid "Person/Entity"
 msgstr "Persona/Entidad"
 
+#: src/components/Login.tsx:383
+msgid "Phone number (optional)"
+msgstr ""
+
 #: src/components/UserTypeInput.tsx:56
 #~ msgid "Please enter a response."
 #~ msgstr "Please enter a response."
@@ -1647,6 +1652,10 @@ msgstr "Persona/Entidad"
 #: src/components/EmailInput.tsx:43
 msgid "Please enter a valid email address."
 msgstr "Introduzca un correo electrónico válido."
+
+#: src/components/PhoneNumberInput.tsx:41
+msgid "Please enter a valid phone number."
+msgstr ""
 
 #: src/components/Subscribe.tsx:26
 msgid "Please enter an email address!"
@@ -1656,7 +1665,7 @@ msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 msgid "Please enter password."
 msgstr "Por favor introduce una contraseña."
 
-#: src/components/UserTypeInput.tsx:36
+#: src/components/UserTypeInput.tsx:37
 msgid "Please select an option."
 msgstr "Elige una opción, por favor."
 
@@ -1953,7 +1962,8 @@ msgstr "Mostrar {0} {1, plural, one {resultado} other {resultados}}"
 #~ msgid "Sign out"
 #~ msgstr "Sign out"
 
-#: src/components/Login.tsx:161
+#: src/components/Login.tsx:164
+#: src/components/Login.tsx:356
 #: src/components/Subscribe.tsx:81
 msgid "Sign up"
 msgstr "Regístrate"
@@ -1972,8 +1982,9 @@ msgstr "Regístrate"
 #~ msgid "Sign up for Data Updates on the buildings you choose:"
 #~ msgstr "Sign up for Data Updates on the buildings you choose:"
 
-#: src/components/Login.tsx:321
-#: src/components/Login.tsx:326
+#: src/components/Login.tsx:340
+#: src/components/Login.tsx:346
+#: src/components/Login.tsx:353
 msgid "Sign up for Email Alerts"
 msgstr ""
 
@@ -2058,7 +2069,19 @@ msgstr ""
 msgid "State Senate District"
 msgstr ""
 
-#: src/components/Login.tsx:312
+#: src/components/Login.tsx:339
+msgid "Step 1 of 3"
+msgstr ""
+
+#: src/components/Login.tsx:345
+msgid "Step 2 of 3"
+msgstr ""
+
+#: src/components/Login.tsx:352
+msgid "Step 3 of 3"
+msgstr ""
+
+#: src/components/Login.tsx:330
 msgid "Submit"
 msgstr "Enviar"
 
@@ -2090,15 +2113,15 @@ msgstr "¡Toma acción en JustFix.org!"
 msgid "Tax Exemptions"
 msgstr "Exenciones de impuestos"
 
-#: src/components/UserTypeInput.tsx:10
+#: src/components/UserTypeInput.tsx:11
 msgid "Tenant"
 msgstr "Inquilino"
 
-#: src/components/UserTypeInput.tsx:12
+#: src/components/UserTypeInput.tsx:13
 msgid "Tenant Advocate"
 msgstr "Defensores de inquilinos"
 
-#: src/components/UserTypeInput.tsx:11
+#: src/components/UserTypeInput.tsx:12
 msgid "Tenant Organizer"
 msgstr "Organizador de inquilinos"
 
@@ -2111,7 +2134,7 @@ msgstr "Los inquilinos en este portafolio han reportado un total de <0>{totalhpd
 msgid "Terms of use"
 msgstr "Condiciones de uso"
 
-#: src/components/Login.tsx:123
+#: src/components/Login.tsx:126
 #: src/components/UserSettingField.tsx:114
 msgid "That email is already used."
 msgstr "El correo electrónico ya está en uso."
@@ -2152,7 +2175,7 @@ msgstr "El quinto <0>peor desalojador</0> de la ciudad en 2018, A&E es un excele
 msgid "The current password you entered is incorrect"
 msgstr "La contraseña que ha ingresado es incorrecta"
 
-#: src/components/Login.tsx:120
+#: src/components/Login.tsx:123
 msgid "The email and/or password you entered is incorrect."
 msgstr "El correo electrónico y/o la contraseña introducidos son incorrectos."
 
@@ -2392,7 +2415,7 @@ msgstr "Utilice la tecla de pestaña para navegar. Pulse la tecla Intro para sel
 msgid "Use this free tool from JustFix to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Utilice esta herramienta gratuita de JustFix para investigar tu edificio e investigar a los arrendadores de Nueva York! Utilizamos el mapeo de propiedad para identificar el portafolio de edificios de un arrendador y proporcionar datos para revelar posibles casos de hostigamiento y desplazamiento de inquilinos."
 
-#: src/components/Login.tsx:307
+#: src/components/Login.tsx:325
 msgid "Use your account to get weekly email alerts on {0}"
 msgstr ""
 
@@ -2546,7 +2569,7 @@ msgstr "Aviso: Este edificio tiene un registro vencido y se vendió después del
 msgid "We compare your search address with a database of over 200k buildings to identify a landlord or management company's portfolio. To learn more, check out <0>our methodology</0>."
 msgstr "Comparamos la dirección que buscaste con una base de datos de más de 200 mil edificios para identificar a un propietario o compañía de gestión. Para obtener más información, consulta <0>nuestra metodología</0>."
 
-#: src/components/Login.tsx:193
+#: src/components/Login.tsx:196
 msgid "We have added Area Alerts to your weekly emails. Visit your <0>email settings</0> to manage Area Alerts."
 msgstr ""
 
@@ -2577,6 +2600,10 @@ msgstr "Enviamos Alertas de Edificios a este correo electrónico."
 #: src/containers/ForgotPasswordPage.tsx:63
 msgid "We sent a reset link to {email}. Please check your inbox and spam."
 msgstr "Hemos enviado un enlace de reinicio a {email}. Por favor, comprueba su buzón de correo y spam."
+
+#: src/components/Login.tsx:347
+msgid "We’ll text you in a few months to ask how we can improve this free service."
+msgstr ""
 
 #: src/containers/VerifyEmailPage.tsx:81
 msgid "We’re having trouble verifying your email at this time."
@@ -2623,7 +2650,7 @@ msgstr "¿Cuál es la diferencia entre un dueño, un propietario y oficial princ
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "Cuando dos partes comparten la misma dirección comercial, los agrupamos como parte del mismo portafolio."
 
-#: src/components/Login.tsx:327
+#: src/components/Login.tsx:354
 msgid "Which best describes you?"
 msgstr "¿Cuál le describe mejor a usted?"
 
@@ -2687,7 +2714,7 @@ msgstr "Año de construcción"
 msgid "Yes"
 msgstr "Sí"
 
-#: src/components/Login.tsx:192
+#: src/components/Login.tsx:195
 #: src/containers/AccountSettingsPage.tsx:90
 msgid "You are logged in"
 msgstr "Ha iniciado sesión"
@@ -2837,7 +2864,7 @@ msgstr "Este correo electrónico ya está verificado"
 #~ msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Service</1>."
 #~ msgstr "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Service</1>."
 
-#: src/components/Login.tsx:131
+#: src/components/Login.tsx:134
 msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Use</1>."
 msgstr "Su privacidad es importante a nosotros. Lea nuestra <0>Política de privacidad</0> y <1>Términos de uso</1>."
 

--- a/client/src/styles/PhoneNumberInput.scss
+++ b/client/src/styles/PhoneNumberInput.scss
@@ -1,0 +1,58 @@
+@import "_vars.scss";
+@import "_typography.scss";
+
+.phone-input-field {
+  .phone-input-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    label {
+      @include wow-body-standard;
+      text-align: left;
+    }
+
+    a {
+      color: $justfix-black;
+      font-size: 0.8125rem;
+    }
+  }
+
+  .phone-input {
+    display: flex;
+
+    input {
+      flex: 1;
+      font-size: 1rem; // below 16px zooms on mobile
+
+      &:focus {
+        border: 2px $justfix-black solid;
+        box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+      }
+
+      &.invalid {
+        border-color: $justfix-orange;
+      }
+
+      &.invalid:focus {
+        border-color: $justfix-black;
+      }
+    }
+  }
+
+  .phone-input-errors {
+    display: flex;
+    flex-direction: column;
+
+    span {
+      display: flex;
+      font-size: 0.8125rem;
+      color: #ba4300;
+
+      svg {
+        height: 0.875rem;
+        width: 0.875rem;
+      }
+    }
+  }
+}

--- a/client/src/util/helpers.ts
+++ b/client/src/util/helpers.ts
@@ -293,6 +293,29 @@ const helpers = {
     return this.capitalize(date.toLocaleDateString(locale || defaultLocale, options));
   },
 
+  // Copied from gce-screener
+  formatPhoneNumber(value: string): string {
+    // remove all non-digit characters
+    const cleaned = value.replace(/\D/g, "");
+    // limit to 10 characters
+    const limited = cleaned.slice(0, 10);
+
+    // format with parentheses and dashes e.g. (555) 666-7777
+    const match = limited.match(/^(\d{0,3})(\d{0,3})(\d{0,4})$/);
+    if (match) {
+      const [, part1, part2, part3] = match;
+      const formatted = [
+        part1 ? `(${part1}` : "",
+        part2 ? `) ${part2}` : "",
+        part3 ? `-${part3}` : "",
+      ]
+        .join("")
+        .trim();
+      return formatted;
+    }
+    return value;
+  },
+
   /** The quarter number written out as it's range of months (ex: "1" becomes "Jan - Mar")  */
   getMonthRangeFromQuarter(quarter: "1" | "2" | "3" | "4", locale?: SupportedLocale): string {
     const monthRange = {

--- a/jfauthprovider/views.py
+++ b/jfauthprovider/views.py
@@ -81,6 +81,7 @@ def register(request):
         "username": request.POST.get("username"),
         "password": request.POST.get("password"),
         "user_type": request.POST.get("user_type"),
+        "phone_number": request.POST.get("phone_number"),
         "origin": request.headers["Origin"],
     }
 


### PR DESCRIPTION
Adds a new (optional) step to account creation to capture user phone numbers. Borrows input UI phone number formatting from gce-screener. Updates all the authclient/views backend logic to reflect changes to auth-provider. Updates the Login component to add the new step (in all cases, via nav, building, or area alerts), and adds a "step 1 of 3" progress to the top of the login module during registration.

Companion PR on auth-provider: https://github.com/JustFixNYC/auth-provider/pull/111

[sc-16527]