### PR TITLE
Rollbar failed to fetch issue

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -34,7 +34,13 @@ type PasswordResetResponse = Omit<VerifyEmailResponse, "statusCode"> & {
 let _user: JustfixUser | undefined;
 const user = () => _user;
 const fetchUser = async () => {
-  const authCheck = await userAuthenticated();
+  let authCheck;
+  try {
+    authCheck = await userAuthenticated();
+  } catch (e) {
+    if (e instanceof NetworkError) return;
+    throw e;
+  }
 
   if (!authCheck) {
     clearUser();
@@ -429,15 +435,12 @@ const postLoginCredentials = async (
   return await result.json();
 };
 
-// TODO shakao Move shared APIClient functions to util
 const friendlyFetch: typeof fetch = async (input, init) => {
   let response: Response;
   try {
     response = await fetch(input, init);
-    console.log(response);
   } catch (e) {
     if (e instanceof Error) {
-      window.Rollbar.error(e.message, { input, init });
       throw new NetworkError(e.message);
     } else {
       throw new Error("Unexpected error");

--- a/docker-update.sh
+++ b/docker-update.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
-if docker-compose build; then
-  if docker-compose run app ./update.sh; then
+if docker compose build; then
+  if docker compose run app ./update.sh; then
     echo
     echo "Docker environment updated successfully."
     exit 0
@@ -13,7 +13,7 @@ echo "Alas, something didn't work when trying to update your Docker setup."
 echo "If you're not sure what the problem is, you might want to just "
 echo "reset your environment by running:"
 echo
-echo "    docker-compose down -v"
+echo "    docker compose down -v"
 echo "    $0"
 echo
 echo "Note that this may reset your database! It will also re-fetch"


### PR DESCRIPTION
https://app.rollbar.com/a/justfixnyc-production/fix/item/who-owns-what/2703

We've seen a flooding of `Error: failed to fetch` errors on Who Owns What for a few months now. The occurrences that trigger this Rollbar error in particular is coming from the `/auth_check` endpoint with no HTTP status code. This is most likely happening because of adblockers or users' internet connection, which are ultimately expected network failures that shouldn't be reported to Rollbar. 

We had a leftover console statement in our `friendlyFetch()` that is now deleted and I also got rid of the call to Rollbar in the low level fetch helper. 

As a side effect to this fix, I think it would actually fix this other Failed to Fetch error as well which seems more related to CORS but i think has to do with the order of error reporting calls
https://app.rollbar.com/a/justfixnyc-production/fix/item/who-owns-what/3216