### PR TITLE
Building Alerts SQL and API response update

### DIFF
--- a/wow/sql/alerts_building.sql
+++ b/wow/sql/alerts_building.sql
@@ -4,6 +4,7 @@ SELECT
     hpd_viol_all__bldg_month AS hpd_viol__month,
     hpd_comp__week,
     hpd_comp__bldg_month AS hpd_comp__month,
+    hpd_comp__bldg_month_by_type AS hpd_comp__month_by_type,
     dob_ecb_viol__week,
     dob_ecb_viol__bldg_month AS dob_ecb_viol__month,
     dob_comp__week,

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -1,4 +1,5 @@
 import csv
+import json
 from typing import Any, Dict, List
 from io import StringIO
 from django.urls import path
@@ -8,7 +9,7 @@ import pytest
 
 from wow.apiutil import api
 from project.urls import handler500  # noqa
-from wow.views import _fixup_addr_for_csv
+from wow.views import _fixup_addr_for_csv, format_hpd_comp_month_by_type
 
 
 @api
@@ -206,6 +207,80 @@ class TestFixupAddrForCsv:
             "recentcomplaintsbytype": "",
             "allcontacts": "",
         }
+
+
+SAMPLE_COMPLAINTS_BY_TYPE = [
+    {"minorcategory": "CEILING", "problemcode": "HOLE OR CRACKED", "count": 5},
+    {
+        "minorcategory": "WINDOW FRAME",
+        "problemcode": "LOOSE OR DEFECTIVE",
+        "count": 4,
+    },
+    {
+        "minorcategory": "RADIATOR",
+        "problemcode": "MISSING OR REMOVED",
+        "count": 3,
+    },
+]
+
+SAMPLE_COMPLAINTS_SUMMARY = (
+    "Ceiling (hole or cracked), Window frame (loose or defective), "
+    "Radiator (missing or removed), +72 more"
+)
+
+
+class TestFormatHpdCompMonthByType:
+    def test_formats_top_types_and_remaining_count(self):
+        assert (
+            format_hpd_comp_month_by_type(SAMPLE_COMPLAINTS_BY_TYPE, 84)
+            == SAMPLE_COMPLAINTS_SUMMARY
+        )
+
+    def test_parses_json_string_from_postgres(self):
+        assert (
+            format_hpd_comp_month_by_type(json.dumps(SAMPLE_COMPLAINTS_BY_TYPE), 84)
+            == SAMPLE_COMPLAINTS_SUMMARY
+        )
+
+    def test_returns_none_when_missing(self):
+        assert format_hpd_comp_month_by_type(None, 12) is None
+        assert format_hpd_comp_month_by_type([], 12) is None
+
+    def test_zero_remaining_omits_count(self):
+        assert format_hpd_comp_month_by_type(SAMPLE_COMPLAINTS_BY_TYPE, 12) == (
+            "Ceiling (hole or cracked), Window frame (loose or defective), "
+            "Radiator (missing or removed)"
+        )
+
+    @pytest.mark.parametrize(
+        "complaint, expected",
+        [
+            (
+                {"minorcategory": "WINDOWS", "problemcode": "OTHER", "count": 1},
+                "Windows",
+            ),
+            (
+                {
+                    "minorcategory": "WINDOW GUARD BROKEN/MISSING",
+                    "problemcode": "CHILD UNDER 11",
+                    "count": 1,
+                },
+                "Window guard broken/missing",
+            ),
+            (
+                {
+                    "minorcategory": "WINDOW GUARDS",
+                    "problemcode": "CHILD UNDER 11",
+                    "count": 1,
+                },
+                "Window guards",
+            )
+        ],
+    )
+    def test_special_category_and_problem_formatting(self, complaint, expected):
+        assert (
+            format_hpd_comp_month_by_type([complaint], complaint["count"]) == expected
+        )
 
 
 class TestServerError:

--- a/wow/tests/test_views.py
+++ b/wow/tests/test_views.py
@@ -274,7 +274,7 @@ class TestFormatHpdCompMonthByType:
                     "count": 1,
                 },
                 "Window guards",
-            )
+            ),
         ],
     )
     def test_special_category_and_problem_formatting(self, complaint, expected):

--- a/wow/views.py
+++ b/wow/views.py
@@ -240,7 +240,7 @@ def format_hpd_comp_type_label(minorcategory: str, problemcode: str) -> str:
     minor_key = minorcategory.upper()
     problem_key = problemcode.upper()
     minor = minorcategory.capitalize()
