### PR TITLE
adjust styles on otp input for webkit / ios

### DIFF
--- a/client/src/components/CodeEntry.test.tsx
+++ b/client/src/components/CodeEntry.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { I18nProvider } from "@lingui/react";
+
+import catalogEn from "../locales/en/messages";
+import { CodeEntry } from "./CodeEntry";
+
+const catalogs = { en: catalogEn };
+
+describe("CodeEntry paste", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    document.body.removeChild(container);
+  });
+
+  it("sanitizes pasted clipboard text into the OTP field", () => {
+    act(() => {
+      ReactDOM.render(
+        <I18nProvider language="en" catalogs={catalogs}>
+          <CodeEntry email="tenant@example.com" onVerify={jest.fn()} onResend={jest.fn()} />
+        </I18nProvider>,
+        container
+      );
+    });
+
+    const input = container.querySelector(".otp-input__field") as HTMLInputElement;
+    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, "clipboardData", {
+      value: { getData: () => "12 34-56789" },
+    });
+
+    act(() => {
+      input.dispatchEvent(pasteEvent);
+    });
+
+    expect(input.value).toBe("123456");
+    expect(container.querySelectorAll(".otp-input__cell")[5]?.textContent).toBe("6");
+  });
+});

--- a/client/src/components/OtpInput.test.tsx
+++ b/client/src/components/OtpInput.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+
+import { OtpInput } from "./OtpInput";
+
+describe("OtpInput", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    document.body.removeChild(container);
+  });
+
+  it("exposes one-time-code autocomplete on the real input", () => {
+    act(() => {
+      ReactDOM.render(<OtpInput id="otp" name="code" value="" onChange={jest.fn()} />, container);
+    });
+
+    const input = container.querySelector(".otp-input__field") as HTMLInputElement;
+    expect(input.autocomplete).toBe("one-time-code");
+    expect(input.inputMode).toBe("numeric");
+  });
+
+  it("forwards paste events to onPaste", () => {
+    const onPaste = jest.fn();
+
+    act(() => {
+      ReactDOM.render(
+        <OtpInput id="otp" name="code" value="" onChange={jest.fn()} onPaste={onPaste} />,
+        container
+      );
+    });
+
+    const input = container.querySelector(".otp-input__field") as HTMLInputElement;
+    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, "clipboardData", {
+      value: { getData: () => "123456" },
+    });
+
+    act(() => {
+      input.dispatchEvent(pasteEvent);
+    });
+
+    expect(onPaste).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders decorative cells from value", () => {
+    act(() => {
+      ReactDOM.render(
+        <OtpInput id="otp" name="code" value="123" onChange={jest.fn()} />,
+        container
+      );
+    });
+
+    const cells = container.querySelectorAll(".otp-input__cell");
+    expect(cells[0]?.textContent).toBe("1");
+    expect(cells[1]?.textContent).toBe("2");
+    expect(cells[2]?.textContent).toBe("3");
+    expect(cells[3]?.textContent).toBe("");
+  });
+});

--- a/client/src/styles/OtpInput.scss
+++ b/client/src/styles/OtpInput.scss
@@ -68,10 +68,6 @@
     }
   }
 
-  &:focus-within:not(&--invalid):not(&--disabled) &__cell {
-    border-color: $justfix-blue;
-  }
-
   &--invalid &__cell {
     border-color: $justfix-red;
   }

--- a/client/src/styles/OtpInput.scss
+++ b/client/src/styles/OtpInput.scss
@@ -27,8 +27,11 @@
   }
 
   &__field {
+    background: transparent;
     border: 0;
     box-sizing: border-box;
+    caret-color: transparent;
+    color: transparent;
     cursor: text;
     height: 100%;
     top: 0;
@@ -36,10 +39,25 @@
     bottom: 0;
     left: 0;
     margin: 0;
-    opacity: 0;
     padding: 0;
     position: absolute;
+    user-select: text;
     width: 100%;
+    -webkit-touch-callout: default;
+    -webkit-user-select: text;
+
+    &::selection {
+      background: transparent;
+      color: transparent;
+    }
+
+    &:-webkit-autofill,
+    &:-webkit-autofill:hover,
+    &:-webkit-autofill:focus {
+      -webkit-box-shadow: 0 0 0 1000px transparent inset;
+      -webkit-text-fill-color: transparent;
+      transition: background-color 5000s ease-in-out 0s;
+    }
   }
 
   &--invalid &__cell {

--- a/client/src/styles/OtpInput.scss
+++ b/client/src/styles/OtpInput.scss
@@ -39,12 +39,20 @@
     bottom: 0;
     left: 0;
     margin: 0;
+    outline: none;
     padding: 0;
     position: absolute;
     user-select: text;
     width: 100%;
+    -webkit-tap-highlight-color: transparent;
     -webkit-touch-callout: default;
     -webkit-user-select: text;
+
+    &:focus,
+    &:focus-visible {
+      box-shadow: none;
+      outline: none;
+    }
 
     &::selection {
       background: transparent;
@@ -58,6 +66,10 @@
       -webkit-text-fill-color: transparent;
       transition: background-color 5000s ease-in-out 0s;
     }
+  }
+
+  &:focus-within:not(&--invalid):not(&--disabled) &__cell {
+    border-color: $justfix-blue;
   }
 
   &--invalid &__cell {


### PR DESCRIPTION
On IOS safari + chrome, I was able to focus the otp input to get the keyboard to activate, but I couldn't get the paste option to appear. Apparently there is a known quirk to how these otp inputs are set up if you set the `opacity: 0`. This applies the typical fix and some extra webkit protective measures