### PR TITLE
Building Alerts Standalone VQA 

### DIFF
--- a/client/src/components/LegalFooter.tsx
+++ b/client/src/components/LegalFooter.tsx
@@ -18,8 +18,7 @@ const LegalFooter = () => {
             <Trans>
               Disclaimer: The information in JustFix does not constitute legal advice and must not
               be used as a substitute for the advice of a lawyer qualified to give advice on legal
-              issues pertaining to housing. We can help direct you to free legal services if
-              necessary.
+              issues pertaining to housing.
             </Trans>
           </p>
           <p>

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -330,7 +330,8 @@ const Navbar = () => {
       className={classnames(
         "App__header",
         "navbar",
-        allowChangingPortfolioMethod && !isLegacy ? "wowza-styling" : "legacy-styling"
+        allowChangingPortfolioMethod && !isLegacy ? "wowza-styling" : "legacy-styling",
+        isBuildingAlerts && "App__header--building-alerts"
       )}
     >
       <HomeLink />

--- a/client/src/containers/App.tsx
+++ b/client/src/containers/App.tsx
@@ -20,7 +20,7 @@ import {
   LocaleRedirect,
 } from "../i18n";
 import { withI18n, withI18nProps } from "@lingui/react";
-import { createWhoOwnsWhatRoutePaths } from "../routes";
+import { createWhoOwnsWhatRoutePaths, isBuildingAlertsPath } from "../routes";
 import { VersionUpgrader } from "./VersionUpgrader";
 import { useMachine } from "@xstate/react";
 
@@ -61,26 +61,47 @@ const BRANCH_NAME = process.env.REACT_APP_BRANCH;
 
 const HomeLink = withI18n()((props: withI18nProps) => {
   const { i18n } = props;
-  const title = i18n._(t`Who owns what`);
-
   const { home, legacy } = createWhoOwnsWhatRoutePaths();
   const { pathname } = useLocation();
+  const isBuildingAlerts = isBuildingAlertsPath(pathname);
+  const isLegacy = isLegacyPath(pathname);
+  const homePath = isLegacy ? legacy.home : home;
+  const title = isBuildingAlerts ? i18n._(t`Building alerts`) : i18n._(t`Who owns what`);
+  const legacyClass = isLegacy && "legacy-styling";
+  const logo = <JFLogo className={classnames("jf-logo", legacyClass)} />;
+  const divider = <JFLogoDivider className={classnames("jf-logo-divider", legacyClass)} />;
+  const pageTitle = <h1 className={classnames("page-title", legacyClass)}>{widont(title)}</h1>;
+
+  if (isBuildingAlerts) {
+    return (
+      <div className="App__header-brand">
+        <JFCLLocaleLink
+          aria-label={i18n._(t`Who owns what`)}
+          onClick={() => {
+            window.gtag("event", "site-title");
+          }}
+          to={homePath}
+        >
+          {logo}
+        </JFCLLocaleLink>
+        {divider}
+        {pageTitle}
+      </div>
+    );
+  }
 
   return (
     <JFCLLocaleLink
+      className="App__header-brand"
       aria-label={i18n._(t`Who owns what`)}
       onClick={() => {
         window.gtag("event", "site-title");
       }}
-      to={isLegacyPath(pathname) ? legacy.home : home}
+      to={homePath}
     >
-      <JFLogo className={classnames("jf-logo", isLegacyPath(pathname) && "legacy-styling")} />
-      <JFLogoDivider
-        className={classnames("jf-logo-divider", isLegacyPath(pathname) && "legacy-styling")}
-      />
-      <h1 className={classnames("page-title", isLegacyPath(pathname) && "legacy-styling")}>
-        {widont(title)}
-      </h1>
+      {logo}
+      {divider}
+      {pageTitle}
     </JFCLLocaleLink>
   );
 });
@@ -262,27 +283,32 @@ const getAccountNavLinks = (fromPath: string, isSignedIn?: boolean) => {
       ];
 };
 
-const getMainNavLinks = (isLegacyPath?: boolean) => {
+const getMainNavLinks = (isLegacyPath?: boolean, isBuildingAlerts?: boolean) => {
   const { about, howToUse, legacy } = createWhoOwnsWhatRoutePaths();
-  return [
+  const links = [
     <SearchLink key={1} />,
-    <LocaleNavLink to={isLegacyPath ? legacy.about : about} key={2}>
-      <Trans>About</Trans>
-    </LocaleNavLink>,
-    <LocaleNavLink
-      to={isLegacyPath ? legacy.howToUse : howToUse}
-      key={3}
-      onClick={() => {
-        logAmplitudeEvent("navbarHowToUse");
-        window.gtag("event", "navbar-how-to-use");
-      }}
-    >
-      <Trans>How to use</Trans>
-    </LocaleNavLink>,
+    ...(!isBuildingAlerts
+      ? [
+          <LocaleNavLink to={isLegacyPath ? legacy.about : about} key={2}>
+            <Trans>About</Trans>
+          </LocaleNavLink>,
+          <LocaleNavLink
+            to={isLegacyPath ? legacy.howToUse : howToUse}
+            key={3}
+            onClick={() => {
+              logAmplitudeEvent("navbarHowToUse");
+              window.gtag("event", "navbar-how-to-use");
+            }}
+          >
+            <Trans>How to use</Trans>
+          </LocaleNavLink>,
+        ]
+      : []),
     <a href="https://donorbox.org/donate-to-justfix-nyc" key={4}>
       <Trans>Donate</Trans>
     </a>,
   ];
+  return links;
 };
 
 const Navbar = () => {
@@ -291,6 +317,9 @@ const Navbar = () => {
   const isDemoSite = process.env.REACT_APP_DEMO_SITE === "1";
   const allowChangingPortfolioMethod =
     process.env.REACT_APP_ENABLE_NEW_WOWZA_PORTFOLIO_MAPPING === "1";
+  const isLegacy = isLegacyPath(pathname);
+  const isBuildingAlerts = isBuildingAlertsPath(pathname);
+  const mainNavLinks = getMainNavLinks(isLegacy, isBuildingAlerts);
 
   const userContext = useContext(UserContext);
 
@@ -301,7 +330,7 @@ const Navbar = () => {
       className={classnames(
         "App__header",
         "navbar",
-        allowChangingPortfolioMethod && !isLegacyPath(pathname) ? "wowza-styling" : "legacy-styling"
+        allowChangingPortfolioMethod && !isLegacy ? "wowza-styling" : "legacy-styling"
       )}
     >
       <HomeLink />
@@ -313,12 +342,12 @@ const Navbar = () => {
       <nav className="inline">
         {addFeatureCalloutWidget && <FeatureCalloutWidget />}
         <span className="hide-lg">
-          {getMainNavLinks(isLegacyPath(pathname))}
+          {mainNavLinks}
           <LocaleSwitcher />
-          {!isLegacyPath(pathname) && getAccountNavLinks(pathname, !!userContext?.user?.email)}
+          {!isLegacy && getAccountNavLinks(pathname, !!userContext?.user?.email)}
         </span>
         <Dropdown>
-          {getMainNavLinks(isLegacyPath(pathname)).map((link, i) => (
+          {mainNavLinks.map((link, i) => (
             <li className="menu-item" key={i}>
               {link}
             </li>
@@ -326,7 +355,7 @@ const Navbar = () => {
           <li className="menu-item">
             <LocaleSwitcherWithFullLanguageName />
           </li>
-          {!isLegacyPath(pathname) &&
+          {!isLegacy &&
             getAccountNavLinks(pathname, !!userContext?.user?.email).map((link, i) => (
               <li className="menu-item" key={`account-${i}`}>
                 {link}

--- a/client/src/containers/BuildingAlertsPage.tsx
+++ b/client/src/containers/BuildingAlertsPage.tsx
@@ -264,12 +264,14 @@ const BuildingAlertsPage = withI18n()((props: withI18nProps) => {
               or city agencies to push for repairs and accountability.
             </Trans>
             <Trans render="p">
-              Remember, you have a right to a habitable home. <a href="https://www.justfix.org/building-alerts/">Learn more</a> about your
-              right to a habitable home.
+              Remember, you have a right to a habitable home.{" "}
+              <a href="https://www.justfix.org/building-alerts/">Learn more</a> about your right to
+              a habitable home.
             </Trans>
             <Trans render="p">
               You also have a right to organize with your neighbors to assert your rights.{" "}
-              <a href="https://www.justfix.org/building-alerts/">Learn more</a> about your right to organize.
+              <a href="https://www.justfix.org/building-alerts/">Learn more</a> about your right to
+              organize.
             </Trans>
           </div>
         </div>

--- a/client/src/containers/BuildingAlertsPage.tsx
+++ b/client/src/containers/BuildingAlertsPage.tsx
@@ -264,12 +264,12 @@ const BuildingAlertsPage = withI18n()((props: withI18nProps) => {
               or city agencies to push for repairs and accountability.
             </Trans>
             <Trans render="p">
-              Remember, you have a right to a habitable home. <a href="#">Learn more</a> about your
+              Remember, you have a right to a habitable home. <a href="https://www.justfix.org/building-alerts/">Learn more</a> about your
               right to a habitable home.
             </Trans>
             <Trans render="p">
               You also have a right to organize with your neighbors to assert your rights.{" "}
-              <a href="#">Learn more</a> about your right to organize.
+              <a href="https://www.justfix.org/building-alerts/">Learn more</a> about your right to organize.
             </Trans>
           </div>
         </div>

--- a/client/src/containers/BuildingAlertsPage.tsx
+++ b/client/src/containers/BuildingAlertsPage.tsx
@@ -152,15 +152,14 @@ const BuildingAlertsPage = withI18n()((props: withI18nProps) => {
         <div className="BuildingAlertsPage__hero">
           <div className="BuildingAlertsPage__hero-content">
             <h1>
-              <Trans>
-                Track new complaints, violations, and eviction filings in your building.
-              </Trans>
+              <Trans>Track complaints, violations, and eviction filings in your building.</Trans>
             </h1>
 
             <Trans render="p">
-              This service is free and confidential.{" "}
+              This service is free and confidential. <br />
+              Updates are sent weekly to your inbox.{" "}
               <JFCLLink onClick={() => setShowPreviewModal(true)} className="link-button">
-                Preview an alert
+                See example
               </JFCLLink>
             </Trans>
             <div className="BuildingAlertsPage__search">
@@ -178,7 +177,7 @@ const BuildingAlertsPage = withI18n()((props: withI18nProps) => {
                   />
                 </div>
                 <Button
-                  labelText={i18n._(t`Get started`)}
+                  labelText={i18n._(t`Track Building`)}
                   loading={isLoadingRecord}
                   onClick={handleGetStarted}
                 />
@@ -218,16 +217,59 @@ const BuildingAlertsPage = withI18n()((props: withI18nProps) => {
             <h3>
               <Trans>What you’ll get</Trans>
             </h3>
-            <Trans render="p">
-              You’ll get weekly updates about new HPD complaints, HPD violations, DOB
-              complaints/violations, and eviction filings in your building.
-            </Trans>
+            <Trans render="p">In your weekly email we’ll include the number of new:</Trans>
+            <ol className="BuildingAlertsPage__list">
+              <li>
+                <strong className="BuildingAlertsPage__list-title">
+                  <Trans>Complaints</Trans>
+                </strong>
+                <Trans render="p">
+                  Complaints are made by tenants to the city about problems like leaks, lack of
+                  heat, elevator outages, and unsafe construction.
+                </Trans>
+              </li>
+              <li>
+                <strong className="BuildingAlertsPage__list-title">
+                  <Trans>Violations</Trans>
+                </strong>
+                <Trans render="p">
+                  Violations are documented by city inspectors when they find that a building or
+                  landlord has not complied with the law.
+                </Trans>
+              </li>
+              <li>
+                <strong className="BuildingAlertsPage__list-title">
+                  <Trans>Eviction filings</Trans>
+                </strong>
+                <Trans render="p">
+                  Eviction filings show when a landlord has started an eviction case in Housing
+                  Court against a tenant in your building.
+                </Trans>
+              </li>
+            </ol>
+          </div>
+        </div>
+
+        <div className="BuildingAlertsPage__section BuildingAlertsPage__section--bordered">
+          <div className="BuildingAlertsPage__section-content">
             <h3>
-              <Trans>Why it matters</Trans>
+              <Trans>What you can do</Trans>
             </h3>
             <Trans render="p">
-              You’ll be able to see whether issues that you’re dealing alone are also being reported
-              by your neighbors.
+              This service can help you learn if the housing problems you’re facing on your own are
+              widespread in your building.
+            </Trans>
+            <Trans render="p">
+              You can use this information to connect with your neighbors and approach your landlord
+              or city agencies to push for repairs and accountability.
+            </Trans>
+            <Trans render="p">
+              Remember, you have a right to a habitable home. <a href="#">Learn more</a> about your
+              right to a habitable home.
+            </Trans>
+            <Trans render="p">
+              You also have a right to organize with your neighbors to assert your rights.{" "}
+              <a href="#">Learn more</a> about your right to organize.
             </Trans>
           </div>
         </div>
@@ -235,16 +277,24 @@ const BuildingAlertsPage = withI18n()((props: withI18nProps) => {
         <div className="BuildingAlertsPage__section">
           <div className="BuildingAlertsPage__section-content">
             <h3>
-              <Trans>About this site</Trans>
+              <Trans>About JustFix</Trans>
             </h3>
             <Trans render="p">
-              A nonprofit organization that builds online tools to help New Yorkers achieve
-              affordable, healthy, eviction-free housing.
+              Building Alerts is a free service created and maintained by JustFix, a nonprofit that
+              builds free digital tools to help New Yorkers exercise their rights to healthy,
+              affordable, and eviction-free housing.
+            </Trans>
+            <Trans render="p">
+              Contact us at <a href="mailto:support@justfix.org">support@justfix.org</a>
             </Trans>
           </div>
         </div>
 
-        <LegalFooter />
+        <div className="BuildingAlertsPage__footer">
+          <div className="BuildingAlertsPage__footer-content">
+            <LegalFooter />
+          </div>
+        </div>
 
         <Modal
           showModal={showPreviewModal}

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -386,6 +386,10 @@ msgstr "Borough"
 msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
+#: src/containers/App.tsx:69
+msgid "Building alerts"
+msgstr "Building alerts"
+
 #: src/components/EmailAlertSignup.tsx:133
 #: src/containers/AccountSettingsPage.tsx:109
 #: src/containers/BuildingAlertsPage.tsx:133

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -86,9 +86,15 @@ msgstr "<0>Add another area alert</0>"
 #~ msgid "<0>Click to log in</0> if you are not redirected"
 #~ msgstr "<0>Click to log in</0> if you are not redirected"
 
+#~ msgid "<0>Complaints:</0> Complaints are made by tenants to the city about problems like leaks, lack of heat, elevator outages, and unsafe construction."
+#~ msgstr "<0>Complaints:</0> Complaints are made by tenants to the city about problems like leaks, lack of heat, elevator outages, and unsafe construction."
+
 #: src/containers/AccountSettingsPage.tsx:108
 #~ msgid "<0>Create a district</0> to add to your weekly emails"
 #~ msgstr "<0>Create a district</0> to add to your weekly emails"
+
+#~ msgid "<0>Eviction filings:</0> Eviction filings show when a landlord has started an eviction case in Housing Court against a tenant in your building."
+#~ msgstr "<0>Eviction filings:</0> Eviction filings show when a landlord has started an eviction case in Housing Court against a tenant in your building."
 
 #: src/containers/AccountSettingsPage.tsx:141
 msgid "<0>Get a weekly email that identifies buildings and portfolios that exhibit urgent displacement indicators within a single area or multiple areas of the city.</0><1>Add area alerts</1> to add to your weekly emails"
@@ -167,6 +173,9 @@ msgstr "<0>This property is not required to register with HPD</0> because it doe
 msgid "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 msgstr "<0>This property should be registered with HPD</0> because it has more than 2 residential units."
 
+#~ msgid "<0>Violations:</0> Violations are documented by city inspectors when they find that a building or landlord has not complied with the law."
+#~ msgstr "<0>Violations:</0> Violations are documented by city inspectors when they find that a building or landlord has not complied with the law."
+
 #: src/components/DetailView.tsx:63
 msgid "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
 msgstr "<0>While the legal owner of a building is often a company (usually called an “LLC”), these names and business addresses registered with HPD offer a clearer picture of who really controls the building.</0><1>People listed here as “Head Officer” or “Owner” usually have ties to building ownership, while “Site Managers” are part of management. That being said, these names are self reported by the landlord, so they can be misleading.</1><2>Learn more about HPD registrations and how this information powers this tool on the <3>About page</3>.</2>"
@@ -195,9 +204,8 @@ msgstr "A DOB Violation is a notice that a property is not in compliance with ap
 msgid "A new set of dropdown menus and design tweaks make it more comfortable to use Who Owns What on the go."
 msgstr "A new set of dropdown menus and design tweaks make it more comfortable to use Who Owns What on the go."
 
-#: src/containers/BuildingAlertsPage.tsx:201
-msgid "A nonprofit organization that builds online tools to help New Yorkers achieve affordable, healthy, eviction-free housing."
-msgstr "A nonprofit organization that builds online tools to help New Yorkers achieve affordable, healthy, eviction-free housing."
+#~ msgid "A nonprofit organization that builds online tools to help New Yorkers achieve affordable, healthy, eviction-free housing."
+#~ msgstr "A nonprofit organization that builds online tools to help New Yorkers achieve affordable, healthy, eviction-free housing."
 
 #: src/components/UsefulLinks.tsx:51
 #: src/containers/NychaPage.tsx:176
@@ -209,13 +217,16 @@ msgid "APPLIANCE"
 msgstr "APPLIANCE"
 
 #: src/containers/AboutPage.tsx:13
-#: src/containers/App.tsx:143
+#: src/containers/App.tsx:161
 msgid "About"
 msgstr "About"
 
-#: src/containers/BuildingAlertsPage.tsx:199
-msgid "About this site"
-msgstr "About this site"
+#: src/containers/BuildingAlertsPage.tsx:238
+msgid "About JustFix"
+msgstr "About JustFix"
+
+#~ msgid "About this site"
+#~ msgstr "About this site"
 
 #: src/components/ViolationsSummary.tsx:28
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
@@ -352,7 +363,7 @@ msgstr "Associated names/entities: {0}"
 #~ msgstr "At this time we can only support {SUBSCRIPTION_LIMIT} buildings in each email. Please visit your <0>account</0> to manage the buildings in your email. If you would like to track more buildings, please let us know by submiting a <1>request form</1>."
 
 #: src/components/EmailAlertSignup.tsx:113
-#: src/containers/BuildingAlertsPage.tsx:223
+#: src/containers/BuildingAlertsPage.tsx:270
 msgid "At this time we can only support {subscriptionLimit} buildings in each email. Please visit your <0>account</0> to manage the buildings in your email. If you would like to track more buildings, please let us know by submiting a <1>request form</1>."
 msgstr "At this time we can only support {subscriptionLimit} buildings in each email. Please visit your <0>account</0> to manage the buildings in your email. If you would like to track more buildings, please let us know by submiting a <1>request form</1>."
 
@@ -386,15 +397,15 @@ msgstr "Borough"
 msgid "Borough Management Office:"
 msgstr "Borough Management Office:"
 
-#: src/containers/App.tsx:69
-msgid "Building alerts"
-msgstr "Building alerts"
-
 #: src/components/EmailAlertSignup.tsx:133
 #: src/containers/AccountSettingsPage.tsx:109
-#: src/containers/BuildingAlertsPage.tsx:133
+#: src/containers/BuildingAlertsPage.tsx:131
 msgid "Building Alerts"
 msgstr "Building Alerts"
+
+#: src/containers/BuildingAlertsPage.tsx:240
+msgid "Building Alerts is a free service created and maintained by JustFix, a nonprofit that builds free digital tools to help New Yorkers exercise their rights to healthy, affordable, and eviction-free housing."
+msgstr "Building Alerts is a free service created and maintained by JustFix, a nonprofit that builds free digital tools to help New Yorkers exercise their rights to healthy, affordable, and eviction-free housing."
 
 #: src/components/IndicatorsDatasets.tsx:68
 msgid "Building Permit Applications"
@@ -412,6 +423,10 @@ msgstr "Building Size"
 #: src/containers/AccountSettingsPage.tsx:60
 #~ msgid "Building Updates"
 #~ msgstr "Building Updates"
+
+#: src/containers/App.tsx:55
+msgid "Building alerts"
+msgstr "Building alerts"
 
 #: src/components/PropertiesSummary.tsx:49
 msgid "Building info"
@@ -595,9 +610,17 @@ msgstr "Close"
 msgid "Community District"
 msgstr "Community District"
 
+#: src/containers/BuildingAlertsPage.tsx:182
+msgid "Complaints"
+msgstr "Complaints"
+
 #: src/components/IndicatorsDatasets.tsx:13
 msgid "Complaints Issued"
 msgstr "Complaints Issued"
+
+#: src/containers/BuildingAlertsPage.tsx:184
+msgid "Complaints are made by tenants to the city about problems like leaks, lack of heat, elevator outages, and unsafe construction."
+msgstr "Complaints are made by tenants to the city about problems like leaks, lack of heat, elevator outages, and unsafe construction."
 
 #: src/components/ComplaintsSummary.tsx:9
 msgid "Complaints to 311"
@@ -610,6 +633,10 @@ msgstr "Complaints to 311"
 #: src/containers/AccountSettingsPage.tsx:153
 msgid "Contact support@justfix.org to delete your account or get help"
 msgstr "Contact support@justfix.org to delete your account or get help"
+
+#: src/containers/BuildingAlertsPage.tsx:245
+msgid "Contact us at <0>support@justfix.org</0>"
+msgstr "Contact us at <0>support@justfix.org</0>"
 
 #: src/components/PortfolioTable.tsx:243
 #~ msgid "Contacts"
@@ -683,7 +710,7 @@ msgstr "DOORS"
 msgid "Date"
 msgstr "Date"
 
-#: src/containers/App.tsx:167
+#: src/containers/App.tsx:191
 msgid "Demo Site"
 msgstr "Demo Site"
 
@@ -702,8 +729,12 @@ msgstr "Didn’t receive an email?"
 #~ msgstr "Didn’t receive an email?<0/>Click here to try again."
 
 #: src/components/LegalFooter.tsx:15
-msgid "Disclaimer: The information in JustFix does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
-msgstr "Disclaimer: The information in JustFix does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
+msgid "Disclaimer: The information in JustFix does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing."
+msgstr "Disclaimer: The information in JustFix does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing."
+
+#: src/components/LegalFooter.tsx:15
+#~ msgid "Disclaimer: The information in JustFix does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
+#~ msgstr "Disclaimer: The information in JustFix does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
 #: src/components/Indicators.tsx:206
 #: src/components/Indicators.tsx:207
@@ -719,8 +750,8 @@ msgstr "Display:"
 msgid "Don't have an account?"
 msgstr "Don't have an account?"
 
-#: src/components/LegalFooter.tsx:35
-#: src/containers/App.tsx:152
+#: src/components/LegalFooter.tsx:34
+#: src/containers/App.tsx:172
 msgid "Donate"
 msgstr "Donate"
 
@@ -768,7 +799,7 @@ msgid "Email address verified"
 msgstr "Email address verified"
 
 #: src/containers/AccountSettingsPage.tsx:99
-#: src/containers/App.tsx:126
+#: src/containers/App.tsx:142
 msgid "Email settings"
 msgstr "Email settings"
 
@@ -809,8 +840,8 @@ msgstr "Enter minimum and maximum number of units, or leave either blank, then a
 msgid "Enter new email address"
 msgstr "Enter new email address"
 
-#: src/containers/BuildingAlertsPage.tsx:132
-#: src/containers/BuildingAlertsPage.tsx:155
+#: src/containers/BuildingAlertsPage.tsx:130
+#: src/containers/BuildingAlertsPage.tsx:151
 msgid "Enter your address"
 msgstr "Enter your address"
 
@@ -848,6 +879,14 @@ msgstr "Eviction cases filed in Housing Court since 2017. This data comes from t
 #: src/components/BuildingStatsTable.tsx:131
 msgid "Eviction cases filed in Housing Court since 2017. This data comes from the Office of Court Administration via the OCA Data Collective in collaboration with the Right to Counsel Coalition."
 msgstr "Eviction cases filed in Housing Court since 2017. This data comes from the Office of Court Administration via the OCA Data Collective in collaboration with the Right to Counsel Coalition."
+
+#: src/containers/BuildingAlertsPage.tsx:200
+msgid "Eviction filings"
+msgstr "Eviction filings"
+
+#: src/containers/BuildingAlertsPage.tsx:202
+msgid "Eviction filings show when a landlord has started an eviction case in Housing Court against a tenant in your building."
+msgstr "Eviction filings show when a landlord has started an eviction case in Housing Court against a tenant in your building."
 
 #: src/components/PropertiesSummary.tsx:71
 #: src/containers/NychaPage.tsx:91
@@ -992,9 +1031,8 @@ msgstr "Get a weekly email that lists the top buildings in your area where tenan
 #~ msgid "Get email updates for this building"
 #~ msgstr "Get email updates for this building"
 
-#: src/containers/BuildingAlertsPage.tsx:157
-msgid "Get started"
-msgstr "Get started"
+#~ msgid "Get started"
+#~ msgstr "Get started"
 
 #: src/components/Login.tsx:254
 #: src/components/Login.tsx:294
@@ -1068,7 +1106,7 @@ msgstr "How are the results calculated?"
 msgid "How is this building associated to this portfolio?"
 msgstr "How is this building associated to this portfolio?"
 
-#: src/containers/App.tsx:149
+#: src/containers/App.tsx:167
 #: src/containers/HowToUsePage.tsx:13
 msgid "How to use"
 msgstr "How to use"
@@ -1129,6 +1167,10 @@ msgstr "I was checking out this building on Who Owns What, a free landlord resea
 msgid "In March 2023 this version will be discontinued. Switch to the new version or learn more."
 msgstr "In March 2023 this version will be discontinued. Switch to the new version or learn more."
 
+#: src/containers/BuildingAlertsPage.tsx:178
+msgid "In your weekly email we’ll include the number of new:"
+msgstr "In your weekly email we’ll include the number of new:"
+
 #: src/containers/NotRegisteredPage.tsx:64
 msgid "Incomplete registration for {usersInputAddressFragment}."
 msgstr "Incomplete registration for {usersInputAddressFragment}."
@@ -1157,7 +1199,7 @@ msgstr "Join the fight for tenant rights!"
 msgid "Joint Owner"
 msgstr "Joint Owner"
 
-#: src/components/LegalFooter.tsx:23
+#: src/components/LegalFooter.tsx:22
 msgid "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix, Inc is a registered 501(c)(3) nonprofit organization."
 
@@ -1274,7 +1316,7 @@ msgstr "Location"
 #: src/components/Login.tsx:161
 #: src/components/Login.tsx:348
 #: src/components/Login.tsx:351
-#: src/containers/App.tsx:134
+#: src/containers/App.tsx:150
 msgid "Log in"
 msgstr "Log in"
 
@@ -1346,7 +1388,7 @@ msgstr "MIN"
 msgid "MOLD"
 msgstr "MOLD"
 
-#: src/components/LegalFooter.tsx:29
+#: src/components/LegalFooter.tsx:28
 msgid "Made by the team at <0>JustFix.org</0>"
 msgstr "Made by the team at <0>JustFix.org</0>"
 
@@ -1406,7 +1448,7 @@ msgstr "May be issued official Orders"
 msgid "Menu"
 msgstr "Menu"
 
-#: src/components/LegalFooter.tsx:45
+#: src/components/LegalFooter.tsx:44
 #: src/containers/Methodology.tsx:14
 msgid "Methodology"
 msgstr "Methodology"
@@ -1708,7 +1750,7 @@ msgstr "Please enter a valid email address."
 msgid "Please enter a valid phone number."
 msgstr "Please enter a valid phone number."
 
-#: src/containers/BuildingAlertsPage.tsx:172
+#: src/containers/BuildingAlertsPage.tsx:168
 msgid "Please enter an address"
 msgstr "Please enter an address"
 
@@ -1744,7 +1786,7 @@ msgstr "Previous"
 msgid "Previous page"
 msgstr "Previous page"
 
-#: src/components/LegalFooter.tsx:41
+#: src/components/LegalFooter.tsx:40
 #: src/containers/PrivacyPolicyPage.tsx:11
 msgid "Privacy policy"
 msgstr "Privacy policy"
@@ -1774,6 +1816,10 @@ msgstr "Read more in our Methodology section"
 #: src/containers/NotRegisteredPage.tsx:108
 msgid "Registration expired:"
 msgstr "Registration expired:"
+
+#: src/containers/BuildingAlertsPage.tsx:224
+msgid "Remember, you have a right to a habitable home. <0>Learn more</0> about your right to a habitable home."
+msgstr "Remember, you have a right to a habitable home. <0>Learn more</0> about your right to a habitable home."
 
 #: src/containers/AccountSettingsPage.tsx:27
 #: src/containers/AccountSettingsPage.tsx:37
@@ -1880,11 +1926,11 @@ msgstr "STAIRS"
 msgid "Sample Area Alert Email"
 msgstr "Sample Area Alert Email"
 
-#: src/containers/BuildingAlertsPage.tsx:213
+#: src/containers/BuildingAlertsPage.tsx:260
 msgid "Sample Building Alert Email"
 msgstr "Sample Building Alert Email"
 
-#: src/containers/BuildingAlertsPage.tsx:216
+#: src/containers/BuildingAlertsPage.tsx:263
 msgid "Sample of building alert email showing complaints, violations, and eviction filings"
 msgstr "Sample of building alert email showing complaints, violations, and eviction filings"
 
@@ -1901,7 +1947,7 @@ msgid "Save selections"
 msgstr "Save selections"
 
 #: src/components/Multiselect.tsx:71
-#: src/containers/App.tsx:117
+#: src/containers/App.tsx:133
 msgid "Search"
 msgstr "Search"
 
@@ -2112,7 +2158,7 @@ msgstr "Sorry, it looks like there's an error on the map. Try again on a differe
 msgid "Sorry, something went wrong with the password reset."
 msgstr "Sorry, something went wrong with the password reset."
 
-#: src/containers/BuildingAlertsPage.tsx:166
+#: src/containers/BuildingAlertsPage.tsx:162
 msgid "Sorry, that address is not available for Building Alerts. Please try another address."
 msgstr "Sorry, that address is not available for Building Alerts. Please try another address."
 
@@ -2120,7 +2166,7 @@ msgstr "Sorry, that address is not available for Building Alerts. Please try ano
 msgid "Sorry, the page you are looking for doesn't seem to exist."
 msgstr "Sorry, the page you are looking for doesn't seem to exist."
 
-#: src/components/LegalFooter.tsx:48
+#: src/components/LegalFooter.tsx:47
 msgid "Source code"
 msgstr "Source code"
 
@@ -2204,7 +2250,7 @@ msgstr "Tenant Organizer"
 msgid "Tenants in this portfolio have reported a total of <0>{totalhpdcomplaints}</0> {totalhpdcomplaints, plural, one {complaint} other {complaints}} to 311, <1>{totalrecenthpdcomplaints}</1> of which {totalrecenthpdcomplaints, plural, one {was} other {were}} reported in the last three years."
 msgstr "Tenants in this portfolio have reported a total of <0>{totalhpdcomplaints}</0> {totalhpdcomplaints, plural, one {complaint} other {complaints}} to 311, <1>{totalrecenthpdcomplaints}</1> of which {totalrecenthpdcomplaints, plural, one {was} other {were}} reported in the last three years."
 
-#: src/components/LegalFooter.tsx:38
+#: src/components/LegalFooter.tsx:37
 #: src/containers/TermsOfUsePage.tsx:11
 msgid "Terms of use"
 msgstr "Terms of use"
@@ -2394,9 +2440,20 @@ msgstr "This represents <0>{0}%</0> of the total size of this portfolio."
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 
-#: src/containers/BuildingAlertsPage.tsx:143
-msgid "This service is free and confidential. <0>Preview an alert</0>"
-msgstr "This service is free and confidential. <0>Preview an alert</0>"
+#: src/containers/BuildingAlertsPage.tsx:216
+msgid "This service can help you learn if the housing problems you’re facing on your own are widespread in your building."
+msgstr "This service can help you learn if the housing problems you’re facing on your own are widespread in your building."
+
+#: src/containers/BuildingAlertsPage.tsx:139
+msgid "This service is free and confidential. <0/>Updates are sent weekly to your inbox. <1>See example</1>"
+msgstr "This service is free and confidential. <0/>Updates are sent weekly to your inbox. <1>See example</1>"
+
+#~ msgid "This service is free and confidential. <0>Preview an alert</0>"
+#~ msgstr "This service is free and confidential. <0>Preview an alert</0>"
+
+#: src/containers/BuildingAlertsPage.tsx
+#~ msgid "This service is free and confidential. Updates are sent weekly to your inbox. <0>See example</0>"
+#~ msgstr "This service is free and confidential. Updates are sent weekly to your inbox. <0>See example</0>"
 
 #: src/components/BuildingStatsTable.tsx:92
 #~ msgid "This tracks how rent stabilized units in the building have changed (i.e. \"{delta}\") from 2007 to {0}. If the number for {1} is red, this means there has been a loss in stabilized units! These counts are estimated from the DOF Property Tax Bills."
@@ -2446,9 +2503,16 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Total Violations"
 
-#: src/containers/BuildingAlertsPage.tsx:138
-msgid "Track new complaints, violations, and eviction filings in your building."
-msgstr "Track new complaints, violations, and eviction filings in your building."
+#: src/containers/BuildingAlertsPage.tsx:153
+msgid "Track Building"
+msgstr "Track Building"
+
+#: src/containers/BuildingAlertsPage.tsx:136
+msgid "Track complaints, violations, and eviction filings in your building."
+msgstr "Track complaints, violations, and eviction filings in your building."
+
+#~ msgid "Track new complaints, violations, and eviction filings in your building."
+#~ msgstr "Track new complaints, violations, and eviction filings in your building."
 
 #: src/components/PortfolioFilters.tsx:227
 msgid "Try adjusting or clearing the filters to show more than 0 results."
@@ -2631,10 +2695,18 @@ msgstr "View portfolio map"
 msgid "View trends over time"
 msgstr "View trends over time"
 
+#: src/containers/BuildingAlertsPage.tsx:191
+msgid "Violations"
+msgstr "Violations"
+
 #: src/components/IndicatorsDatasets.tsx:42
 #: src/components/IndicatorsDatasets.tsx:99
 msgid "Violations Issued"
 msgstr "Violations Issued"
+
+#: src/containers/BuildingAlertsPage.tsx:193
+msgid "Violations are documented by city inspectors when they find that a building or landlord has not complied with the law."
+msgstr "Violations are documented by city inspectors when they find that a building or landlord has not complied with the law."
 
 #: src/components/EngagementPanel.tsx:17
 msgid "Visit our website"
@@ -2732,7 +2804,11 @@ msgstr "What are {0}?"
 msgid "What happens if the landlord has failed to register?"
 msgstr "What happens if the landlord has failed to register?"
 
-#: src/containers/BuildingAlertsPage.tsx:180
+#: src/containers/BuildingAlertsPage.tsx:214
+msgid "What you can do"
+msgstr "What you can do"
+
+#: src/containers/BuildingAlertsPage.tsx:176
 msgid "What you’ll get"
 msgstr "What you’ll get"
 
@@ -2780,8 +2856,9 @@ msgstr "Who Owns What is a free tool built by JustFix to research property owner
 #: src/components/Page.tsx:10
 #: src/components/Page.tsx:20
 #: src/components/Page.tsx:20
-#: src/containers/App.tsx:50
-#: src/containers/App.tsx:53
+#: src/containers/App.tsx:55
+#: src/containers/App.tsx:62
+#: src/containers/App.tsx:71
 msgid "Who owns what"
 msgstr "Who owns what"
 
@@ -2808,9 +2885,8 @@ msgstr "Who’s the landlord of this building?"
 msgid "Why am I seeing such a big portfolio?"
 msgstr "Why am I seeing such a big portfolio?"
 
-#: src/containers/BuildingAlertsPage.tsx:187
-msgid "Why it matters"
-msgstr "Why it matters"
+#~ msgid "Why it matters"
+#~ msgstr "Why it matters"
 
 #: src/components/BuildingStatsTable.tsx:54
 #: src/components/BuildingStatsTable.tsx:57
@@ -2820,6 +2896,10 @@ msgstr "Year Built"
 #: src/components/PortfolioTable.tsx:368
 msgid "Yes"
 msgstr "Yes"
+
+#: src/containers/BuildingAlertsPage.tsx:228
+msgid "You also have a right to organize with your neighbors to assert your rights. <0>Learn more</0> about your right to organize."
+msgstr "You also have a right to organize with your neighbors to assert your rights. <0>Learn more</0> about your right to organize."
 
 #: src/components/Login.tsx:206
 #: src/containers/AccountSettingsPage.tsx:102
@@ -2920,8 +3000,12 @@ msgstr "You can now close this window, <0>search for another building</0> to fol
 #~ msgid "You can now start receiving Building Updates"
 #~ msgstr "You can now start receiving Building Updates"
 
+#: src/containers/BuildingAlertsPage.tsx:220
+msgid "You can use this information to connect with your neighbors and approach your landlord or city agencies to push for repairs and accountability."
+msgstr "You can use this information to connect with your neighbors and approach your landlord or city agencies to push for repairs and accountability."
+
 #: src/components/EmailAlertSignup.tsx:112
-#: src/containers/BuildingAlertsPage.tsx:222
+#: src/containers/BuildingAlertsPage.tsx:269
 msgid "You have reached the maximum number of Building Alerts"
 msgstr "You have reached the maximum number of Building Alerts"
 
@@ -2977,13 +3061,11 @@ msgstr "Your email is already verified"
 msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Use</1>."
 msgstr "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Use</1>."
 
-#: src/containers/BuildingAlertsPage.tsx:189
-msgid "You’ll be able to see whether issues that you’re dealing alone are also being reported by your neighbors."
-msgstr "You’ll be able to see whether issues that you’re dealing alone are also being reported by your neighbors."
+#~ msgid "You’ll be able to see whether issues that you’re dealing alone are also being reported by your neighbors."
+#~ msgstr "You’ll be able to see whether issues that you’re dealing alone are also being reported by your neighbors."
 
-#: src/containers/BuildingAlertsPage.tsx:182
-msgid "You’ll get weekly updates about new HPD complaints, HPD violations, DOB complaints/violations, and eviction filings in your building."
-msgstr "You’ll get weekly updates about new HPD complaints, HPD violations, DOB complaints/violations, and eviction filings in your building."
+#~ msgid "You’ll get weekly updates about new HPD complaints, HPD violations, DOB complaints/violations, and eviction filings in your building."
+#~ msgstr "You’ll get weekly updates about new HPD complaints, HPD violations, DOB complaints/violations, and eviction filings in your building."
 
 #: src/components/EmailAlertSignup.tsx:67
 msgid "You’re signed up for Building Alerts for {0} {1}, {2}."

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -391,6 +391,10 @@ msgstr "Municipio"
 msgid "Borough Management Office:"
 msgstr "Oficina de Gestión Municipal:"
 
+#: src/containers/App.tsx:69
+msgid "Building alerts"
+msgstr "Alertas por edificio"
+
 #: src/components/EmailAlertSignup.tsx:133
 #: src/containers/AccountSettingsPage.tsx:109
 #: src/containers/BuildingAlertsPage.tsx:133

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -200,9 +200,8 @@ msgstr "Una infracción del DOB es una notificación de que una propiedad no cum
 msgid "A new set of dropdown menus and design tweaks make it more comfortable to use Who Owns What on the go."
 msgstr "Un nuevo conjunto de menús desplegables y ajustes de diseño hacen que sea más cómodo usar Who Owns What a donde vaya."
 
-#: src/containers/BuildingAlertsPage.tsx:201
-msgid "A nonprofit organization that builds online tools to help New Yorkers achieve affordable, healthy, eviction-free housing."
-msgstr "Una organización sin ánimo de lucro que crea herramientas en línea para ayudar a los neoyorquinos a conseguir una vivienda asequible, saludable y sin riesgo de desahucio."
+#~ msgid "A nonprofit organization that builds online tools to help New Yorkers achieve affordable, healthy, eviction-free housing."
+#~ msgstr "Una organización sin ánimo de lucro que crea herramientas en línea para ayudar a los neoyorquinos a conseguir una vivienda asequible, saludable y sin riesgo de desahucio."
 
 #: src/components/UsefulLinks.tsx:51
 #: src/containers/NychaPage.tsx:176
@@ -218,9 +217,8 @@ msgstr "MEDIO DOMÉSTICO"
 msgid "About"
 msgstr "Acerca de"
 
-#: src/containers/BuildingAlertsPage.tsx:199
-msgid "About this site"
-msgstr "Acerca de este sitio"
+#~ msgid "About this site"
+#~ msgstr "Acerca de este sitio"
 
 #: src/components/ViolationsSummary.tsx:28
 msgid "According to available HPD data, this portfolio has received <0>{totalviolations}</0> total violations."
@@ -997,9 +995,8 @@ msgstr "Reciba un correo electrónico semanal que enumera los principales edific
 #~ msgid "Get email updates for this building"
 #~ msgstr "Get email updates for this building"
 
-#: src/containers/BuildingAlertsPage.tsx:157
-msgid "Get started"
-msgstr "Iniciar"
+#~ msgid "Get started"
+#~ msgstr "Iniciar"
 
 #: src/components/Login.tsx:254
 #: src/components/Login.tsx:294
@@ -2399,9 +2396,8 @@ msgstr "Esto representa el <0>{0}%</0> del tamaño total de esta cartera."
 msgid "This represents the total number of HPD Violations (both open & closed) recorded by the city."
 msgstr "Esto representa el número total de infracciones del HPD (tanto actuales como cerradas) registradas por la ciudad."
 
-#: src/containers/BuildingAlertsPage.tsx:143
-msgid "This service is free and confidential. <0>Preview an alert</0>"
-msgstr "Este servicio es gratuito y confidencial. <0>Ver un avance de una alerta</0>"
+#~ msgid "This service is free and confidential. <0>Preview an alert</0>"
+#~ msgstr "Este servicio es gratuito y confidencial. <0>Ver un avance de una alerta</0>"
 
 #: src/components/BuildingStatsTable.tsx:92
 #~ msgid "This tracks how rent stabilized units in the building have changed (i.e. \"{delta}\") from 2007 to {0}. If the number for {1} is red, this means there has been a loss in stabilized units! These counts are estimated from the DOF Property Tax Bills."
@@ -2451,9 +2447,8 @@ msgstr "Total"
 msgid "Total Violations"
 msgstr "Infracciones totales"
 
-#: src/containers/BuildingAlertsPage.tsx:138
-msgid "Track new complaints, violations, and eviction filings in your building."
-msgstr "Lleva un control de las nuevas quejas, infracciones y solicitudes de desahucio que haya en tu edificio."
+#~ msgid "Track new complaints, violations, and eviction filings in your building."
+#~ msgstr "Lleva un control de las nuevas quejas, infracciones y solicitudes de desahucio que haya en tu edificio."
 
 #: src/components/PortfolioFilters.tsx:227
 msgid "Try adjusting or clearing the filters to show more than 0 results."
@@ -2813,9 +2808,8 @@ msgstr "¿Quién es el arrendador de este edificio?"
 msgid "Why am I seeing such a big portfolio?"
 msgstr "¿Por qué estoy viendo una cartera tan grande?"
 
-#: src/containers/BuildingAlertsPage.tsx:187
-msgid "Why it matters"
-msgstr "Por qué importa"
+#~ msgid "Why it matters"
+#~ msgstr "Por qué importa"
 
 #: src/components/BuildingStatsTable.tsx:54
 #: src/components/BuildingStatsTable.tsx:57
@@ -2982,13 +2976,11 @@ msgstr "Este correo electrónico ya está verificado"
 msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Use</1>."
 msgstr "Su privacidad es importante a nosotros. Lea nuestra <0>Política de privacidad</0> y <1>Términos de uso</1>."
 
-#: src/containers/BuildingAlertsPage.tsx:189
-msgid "You’ll be able to see whether issues that you’re dealing alone are also being reported by your neighbors."
-msgstr "Podrás ver si los problemas con los que estás lidiando tú solo también los están denunciando tus vecinos."
+#~ msgid "You’ll be able to see whether issues that you’re dealing alone are also being reported by your neighbors."
+#~ msgstr "Podrás ver si los problemas con los que estás lidiando tú solo también los están denunciando tus vecinos."
 
-#: src/containers/BuildingAlertsPage.tsx:182
-msgid "You’ll get weekly updates about new HPD complaints, HPD violations, DOB complaints/violations, and eviction filings in your building."
-msgstr "Recibirás actualizaciones semanales sobre nuevas denuncias ante el HPD, infracciones del HPD, denuncias e infracciones ante el DOB y solicitudes de desahucio en tu edificio."
+#~ msgid "You’ll get weekly updates about new HPD complaints, HPD violations, DOB complaints/violations, and eviction filings in your building."
+#~ msgstr "Recibirás actualizaciones semanales sobre nuevas denuncias ante el HPD, infracciones del HPD, denuncias e infracciones ante el DOB y solicitudes de desahucio en tu edificio."
 
 #: src/components/EmailAlertSignup.tsx:67
 msgid "You’re signed up for Building Alerts for {0} {1}, {2}."
@@ -3205,3 +3197,84 @@ msgstr "{value, plural, one {Una queja del HPD emitida desde el 2012} other {# q
 msgid "{value, plural, one {One HPD Violation Issued since 2012} other {# HPD Violations Issued since 2012}}"
 msgstr "{value, plural, one {Una infracción del HPD emitida desde el 2012} other {# infracciones del HPD emitidas desde el 2012}}"
 
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Track complaints, violations, and eviction filings in your building."
+msgstr "Lleva un control de las quejas, infracciones y solicitudes de desahucio que haya en tu edificio."
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "This service is free and confidential. Updates are sent weekly to your inbox. <0>See example</0>"
+msgstr "Este servicio es gratuito y confidencial. Las actualizaciones se envían semanalmente a tu bandeja de entrada. <0>Ver ejemplo</0>"
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Track Building"
+msgstr "Seguir edificio"
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "In your weekly email we’ll include the number of new:"
+msgstr "En tu correo semanal incluiremos el número de nuevos:"
+
+#~ msgid "<0>Complaints:</0> Complaints are made by tenants to the city about problems like leaks, lack of heat, elevator outages, and unsafe construction."
+#~ msgstr "<0>Quejas:</0> Las quejas las presentan los inquilinos a la ciudad por problemas como filtraciones, falta de calefacción, fallos del ascensor y construcción insegura."
+
+#~ msgid "<0>Violations:</0> Violations are documented by city inspectors when they find that a building or landlord has not complied with the law."
+#~ msgstr "<0>Infracciones:</0> Las infracciones las documentan los inspectores de la ciudad cuando encuentran que un edificio o un arrendador no ha cumplido con la ley."
+
+#~ msgid "<0>Eviction filings:</0> Eviction filings show when a landlord has started an eviction case in Housing Court against a tenant in your building."
+#~ msgstr "<0>Solicitudes de desahucio:</0> Las solicitudes de desahucio muestran cuándo un arrendador ha iniciado un caso de desahucio en el Tribunal de Vivienda contra un inquilino de tu edificio."
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "What you can do"
+msgstr "Qué puedes hacer"
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "This service can help you learn if the housing problems you’re facing on your own are widespread in your building."
+msgstr "Este servicio puede ayudarte a saber si los problemas de vivienda que enfrentas por tu cuenta son generalizados en tu edificio."
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "You can use this information to connect with your neighbors and approach your landlord or city agencies to push for repairs and accountability."
+msgstr "Puedes usar esta información para conectar con tus vecinos y acercarte a tu arrendador o a las agencias de la ciudad para exigir reparaciones y responsabilidad."
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Remember, you have a right to a habitable home. <0>Learn more</0> about your right to a habitable home."
+msgstr "Recuerda que tienes derecho a una vivienda habitable. <0>Más información</0> sobre tu derecho a una vivienda habitable."
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "You also have a right to organize with your neighbors to assert your rights. <0>Learn more</0> about your right to organize."
+msgstr "También tienes derecho a organizarte con tus vecinos para hacer valer tus derechos. <0>Más información</0> sobre tu derecho a organizarte."
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "About JustFix"
+msgstr "Acerca de JustFix"
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Building Alerts is a free service created and maintained by JustFix, a nonprofit that builds free digital tools to help New Yorkers exercise their rights to healthy, affordable, and eviction-free housing."
+msgstr "Building Alerts es un servicio gratuito creado y mantenido por JustFix, una organización sin ánimo de lucro que construye herramientas digitales gratuitas para ayudar a los neoyorquinos a ejercer sus derechos a una vivienda saludable, asequible y sin riesgo de desahucio."
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Contact us at <0>support@justfix.org</0>"
+msgstr "Contáctanos en <0>support@justfix.org</0>"
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Complaints"
+msgstr "Quejas"
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Violations"
+msgstr "Infracciones"
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Eviction filings"
+msgstr "Solicitudes de desahucio"
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Complaints are made by tenants to the city about problems like leaks, lack of heat, elevator outages, and unsafe construction."
+msgstr "Las quejas las presentan los inquilinos a la ciudad por problemas como filtraciones, falta de calefacción, fallos del ascensor y construcción insegura."
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Violations are documented by city inspectors when they find that a building or landlord has not complied with the law."
+msgstr "Las infracciones las documentan los inspectores de la ciudad cuando encuentran que un edificio o un arrendador no ha cumplido con la ley."
+
+#: src/containers/BuildingAlertsPage.tsx
+msgid "Eviction filings show when a landlord has started an eviction case in Housing Court against a tenant in your building."
+msgstr "Las solicitudes de desahucio muestran cuándo un arrendador ha iniciado un caso de desahucio en el Tribunal de Vivienda contra un inquilino de tu edificio."

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -18,6 +18,12 @@ export const isAddressPageRoute = (pathname: string) => {
   return path.startsWith("/address");
 };
 
+/**
+ * Determines whether a url corresponds to the Building Alerts landing page.
+ */
+export const isBuildingAlertsPath = (pathname: string) =>
+  removeLocalePrefix(pathname).startsWith("/building-alerts");
+
 export const removeIndicatorSuffix = (pathname: string) => pathname.replace(/\/:indicator.*/, "");
 
 export const createRouteForAddressPage = (

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -224,6 +224,17 @@
       }
     }
   }
+
+  &.App__header--building-alerts {
+    font-family: $body-font;
+
+    .App__header-brand,
+    .page-title,
+    nav a,
+    nav button {
+      font-family: $body-font;
+    }
+  }
 }
 
 .App__body {

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -151,13 +151,14 @@
     }
   }
 
-  & > a,
-  a:hover,
-  a:focus {
+  .App__header-brand,
+  .App__header-brand a,
+  .App__header-brand a:hover,
+  .App__header-brand a:focus {
     text-decoration: none !important;
   }
 
-  & > a {
+  .App__header-brand {
     width: fit-content;
     max-width: 75%;
     text-align: center;

--- a/client/src/styles/BuildingAlertsPage.scss
+++ b/client/src/styles/BuildingAlertsPage.scss
@@ -20,12 +20,17 @@ $content-box-width: 51.375rem; // 822px
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 4rem;
+    padding-top: 2.5rem;
+    padding-bottom: 3rem;
 
     @include for-phone-only {
       padding: unset;
       padding: 1.5rem 1.5rem 2rem;
     }
+  }
+
+  .BuildingAlertsPage__section {
+    padding: 3rem;
   }
 
   .BuildingAlertsPage__hero-content,
@@ -84,6 +89,7 @@ $content-box-width: 51.375rem; // 822px
 
     button.jfcl-button {
       flex-shrink: 0;
+      font-family: $body-font;
 
       @include for-phone-only {
         width: 100%;
@@ -256,6 +262,109 @@ $content-box-width: 51.375rem; // 822px
       font-weight: 500;
       line-height: 120%; /* 1.8rem */
       letter-spacing: 0.045rem;
+
+      & + p {
+        margin-top: 1.5rem;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: underline;
+
+        &:hover,
+        &:focus {
+          text-decoration: none;
+        }
+      }
+    }
+  }
+
+  .BuildingAlertsPage__list {
+    margin: 1.5rem 0 0;
+    padding-left: 1.5rem;
+    list-style-position: outside;
+    font-size: 1.5rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 120%;
+    letter-spacing: 0.045rem;
+
+    li {
+      &::marker {
+        font-weight: 600;
+      }
+
+      & + li {
+        margin-top: 1.5rem;
+      }
+    }
+
+    .BuildingAlertsPage__list-title {
+      font-weight: 600;
+    }
+
+    p {
+      display: block;
+      margin: 0.25rem 0 0;
+      font-weight: 500;
+    }
+  }
+
+  .BuildingAlertsPage__footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 4rem;
+    background-color: $justfix-white-200;
+    border-top: 0.0625rem solid $justfix-black;
+
+    @include for-phone-only {
+      padding: 0 1.5rem;
+    }
+  }
+
+  .BuildingAlertsPage__footer-content {
+    width: 100%;
+    max-width: $content-box-width;
+    font-size: 1.125rem;
+
+    .LegalFooter.container {
+      max-width: none;
+      width: 100%;
+      margin: 0;
+      padding: 0;
+    }
+
+    .LegalFooter {
+      font-family: $body-font;
+      color: $justfix-black;
+      background-color: $justfix-white-200;
+
+      .Links,
+      .Disclaimer {
+        padding: 2rem 0 1.5rem 0;
+        border-top: none;
+        background-color: $justfix-white-200;
+        color: $justfix-black;
+
+        a {
+          color: $justfix-black;
+        }
+      }
+
+      .Disclaimer {
+        @include for-tablet-landscape-up {
+          padding-right: 1rem;
+        }
+      }
+
+      .Links {
+        border-top: 0.0625rem solid $justfix-black;
+
+        @include for-tablet-landscape-up {
+          border-top: none;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This is a first pass at the Building Alerts standalone page. It has the following changes: 
- Nav bar is different than how it looks on the rest of Who Owns What pages
  - The product name is now on the nav bar (Building Alerts instead of Who Owns What) for better orienting first time users 
  - Hide `About` and `How to Use` links.  
  - Only logo is clickable to navigate back to WOW home page. Previously, the logo and product name were clickable as one element. On Mobile, the only way to navigate to the WOW home page is via the nav menu item `Search`
- Footer style is different on this page than how it looks on rest of Who Owns What pages
- Button style override just for this page to use Degular
- Update latest copy
- Update page styles to match mocks