-    
+
     # calling these out because the problemcode is very long and/or redundant
     WINDOW_GUARD_CATEGORIES = {
         "WINDOW GUARD BROKEN/MISSING",
@@ -267,7 +267,7 @@ def format_hpd_comp_month_by_type(
     if isinstance(complaints_by_type, str):
         complaints_by_type = json.loads(complaints_by_type)
 
-    # failsafe in case the complaints_by_type is [] or None after json.loads 
+    # failsafe in case the complaints_by_type is [] or None after json.loads
     if not complaints_by_type:
         return None
 
@@ -287,6 +287,7 @@ def format_hpd_comp_month_by_type(
     if remaining > 0:
         return f"{summary}, +{remaining} more"
     return summary
+
 
 @api
 def signature_building(request):

--- a/wow/views.py
+++ b/wow/views.py
@@ -1,8 +1,9 @@
 import ast
 import csv
+import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Union
 from django.http import HttpResponse, JsonResponse
 
 from .dbutil import call_db_func, exec_db_query
@@ -209,8 +210,10 @@ def email_alerts_building(request):
     current month, or when the last week spans the start of a new month it
     covers the complete prior month. For each BBL the following indicator are included:
      - bbl
-     - hpd_viol__week, hpd_viol__month - HPD complaints (0 or greater)
-     - hpd_comp__week, hpd_comp__month - HPD violations (0 or greater)
+     - hpd_comp__week, hpd_comp__month - HPD complaints (0 or greater)
+     - hpd_comp__month_by_type - Top 3 HPD complaint types for the month as a
+       sentence-cased summary, with remaining complaint count as "+N more"
+     - hpd_viol__week, hpd_viol__month - HPD violations (0 or greater)
      - dob_comp__week, dob_comp__month - DOB complaints (0 or greater)
      - dob_ecb_viol__week, dob_ecb_viol__month - DOB violations (0 or greater)
      - evictions_filed__week, evictions_filed__month - Eviction filings
@@ -225,8 +228,65 @@ def email_alerts_building(request):
     bbls = get_validated_form_data(PaddedBBLListForm, request.GET)
     query_sql = SQL_DIR / "alerts_building.sql"
     result = exec_db_query(query_sql, bbls)
+    for row in result:
+        row["hpd_comp__month_by_type"] = format_hpd_comp_month_by_type(
+            row.get("hpd_comp__month_by_type"),
+            row.get("hpd_comp__month"),
+        )
     return JsonResponse({"result": list(result)})
 
+
+def format_hpd_comp_type_label(minorcategory: str, problemcode: str) -> str:
+    minor_key = minorcategory.upper()
+    problem_key = problemcode.upper()
+    minor = minorcategory.capitalize()
+    
+    # calling these out because the problemcode is very long and/or redundant
+    WINDOW_GUARD_CATEGORIES = {
+        "WINDOW GUARD BROKEN/MISSING",
+        "WINDOW GUARDS",
+    }
+
+    if problem_key == "OTHER" or minor_key in WINDOW_GUARD_CATEGORIES:
+        return minor
+    return f"{minor} ({problemcode.lower()})"
+
+
+def format_hpd_comp_month_by_type(
+    complaints_by_type: Union[None, str, List[Dict[str, Any]]],
+    hpd_comp_month: Optional[int],
+) -> Optional[str]:
+    """
+    Turn the top three HPD complaint types from the current month into a
+    single sentence-cased summary, with any remaining complaints counted at
+    the end
+    """
+    if not complaints_by_type:
+        return None
+
+    if isinstance(complaints_by_type, str):
+        complaints_by_type = json.loads(complaints_by_type)
+
+    # failsafe in case the complaints_by_type is [] or None after json.loads 
+    if not complaints_by_type:
+        return None
+
+    labels = []
+    listed_count = 0
+    for complaint in complaints_by_type:
+        labels.append(
+            format_hpd_comp_type_label(
+                complaint.get("minorcategory") or "",
+                complaint.get("problemcode") or "",
+            )
+        )
+        listed_count += complaint.get("count") or 0
+
+    remaining = (hpd_comp_month or 0) - listed_count
+    summary = ", ".join(labels)
+    if remaining > 0:
+        return f"{summary}, +{remaining} more"
+    return summary
 
 @api
 def signature_building(request):

--- a/wow/views.py
+++ b/wow/views.py
@@ -267,8 +267,8 @@ def format_hpd_comp_month_by_type(
     if isinstance(complaints_by_type, str):
         complaints_by_type = json.loads(complaints_by_type)
 
-    # failsafe in case the complaints_by_type is [] or None after json.loads
-    if not complaints_by_type:
+    # failsafe in case json.loads returned []/None, or a non-list JSON value
+    if not isinstance(complaints_by_type, list) or not complaints_by_type:
         return None
 
     labels = []


### PR DESCRIPTION
- adds the column `hpd_comp__bldg_month_by_type`, which represents the top 3 HPD complaints by type for the month, to the SQL query that is run from the API endpoint called by `auth-provider`
- adds the top 3 HPD complaints by type in a formatted string to the Building Alerts API response 
  - list is formatted as comma separated values of `minorcategory (problemcode)`  i.e. Air-conditioning (leaking or defective) 
  - any `problemcode = OTHER` is ignored and only its corresponding `minorcategory` is in the final formatted string
  - specific callouts for `minorcategory = WINDOW GUARD BROKEN/MISSING` and `minorcategory = WINDOW GUARDS` to not list the `problemcode` because it was long and redundant
- adds tests to confirm new formatting