### PR TITLE
Remove the non-emergency filter from indicators table query

### DIFF
--- a/sql/create_indicators_table.sql
+++ b/sql/create_indicators_table.sql
@@ -151,7 +151,6 @@ hpd_comp_by_type_long AS (
         CROSS JOIN hpd_complaints_and_problems hcp
         WHERE hcp.receiveddate BETWEEN ed.email_date_bldg_month_start
                                    AND ed.email_date_bldg_month_end
-          AND hcp.type <> 'NON EMERGENCY'
         GROUP BY
             hcp.bbl,
             hcp.minorcategory,


### PR DESCRIPTION
The building alerts table displays all complaints regardless of emergency status, so the descriptions should be aligned with the counts that are being displayed. This error was caught because I found an example during QA where there were 2 complaints reported for the month of August but `hpd_viol_all__bldg_month = null`
<img width="620" height="221" alt="Screenshot 2026-08-24 at 1 09 42 AM" src="https://github.com/user-attachments/assets/0e3b792b-8c9a-4e96-8d6a-ce1c1bc345cb" />
