### PR TITLE
bug fix: OTP verification in new session 

### DIFF
--- a/client/src/components/UserContext.test.ts
+++ b/client/src/components/UserContext.test.ts
@@ -1,0 +1,44 @@
+import { applyAuthCheckUser } from "./UserContext";
+
+const loggedInUser = {
+  email: "tenant@example.com",
+  verified: true,
+  id: 42,
+  type: "tenant",
+  buildingSubscriptions: [{ bbl: "1234567890" }],
+  districtSubscriptions: [],
+  subscriptionLimit: 15,
+};
+
+describe("applyAuthCheckUser", () => {
+  it("does not let a stale logged-out auth_check replace a magic-link session", () => {
+    const staleAuthCheck = { error: "Auth request failed (401)" };
+
+    expect(applyAuthCheckUser(loggedInUser as any, staleAuthCheck)).toEqual(loggedInUser);
+  });
+
+  it("keeps a logged-in session when fetchUser returns nothing (network error)", () => {
+    expect(applyAuthCheckUser(loggedInUser as any, undefined)).toEqual(loggedInUser);
+  });
+
+  it("records a logged-out sentinel when there is no session yet", () => {
+    const result = applyAuthCheckUser(undefined, { error: "Auth request failed (401)" });
+
+    expect(result?.email).toBeUndefined();
+    expect(result?.buildingSubscriptions).toEqual([]);
+  });
+
+  it("applies a successful auth_check when context is still empty", () => {
+    const result = applyAuthCheckUser(undefined, {
+      email: "tenant@example.com",
+      verified: true,
+      id: 42,
+      type: "tenant",
+      subscriptions: [{ bbl: "1234567890" }],
+      district_subscriptions: [],
+      subscription_limit: 15,
+    });
+
+    expect(result).toEqual(loggedInUser);
+  });
+});

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -100,36 +100,48 @@ const toJustfixUser = (raw: any): JustfixUser | undefined => {
   };
 };
 
+const mapFetchedUser = (fetched: any): JustfixUser | undefined => {
+  const normalized = toJustfixUser(fetched);
+  if (!normalized) return;
+  return {
+    ...normalized,
+    buildingSubscriptions: (normalized.buildingSubscriptions || []).map((s: any) => ({ ...s })),
+    districtSubscriptions: (normalized.districtSubscriptions || []).map((s: any) => ({ ...s })),
+  };
+};
+
+/**
+ * Merge the mount-time auth_check into context without clobbering a session
+ * established while that request was in flight (magic-link landing in a
+ * fresh browser verifies in parallel with auth_check).
+ */
+export const applyAuthCheckUser = (
+  current: JustfixUser | undefined,
+  fetched: any
+): JustfixUser | undefined => {
+  if (current?.email) return current;
+  return mapFetchedUser(fetched);
+};
+
 export const UserContextProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<JustfixUser>();
 
   const updateUserSubscriptions = useCallback((_user: JustfixUser | undefined):
     | JustfixUser
     | undefined => {
-    const normalized = toJustfixUser(_user);
-    if (!normalized) return;
-    const updatedUser = {
-      ...normalized,
-      buildingSubscriptions:
-        normalized.buildingSubscriptions?.map((s: any) => {
-          return { ...s };
-        }) || [],
-      districtSubscriptions:
-        normalized.districtSubscriptions?.map((s: any) => {
-          return { ...s };
-        }) || [],
-    };
+    const updatedUser = mapFetchedUser(_user);
+    if (!updatedUser) return;
     setUser(updatedUser);
     return updatedUser;
   }, []);
 
   useEffect(() => {
     const asyncFetchUser = async () => {
-      const _user = await AuthClient.fetchUser();
-      updateUserSubscriptions(_user);
+      const fetched = await AuthClient.fetchUser();
+      setUser((current) => applyAuthCheckUser(current, fetched));
     };
     asyncFetchUser();
-  }, [updateUserSubscriptions]);
+  }, []);
 
   const startLogin = useCallback(async (email: string) => {
     try {


### PR DESCRIPTION
if a user (new or existing) clicks a magic link on a browser or device they do not already have an established app session state, the login doesn't go through. if there's a pending building subscription, that does actually get resolved in the backend. this has to do with a mismatch between two endpoints that are called at the same time. the auth_check endpoint returns the user object based on the app session state and verify-magic-link endpoint sets cookies and returns a valid user object