### PR TITLE
disable click events on toast container when inactive

### DIFF
--- a/client/src/components/ToastAlert.tsx
+++ b/client/src/components/ToastAlert.tsx
@@ -17,7 +17,7 @@ export const ToastAlert: React.FC<ToastAlertProps> = (props) => {
   const { showToast, setShowToast, i18n, timeout, className, ...alertProps } = props;
 
   return (
-    <div className="toast-alert-container">
+    <div className={classNames("toast-alert-container", !showToast && "is-inactive")}>
       <CSSTransition
         in={showToast}
         timeout={timeout}

--- a/client/src/styles/_toastalert.scss
+++ b/client/src/styles/_toastalert.scss
@@ -8,6 +8,10 @@
   left: 0;
   width: 100%;
 
+  &.is-inactive {
+    pointer-events: none;
+  }
+
   .toast-alert {
     position: relative;
 


### PR DESCRIPTION
On building pages there is a permanent container for the toast alerts to appear within, and it's currently preventing clicks through to the top nav logo/home button even when the toast is not present. This adds `pointer-events: none` when the toast is not present to fix this while still allowing click events (like for the link within the new area subscription confirmation toast)

<img width="704" height="244" alt="image" src="https://github.com/user-attachments/assets/b98b6758-771a-4682-90fb-a48078cbbd72" />

[sc-16583]