### PR TITLE
Display addr fix

### DIFF
--- a/client/src/components/AuthClient.ts
+++ b/client/src/components/AuthClient.ts
@@ -68,6 +68,8 @@ export type PendingBuildingSubscription = {
   streetname: string;
   zip: string;
   boro: string;
+  housenumber_display?: string;
+  streetname_display?: string;
 };
 
 export type SendLoginCodeOptions = {
@@ -107,6 +109,12 @@ const sendLoginCode = async (email: string, options?: SendLoginCodeOptions) => {
     params.streetname = options.building.streetname;
     params.zip = options.building.zip;
     params.boro = options.building.boro;
+    if (options.building.housenumber_display !== undefined) {
+      params.housenumber_display = options.building.housenumber_display;
+    }
+    if (options.building.streetname_display !== undefined) {
+      params.streetname_display = options.building.streetname_display;
+    }
   }
   if (options?.district) {
     params.district = JSON.stringify(options.district);

--- a/client/src/components/EmailAlertSignup.test.ts
+++ b/client/src/components/EmailAlertSignup.test.ts
@@ -58,6 +58,31 @@ describe("EmailVerificationPrompt resend", () => {
     );
   });
 
+  it("includes building display fields when present on send-code", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ otp: { status: "sent" } }));
+
+    await AuthClient.sendLoginCode("new@example.com", {
+      userType: "Tenant",
+      building: {
+        bbl: "3016780054",
+        housenumber: "196",
+        streetname: "Ralph Avenue",
+        zip: "11261",
+        boro: "Brooklyn",
+        housenumber_display: "196A",
+        streetname_display: "RALPH AVENUE",
+      },
+    });
+
+    expect(fetchMock.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        body:
+          "email=new%40example.com&user_type=Tenant&bbl=3016780054&housenumber=196&streetname=Ralph%20Avenue&zip=11261&boro=Brooklyn&housenumber_display=196A&streetname_display=RALPH%20AVENUE",
+      })
+    );
+  });
+
   it("includes stringified district from the area-alerts login path", async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ otp: { status: "sent" } }));
     const district = [

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -155,25 +155,6 @@ const LoginWithoutI18n = (props: withI18nProps) => {
     return formatAddr(addr, withBoro);
   };
 
-  const subscribeOnSuccess = async (user: JustfixUser) => {
-    if (addr) {
-      await userContext.subscribeBuilding(
-        addr.bbl,
-        addr.housenumber,
-        addr.streetname,
-        addr.zip ?? "",
-        addr.boro,
-        user,
-        fromBuildingAlerts ? housenumberDisplay : undefined,
-        fromBuildingAlerts ? streetnameDisplay : undefined
-      );
-    }
-
-    if (district) {
-      await userContext.subscribeDistrict(district, user);
-    }
-  };
-
   const resetAlertErrorStates = () => {
     setPageError("");
     setOtpError("");
@@ -200,6 +181,12 @@ const LoginWithoutI18n = (props: withI18nProps) => {
         streetname: addr.streetname,
         zip: addr.zip ?? "",
         boro: addr.boro,
+        ...(fromBuildingAlerts && housenumberDisplay !== undefined
+          ? { housenumber_display: housenumberDisplay }
+          : {}),
+        ...(fromBuildingAlerts && streetnameDisplay !== undefined
+          ? { streetname_display: streetnameDisplay }
+          : {}),
       };
     }
     if (district) {
@@ -377,7 +364,7 @@ const LoginWithoutI18n = (props: withI18nProps) => {
   const onVerifyOtp = async (code: string) => {
     window.gtag("event", "login-verify-otp", eventParams());
     try {
-      const resp = await userContext.verifyOtp(email, code, subscribeOnSuccess);
+      const resp = await userContext.verifyOtp(email, code);
       if (resp?.error) {
         reportUnexpectedAuthError(resp.error);
         setOtpError(mapAuthError(resp.error, i18n));

--- a/client/src/locales/en/messages.po
+++ b/client/src/locales/en/messages.po
@@ -140,7 +140,7 @@ msgstr "<0>Search an address</0> to add to your Building Alerts"
 #~ msgid "<0>Search for an address</0> to add to your Building Alerts"
 #~ msgstr "<0>Search for an address</0> to add to your Building Alerts"
 
-#: src/components/Login.tsx:204
+#: src/components/Login.tsx:193
 #: src/containers/UnsubscribePage.tsx:109
 #: src/containers/VerifyEmailPage.tsx:100
 msgid "<0>Search for an address</0> to add to your Building Alerts, <1>subscribe to Area Alerts</1>, or visit your <2>email settings</2> page to manage subscriptions."
@@ -807,7 +807,7 @@ msgstr "Edit"
 msgid "Email"
 msgstr "Email"
 
-#: src/components/Login.tsx:370
+#: src/components/Login.tsx:359
 #: src/components/UserSettingField.tsx:162
 #: src/components/UserSettingField.tsx:168
 #: src/components/UserSettingField.tsx:177
@@ -1351,7 +1351,7 @@ msgstr "Location"
 msgid "Log in"
 msgstr "Log in"
 
-#: src/components/Login.tsx:326
+#: src/components/Login.tsx:315
 msgid "Log in / Sign up"
 msgstr "Log in / Sign up"
 
@@ -1363,7 +1363,7 @@ msgstr "Log in / Sign up"
 msgid "Log in / sign up"
 msgstr "Log in / sign up"
 
-#: src/components/Login.tsx:323
+#: src/components/Login.tsx:312
 msgid "Log in or sign up to get weekly email updates on this building."
 msgstr "Log in or sign up to get weekly email updates on this building."
 
@@ -1593,7 +1593,7 @@ msgstr "New link sent"
 #~ msgstr "New password"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/Login.tsx:339
+#: src/components/Login.tsx:328
 msgid "Next"
 msgstr "Next"
 
@@ -1776,7 +1776,7 @@ msgstr "People"
 msgid "Person/Entity"
 msgstr "Person/Entity"
 
-#: src/components/Login.tsx:372
+#: src/components/Login.tsx:361
 msgid "Phone number (optional)"
 msgstr "Phone number (optional)"
 
@@ -2134,7 +2134,7 @@ msgstr "Showing {0} {1, plural, one {result} other {results}}"
 #~ msgid "Sign out"
 #~ msgstr "Sign out"
 
-#: src/components/Login.tsx:346
+#: src/components/Login.tsx:335
 #: src/components/Subscribe.tsx:81
 msgid "Sign up"
 msgstr "Sign up"
@@ -2153,8 +2153,8 @@ msgstr "Sign up"
 #~ msgid "Sign up for Data Updates on the buildings you choose:"
 #~ msgstr "Sign up for Data Updates on the buildings you choose:"
 
-#: src/components/Login.tsx:336
-#: src/components/Login.tsx:343
+#: src/components/Login.tsx:325
+#: src/components/Login.tsx:332
 msgid "Sign up for Email Alerts"
 msgstr "Sign up for Email Alerts"
 
@@ -2256,7 +2256,7 @@ msgstr "State Assembly District"
 msgid "State Senate District"
 msgstr "State Senate District"
 
-#: src/components/Login.tsx:335
+#: src/components/Login.tsx:324
 msgid "Step 1 of 2"
 msgstr "Step 1 of 2"
 
@@ -2264,7 +2264,7 @@ msgstr "Step 1 of 2"
 #~ msgid "Step 1 of 3"
 #~ msgstr "Step 1 of 3"
 
-#: src/components/Login.tsx:342
+#: src/components/Login.tsx:331
 msgid "Step 2 of 2"
 msgstr "Step 2 of 2"
 
@@ -2276,7 +2276,7 @@ msgstr "Step 2 of 2"
 #~ msgid "Step 3 of 3"
 #~ msgstr "Step 3 of 3"
 
-#: src/components/Login.tsx:332
+#: src/components/Login.tsx:321
 msgid "Submit"
 msgstr "Submit"
 
@@ -2692,11 +2692,11 @@ msgstr "Use the tab key to navigate. Press the enter key to select."
 msgid "Use this free tool from JustFix to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Use this free tool from JustFix to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 
-#: src/components/Login.tsx:328
+#: src/components/Login.tsx:317
 msgid "Use your account to get weekly email alerts on the areas you select."
 msgstr "Use your account to get weekly email alerts on the areas you select."
 
-#: src/components/Login.tsx:329
+#: src/components/Login.tsx:318
 msgid "Use your account to get weekly email alerts on the buildings you select."
 msgstr "Use your account to get weekly email alerts on the buildings you select."
 
@@ -2880,11 +2880,11 @@ msgstr "We compare your search address with a database of over 200k buildings to
 msgid "We couldn't send the email. Please try again."
 msgstr "We couldn't send the email. Please try again."
 
-#: src/components/Login.tsx:200
+#: src/components/Login.tsx:189
 msgid "We have added Area Alerts to your weekly emails. Visit your <0>email settings</0> to manage Area Alerts."
 msgstr "We have added Area Alerts to your weekly emails. Visit your <0>email settings</0> to manage Area Alerts."
 
-#: src/components/Login.tsx:178
+#: src/components/Login.tsx:167
 msgid "We no longer use passwords — enter your email for a code or link."
 msgstr "We no longer use passwords — enter your email for a code or link."
 
@@ -2933,7 +2933,7 @@ msgstr "We sent a new code to <0>{oldEmail}</0>"
 msgid "We sent your code to <0>{email}</0>"
 msgstr "We sent your code to <0>{email}</0>"
 
-#: src/components/Login.tsx:337
+#: src/components/Login.tsx:326
 msgid "We’ll text you in a few months to ask how we can improve this free service."
 msgstr "We’ll text you in a few months to ask how we can improve this free service."
 
@@ -2998,7 +2998,7 @@ msgstr "What’s the difference between a landlord, an owner, and head officer?"
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "When two parties share the same business address, we group them as part of the same portfolio."
 
-#: src/components/Login.tsx:344
+#: src/components/Login.tsx:333
 msgid "Which best describes you?"
 msgstr "Which best describes you?"
 
@@ -3078,7 +3078,7 @@ msgstr "You also have a right to organize with your neighbors and to exercise yo
 #~ msgid "You also have a right to organize with your neighbors to assert your rights. <0>Learn more</0> about your right to organize."
 #~ msgstr "You also have a right to organize with your neighbors to assert your rights. <0>Learn more</0> about your right to organize."
 
-#: src/components/Login.tsx:199
+#: src/components/Login.tsx:188
 #: src/containers/AccountSettingsPage.tsx:104
 #: src/containers/VerifyEmailPage.tsx:99
 msgid "You are logged in"
@@ -3243,7 +3243,7 @@ msgstr "Your email is already verified"
 #~ msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Service</1>."
 #~ msgstr "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Service</1>."
 
-#: src/components/Login.tsx:184
+#: src/components/Login.tsx:173
 msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Use</1>."
 msgstr "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Use</1>."
 

--- a/client/src/locales/es/messages.po
+++ b/client/src/locales/es/messages.po
@@ -145,7 +145,7 @@ msgstr "<0>Busque una dirección</0> para agregarla a sus alertas por edificio"
 #~ msgid "<0>Search for an address</0> to add to your Building Alerts"
 #~ msgstr "<0>Search for an address</0> to add to your Building Alerts"
 
-#: src/components/Login.tsx:204
+#: src/components/Login.tsx:193
 #: src/containers/UnsubscribePage.tsx:109
 #: src/containers/VerifyEmailPage.tsx:100
 msgid "<0>Search for an address</0> to add to your Building Alerts, <1>subscribe to Area Alerts</1>, or visit your <2>email settings</2> page to manage subscriptions."
@@ -812,7 +812,7 @@ msgstr "Editar"
 msgid "Email"
 msgstr "Correo"
 
-#: src/components/Login.tsx:370
+#: src/components/Login.tsx:359
 #: src/components/UserSettingField.tsx:162
 #: src/components/UserSettingField.tsx:168
 #: src/components/UserSettingField.tsx:177
@@ -1356,7 +1356,7 @@ msgstr "Ubicación"
 msgid "Log in"
 msgstr "Iniciar sesión"
 
-#: src/components/Login.tsx:326
+#: src/components/Login.tsx:315
 msgid "Log in / Sign up"
 msgstr "Iniciar sesión / Registrarse"
 
@@ -1368,7 +1368,7 @@ msgstr "Iniciar sesión / Registrarse"
 msgid "Log in / sign up"
 msgstr "Iniciar sesión / Registrarse"
 
-#: src/components/Login.tsx:323
+#: src/components/Login.tsx:312
 msgid "Log in or sign up to get weekly email updates on this building."
 msgstr "Inicia sesión o regístrate para recibir actualizaciones semanales por correo electrónico sobre este edificio."
 
@@ -1598,7 +1598,7 @@ msgstr "Nuevo enlace enviado"
 #~ msgstr "New password"
 
 #: src/components/FeatureCalloutWidget.tsx:81
-#: src/components/Login.tsx:339
+#: src/components/Login.tsx:328
 msgid "Next"
 msgstr "Siguiente"
 
@@ -1781,7 +1781,7 @@ msgstr "Personas"
 msgid "Person/Entity"
 msgstr "Persona/Entidad"
 
-#: src/components/Login.tsx:372
+#: src/components/Login.tsx:361
 msgid "Phone number (optional)"
 msgstr "Número de teléfono (opcional)"
 
@@ -2139,7 +2139,7 @@ msgstr "Mostrar {0} {1, plural, one {resultado} other {resultados}}"
 #~ msgid "Sign out"
 #~ msgstr "Sign out"
 
-#: src/components/Login.tsx:346
+#: src/components/Login.tsx:335
 #: src/components/Subscribe.tsx:81
 msgid "Sign up"
 msgstr "Regístrese"
@@ -2158,8 +2158,8 @@ msgstr "Regístrese"
 #~ msgid "Sign up for Data Updates on the buildings you choose:"
 #~ msgstr "Sign up for Data Updates on the buildings you choose:"
 
-#: src/components/Login.tsx:336
-#: src/components/Login.tsx:343
+#: src/components/Login.tsx:325
+#: src/components/Login.tsx:332
 msgid "Sign up for Email Alerts"
 msgstr "Suscríbase a las alertas por correo electrónico"
 
@@ -2261,7 +2261,7 @@ msgstr "Distrito de la Asamblea estatal"
 msgid "State Senate District"
 msgstr "Distrito del Senado estatal"
 
-#: src/components/Login.tsx:335
+#: src/components/Login.tsx:324
 msgid "Step 1 of 2"
 msgstr "Paso 1 de 2"
 
@@ -2269,7 +2269,7 @@ msgstr "Paso 1 de 2"
 #~ msgid "Step 1 of 3"
 #~ msgstr "Step 1 of 3"
 
-#: src/components/Login.tsx:342
+#: src/components/Login.tsx:331
 msgid "Step 2 of 2"
 msgstr "Paso 2 de 2"
 
@@ -2281,7 +2281,7 @@ msgstr "Paso 2 de 2"
 #~ msgid "Step 3 of 3"
 #~ msgstr "Step 3 of 3"
 
-#: src/components/Login.tsx:332
+#: src/components/Login.tsx:321
 msgid "Submit"
 msgstr "Enviar"
 
@@ -2697,11 +2697,11 @@ msgstr "Utilice la tecla \"Tab\". para navegar. Pulse la tecla \"Intro.\" para s
 msgid "Use this free tool from JustFix to research your building and investigate landlords! We use property ownership mapping to identify a landlord's portfolio and provide data to indicate potential tenant harassment and displacement."
 msgstr "Utilice esta herramienta gratuita de JustFix para buscar su edificio e investigar a los arrendadores. Utilizamos el mapeo de propietarios de propiedades para identificar la cartera de propiedades de un arrendador y proporcionar información para indicar posibles casos de acoso y desplazamiento de inquilinos."
 
-#: src/components/Login.tsx:328
+#: src/components/Login.tsx:317
 msgid "Use your account to get weekly email alerts on the areas you select."
 msgstr "Usa tu cuenta para recibir alertas semanales por correo electrónico sobre las áreas que elijas."
 
-#: src/components/Login.tsx:329
+#: src/components/Login.tsx:318
 msgid "Use your account to get weekly email alerts on the buildings you select."
 msgstr "Usa tu cuenta para recibir alertas semanales por correo electrónico sobre los edificios que elijas."
 
@@ -2885,11 +2885,11 @@ msgstr "Comparamos la dirección que buscó con una base de datos de más de 200
 msgid "We couldn't send the email. Please try again."
 msgstr "No hemos podido enviar el correo. Inténtalo de nuevo."
 
-#: src/components/Login.tsx:200
+#: src/components/Login.tsx:189
 msgid "We have added Area Alerts to your weekly emails. Visit your <0>email settings</0> to manage Area Alerts."
 msgstr "Hemos añadido Alertas por zona a sus correos electrónicos semanales. Visite la página de <0>Configuración de correo electrónico</0> para administrar sus Alertas por zona."
 
-#: src/components/Login.tsx:178
+#: src/components/Login.tsx:167
 msgid "We no longer use passwords — enter your email for a code or link."
 msgstr "Ya no usamos contraseñas: introduce tu correo para recibir un código o un enlace."
 
@@ -2938,7 +2938,7 @@ msgstr "Te hemos enviado un nuevo código a <0>{oldEmail}</0>"
 msgid "We sent your code to <0>{email}</0>"
 msgstr "Te hemos enviado tu código a <0>{email}</0>"
 
-#: src/components/Login.tsx:337
+#: src/components/Login.tsx:326
 msgid "We’ll text you in a few months to ask how we can improve this free service."
 msgstr "Le enviaremos un mensaje de texto en unos meses para preguntarle cómo podemos mejorar este servicio gratuito."
 
@@ -3003,7 +3003,7 @@ msgstr "¿Cuál es la diferencia entre un arrendador, un propietario y un oficia
 msgid "When two parties share the same business address, we group them as part of the same portfolio."
 msgstr "Cuando dos partes comparten la misma dirección comercial, los agrupamos como parte de la misma cartera."
 
-#: src/components/Login.tsx:344
+#: src/components/Login.tsx:333
 msgid "Which best describes you?"
 msgstr "¿Cuál de estas opciones lo describe mejor a usted?"
 
@@ -3083,7 +3083,7 @@ msgstr "También tienes derecho a organizarte con tus vecinos y a ejercer tus de
 #~ msgid "You also have a right to organize with your neighbors to assert your rights. <0>Learn more</0> about your right to organize."
 #~ msgstr "You also have a right to organize with your neighbors to assert your rights. <0>Learn more</0> about your right to organize."
 
-#: src/components/Login.tsx:199
+#: src/components/Login.tsx:188
 #: src/containers/AccountSettingsPage.tsx:104
 #: src/containers/VerifyEmailPage.tsx:99
 msgid "You are logged in"
@@ -3248,7 +3248,7 @@ msgstr "Este correo electrónico ya está verificado"
 #~ msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Service</1>."
 #~ msgstr "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Service</1>."
 
-#: src/components/Login.tsx:184
+#: src/components/Login.tsx:173
 msgid "Your privacy is important to us. Read our <0>Privacy Policy</0> and <1>Terms of Use</1>."
 msgstr "Su privacidad es importante a nosotros. Lea nuestra <0>Política de privacidad</0> y <1>Términos de uso</1>."
 

--- a/jfauthprovider/tests/test_views.py
+++ b/jfauthprovider/tests/test_views.py
@@ -103,6 +103,45 @@ class TestLoginSendCodeProxy:
         )
 
     @patch("jfauthprovider.views.client_secret_request")
+    def test_login_send_code_forwards_building_display_fields(
+        self, mock_request, client
+    ):
+        mock_request.return_value = make_auth_response(200, {"otp": "123456"})
+
+        res = client.post(
+            "/auth/login/send-code",
+            {
+                "email": "test@example.com",
+                "bbl": "3016780054",
+                "housenumber": "196",
+                "streetname": "Ralph Avenue",
+                "zip": "11261",
+                "boro": "Brooklyn",
+                "housenumber_display": "196A",
+                "streetname_display": "RALPH AVENUE",
+            },
+            HTTP_ORIGIN=ORIGIN,
+        )
+
+        assert res.status_code == 200
+        mock_request.assert_called_once_with(
+            "user/login/send-code/",
+            {
+                "email": "test@example.com",
+                "user_type": None,
+                "phone_number": None,
+                "origin": ORIGIN,
+                "bbl": "3016780054",
+                "housenumber": "196",
+                "streetname": "Ralph Avenue",
+                "zip": "11261",
+                "boro": "Brooklyn",
+                "housenumber_display": "196A",
+                "streetname_display": "RALPH AVENUE",
+            },
+        )
+
+    @patch("jfauthprovider.views.client_secret_request")
     def test_login_send_code_forwards_district(self, mock_request, client):
         mock_request.return_value = make_auth_response(200, {"otp": "123456"})
         district_json = json.dumps(

--- a/jfauthprovider/views.py
+++ b/jfauthprovider/views.py
@@ -39,7 +39,16 @@ def login_send_code(request):
     origin = request.headers.get("Origin")
     if origin:
         post_data["origin"] = origin
-    for key in ("bbl", "housenumber", "streetname", "zip", "boro", "district"):
+    for key in (
+        "bbl",
+        "housenumber",
+        "streetname",
+        "zip",
+        "boro",
+        "housenumber_display",
+        "streetname_display",
+        "district",
+    ):
         value = request.POST.get(key)
         if value:
             post_data[key] = value


### PR DESCRIPTION
## Summary

Building Alerts users who sign up via login (OTP or magic link) were receiving confirmation emails with the canonical address instead of their GeoSearch display address. Display fields were stored on the pending intent model in auth-provider but never reached send-code from the WOW client or jfauthprovider proxy. A second client subscribe after verify patched display in the DB too late — after the confirmation email had already been sent.

This PR completes the end-to-end fix: display fields flow through send-code into the pending intent, and subscription creation stays server-side on verify (no duplicate client subscribe).

Companion auth-provider changes: https://github.com/JustFixNYC/auth-provider/pull/184



## Changes

- **`client/src/components/AuthClient.ts`**: Extend `PendingBuildingSubscription` with optional display fields; include them in `sendLoginCode` POST body when set.
- **`client/src/components/Login.tsx`**: Include GeoSearch display fields in `sendCodeOptions` when `fromBuildingAlerts`; remove `subscribeOnSuccess` (pending intent + verify owns subscription creation for building and district).
- **`jfauthprovider/views.py`**: Forward `housenumber_display` / `streetname_display` in `login_send_code`.
- **Tests**: Proxy forward test + client send-code body assertion in `EmailAlertSignup.test.ts`.

## Test plan

- [x] `pytest jfauthprovider/tests/test_views.py -q`
- [x] `cd client && yarn tsc --noEmit && yarn test --watchAll=false --testPathPattern='EmailAlertSignup.test'`
- [x] Deploy with auth-provider companion PR
- [ ] Building Alerts → login (new account) → OTP verify: confirmation shows display address; DB has `*_display` at verify time
- [ ] Same flow via magic link (same browser + other device)
- [x] Building page follow (logged-in): confirmation still uses canonical address (unchanged)